### PR TITLE
Abilities Explorer: Add contextual help to the abilities pages.

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -41,8 +41,7 @@ class Admin_Page {
 	 * @since 0.2.0
 	 */
 	public function add_admin_menu(): void {
-		// Add menu item under the Tools menu.
-		add_submenu_page(
+		$hook = add_submenu_page(
 			'tools.php',
 			__( 'Abilities Explorer', 'ai' ),
 			__( 'Abilities Explorer', 'ai' ),
@@ -50,6 +49,10 @@ class Admin_Page {
 			'ai-abilities-explorer',
 			array( $this, 'render_page' )
 		);
+
+		if ( $hook ) {
+			add_action( "load-{$hook}", array( $this, 'add_help_tabs' ) );
+		}
 	}
 
 	/**
@@ -464,5 +467,62 @@ class Admin_Page {
 				)
 			);
 		}
+	}
+
+	/**
+	 * Add contextual help tabs to the screen.
+	 *
+	 * @since x.x.x
+	 */
+	public function add_help_tabs(): void {
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return;
+		}
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'abilities-overview',
+				'title'   => __( 'Overview', 'ai' ),
+				'content' =>
+					'<p>' . esc_html__( 'Abilities are a standardized way for WordPress core, plugins, and themes to expose discrete units of functionality. Each ability has a name, optional input/output schemas, and can be invoked programmatically.', 'ai' ) . '</p>' .
+					'<p>' . esc_html__( 'The Abilities Explorer lets you browse every registered ability, inspect its schemas, and test it with custom input right from the admin.', 'ai' ) . '</p>',
+			)
+		);
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'abilities-providers',
+				'title'   => esc_html__( 'Providers', 'ai' ),
+				'content' =>
+					'<p>' . esc_html__( 'Every ability is associated with a provider that indicates where it comes from:', 'ai' ) . '</p>' .
+					'<ul>' .
+						'<li><strong>' . esc_html__( 'Core', 'ai' ) . '</strong>: ' . esc_html__( 'Built into WordPress itself.', 'ai' ) . '</li>' .
+						'<li><strong>' . esc_html__( 'Plugin', 'ai' ) . '</strong>: ' . esc_html__( 'Registered by an active plugin.', 'ai' ) . '</li>' .
+						'<li><strong>' . esc_html__( 'Theme', 'ai' ) . '</strong>: ' . esc_html__( 'Registered by the active theme.', 'ai' ) . '</li>' .
+					'</ul>',
+			)
+		);
+
+		$screen->add_help_tab(
+			array(
+				'id'      => 'abilities-testing',
+				'title'   => esc_html__( 'Testing', 'ai' ),
+				'content' =>
+					'<p>' . esc_html__( 'You can test any ability directly from this screen:', 'ai' ) . '</p>' .
+					'<ol>' .
+						'<li>' . __( 'Click "Test" next to an ability in the list.', 'ai' ) . '</li>' .
+						'<li>' . __( 'Edit the pre-filled JSON input if the ability accepts parameters.', 'ai' ) . '</li>' .
+						'<li>' . __( 'Use "Validate Input" to check your JSON against the schema.', 'ai' ) . '</li>' .
+						'<li>' . __( 'Click "Invoke Ability" to execute it and see the result.', 'ai' ) . '</li>' .
+					'</ol>',
+			)
+		);
+
+		$screen->set_help_sidebar(
+			'<p><strong>' . esc_html__( 'For more information:', 'ai' ) . '</strong></p>' .
+			'<p><a href="https://developer.wordpress.org/apis/abilities/" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Abilities API Documentation', 'ai' ) . '</a></p>'
+		);
 	}
 }

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -50,9 +50,11 @@ class Admin_Page {
 			array( $this, 'render_page' )
 		);
 
-		if ( $hook ) {
-			add_action( "load-{$hook}", array( $this, 'add_help_tabs' ) );
+		if ( ! $hook ) {
+			return;
 		}
+
+		add_action( "load-{$hook}", array( $this, 'add_help_tabs' ) );
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -519,7 +519,7 @@ class Admin_Page {
 					'<p>' . esc_html__( 'You can test any ability directly from this screen:', 'ai' ) . '</p>' .
 					'<ol>' .
 						'<li>' . __( 'Click "Test" next to an ability in the list.', 'ai' ) . '</li>' .
-						'<li>' . __( 'Edit the pre-filled JSON input if the ability accepts parameters.', 'ai' ) . '</li>' .
+						'<li>' . __( 'Edit the pre-filled Input Data if the ability accepts JSON parameters.', 'ai' ) . '</li>' .
 						'<li>' . __( 'Use "Validate Input" to check your JSON against the schema.', 'ai' ) . '</li>' .
 						'<li>' . __( 'Click "Invoke Ability" to execute it and see the result.', 'ai' ) . '</li>' .
 					'</ol>',


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Adds contextual help section to the abilities explorer pages explaining what abilities are and how to use them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Users unfamiliar with the abilities explorer need guidance on what this feature does and how to interact with it. Contextual help makes the tool more accessible without cluttering the main interface.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

Added a help section that appears in the contextual help panel, explaining abilities and their usage.

## Testing Instructions

1. Go to Tools > Abilities explorer
2. Check the "Help" tab at the top right.
3. Confirm you get the three tabs with the contextual information, and that the information is clear. (I chose those texts, open to hear some feedback).


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b00e3282-7568-4003-ad42-3d578ba1b899

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-243-803480a1a03fc94c19ba86d4ea1b72c88b5fcf0d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->