### PR TITLE
Ensure we set a higher timeout when generating images

### DIFF
--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -15,6 +15,7 @@ use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI_Client\AI_Client;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 
 use function WordPress\AI\get_preferred_image_models;
@@ -165,8 +166,12 @@ class Generate_Image extends Abstract_Ability {
 	 * @return array{data: string, provider_metadata: array<string, string>, model_metadata: array<string, string>}|\WP_Error The generated image data, provider metadata, and model metadata, or a WP_Error if there was an error.
 	 */
 	protected function generate_image( string $prompt ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
+		$request_options = new RequestOptions();
+		$request_options->setTimeout( 90 );
+
 		// Generate the image using the AI client.
 		$result = AI_Client::prompt_with_wp_error( $prompt )
+			->using_request_options( $request_options )
 			->as_output_file_type( FileTypeEnum::inline() )
 			->using_model_preference( ...get_preferred_image_models() )
 			->generate_image_result();


### PR DESCRIPTION
## What?

Increases the timeout from 30s to 90s when generating images

## Why?

Image generation can take 60+ seconds, particularly when using more advances modes like `gpt-image-1`. The default timeout the WP AI Client sets is 30 seconds so you're likely to run into timeouts before the image generation is done.

## How?

Uses the `using_request_options` option to increase the timeout to 90 seconds when generating an image.

This was previously in place but was seemingly accidentally removed while making some other changes 😭 

### Use of AI Tools

None

## Testing Instructions

1. Turn on the Image Generation Experiment
2. Ensure you have valid AI credentials
3. Create a post giving it some content and a title
4. Click the `Generate featured image` button in the post status sidebar
5. Ensure an image is generated and saved properly

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-226-56efce509133017e87849b9c6e4a7a51d2aec854.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->