### PR TITLE
Standardize to using `runAbility` to call our Abilities

### DIFF
--- a/docs/experiments/excerpt-generation.md
+++ b/docs/experiments/excerpt-generation.md
@@ -40,7 +40,6 @@ The ability can be called directly via REST API, making it useful for automation
 1. **PHP Side:**
    - `enqueue_assets()` loads `experiments/excerpt-generation` (`src/experiments/excerpt-generation/index.tsx`) and localizes `window.aiExcerptGenerationData` with:
      - `enabled`: Whether the experiment is enabled
-     - `path`: The REST API path to the ability (`/wp-json/wp-abilities/v1/abilities/ai/excerpt-generation/run`)
 
 2. **React Side:**
    - The React entry point (`index.tsx`) registers a WordPress plugin that hooks into the excerpt panel using `__experimentalPluginPostExcerpt`

--- a/docs/experiments/summarization.md
+++ b/docs/experiments/summarization.md
@@ -42,7 +42,6 @@ The ability can be called directly via REST API, making it useful for automation
 1. **PHP Side:**
    - `enqueue_assets()` loads `experiments/summarization` (`src/experiments/summarization/index.tsx`) and localizes `window.aiSummarizationData` with:
      - `enabled`: Whether the experiment is enabled
-     - `path`: The REST API path to the ability (`/wp-json/wp-abilities/v1/abilities/ai/summarization/run`)
 
 2. **React Side:**
    - The React entry point (`index.tsx`) registers:

--- a/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
+++ b/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
@@ -93,7 +93,6 @@ class Excerpt_Generation extends Abstract_Experiment {
 			'ExcerptGenerationData',
 			array(
 				'enabled' => $this->is_enabled(),
-				'path'    => Excerpt_Generation_Ability::path( $this->get_id() ),
 			)
 		);
 	}

--- a/includes/Experiments/Summarization/Summarization.php
+++ b/includes/Experiments/Summarization/Summarization.php
@@ -104,7 +104,6 @@ class Summarization extends Abstract_Experiment {
 			'SummarizationData',
 			array(
 				'enabled' => $this->is_enabled(),
-				'path'    => Summarization_Ability::path( $this->get_id() ),
 			)
 		);
 	}

--- a/includes/Experiments/Title_Generation/Title_Generation.php
+++ b/includes/Experiments/Title_Generation/Title_Generation.php
@@ -95,7 +95,6 @@ class Title_Generation extends Abstract_Experiment {
 			'TitleGenerationData',
 			array(
 				'enabled' => $this->is_enabled(),
-				'path'    => Title_Generation_Ability::path( $this->get_id() ),
 			)
 		);
 	}

