### PR TITLE
Fix: Add missing strict_types declarations to Abilities Explorer

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
+++ b/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
@@ -9,6 +9,8 @@
  * @since 0.2.0
  */
 
+declare( strict_types=1 );
+
 namespace WordPress\AI\Experiments\Abilities_Explorer;
 
 use WordPress\AI\Abstracts\Abstract_Experiment;

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -9,6 +9,8 @@
  * @since 0.2.0
  */
 
+declare( strict_types=1 );
+
 namespace WordPress\AI\Experiments\Abilities_Explorer;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -8,6 +8,8 @@
  * @since 0.2.0
  */
 
+declare( strict_types=1 );
+
 namespace WordPress\AI\Experiments\Abilities_Explorer;
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -8,6 +8,8 @@
  * @since 0.2.0
  */
 
+declare( strict_types=1 );
+
 namespace WordPress\AI\Experiments\Abilities_Explorer;
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
## Description
This PR standardizes the code in the `includes/Experiments/Abilities_Explorer` directory by adding: `declare( strict_types=1 );` to files where it was missing.

## Changes
Added `declare( strict_types=1 );` to:

- `includes/Experiments/Abilities_Explorer/Abilities_Explorer.php`
- `includes/Experiments/Abilities_Explorer/Ability_Handler.php`
- `includes/Experiments/Abilities_Explorer/Ability_Table.php`
- `includes/Experiments/Abilities_Explorer/Admin_Page.php`

## Reasoning
- Ensures strict type enforcement
- Improves type safety and reduces implicit type coercion bugs
- Aligns these files with the rest of the codebase (e.g., `includes/bootstrap.php`, `includes/helpers.php`)
- Maintains consistency and coding standards across the project

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-208-13519691cbcb2c28ca062b0e683179ec04fcd6d2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->