### PR TITLE
Docs: Add missing descriptions to @return tags

### DIFF
--- a/includes/Experiments/Example_Experiment/Example_Experiment.php
+++ b/includes/Experiments/Example_Experiment/Example_Experiment.php
@@ -64,7 +64,7 @@ class Example_Experiment extends Abstract_Experiment {
 	 * @since 0.1.0
 	 *
 	 * @param array<string, string> $title Title parts.
-	 * @return array<string, string>
+	 * @return array<string, string> Modified title parts.
 	 */
 	public function modify_title( array $title ): array {
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && isset( $title['site'] ) ) {
@@ -95,7 +95,7 @@ class Example_Experiment extends Abstract_Experiment {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return array<string, mixed>
+	 * @return array<string, mixed> Response data.
 	 */
 	public function rest_endpoint_callback(): array {
 		return array(
@@ -112,7 +112,7 @@ class Example_Experiment extends Abstract_Experiment {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return bool
+	 * @return bool True if the user has permission, false otherwise.
 	 */
 	public function rest_permission_callback(): bool {
 		return current_user_can( 'manage_options' );


### PR DESCRIPTION
## Description
This PR addresses missing descriptions in `@return` tags within the `includes` directory, ensuring compliance with documentation standards.

## Changes
- Added missing descriptions to `@return` tags in `includes/Experiments/Example_Experiment/Example_Experiment.php`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-210-965498c0e4d5a46ffe6f5211d10c7dfb6e55871a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->