### PR TITLE
Abilities Explorer: Fix "copy" button placement.

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
+++ b/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
@@ -79,7 +79,7 @@ class Abilities_Explorer extends Abstract_Experiment {
 					'error'         => esc_html__( 'Error', 'ai' ),
 					'invalidJson'   => esc_html__( 'Invalid JSON input', 'ai' ),
 					'confirmInvoke' => esc_html__( 'Are you sure you want to invoke this ability?', 'ai' ),
-					'copySuccess'   => esc_html__( 'Copied to clipboard!', 'ai' ),
+					'copySuccess'   => esc_html__( 'Copied!', 'ai' ),
 					'copyError'     => esc_html__( 'Failed to copy', 'ai' ),
 				),
 			)

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -202,23 +202,29 @@ class Admin_Page {
 			<?php if ( ! empty( $ability['input_schema'] ) ) : ?>
 				<div class="ability-detail-section">
 					<h3><?php esc_html_e( 'Input Schema', 'ai' ); ?></h3>
-					<button type="button" class="button button-small ability-copy-btn" data-copy="input-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-					<pre class="ability-schema-display" id="input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					<div class="ability-schema-wrapper">
+						<button type="button" class="button button-small ability-copy-btn" data-copy="input-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
+						<pre class="ability-schema-display" id="input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					</div>
 				</div>
 			<?php endif; ?>
 
 			<?php if ( ! empty( $ability['output_schema'] ) ) : ?>
 				<div class="ability-detail-section">
 					<h3><?php esc_html_e( 'Output Schema', 'ai' ); ?></h3>
-					<button type="button" class="button button-small ability-copy-btn" data-copy="output-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-					<pre class="ability-schema-display" id="output-schema"><?php echo esc_html( (string) wp_json_encode( $ability['output_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					<div class="ability-schema-wrapper">
+						<button type="button" class="button button-small ability-copy-btn" data-copy="output-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
+						<pre class="ability-schema-display" id="output-schema"><?php echo esc_html( (string) wp_json_encode( $ability['output_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					</div>
 				</div>
 			<?php endif; ?>
 
 			<div class="ability-detail-section">
 				<h3><?php esc_html_e( 'Raw Data', 'ai' ); ?></h3>
-				<button type="button" class="button button-small ability-copy-btn" data-copy="raw-data"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-				<pre class="ability-schema-display" id="raw-data"><?php echo esc_html( (string) wp_json_encode( $ability['raw_data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+				<div class="ability-schema-wrapper">
+					<button type="button" class="button button-small ability-copy-btn" data-copy="raw-data"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
+					<pre class="ability-schema-display" id="raw-data"><?php echo esc_html( (string) wp_json_encode( $ability['raw_data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+				</div>
 			</div>
 		</div>
 		<?php

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -504,16 +504,20 @@ import './index.scss';
 		 * @param {boolean}     success - Whether copy was successful.
 		 */
 		showCopyFeedback( button, success ) {
-			const originalText = button.textContent;
+			const originalHTML = button.innerHTML;
 			const feedbackText = success
 				? aiAbilityExplorer.strings.copySuccess
 				: aiAbilityExplorer.strings.copyError;
+			const feedbackIcon = success
+				? '<span class="dashicons dashicons-yes"></span>'
+				: '<span class="dashicons dashicons-no-alt"></span>';
 
-			button.textContent = feedbackText;
+			button.innerHTML =
+				feedbackIcon + ' ' + this.escapeHtml( feedbackText );
 
 			setTimeout( function () {
-				button.textContent = originalText;
-			}, 2000 );
+				button.innerHTML = originalHTML;
+			}, 1500 );
 		},
 
 		/**

--- a/src/experiments/abilities-explorer/index.scss
+++ b/src/experiments/abilities-explorer/index.scss
@@ -153,9 +153,25 @@
 	position: relative;
 }
 
+.ability-schema-wrapper {
+	position: relative;
+}
+
 .ability-copy-btn {
-	float: right;
-	margin-top: -5px;
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+
+	.dashicons {
+		font-size: 16px;
+		width: 16px;
+		height: 16px;
+		vertical-align: middle;
+	}
 }
 
 /* Test Runner */


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes layout issues with the "Copy" button in ability code blocks and improves the copy feedback UX.

## Why?

The "Copy" button was breaking out of the code block and appearing as a separate column instead of overlaying the `<pre>` element. Additionally, the "Copied to clipboard" text caused an abrupt button size change and felt redundant.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->
- Fixed Copy button positioning to properly overlay the code block
- Added icons to success and failure states for better visual feedback
- Changed "Copied to clipboard" to just "Copied" to reduce button size shift


## Testing Instructions

1. Go to Tools > Abilities Explorer
2. Click on "View" for any ability.
3. Then see any of the schema fields and confirm the placement of the button is correct.
4. Click on the button, see the success/failure message changed and has an icon now.
5. Confirm that's still copying into the clipboard.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/5a2d0fa9-cee2-43ef-9366-6617c2ae9020

**With the fix**

https://github.com/user-attachments/assets/a06f243f-3da8-43d1-932e-5115426acc4b

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-245-9f4246104bd8ac6f26299e1132dc2bcc76ee9df1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->