### PR TITLE
Create `wporg-plugin-deploy.yml`

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,0 +1,28 @@
+# Directories
+/.git
+/.github
+/.wordpress-org
+/docs
+/node_modules
+/src
+/tests
+
+# Files
+.*
+ai.zip
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+composer.json
+composer.lock
+CONTRIBUTING.md
+CREDITS.md
+LICENSE.md
+package-lock.json
+package.json
+phpcs.xml.dist
+phpstan.neon.dist
+phpunit.xml.dist
+README.md
+ROADMAP.md
+SECURITY.md
+webpack.config.js

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Directories
+/.git export-ignore
+/.github export-ignore
+/.wordpress-org export-ignore
+/docs export-ignore
+/node_modules export-ignore
+/src export-ignore
+/tests export-ignore
+# /vendor export-ignore # do not ignore.
+
+# Files
+/.* export-ignore
+/ai.zip export-ignore
+/CHANGELOG.md export-ignore
+/CODE_OF_CONDUCT.md export-ignore
+/composer.json export-ignore
+/composer.lock export-ignore
+/CONTRIBUTING.md export-ignore
+/CREDITS.md export-ignore
+/LICENSE.md export-ignore
+/package-lock.json export-ignore
+/package.json export-ignore
+/phpcs.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+/README.md export-ignore
+/ROADMAP.md export-ignore
+/SECURITY.md export-ignore
+/webpack.config.js export-ignore

--- a/.github/workflows/wporg-plugin-deploy.yml
+++ b/.github/workflows/wporg-plugin-deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types: [published]
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  tag:
+    name: New release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: read
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+    - name: Build
+      run: |
+        npm install
+        npm run build
+
+    - name: WordPress Plugin Deploy
+      id: deploy
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+
+    - name: Upload release asset
+      uses: softprops/action-gh-release@5be0e66d93ac7ed76da52eca8bb058f665c3a5fe # v2.4.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: ${{ github.workspace }}/${{ github.event.repository.name }}.zip

--- a/.github/workflows/wporg-plugin-deploy.yml
+++ b/.github/workflows/wporg-plugin-deploy.yml
@@ -20,6 +20,23 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+    - name: Set up PHP
+      uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2.35.4
+      with:
+        php-version: '7.4'
+        coverage: none
+        tools: composer:v2
+
+    - name: Use desired version of Node.js
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      with:
+        node-version-file: '.nvmrc'
+    
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
+      with:
+         composer-options: '--no-dev -o'
+
     - name: Build
       run: |
         npm install


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

_Note that we may want to make use of https://github.com/WordPress/ai/blob/trunk/.github/workflows/build-plugin-zip.yml in place of the Build step in this action, will defer to @dkotter on optimal handling there._

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Relates to #28.

<!-- In a few words, what is the PR actually doing? -->

This pull request introduces a new GitHub Actions workflow to automate deployment of the plugin to WordPress.org when a new release is published. The workflow handles building the plugin, deploying it to WordPress.org, and uploading the release asset to GitHub.

**Deployment automation:**

* Adds a `.github/workflows/wporg-plugin-deploy.yml` workflow that triggers on new release publication, checks out the code, installs dependencies, builds the plugin, deploys it to WordPress.org using 10up's deployment action, and uploads the generated zip file as a GitHub release asset.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This will help automate future releases here on GitHub syncing over to WPORG's SVN.  Note that we likely want to avoid adding in the SVN credentials as repo secrets until we get to the point of (1) being approved by the WPORG Plugin team and having an SVN repo and (2) wanting to make the plugin public there (as we may want to have 1-more releases available here on GitHub for feedback first before formally publishing to WPORG).

We may also want to consider enabling the double-confirm on WPORG for releases, but I'll defer to others to have a strong opinion on that (I'm generally in favor of the extra manual step to help prevent unwanted releases sneaking out in some way).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|


## Test using WordPress Playground
The changes in this pull request can be previewed and tested using this [WordPress Playground](https://wordpress.github.io/wordpress-playground/) instance:

[Click here to test this pull request](https://playground.wordpress.net/#%7B%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22latest%22%7D,%22steps%22:%5B%7B%22step%22:%22mkdir%22,%22path%22:%22/tmp/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/tmp/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=ai&workflow=Pull%2520Request%2520Comments&artifact=ai&pr=93%22,%22caption%22:%22Downloading%20AI%20Experiments%20PR%2093%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/tmp/pr/pr.zip%22,%22extractToPath%22:%22/tmp/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/tmp/pr/ai.zip%22%7D%7D%5D%7D).