### PR TITLE
Fix new lint and config errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ CLAUDE.md
 /tests/_output/*
 !/tests/_output/.gitkeep
 /tests/e2e/artifacts
+/artifacts
 
 # Configs
 /phpcs.xml

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/react-dom": "^18.3.7",
         "@types/wordpress__block-editor": "^15.0.0",
         "@types/wordpress__blocks": "^12.5.18",
+        "@types/wordpress__edit-post": "^8.4.2",
         "@wordpress/e2e-test-utils-playwright": "^1.37.0",
         "@wordpress/env": "^10.37.0",
         "@wordpress/scripts": "^31.2.0",
@@ -7144,6 +7145,111 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@types/wordpress__edit-post": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/@types/wordpress__edit-post/-/wordpress__edit-post-8.4.2.tgz",
+      "integrity": "sha512-rH+ut+I4eedDTvwXnJOrH9jEyi+PhJZQ+KZ31k3BYb8Cmd1qdRK2hJ+kdZu0QJp4XP3HA0/Q6troqYfpkF8B+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "^18",
+        "@wordpress/components": "^28.4.0",
+        "@wordpress/data": "^10.4.0",
+        "@wordpress/editor": "^14.13.0",
+        "@wordpress/element": "^6.4.0"
+      }
+    },
+    "node_modules/@types/wordpress__edit-post/node_modules/@babel/runtime": {
+      "version": "7.25.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+      "integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@types/wordpress__edit-post/node_modules/@types/gradient-parser": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@types/gradient-parser/-/gradient-parser-0.1.3.tgz",
+      "integrity": "sha512-XDbrTSBlQV9nxE1GiDL3FaOPy4G/KaJkhDutBX48Kg8CYZMBARyyDFGCWfWJn4pobmInmwud1xxH7VJMAr0CKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/wordpress__edit-post/node_modules/@wordpress/components": {
+      "version": "28.13.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.13.0.tgz",
+      "integrity": "sha512-JaGcXYtFCvHqa62dtxMAMhu6afvefFOuwfUTNiLYg60CA4UDITt6gf+qhpvKNOzVg4qQRw10o/nryrOMoMAEEg==",
+      "dev": true,
+      "license": "GPL-2.0-or-later",
+      "dependencies": {
+        "@ariakit/react": "^0.4.10",
+        "@babel/runtime": "7.25.7",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "*",
+        "@wordpress/compose": "*",
+        "@wordpress/date": "*",
+        "@wordpress/deprecated": "*",
+        "@wordpress/dom": "*",
+        "@wordpress/element": "*",
+        "@wordpress/escape-html": "*",
+        "@wordpress/hooks": "*",
+        "@wordpress/html-entities": "*",
+        "@wordpress/i18n": "*",
+        "@wordpress/icons": "*",
+        "@wordpress/is-shallow-equal": "*",
+        "@wordpress/keycodes": "*",
+        "@wordpress/primitives": "*",
+        "@wordpress/private-apis": "*",
+        "@wordpress/rich-text": "*",
+        "@wordpress/warning": "*",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.1.9",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "remove-accents": "^0.5.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@types/wordpress__edit-post/node_modules/gradient-parser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/gradient-parser/-/gradient-parser-0.1.5.tgz",
+      "integrity": "sha512-+uPlcVbjrKOnTzvz0MjTj7BfACj8OmxIa1moIjJV7btvhUMSJk0D47RfDCgDrZE3dYMz9Cf5xKJwnrKLjUq0KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -23447,6 +23553,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/react-dom": "^18.3.7",
     "@types/wordpress__block-editor": "^15.0.0",
     "@types/wordpress__blocks": "^12.5.18",
+    "@types/wordpress__edit-post": "^8.4.2",
     "@wordpress/e2e-test-utils-playwright": "^1.37.0",
     "@wordpress/env": "^10.37.0",
     "@wordpress/scripts": "^31.2.0",

--- a/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import React from 'react';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';

--- a/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import React from 'react';
-
-/**
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';

--- a/src/experiments/excerpt-generation/components/ExcerptInlineWrapper.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptInlineWrapper.tsx
@@ -3,11 +3,6 @@
  */
 
 /**
- * External dependencies
- */
-import React from 'react';
-
-/**
  * WordPress dependencies
  */
 import { createRoot, useEffect } from '@wordpress/element';

--- a/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
+++ b/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
@@ -68,7 +68,10 @@ export function useExcerptGeneration(): {
 		);
 
 		try {
-			const generatedExcerpt = await generateExcerpt( postId, content );
+			const generatedExcerpt = await generateExcerpt(
+				postId as number,
+				content
+			);
 
 			// Update the editor store first.
 			editPost( {

--- a/src/experiments/excerpt-generation/index.tsx
+++ b/src/experiments/excerpt-generation/index.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
-import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/edit-post';
+import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/edit-post'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { registerPlugin } from '@wordpress/plugins';
 
 /**

--- a/src/experiments/excerpt-generation/index.tsx
+++ b/src/experiments/excerpt-generation/index.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 /**
  * WordPress dependencies
  */
+// @ts-expect-error - __experimentalPluginPostExcerpt is not in type definitions but exists at runtime
 import { __experimentalPluginPostExcerpt as PluginPostExcerpt } from '@wordpress/edit-post'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { registerPlugin } from '@wordpress/plugins';
 


### PR DESCRIPTION
## What?

Fixing some new linting and config errors coming out of recent merged PRs

## Why?

Want to ensure our GitHub Workflows remain in a passed state

## How?

Coming out of #172, I'm seeing the `artifacts` directory is no longer git-ignored. This directory is added by our E2E tests so we want to ensure this doesn't get committed to our repo. While it would be great if this directory could be nested within our `tests` directory instead of in the root, I'm running into issues with how `wp-scripts` runs these tests and having that change work properly. So for now I'm adding this directory back to our gitignore file.

In addition, seeing a new JS lint error and typescripts errors after the merging in of #143. I think this is also due to changes made in #172 and why these errors weren't flagged originally within #143.

There are some minor typescript errors fixed here and the JS lint error is flagging the use of an experimental API which unfortunately we need to use here as it's the only approach to modify the excerpt panel. So this PR ignores that particular error for now.

## Testing Instructions

Ensure all workflows pass on this PR

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-176-ac50afbc2e080655aeda0acd479d9f26cf2918ce.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->