### PR TITLE
Fix duplicate "Settings saved" notice on settings page

### DIFF
--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -150,7 +150,7 @@ class Settings_Page {
 			}
 			?>
 
-			<?php settings_errors('ai_experiments'); ?>
+			<?php settings_errors( 'ai_experiments' ); ?>
 
 			<form method="post" action="options.php">
 				<?php

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -150,7 +150,7 @@ class Settings_Page {
 			}
 			?>
 
-			<?php settings_errors(); ?>
+			<?php settings_errors('ai_experiments'); ?>
 
 			<form method="post" action="options.php">
 				<?php


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->
#128 

<!-- In a few words, what is the PR actually doing? -->
Fix duplicate settings notice by specifying option group in `settings_errors()`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
While changing and saving any changes on AI Experiments page under admin, it was showing the success message as "Settings saved." twice. This PR fixes it to appear only once.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Specified option group under `settings_error()` method as below
```
settings_errors('ai_experiments');
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to "Admin > Settings > AI Experiments" Page
2. Change / Don't change any settings on this page
3. Click "Save Changes"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->
<img width="852" height="609" alt="image" src="https://github.com/user-attachments/assets/6777d824-f59a-4e26-873c-1b84a514e617" />|<!-- After screenshot here --><img width="918" height="570" alt="image" src="https://github.com/user-attachments/assets/b057eaca-371a-477d-b557-31f233b6476b" />|
