### PR TITLE
Update to the latest release of the WP AI Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "php": ">=7.4",
     "wordpress/abilities-api": "^0.4.0",
     "wordpress/mcp-adapter": "dev-trunk",
-    "wordpress/wp-ai-client": "dev-trunk"
+    "wordpress/wp-ai-client": "0.1.1"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f275018de0bc539ae98c534ab9e40c5a",
+    "content-hash": "08533b755bb4ca06b46c71e090cc2046",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -769,16 +769,16 @@
         },
         {
             "name": "wordpress/wp-ai-client",
-            "version": "dev-trunk",
+            "version": "0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/wp-ai-client.git",
-                "reference": "a41ef6075c1cbb56dfc380fe5c13a347b265d193"
+                "reference": "3c1f14f11f13753d13e58c12902d40f02a5c8207"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/wp-ai-client/zipball/a41ef6075c1cbb56dfc380fe5c13a347b265d193",
-                "reference": "a41ef6075c1cbb56dfc380fe5c13a347b265d193",
+                "url": "https://api.github.com/repos/WordPress/wp-ai-client/zipball/3c1f14f11f13753d13e58c12902d40f02a5c8207",
+                "reference": "3c1f14f11f13753d13e58c12902d40f02a5c8207",
                 "shasum": ""
             },
             "require": {
@@ -799,7 +799,6 @@
                 "wp-phpunit/wp-phpunit": "^6.8",
                 "yoast/phpunit-polyfills": "^4.0"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -847,7 +846,7 @@
                 "issues": "https://github.com/WordPress/wp-ai-client/issues",
                 "source": "https://github.com/WordPress/wp-ai-client"
             },
-            "time": "2025-11-13T00:12:21+00:00"
+            "time": "2025-11-21T22:57:02+00:00"
         }
     ],
     "packages-dev": [
@@ -4138,8 +4137,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "phpcompatibility/php-compatibility": 20,
-        "wordpress/mcp-adapter": 20,
-        "wordpress/wp-ai-client": 20
+        "wordpress/mcp-adapter": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,


### PR DESCRIPTION
## What?

Closes #117

Pulls in the latest release of the WP AI Client

## Why?

We were using an older version of the WP AI Client and the latest release includes a fix from the PHP AI Client when using Google as your AI provider. Also hardcoding to a specific release (0.1.1) instead of pulling from `trunk` so we can have more control over when updates are pulled in.

## How?

Updates our `composer.json` file to pull in the 0.1.1 release and also updates `composer.lock` with those changes

## Testing Instructions

1. Checkout this PR
2. Run `composer install`
3. Ensure things install correctly
4. Ensure you still see an AI Credentials settings page
5. Ensure you can add credentials for Google and those work