--- a/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
+++ b/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
@@ -5,13 +5,16 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { dispatch, select, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 
-const { aiExcerptGenerationData } = window as any;
+/**
+ * Internal dependencies
+ */
+import { runAbility } from '../../../utils/run-ability';
+import type { ExcerptGenerationAbilityInput } from '../types';
 
 /**
  * Generates an excerpt for the given post ID and content.
@@ -24,16 +27,12 @@ async function generateExcerpt(
 	postId: number,
 	content: string
 ): Promise< string > {
-	return apiFetch( {
-		path: aiExcerptGenerationData?.path ?? '',
-		method: 'POST',
-		data: {
-			input: {
-				content,
-				post_id: postId,
-			},
-		},
-	} )
+	const params: ExcerptGenerationAbilityInput = {
+		content,
+		post_id: postId,
+	};
+
+	return runAbility< string >( 'ai/excerpt-generation', params )
 		.then( ( response ) => {
 			if ( response && typeof response === 'string' ) {
 				return response;

--- a/src/experiments/excerpt-generation/types.ts
+++ b/src/experiments/excerpt-generation/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Type definitions for excerpt generation experiment.
+ */
+
+/**
+ * Input parameters for the ai/excerpt-generation ability.
+ */
+export interface ExcerptGenerationAbilityInput {
+	content: string;
+	post_id: number;
+	[ key: string ]: string | number | undefined;
+}

--- a/src/experiments/summarization/functions/generate-summary.ts
+++ b/src/experiments/summarization/functions/generate-summary.ts
@@ -1,9 +1,8 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
-
-const { aiSummarizationData } = window as any;
+import { runAbility } from '../../../utils/run-ability';
+import type { SummarizationAbilityInput } from '../types';
 
 /**
  * Generates a summary for the given post ID and content.
@@ -16,16 +15,12 @@ export async function generateSummary(
 	postId: number,
 	content: string
 ): Promise< string > {
-	return apiFetch( {
-		path: aiSummarizationData?.path ?? '',
-		method: 'POST',
-		data: {
-			input: {
-				context: postId.toString(),
-				content,
-			},
-		},
-	} )
+	const params: SummarizationAbilityInput = {
+		context: postId.toString(),
+		content,
+	};
+
+	return runAbility< string >( 'ai/summarization', params )
 		.then( ( response ) => {
 			if ( response && typeof response === 'string' ) {
 				return response as string;

--- a/src/experiments/summarization/types.ts
+++ b/src/experiments/summarization/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Type definitions for summarization experiment.
+ */
+
+/**
+ * Input parameters for the ai/summarization ability.
+ */
+export interface SummarizationAbilityInput {
+	content: string;
+	context: string;
+	[ key: string ]: string | undefined;
+}

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -5,7 +5,6 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	Flex,
@@ -21,6 +20,15 @@ import { useState } from '@wordpress/element';
 import { update } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
+
+/**
+ * Internal dependencies
+ */
+import { runAbility } from '../../../utils/run-ability';
+import type {
+	TitleGenerationAbilityInput,
+	GeneratedTitlesData,
+} from '../types';
 
 const { aiTitleGenerationData } = window as any;
 
@@ -120,16 +128,12 @@ async function generateTitles(
 	postId: number,
 	content: string
 ): Promise< string[] > {
-	return apiFetch( {
-		path: aiTitleGenerationData?.path ?? '',
-		method: 'POST',
-		data: {
-			input: {
-				post_id: postId,
-				content,
-			},
-		},
-	} )
+	const params: TitleGenerationAbilityInput = {
+		post_id: postId,
+		content,
+	};
+
+	return runAbility< GeneratedTitlesData >( 'ai/title-generation', params )
 		.then( ( response ) => {
 			if (
 				response &&
@@ -186,7 +190,7 @@ export default function TitleToolbar(): JSX.Element | null {
 
 		try {
 			const generatedTitles = await generateTitles(
-				postId as number, // In the off case postId is null, apiFetch will handle it.
+				postId as number,
 				content
 			);
 			setTitles( generatedTitles );

--- a/src/experiments/title-generation/types.ts
+++ b/src/experiments/title-generation/types.ts
@@ -1,0 +1,19 @@
+/**
+ * Type definitions for title generation experiment.
+ */
+
+/**
+ * Input parameters for the ai/title-generation ability.
+ */
+export interface TitleGenerationAbilityInput {
+	content: string;
+	post_id: number;
+	[ key: string ]: string | number | undefined;
+}
+
+/**
+ * Response from the ai/title-generation ability.
+ */
+export interface GeneratedTitlesData {
+	titles: string[];
+}


### PR DESCRIPTION
## What?

Move from using `apiFetch` to using our custom `runAbility` utility function (introduced [here](https://github.com/WordPress/ai/pull/156/changes#diff-98e1d4466497537c9149137dca31aa8c87f9d0fa25c04d209344381b7555095dR107)) to call our Abilities in our UI code.

## Why?

Ensures our codebase is standardized (no more fractured code that uses `apiFetch` in some places and `runAbility` in others.

Also ensures the Abilities JS API is used when available, falling back to using `apiFetch` otherwise.

## How?

- Updates Title Generation, Excerpt Generation and Content Summarization Abilities to use `runAbility` and remove the direct use of `apiFetch`
- Removes the now unused `path` JS localized data

### Use of AI Tools

Used Cursor (running Composer 1.5) to give a first pass on making this change with final changes, plus review and testing, done by me

## Testing Instructions

1. Add valid AI Credentials
2. Turn on Title Generation, Excerpt Generation and Content Summary Experiments
3. Test each individual Experiment and ensure they still work

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-228-356401f2cb9dba978472d50236f25fbbadfd2ecc.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->