### PR TITLE
Abilities Explorer: Remove `cb` column.

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -51,7 +51,6 @@ class Ability_Table extends \WP_List_Table {
 	 */
 	public function get_columns(): array {
 		return array(
-			'cb'       => '<input type="checkbox" />',
 			'name'     => __( 'Name', 'ai' ),
 			'slug'     => __( 'Slug', 'ai' ),
 			'provider' => __( 'Provider', 'ai' ),
@@ -155,12 +154,11 @@ class Ability_Table extends \WP_List_Table {
 	 * {@inheritDoc}
 	 *
 	 * @param array<string,mixed> $item Item data.
+	 * @deprecated x.x.x
 	 */
 	public function column_cb( $item ): string {
-		return sprintf(
-			'<input type="checkbox" name="abilities[]" value="%s" />',
-			esc_attr( $item['slug'] )
-		);
+		_deprecated_function( __FUNCTION__, '0.2.0', 'The checkbox column is no longer displayed.' );
+		return '';
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -154,17 +154,6 @@ class Ability_Table extends \WP_List_Table {
 	 * {@inheritDoc}
 	 *
 	 * @param array<string,mixed> $item Item data.
-	 * @deprecated x.x.x
-	 */
-	public function column_cb( $item ): string {
-		_deprecated_function( __FUNCTION__, 'x.x.x', 'The checkbox column is no longer displayed.' );
-		return '';
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * @param array<string,mixed> $item Item data.
 	 */
 	public function column_name( $item ): string {
 		$detail_url = add_query_arg(

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -157,7 +157,7 @@ class Ability_Table extends \WP_List_Table {
 	 * @deprecated x.x.x
 	 */
 	public function column_cb( $item ): string {
-		_deprecated_function( __FUNCTION__, '0.2.0', 'The checkbox column is no longer displayed.' );
+		_deprecated_function( __FUNCTION__, 'x.x.x', 'The checkbox column is no longer displayed.' );
 		return '';
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Removes the unused "cb" (checkbox) column from the Abilities Explorer table and deprecates the related method.

## Why?

The "cb" column is intended for bulk actions, which we don't have in the Abilities Explorer. Having it there is confusing and clutters the UI.

## How?

Removed the "cb" column from the table display and deprecated the public method that handled it (to avoid breaking changes if extended elsewhere).

## Testing Instructions

1. Visit the "Abilities explorer".
2. Confirm the checkbox column is not there.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="3930" height="2480" alt="Screenshot 2026-02-20 at 18-25-14 Abilities Explorer ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/8c781c2f-01e2-4a97-8d1b-83be9d65af64" />|<img width="3930" height="2480" alt="Screenshot 2026-02-20 at 18-24-53 Abilities Explorer ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/fccad7d5-6a5f-47d4-ad4f-e037f313b614" />|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-246-f14c5075d8ea8a59bfa0287d830f23513d866993.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->