### PR TITLE
Fix plugin review items

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,7 @@ This issue is for tracking changes for the X.Y.Z release.  Target release date: 
 ## [Release steps](https://github.com/wordpress/ai/blob/develop/CONTRIBUTING.md#release-instructions)
 
 - [ ] Branch: Starting from `develop`, cut a release branch named `release/X.Y.Z` for your changes.
-- [ ] Version bump: Bump the version number in `ai.php`, `package-lock.json` (twice), `package.json`, and `readme.txt` if it does not already reflect the version being released.  In `includes/bootstrap.php`, ensure you're updating the `AI_VERSION` version constant.
+- [ ] Version bump: Bump the version number in `ai.php`, `package-lock.json` (twice), `package.json`, and `readme.txt` if it does not already reflect the version being released.  In `includes/bootstrap.php`, ensure you're updating the `AI_EXPERIMENTS_VERSION` version constant.
 - [ ] Update `@since`: Find all new `@since x.x.x` lines and update those with the new version number in place of `x.x.x`.
 - [ ] Changelog: Add/update the changelog in `CHANGELOG.md` and in `readme.txt`.
 - [ ] Props: update `CREDITS.md` file with any new contributors, confirm maintainers are accurate.

--- a/ai.php
+++ b/ai.php
@@ -29,6 +29,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Shortcut constant to the path of this file.
  */
-define( 'WP_AI_DIR', plugin_dir_path( __FILE__ ) );
+define( 'AI_EXPERIMENTS_DIR', plugin_dir_path( __FILE__ ) );
 
-require_once WP_AI_DIR . 'includes/bootstrap.php';
+require_once AI_EXPERIMENTS_DIR . 'includes/bootstrap.php';

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -264,10 +264,10 @@ The plugin provides a set of hooks and filters to allow third-party developers t
 
 ### Registering a Custom Experiment
 
-Developers can register their own experiments using the `ai_register_experiments` action. This is the primary way to add new functionality to the plugin.
+Developers can register their own experiments using the `ai_experiments_register_experiments` action. This is the primary way to add new functionality to the plugin.
 
 ```php
-add_action( 'ai_register_experiments', function( $registry ) {
+add_action( 'ai_experiments_register_experiments', function( $registry ) {
 	$registry->register_experiment( new My_Custom_Experiment() );
 } );
 ```
@@ -311,7 +311,7 @@ add_filter( 'ai_experiments_enabled', '__return_false' );
 
 The plugin also includes the following action hooks:
 
