### PR TITLE
Update license to GPL-2.0-or-later

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@
 * **Test:** Try features as they're released and report feedback.
 
 ## License
-GPL-3
+
+[GPL-2.0-or-later](https://spdx.org/licenses/GPL-2.0-or-later.html)


### PR DESCRIPTION
This pull request updates the license information in the `README.md` file to use a SPDX identifier and adjusts from GPLv3 to GPL-2.0-or-later as the more likely landing place for the eventual plugin.