### PR TITLE
Remove the credentials check from our `is_enabled` check

### DIFF
--- a/includes/Abstracts/Abstract_Experiment.php
+++ b/includes/Abstracts/Abstract_Experiment.php
@@ -13,8 +13,6 @@ use WordPress\AI\Contracts\Experiment;
 use WordPress\AI\Exception\Invalid_Experiment_Metadata_Exception;
 use WordPress\AI\Settings\Settings_Registration;
 
-use function WordPress\AI\has_valid_ai_credentials;
-
 /**
  * Base implementation for experiments.
  *
@@ -170,11 +168,6 @@ abstract class Abstract_Experiment implements Experiment {
 		 * @param bool $experiment_enabled Whether the experiment is enabled.
 		 */
 		$is_enabled = (bool) apply_filters( "ai_experiments_experiment_{$this->id}_enabled", $experiment_enabled );
-
-		// Check if we have valid AI credentials.
-		if ( ! has_valid_ai_credentials() ) {
-			$is_enabled = false;
-		}
 
 		// Cache the result.
 		$this->enabled_cache = $is_enabled;


### PR DESCRIPTION
## What?

Remove the check for valid AI credentials when checking if an Experiment is enabled.

## Why?

In #100, I added checks that run on our settings screen to verify we have valid AI credentials set and if not, show an error message alerting the user. This is helpful for users first setting things up, as this will help guide them through the process of adding AI credentials before turning on an Experiment.

In addition, I added a similar check when we run our `is_enabled` check at the Experiment level. The goal here was to avoid showing an Experiment if the AI credentials are no longer valid (for instance, if someone revoked their API key).

The issue I just realized is that our `is_enabled` check runs basically everywhere, so by running our validation check there, we end up making an API request to the models endpoint on each page load, including the front-end. While this request runs pretty quickly, it's not great for performance to have that always run.

## How?

I considered two different approaches here to fix the problem:

1. Just remove the validation check all together from the `is_enabled` check and ensure we have proper error handling in each Experiment for situations where the AI credentials no longer work
2. Move the validation check into the Experiment level. For example, for Title Generation, add this check prior to enqueuing assets and within our permission or execution callback of the Ability

Open to thoughts but after thinking it over, actually feels like a better user experience to go with the former. So the Experiment stays enabled, the UI is still available but when triggered, an error message is shown that let's the user know something went wrong and hopefully prompts them to go check their credentials.

## Testing Instructions

1. Check out this PR
2. Go to the AI Experiments settings page and ensure an error message is shown, prompting you to enter credentials
3. Add invalid credentials and go back to the AI Experiment settings page and ensure a new error message is shown
4. Add valid credentials and ensure you can now enable Experiments
5. Enable the Title Generation Experiment and ensure this works as expected
6. Go update your AI credentials with a random value, making that invalid now
7. Go try out the Title Generation Experiment again and ensure the UI exists but you get an error message
