### PR TITLE
Remove Example Experiment registration

### DIFF
--- a/includes/Experiment_Loader.php
+++ b/includes/Experiment_Loader.php
@@ -104,7 +104,6 @@ final class Experiment_Loader {
 	 */
 	private function get_default_experiments(): array {
 		$experiment_classes = array(
-			\WordPress\AI\Experiments\Example_Experiment\Example_Experiment::class,
 			\WordPress\AI\Experiments\Title_Generation\Title_Generation::class,
 		);
 

--- a/tests/Integration/Includes/Experiment_LoaderTest.php
+++ b/tests/Integration/Includes/Experiment_LoaderTest.php
@@ -108,18 +108,9 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 		$this->loader->register_default_experiments();
 
 		$this->assertTrue(
-			$this->registry->has_experiment( 'example-experiment' ),
-			'Example experiment should be registered'
-		);
-
-		$this->assertTrue(
 			$this->registry->has_experiment( 'title-generation' ),
 			'Title generation experiment should be registered'
 		);
-
-		$experiment = $this->registry->get_experiment( 'example-experiment' );
-		$this->assertNotNull( $experiment, 'Example experiment should exist' );
-		$this->assertEquals( 'example-experiment', $experiment->get_id() );
 
 		$experiment = $this->registry->get_experiment( 'title-generation' );
 		$this->assertNotNull( $experiment, 'Title generation experiment should exist' );

--- a/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
+++ b/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
@@ -39,6 +39,11 @@ class Example_ExperimentTest extends WP_UnitTestCase {
 		$registry = new Experiment_Registry();
 		$loader   = new Experiment_Loader( $registry );
 		$loader->register_default_experiments();
+
+		// Manually register the Example Experiment since it's no longer loaded by default.
+		$example_experiment = new Example_Experiment();
+		$registry->register_experiment( $example_experiment );
+
 		$loader->initialize_experiments();
 
 		$experiment = $registry->get_experiment( 'example-experiment' );


### PR DESCRIPTION
## What?

Closes #119 

Remove the registration of our Example Experiment.

## Why?

We have an Example Experiment in place which is useful for those looking to contribute or get some ideas on how things can be set up. But this Experiment doesn't actually add any useful functionality and it can be confusing to have this shown in our settings screen. For now we're leaving the code in place but we don't want this to be an Experiment someone can turn on.


## How?

- Removes the Example Experiment from our list of default Experiments we register
- Updates our unit tests to account for this

## Testing Instructions

Go to the AI Experiments settings page and ensure you no longer see a settings section for the Example Experiment