### PR TITLE
Change the event the PR Comment workflow runs on

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install Composer dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
+        with:
+          composer-options: '--no-dev'
 
       - name: Build plugin
         run: npm run build

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -3,13 +3,6 @@ name: Build Plugin Zip
 on:
   workflow_call:
 
-# Cancels all previous workflow runs for pull requests that have not completed.
-concurrency:
-  # The concurrency group contains the workflow name and the branch name for pull requests
-  # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -1,7 +1,7 @@
 name: Pull Request Comments
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ 'opened', 'synchronize', 'reopened', 'edited' ]
 
 # Cancels all previous workflow runs for pull requests that have not completed.

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -8,7 +8,7 @@ on:
 concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.sha }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/build-plugin-zip.yml
     permissions:
       contents: read
+      pull-requests: read
 
   # Leaves a comment on a pull request with a link to test the changes in a WordPress Playground instance.
   playground-details:

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -9,6 +9,7 @@ concurrency:
   # The concurrency group contains the workflow name and the branch name for pull requests
   # or the commit hash for any other events.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.

--- a/package.json
+++ b/package.json
@@ -3,6 +3,13 @@
   "version": "0.1.0",
   "description": "WordPress AI Experiments",
   "license": "GPL-2.0-or-later",
+  "files": [
+    "includes",
+    "vendor",
+    "README.md",
+    "readme.txt",
+    "ai.php"
+  ],
   "scripts": {
     "plugin-zip": "wp-scripts plugin-zip",
     "build": "echo 'Building...'",


### PR DESCRIPTION
### Description of the Change

In #46 we added a GitHub Action workflow to add a Playground testing link to each PR description. There were a few issues with that and we fixed those in #49. In testing coming out of that merge, noticing a few more problems:

1. The branch used to build the zip was still showing as `trunk`, even though we want it to build from the PR branch
2. The final zip didn't include the `vendor` directory

For the first, in looking at the difference between using `pull_request` and `pull_request_target` as the triggering event, `pull_request_target` (which we were using) will always [reference the PR base branch](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target) (typically `trunk` in our case) instead of the last commit to the PR branch itself.

I've adjusted that in this PR to use `pull_request` instead. I believe this is the proper event to use, especially based on this comment from GitHub:

> This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request

For the second issue, I've adjusted our build script to ensure the `vendor` directory is included there but only include non-dev dependencies.

### How to test the Change

Ensure the Playground link gets added properly to this PR description and that link works

## Test using WordPress Playground
The changes in this pull request can be previewed and tested using this [WordPress Playground](https://wordpress.github.io/wordpress-playground/) instance:

[Click here to test this pull request](https://playground.wordpress.net/#%7B%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22latest%22%7D,%22steps%22:%5B%7B%22step%22:%22mkdir%22,%22path%22:%22/tmp/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/tmp/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=ai&workflow=Pull%2520Request%2520Comments&artifact=ai&pr=56%22,%22caption%22:%22Downloading%20AI%20Experiments%20PR%2056%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/tmp/pr/pr.zip%22,%22extractToPath%22:%22/tmp/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/tmp/pr/ai.zip%22%7D%7D%5D%7D).