### PR TITLE
Update format script to only format JS to avoid random JSON file changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:php:fix": "wp-env run tests-cli --env-cwd=wp-content/plugins/ai composer run-script format",
     "lint:php:stan": "wp-env run tests-cli --env-cwd=wp-content/plugins/ai composer run-script stan",
     "test:php": "wp-env run tests-cli --env-cwd=wp-content/plugins/ai vendor/bin/phpunit -c phpunit.xml.dist",
-    "format": "wp-scripts format",
+    "format:js": "wp-scripts format ./src",
     "lint:js": "wp-scripts lint-js"
   },
   "devDependencies": {


### PR DESCRIPTION
## What?
The `npm run format` command currently formats all kinds of files, including `composer.json`, `.github` workflows, etc. The way it formats these is not entirely aligned with the WordPress Coding Standards, and FWIW the project is not following the format that it applies.

## How?
This PR changes the command to _only_ format production JS/TS code, and rename the command to `npm run format:js`. This also brings parity with `npm run lint:js` and avoids having to deal with random accidental file modifications to various config files.

## Test using WordPress Playground
The changes in this pull request can be previewed and tested using this [WordPress Playground](https://wordpress.github.io/wordpress-playground/) instance:

[Click here to test this pull request](https://playground.wordpress.net/#%7B%22preferredVersions%22:%7B%22php%22:%227.4%22,%22wp%22:%22latest%22%7D,%22steps%22:%5B%7B%22step%22:%22mkdir%22,%22path%22:%22/tmp/pr%22%7D,%7B%22step%22:%22writeFile%22,%22path%22:%22/tmp/pr/pr.zip%22,%22data%22:%7B%22resource%22:%22url%22,%22url%22:%22/plugin-proxy.php?org=WordPress&repo=ai&workflow=Pull%2520Request%2520Comments&artifact=ai&pr=114%22,%22caption%22:%22Downloading%20AI%20Experiments%20PR%20114%22%7D%7D,%7B%22step%22:%22unzip%22,%22zipPath%22:%22/tmp/pr/pr.zip%22,%22extractToPath%22:%22/tmp/pr%22%7D,%7B%22step%22:%22installPlugin%22,%22pluginData%22:%7B%22resource%22:%22vfs%22,%22path%22:%22/tmp/pr/ai.zip%22%7D%7D%5D%7D).