-- `ai_register_experiments`: Fires after default experiments are registered, receives `$registry` parameter
+- `ai_experiments_register_experiments`: Fires after default experiments are registered, receives `$registry` parameter
 - `ai_experiments_initialized`: Fires after all registered experiments have been initialized
 
 ### Asset Loading

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -277,7 +277,7 @@ add_action( 'ai_register_experiments', function( $registry ) {
 Modify the list of default experiment classes before they are instantiated:
 
 ```php
-add_filter( 'ai_default_experiment_classes', function( $experiment_classes ) {
+add_filter( 'ai_experiments_default_experiment_classes', function( $experiment_classes ) {
 	// Add a custom experiment
 	$experiment_classes[] = 'My_Namespace\My_Custom_Experiment';
 
@@ -296,7 +296,7 @@ add_filter( 'ai_default_experiment_classes', function( $experiment_classes ) {
 Experiments can be disabled using the `ai_experiment_{$experiment_id}_enabled` filter:
 
 ```php
-add_filter( 'ai_experiment_example-experiment_enabled', '__return_false' );
+add_filter( 'ai_experiments_experiment_example-experiment_enabled', '__return_false' );
 ```
 
 ### Disabling All Experiments

--- a/includes/Abilities/Utilities/Posts.php
+++ b/includes/Abilities/Utilities/Posts.php
@@ -56,7 +56,7 @@ class Posts {
 			array(
 				'label'               => esc_html__( 'Get post details', 'ai' ),
 				'description'         => esc_html__( 'Get the details of a post based on the post ID. Optionally, limit the details to specific fields.', 'ai' ),
-				'category'            => AI_DEFAULT_ABILITY_CATEGORY,
+				'category'            => AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(
@@ -174,7 +174,7 @@ class Posts {
 			array(
 				'label'               => esc_html__( 'Get the post terms', 'ai' ),
 				'description'         => esc_html__( 'Get the terms of a post based on the post ID and optionally filter by taxonomy.', 'ai' ),
-				'category'            => AI_DEFAULT_ABILITY_CATEGORY,
+				'category'            => AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY,
 				'input_schema'        => array(
 					'type'       => 'object',
 					'properties' => array(

--- a/includes/Abstracts/Abstract_Ability.php
+++ b/includes/Abstracts/Abstract_Ability.php
@@ -51,7 +51,7 @@ abstract class Abstract_Ability extends WP_Ability {
 	 * @return string The category of the ability.
 	 */
 	protected function category(): string {
-		return AI_DEFAULT_ABILITY_CATEGORY;
+		return AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY;
 	}
 
 	/**

--- a/includes/Abstracts/Abstract_Experiment.php
+++ b/includes/Abstracts/Abstract_Experiment.php
@@ -169,7 +169,7 @@ abstract class Abstract_Experiment implements Experiment {
 		 *
 		 * @param bool $experiment_enabled Whether the experiment is enabled.
 		 */
-		$is_enabled = (bool) apply_filters( "ai_experiment_{$this->id}_enabled", $experiment_enabled );
+		$is_enabled = (bool) apply_filters( "ai_experiments_experiment_{$this->id}_enabled", $experiment_enabled );
 
 		// Check if we have valid AI credentials.
 		if ( ! has_valid_ai_credentials() ) {

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -36,8 +36,8 @@ class Asset_Loader {
 	 * @param string $file_name The script file name.
 	 */
 	public static function enqueue_script( string $handle, string $file_name ): void {
-		$script_path       = WP_AI_DIR . 'build/' . $file_name . '.js';
-		$script_url        = AI_PLUGIN_URL . 'build/' . $file_name . '.js';
+		$script_path       = AI_EXPERIMENTS_DIR . 'build/' . $file_name . '.js';
+		$script_url        = AI_EXPERIMENTS_PLUGIN_URL . 'build/' . $file_name . '.js';
 		$script_asset_path = $script_path . '.asset.php';
 
 		if ( file_exists( $script_asset_path ) ) {
@@ -67,8 +67,8 @@ class Asset_Loader {
 	 * @param string $file_name The script file name.
 	 */
 	public static function enqueue_style( string $handle, string $file_name ): void {
-		$style_path       = WP_AI_DIR . 'build/' . $file_name . '.css';
-		$style_url        = AI_PLUGIN_URL . 'build/' . $file_name . '.css';
+		$style_path       = AI_EXPERIMENTS_DIR . 'build/' . $file_name . '.css';
+		$style_url        = AI_EXPERIMENTS_PLUGIN_URL . 'build/' . $file_name . '.css';
 		$style_asset_path = $style_path . '.asset.php';
 
 		if ( file_exists( $style_asset_path ) ) {

--- a/includes/Experiment_Loader.php
+++ b/includes/Experiment_Loader.php
@@ -54,7 +54,7 @@ final class Experiment_Loader {
 	 * Registers default experiments.
 	 *
 	 * This is where built-in experiments are registered. Third-party experiments
-	 * should use the 'ai_register_experiments' action hook.
+	 * should use the 'ai_experiments_register_experiments' action hook.
 	 *
 	 * @since 0.1.0
 	 *
@@ -82,7 +82,7 @@ final class Experiment_Loader {
 		 *
 		 * Example:
 		 * ```php
-		 * add_action( 'ai_register_experiments', function( $registry ) {
+		 * add_action( 'ai_experiments_register_experiments', function( $registry ) {
 		 *     $registry->register_experiment( new My_Custom_Experiment() );
 		 * } );
 		 * ```
@@ -211,7 +211,7 @@ final class Experiment_Loader {
 		 *
 		 * @since 0.1.0
 		 */
-		do_action( 'ai_experiments_experiments_initialized' );
+		do_action( 'ai_experiments_initialized' );
 
 		$this->initialized = true;
 	}

--- a/includes/Experiment_Loader.php
+++ b/includes/Experiment_Loader.php
@@ -91,7 +91,7 @@ final class Experiment_Loader {
 		 *
 		 * @param \WordPress\AI\Experiment_Registry $registry The experiment registry instance.
 		 */
-		do_action( 'ai_register_experiments', $this->registry );
+		do_action( 'ai_experiments_register_experiments', $this->registry );
 	}
 
 	/**
@@ -118,7 +118,7 @@ final class Experiment_Loader {
 		 *
 		 * @param array $experiment_classes Array of experiment class names or instances.
 		 */
-		$items = apply_filters( 'ai_default_experiment_classes', $experiment_classes );
+		$items = apply_filters( 'ai_experiments_default_experiment_classes', $experiment_classes );
 
 		$experiments = array();
 		foreach ( $items as $item ) {
@@ -211,7 +211,7 @@ final class Experiment_Loader {
 		 *
 		 * @since 0.1.0
 		 */
-		do_action( 'ai_experiments_initialized' );
+		do_action( 'ai_experiments_experiments_initialized' );
 
 		$this->initialized = true;
 	}

--- a/includes/Experiments/Example_Experiment/README.md
+++ b/includes/Experiments/Example_Experiment/README.md
@@ -30,7 +30,7 @@ This experiment registers a REST endpoint to demonstrate how to expose experimen
 Use the experiment-specific filter:
 
 ```php
-add_filter( 'ai_experiment_example-experiment_enabled', '__return_false' );
+add_filter( 'ai_experiments_experiment_example-experiment_enabled', '__return_false' );
 ```
 
 Or use the generic filter to disable all experiments:

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Bootstrap file for the AI plugin.
+ * Bootstrap file for the AI Experiments plugin.
  *
  * Handles plugin initialization, version checks, and feature loading.
  *
@@ -22,26 +22,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-if ( ! defined( 'AI_VERSION' ) ) {
-	define( 'AI_VERSION', '0.1.0' );
+if ( ! defined( 'AI_EXPERIMENTS_VERSION' ) ) {
+	define( 'AI_EXPERIMENTS_VERSION', '0.1.0' );
 }
-if ( ! defined( 'AI_PLUGIN_FILE' ) ) {
-	define( 'AI_PLUGIN_FILE', defined( 'WP_AI_DIR' ) ? WP_AI_DIR . 'ai.php' : '' );
+if ( ! defined( 'AI_EXPERIMENTS_PLUGIN_FILE' ) ) {
+	define( 'AI_EXPERIMENTS_PLUGIN_FILE', defined( 'AI_EXPERIMENTS_DIR' ) ? AI_EXPERIMENTS_DIR . 'ai.php' : '' );
 }
-if ( ! defined( 'AI_PLUGIN_DIR' ) ) {
-	define( 'AI_PLUGIN_DIR', defined( 'WP_AI_DIR' ) ? WP_AI_DIR : '' );
+if ( ! defined( 'AI_EXPERIMENTS_PLUGIN_DIR' ) ) {
+	define( 'AI_EXPERIMENTS_PLUGIN_DIR', defined( 'AI_EXPERIMENTS_DIR' ) ? AI_EXPERIMENTS_DIR : '' );
 }
-if ( ! defined( 'AI_PLUGIN_URL' ) ) {
-	define( 'AI_PLUGIN_URL', plugin_dir_url( AI_PLUGIN_FILE ) );
+if ( ! defined( 'AI_EXPERIMENTS_PLUGIN_URL' ) ) {
+	define( 'AI_EXPERIMENTS_PLUGIN_URL', plugin_dir_url( AI_EXPERIMENTS_PLUGIN_FILE ) );
 }
-if ( ! defined( 'AI_MIN_PHP_VERSION' ) ) {
-	define( 'AI_MIN_PHP_VERSION', '7.4' );
+if ( ! defined( 'AI_EXPERIMENTS_MIN_PHP_VERSION' ) ) {
+	define( 'AI_EXPERIMENTS_MIN_PHP_VERSION', '7.4' );
 }
-if ( ! defined( 'AI_MIN_WP_VERSION' ) ) {
-	define( 'AI_MIN_WP_VERSION', '6.8' );
+if ( ! defined( 'AI_EXPERIMENTS_MIN_WP_VERSION' ) ) {
+	define( 'AI_EXPERIMENTS_MIN_WP_VERSION', '6.8' );
 }
-if ( ! defined( 'AI_DEFAULT_ABILITY_CATEGORY' ) ) {
-	define( 'AI_DEFAULT_ABILITY_CATEGORY', 'ai-experiments' );
+if ( ! defined( 'AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY' ) ) {
+	define( 'AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY', 'ai-experiments' );
 }
 
 /**
@@ -70,15 +70,15 @@ function version_notice( string $message ): void {
  * @return bool True if PHP version is sufficient, false otherwise.
  */
 function check_php_version(): bool {
-	if ( version_compare( phpversion(), AI_MIN_PHP_VERSION, '<' ) ) {
+	if ( version_compare( phpversion(), AI_EXPERIMENTS_MIN_PHP_VERSION, '<' ) ) {
 		add_action(
 			'admin_notices',
 			static function () {
 				version_notice(
 					sprintf(
 						/* translators: 1: Required PHP version, 2: Current PHP version */
-						__( 'AI plugin requires PHP version %1$s or higher. You are running PHP version %2$s.', 'ai' ),
-						AI_MIN_PHP_VERSION,
+						__( 'AI Experiments plugin requires PHP version %1$s or higher. You are running PHP version %2$s.', 'ai' ),
+						AI_EXPERIMENTS_MIN_PHP_VERSION,
 						PHP_VERSION
 					)
 				);
@@ -99,7 +99,7 @@ function check_php_version(): bool {
 function check_wp_version(): bool {
 	global $wp_version;
 
-	if ( version_compare( $wp_version, AI_MIN_WP_VERSION, '<' ) ) {
+	if ( version_compare( $wp_version, AI_EXPERIMENTS_MIN_WP_VERSION, '<' ) ) {
 		add_action(
 			'admin_notices',
 			static function () {
@@ -107,8 +107,8 @@ function check_wp_version(): bool {
 				version_notice(
 					sprintf(
 						/* translators: 1: Required WordPress version, 2: Current WordPress version */
-						__( 'AI plugin requires WordPress version %1$s or higher. You are running WordPress version %2$s.', 'ai' ),
-						AI_MIN_WP_VERSION,
+						__( 'AI Experiments plugin requires WordPress version %1$s or higher. You are running WordPress version %2$s.', 'ai' ),
+						AI_EXPERIMENTS_MIN_WP_VERSION,
 						$wp_version
 					)
 				);
@@ -131,7 +131,7 @@ function display_composer_notice(): void {
 			<?php
 			printf(
 				/* translators: %s: composer install command */
-				esc_html__( 'Your installation of the AI plugin is incomplete. Please run %s.', 'ai' ),
+				esc_html__( 'Your installation of the AI Experiments plugin is incomplete. Please run %s.', 'ai' ),
 				'<code>composer install</code>'
 			);
 			?>
@@ -159,11 +159,11 @@ function load(): void {
 	}
 
 	// Load the Jetpack autoloader.
-	if ( ! file_exists( AI_PLUGIN_DIR . 'vendor/autoload_packages.php' ) ) {
+	if ( ! file_exists( AI_EXPERIMENTS_PLUGIN_DIR . 'vendor/autoload_packages.php' ) ) {
 		add_action( 'admin_notices', __NAMESPACE__ . '\display_composer_notice' );
 		return;
 	}
-	require_once AI_PLUGIN_DIR . 'vendor/autoload_packages.php';
+	require_once AI_EXPERIMENTS_PLUGIN_DIR . 'vendor/autoload_packages.php';
 
 	$loaded = true;
 
@@ -209,7 +209,7 @@ function initialize_experiments(): void {
 				 * in the future if we need/want more specific categories.
 				 */
 				wp_register_ability_category(
-					AI_DEFAULT_ABILITY_CATEGORY,
+					AI_EXPERIMENTS_DEFAULT_ABILITY_CATEGORY,
 					array(
 						'label'       => __( 'AI Experiments', 'ai' ),
 						'description' => __( 'Various AI experiments.', 'ai' ),

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -25,13 +25,12 @@ function normalize_content( string $content ): string {
 	 * Hook to filter content before cleaning it.
 	 *
 	 * @since 0.1.0
-	 * @hook ai_pre_normalize_content
 	 *
 	 * @param string $post_content The post content.
 	 *
 	 * @return string The filtered Post content.
 	 */
-	$content = (string) apply_filters( 'ai_pre_normalize_content', $content );
+	$content = (string) apply_filters( 'ai_experiments_pre_normalize_content', $content );
 
 	// Strip HTML entities.
 	$content = preg_replace( '/&#?[a-z0-9]{2,8};/i', '', $content );
@@ -49,13 +48,12 @@ function normalize_content( string $content ): string {
 	 * Filters the normalized content to allow for additional cleanup.
 	 *
 	 * @since 0.1.0
-	 * @hook ai_normalize_content
 	 *
 	 * @param string $content The normalized content.
 	 *
 	 * @return string The filtered normalized content.
 	 */
-	$content = (string) apply_filters( 'ai_normalize_content', (string) $content );
+	$content = (string) apply_filters( 'ai_experiments_normalize_content', (string) $content );
 
 	return trim( $content );
 }
@@ -151,12 +149,11 @@ function get_preferred_models(): array {
 	 * Filters the preferred models.
 	 *
 	 * @since 0.1.0
-	 * @hook ai_preferred_models
 	 *
 	 * @param array<int, array{string, string}> $preferred_models The preferred models.
 	 * @return array<int, array{string, string}> The filtered preferred models.
 	 */
-	return (array) apply_filters( 'ai_preferred_models', $preferred_models );
+	return (array) apply_filters( 'ai_experiments_preferred_models', $preferred_models );
 }
 
 /**
@@ -204,12 +201,11 @@ function has_valid_ai_credentials(): bool {
 	 * Allows overriding the credentials check, useful for testing.
 	 *
 	 * @since 0.1.0
-	 * @hook ai_pre_has_valid_credentials_check
 	 *
 	 * @param bool|null $has_valid_credentials Whether valid credentials are available. Return null to use default check.
 	 * @return bool|null True if valid credentials are available, false otherwise, or null to use default check.
 	 */
-	$valid = apply_filters( 'ai_pre_has_valid_credentials_check', null );
+	$valid = apply_filters( 'ai_experiments_pre_has_valid_credentials_check', null );
 	if ( null !== $valid ) {
 		return (bool) $valid;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,9 @@ AI Experiments is a plugin for testing and developing AI-powered experiments for
 
 1. Upload the plugin files to the `/wp-content/plugins/ai` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Use the Settings->AI screen to configure the plugin.
+3. Go to `Settings -> AI Credentials` and add at least one valid AI credential.
+4. Go to `Settings -> AI Experiments` and globally enable experiments and then enable the individual experiments you want to test.
+5. Start experimenting with AI features! For the Title Generation experiment, edit a post and click into the title field. You should see a `Generate/Re-generate` button above the field. Click that button and after the request is complete, title suggestions will be displayed in a modal. Choose the title you like and click the `Select` button to insert it into the title field.
 
 == Frequently Asked Questions ==
 

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -150,7 +150,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiment_LoaderTest.php
+++ b/tests/Integration/Includes/Experiment_LoaderTest.php
@@ -127,16 +127,16 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test ai_register_experiments action hook fires.
+	 * Test ai_experiments_register_experiments action hook fires.
 	 *
 	 * @since 0.1.0
 	 */
-	public function test_ai_register_experiments_hook_fires() {
+	public function test_ai_experiments_register_experiments_hook_fires() {
 		$hook_fired = false;
 		$passed_registry = null;
 
 		add_action(
-			'ai_register_experiments',
+			'ai_experiments_register_experiments',
 			function ( $registry ) use ( &$hook_fired, &$passed_registry ) {
 				$hook_fired = true;
 				$passed_registry = $registry;
@@ -145,7 +145,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 
 		$this->loader->register_default_experiments();
 
-		$this->assertTrue( $hook_fired, 'ai_register_experiments hook should fire' );
+		$this->assertTrue( $hook_fired, 'ai_experiments_register_experiments hook should fire' );
 		$this->assertSame(
 			$this->registry,
 			$passed_registry,
@@ -160,7 +160,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 	 */
 	public function test_third_party_experiment_registration() {
 		add_action(
-			'ai_register_experiments',
+			'ai_experiments_register_experiments',
 			function ( $registry ) {
 				$custom_experiment = new Mock_Experiment();
 				$registry->register_experiment( $custom_experiment );

--- a/tests/Integration/Includes/Experiment_LoaderTest.php
+++ b/tests/Integration/Includes/Experiment_LoaderTest.php
@@ -82,7 +82,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
 
 		$this->registry = new Experiment_Registry();
 		$this->loader   = new Experiment_Loader( $this->registry );
@@ -284,7 +284,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 		$this->registry->register_experiment( $experiment );
 
 		// Disable the experiment.
-		add_filter( 'ai_experiment_mock-experiment_enabled', '__return_false' );
+		add_filter( 'ai_experiments_experiment_mock-experiment_enabled', '__return_false' );
 
 		$this->loader->initialize_experiments();
 

--- a/tests/Integration/Includes/Experiment_RegistryTest.php
+++ b/tests/Integration/Includes/Experiment_RegistryTest.php
@@ -68,7 +68,7 @@ class Experiment_Registry_Test extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
 
 		$this->registry = new Experiment_Registry();
 	}
@@ -193,7 +193,7 @@ class Experiment_Registry_Test extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_disabled_experiments_not_initialized() {
-		add_filter( 'ai_experiment_test-experiment_enabled', '__return_false' );
+		add_filter( 'ai_experiments_experiment_test-experiment_enabled', '__return_false' );
 
 		$experiment = new Test_Experiment();
 		$this->registry->register_experiment( $experiment );

--- a/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
+++ b/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
@@ -30,7 +30,7 @@ class Example_ExperimentTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );

--- a/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
@@ -30,7 +30,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -111,7 +111,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_normalize_content_applies_filters() {
-		add_filter( 'ai_pre_normalize_content', function( $content ) {
+		add_filter( 'ai_experiments_pre_normalize_content', function( $content ) {
 			return 'Filtered: ' . $content;
 		} );
 
@@ -119,7 +119,7 @@ class HelpersTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'Filtered:', $result, 'Should apply pre-normalize filter' );
 
-		remove_all_filters( 'ai_pre_normalize_content' );
+		remove_all_filters( 'ai_experiments_pre_normalize_content' );
 	}
 
 	/**
@@ -288,7 +288,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_applies_filter() {
 		add_filter(
-			'ai_preferred_models',
+			'ai_experiments_preferred_models',
 			function( $models ) {
 				// Add a custom model.
 				$models[] = array(
@@ -305,7 +305,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'custom', $result[4][0], 'Fifth model provider should be custom' );
 		$this->assertEquals( 'custom-model', $result[4][1], 'Fifth model name should be custom-model' );
 
-		remove_all_filters( 'ai_preferred_models' );
+		remove_all_filters( 'ai_experiments_preferred_models' );
 	}
 
 	/**
@@ -315,7 +315,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_filter_can_replace_models() {
 		add_filter(
-			'ai_preferred_models',
+			'ai_experiments_preferred_models',
 			function( $models ) {
 				// Replace with a single model.
 				return array(
@@ -333,7 +333,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'test', $result[0][0], 'Model provider should be test' );
 		$this->assertEquals( 'test-model', $result[0][1], 'Model name should be test-model' );
 
-		remove_all_filters( 'ai_preferred_models' );
+		remove_all_filters( 'ai_experiments_preferred_models' );
 	}
 }
 


### PR DESCRIPTION
## What?

Closes #110

A few minor things were flagged during the plugin review process and this PR fixes those.

## Why?

In order to get the plugin on WordPress.org, we need to ensure we pass the plugin review.

## How?

- Switches to a more specific namespace for all constants and hooks, `AI_EXPERIMENTS` and `ai_experiments` (these are pretty lengthy so open to suggestions if we want to shorten this)
- Adds slightly more specific testing instructions to the `readme.txt`

## Testing Instructions

Verify all changes look good here and all existing functionality still works
