### PR TITLE
Ensure the right version of the PHP AI Client is installed

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -702,16 +702,16 @@
         },
         {
             "name": "wordpress/php-ai-client",
-            "version": "0.2.0",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/php-ai-client.git",
-                "reference": "81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2"
+                "reference": "61ecd7c86329d0cc3d17567891f363d8f3fc3be6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2",
-                "reference": "81a104a9bc5f887e3fbecea6e0d9cd8eab3be0b2",
+                "url": "https://api.github.com/repos/WordPress/php-ai-client/zipball/61ecd7c86329d0cc3d17567891f363d8f3fc3be6",
+                "reference": "61ecd7c86329d0cc3d17567891f363d8f3fc3be6",
                 "shasum": ""
             },
             "require": {
@@ -765,7 +765,7 @@
                 "issues": "https://github.com/WordPress/php-ai-client/issues",
                 "source": "https://github.com/WordPress/php-ai-client"
             },
-            "time": "2025-10-21T00:05:14+00:00"
+            "time": "2025-11-17T18:04:50+00:00"
         },
         {
             "name": "wordpress/wp-ai-client",


### PR DESCRIPTION
## What?

Ensure the right version of the PHP AI Client is pulled in from the WP AI Client update

## Why?

In #118, I updated our composer config to pull in the latest release of the WP AI Client package (0.1.1) instead of pulling in `trunk`. This was supposed to pull in the latest release of the PHP AI Client (0.2.1) but it seems that just running the `composer require wordpress/wp-ai-client:0.1.1` command didn't pull in the downstream dependencies so it was still using the 0.2.0 release of that package.
  
## How?

Initially tried running `composer update` to bring in everything but there appears to be some conflicts with our PHPCS tools coming out of [recent changes](https://github.com/PHPCompatibility/PHPCompatibility/commit/93ef2b82ff05534a976259c45783202887cfc8bf) made to the `develop` branch of the `phpcompatibility/php-compatibility` package. So instead of trying to fix all of those, I ran `composer require wordpress/wp-ai-client:0.1.1 -W` to bring in the updated version of the PHP AI Client package (the `-W` flag was the trick here)

## Testing Instructions

n/a
