### PR TITLE
Fix new Plugin Check errors

### DIFF
--- a/includes/Abilities/Utilities/Posts.php
+++ b/includes/Abilities/Utilities/Posts.php
@@ -11,6 +11,10 @@ namespace WordPress\AI\Abilities\Utilities;
 
 use WP_Error;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Post utility WordPress Abilities.
  *

--- a/includes/Experiments/Example_Experiment/Example_Experiment.php
+++ b/includes/Experiments/Example_Experiment/Example_Experiment.php
@@ -11,6 +11,10 @@ namespace WordPress\AI\Experiments\Example_Experiment;
 
 use WordPress\AI\Abstracts\Abstract_Experiment;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Reference experiment demonstrating hooks and REST endpoints.
  *

--- a/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
+++ b/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
@@ -12,6 +12,10 @@ namespace WordPress\AI\Experiments\Excerpt_Generation;
 use WordPress\AI\Abilities\Excerpt_Generation\Excerpt_Generation as Excerpt_Generation_Ability;
 use WordPress\AI\Abstracts\Abstract_Experiment;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Excerpt generation experiment.
  *

--- a/includes/Experiments/Image_Generation/Image_Generation.php
+++ b/includes/Experiments/Image_Generation/Image_Generation.php
@@ -13,6 +13,10 @@ use WordPress\AI\Abilities\Image\Generate_Image as Image_Generation_Ability;
 use WordPress\AI\Abilities\Image\Import_Base64_Image as Image_Import_Ability;
 use WordPress\AI\Abstracts\Abstract_Experiment;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Image generation experiment.
  *

--- a/includes/Experiments/Title_Generation/Title_Generation.php
+++ b/includes/Experiments/Title_Generation/Title_Generation.php
@@ -13,6 +13,10 @@ use WordPress\AI\Abilities\Title_Generation\Title_Generation as Title_Generation
 use WordPress\AI\Abstracts\Abstract_Experiment;
 use WordPress\AI\Asset_Loader;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Title generation experiment.
  *

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -17,6 +17,10 @@ use WordPress\AI\Experiment_Registry;
 use function WordPress\AI\has_ai_credentials;
 use function WordPress\AI\has_valid_ai_credentials;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Manages the admin settings page for AI experiments.
  *

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -12,6 +12,10 @@ namespace WordPress\AI;
 use Throwable;
 use WordPress\AI_Client\AI_Client;
 
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
 /**
  * Normalizes the content by cleaning it and removing unwanted HTML tags.
  *

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -12,6 +12,14 @@ namespace WordPress\AI;
 use Throwable;
 use WordPress\AI_Client\AI_Client;
 
+/**
+ * Purposely using return instead of exit here.
+ *
+ * This file is loaded via the composer files directive.
+ * When tools like PHPCS and PHPStan run, they include
+ * our composer autoloader and that will then load this file,
+ * causing the script to exit and not function properly.
+ */
 if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }


### PR DESCRIPTION
## What?

Addresses new Plugin Check errors

## Why?

The Plugin Check plugin was recently updated and there is now a more aggressive check around direct file access. This has caused new errors to start showing in our Plugin Check workflow so this PR addresses those.

## How?

Adds the following to files that are being flagged:

```php
if ( ! defined( 'ABSPATH' ) ) {
	exit;
}
```

## Testing Instructions

Ensure the Plugin Check workflow passes on this PR

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-167-8d17f75fb8a372432f72caf3b4832ee7c80eeeaf.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->