### PR TITLE
Fix asset loader bugs causing missing dependencies, lack of RTL support, lack of inlining for performance

### DIFF
--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -109,9 +109,10 @@ class Asset_Loader {
 			return;
 		}
 		wp_style_add_data( 'ai_' . $handle, 'rtl', 'replace' );
-		if ( is_rtl() ) {
-			wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
+		if ( ! is_rtl() ) {
+			return;
 		}
+		wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
 	}
 
 	/**

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -109,7 +109,9 @@ class Asset_Loader {
 			return;
 		}
 		wp_style_add_data( 'ai_' . $handle, 'rtl', 'replace' );
-		wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
+		if ( is_rtl() ) {
+			wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
+		}
 	}
 
 	/**

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -105,10 +105,11 @@ class Asset_Loader {
 		wp_style_add_data( 'ai_' . $handle, 'path', $style_path );
 
 		$rtl_style_path = str_replace( '.css', '-rtl.css', $style_path );
-		if ( file_exists( $rtl_style_path ) ) {
-			wp_style_add_data( 'ai_' . $handle, 'rtl', 'replace' );
-			wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
+		if ( ! file_exists( $rtl_style_path ) ) {
+			return;
 		}
+		wp_style_add_data( 'ai_' . $handle, 'rtl', 'replace' );
+		wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
 	}
 
 	/**

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -32,15 +32,23 @@ class Asset_Loader {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $handle The handle for the script.
-	 * @param string $file_name The script file name.
+	 * @param string                    $handle     The handle for the script.
+	 * @param string                    $file_name  The script file name.
+	 * @param array<string, mixed>|null $asset_data Optional asset metadata (dependencies and version).
 	 */
-	public static function enqueue_script( string $handle, string $file_name ): void {
+	public static function enqueue_script( string $handle, string $file_name, ?array $asset_data = null ): void {
 		$script_path       = AI_EXPERIMENTS_DIR . 'build/' . $file_name . '.js';
 		$script_url        = AI_EXPERIMENTS_PLUGIN_URL . 'build/' . $file_name . '.js';
-		$script_asset_path = $script_path . '.asset.php';
+		$script_asset_path = substr( $script_path, 0, -3 ) . '.asset.php';
 
-		if ( file_exists( $script_asset_path ) ) {
+		if ( is_array( $asset_data ) ) {
+			if ( ! isset( $asset_data['dependencies'] ) ) {
+				$asset_data['dependencies'] = array();
+			}
+			if ( ! isset( $asset_data['version'] ) ) {
+				$asset_data['version'] = filemtime( $script_path );
+			}
+		} elseif ( file_exists( $script_asset_path ) ) {
 			$asset_data = require $script_asset_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		} else {
 			$asset_data = array(
@@ -54,7 +62,7 @@ class Asset_Loader {
 			$script_url,
 			$asset_data['dependencies'],
 			$asset_data['version'],
-			true
+			array( 'strategy' => 'defer' )
 		);
 	}
 
@@ -63,15 +71,23 @@ class Asset_Loader {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $handle The handle for the style.
-	 * @param string $file_name The script file name.
+	 * @param string                    $handle     The handle for the style.
+	 * @param string                    $file_name  The script file name.
+	 * @param array<string, mixed>|null $asset_data Optional asset metadata (dependencies and version).
 	 */
-	public static function enqueue_style( string $handle, string $file_name ): void {
+	public static function enqueue_style( string $handle, string $file_name, ?array $asset_data = null ): void {
 		$style_path       = AI_EXPERIMENTS_DIR . 'build/' . $file_name . '.css';
 		$style_url        = AI_EXPERIMENTS_PLUGIN_URL . 'build/' . $file_name . '.css';
-		$style_asset_path = $style_path . '.asset.php';
+		$style_asset_path = substr( $style_path, 0, -4 ) . '.asset.php';
 
-		if ( file_exists( $style_asset_path ) ) {
+		if ( is_array( $asset_data ) ) {
+			if ( ! isset( $asset_data['dependencies'] ) ) {
+				$asset_data['dependencies'] = array();
+			}
+			if ( ! isset( $asset_data['version'] ) ) {
+				$asset_data['version'] = filemtime( $style_path );
+			}
+		} elseif ( file_exists( $style_asset_path ) ) {
 			$asset_data = require $style_asset_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 		} else {
 			$asset_data = array(
@@ -86,6 +102,13 @@ class Asset_Loader {
 			array(),
 			$asset_data['version']
 		);
+		wp_style_add_data( 'ai_' . $handle, 'path', $style_path );
+
+		$rtl_style_path = str_replace( '.css', '-rtl.css', $style_path );
+		if ( file_exists( $rtl_style_path ) ) {
+			wp_style_add_data( 'ai_' . $handle, 'rtl', 'replace' );
+			wp_style_add_data( 'ai_' . $handle, 'path', $rtl_style_path );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What?

The `Asset_Loader` implementation has several problems:

* The PHP build asset check is wrong, it's currently always failing.
* RTL language support is missing.
* The stylesheet file path should be provided to benefit from conditional inlining CSS for performance in WP Core.
* It's not possible to pass asset data manually, which can lead to unperformant and sometimes inaccurate `filemtime` calls.

## How?

This PR addresses the above issues.

## Test using WordPress Playground
The changes in this pull request can be previewed and tested using this [WordPress Playground](https://wordpress.github.io/wordpress-playground/) instance:

[Click here to test this pull request](https://playground.wordpress.net/#%7B%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22latest%22%7D,%22steps%22:%5B%7B%22step%22:%22mkdir%22,%22path%22:%22/tmp/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/tmp/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=ai&workflow=Pull%2520Request%2520Comments&artifact=ai&pr=113%22,%22caption%22:%22Downloading%20AI%20Experiments%20PR%20113%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/tmp/pr/pr.zip%22,%22extractToPath%22:%22/tmp/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/tmp/pr/ai.zip%22%7D%7D%5D%7D).