### PR TITLE
Switch from `unlink` to `wp_delete_file`

### DIFF
--- a/includes/Abilities/Image/Import_Base64_Image.php
+++ b/includes/Abilities/Image/Import_Base64_Image.php
@@ -242,7 +242,7 @@ class Import_Base64_Image extends Abstract_Ability {
 		$bytes_written = file_put_contents( $temp_file, $decoded_data ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 
 		if ( false === $bytes_written ) {
-			@unlink( $temp_file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, Generic.PHP.NoSilencedErrors.Forbidden, WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+			wp_delete_file( $temp_file );
 			return new WP_Error(
 				'write_failed',
 				esc_html__( 'Failed to write image data to temporary file.', 'ai' )
@@ -276,7 +276,7 @@ class Import_Base64_Image extends Abstract_Ability {
 
 		// Clean up temp file if it still exists.
 		if ( file_exists( $temp_file ) ) {
-			@unlink( $temp_file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, Generic.PHP.NoSilencedErrors.Forbidden, WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+			wp_delete_file( $temp_file );
 		}
 
 		// Ensure the import worked.


### PR DESCRIPTION
## What?

Closes #160

Fixes failing Plugin Check tests

## Why?

We recently updated our plugin check tests and we now have a new failure. This PR addresses that

## How?

Switch from using `unlink` to using `wp_delete_file` (which uses `unlink` under the hood)

## Testing Instructions

Not really needed but if desired, can follow testing instructions in #134

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-163-2ab5a97a19b46348fca320ce9bcabe96e6ba4315.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->