### PR TITLE
Docs: Fix missing global tag and remove non-standard hook tag

### DIFF
--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -94,6 +94,8 @@ function check_php_version(): bool {
  *
  * @since 0.1.0
  *
+ * @global string $wp_version WordPress version.
+ *
  * @return bool True if WordPress version is sufficient, false otherwise.
  */
 function check_wp_version(): bool {

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -161,7 +161,6 @@ function get_preferred_models_for_text_generation(): array {
 	 * Filters the preferred models for text generation.
 	 *
 	 * @since 0.2.1
-	 * @hook ai_experiments_preferred_models_for_text_generation
 	 *
 	 * @param array<int, array{string, string}> $preferred_models The preferred models for text generation.
 	 * @return array<int, array{string, string}> The filtered preferred models.


### PR DESCRIPTION
## Description
This PR addresses inline documentation issues in includes/bootstrap.php and includes/helpers.php to align with WordPress coding standards.

## Changes
*   **includes/bootstrap.php**: Added the missing `@global` tag for `$wp_version` in the check_wp_version() function docblock.
*   **includes/helpers.php**: Removed the non-standard `@hook` tag from the get_preferred_models_for_text_generation function docblock.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-207-b8c3e49e1ed1e2fb5e65a07aa867fee657e8454d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->