### PR TITLE
Change `contents` permissions from read to write on our `PR Playground Preview` workflow

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -27,7 +27,7 @@ jobs:
       artifact-url: ${{ steps.expose.outputs.artifact-url }}
       artifact-name: ${{ steps.expose.outputs.artifact-name }}
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## What?

Try and fix permission failures on the `PR Playground Preview` workflow

## Why?

We are trying out a new approach to adding a Playground preview link to PRs. The initial work for this was merged in #144 (needed to be merged to test) and we're now seeing permission failures (see https://github.com/WordPress/ai/actions/runs/20372680375/job/58542974618).


## How?

Updates the `contents` permissions from `read` to `write` to see if that fixes things

## Testing Instructions

Hopefully a Playground testing link will be added to this PR. _Edit: still getting the same permission error. Looks like this may need merged first before GitHub picks up the change?_