### PR TITLE
Add basic webpack config

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "WordPress AI Experiments",
   "license": "GPL-2.0-or-later",
   "files": [
+    "build",
     "includes",
     "vendor",
     "README.md",

--- a/src/admin/settings/index.scss
+++ b/src/admin/settings/index.scss
@@ -1,0 +1,4 @@
+// Placeholder used as an example.
+.admin-settings {
+	background-color: blue;
+}

--- a/src/experiments/example-experiment/index.scss
+++ b/src/experiments/example-experiment/index.scss
@@ -1,0 +1,3 @@
+.test {
+	background-color: red;
+}

--- a/src/experiments/example-experiment/index.scss
+++ b/src/experiments/example-experiment/index.scss
@@ -1,3 +1,4 @@
+// Placeholder used as an example.
 .test {
 	background-color: red;
 }

--- a/src/experiments/example-experiment/index.tsx
+++ b/src/experiments/example-experiment/index.tsx
@@ -1,0 +1,12 @@
+// Example only.
+
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+
+import './index.scss';
+
+const ExampleExperiment = () => {
+	return <div className="test">{ __( 'Example Experiment', 'ai' ) }</div>;
+};
+
+export default ExampleExperiment;

--- a/src/experiments/example-experiment/index.tsx
+++ b/src/experiments/example-experiment/index.tsx
@@ -1,4 +1,4 @@
-// Example only.
+// Placeholder used as an example.
 
 import React from 'react';
 import { __ } from '@wordpress/i18n';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,13 @@
+const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
+
+const webpackConfig = {
+	...defaultConfig,
+	entry: {
+		...defaultConfig.entry(),
+		'admin/settings': './src/admin/settings/index.scss',
+		'experiments/example-experiment':
+			'./src/experiments/example-experiment/index.tsx',
+	},
+};
+
+module.exports = webpackConfig;


### PR DESCRIPTION
## What?

This is a followup to #87 that provides a basic webpack config file as well as examples of how assets (CSS, JS/TS files) can be managed.

## Why?

While we added in an `Asset_Loader` class in #87, we didn't provide the actual implementation steps needed to build files. This PR does that.

## How?

- Add in a basic `webpack.config.js` file that shows how to customize entry points
- Add in some examples within `/src/` to show how things like Experiments or admin-related CSS could be loaded

## Testing Instructions

n/a