### PR TITLE
Abilities Explorer: Add i18n to labels.

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -119,6 +119,21 @@ class Ability_Handler {
 	}
 
 	/**
+	 * Get translatable provider labels keyed by provider slug.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string,string> Map of provider slug to translated label.
+	 */
+	public static function get_provider_labels(): array {
+		return array(
+			'Core'   => __( 'Core', 'ai' ),
+			'Plugin' => __( 'Plugin', 'ai' ),
+			'Theme'  => __( 'Theme', 'ai' ),
+		);
+	}
+
+	/**
 	 * Detect ability provider (Core, Plugin, or Theme).
 	 *
 	 * @since 0.2.0

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -134,6 +134,18 @@ class Ability_Handler {
 	}
 
 	/**
+	 * Get the label for a provider.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $provider Provider slug.
+	 * @return string Provider label.
+	 */
+	public static function get_provider_label( string $provider ): string {
+		return self::get_provider_labels()[ $provider ] ?? $provider;
+	}
+
+	/**
 	 * Detect ability provider (Core, Plugin, or Theme).
 	 *
 	 * @since 0.2.0

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -206,13 +206,11 @@ class Ability_Table extends \WP_List_Table {
 	public function column_provider( $item ): string {
 		$provider = $item['provider'];
 		$class    = 'ability-provider ability-provider-' . strtolower( $provider );
-		$labels   = Ability_Handler::get_provider_labels();
-		$label    = $labels[ $provider ] ?? $provider;
 
 		return sprintf(
 			'<span class="%s">%s</span>',
 			esc_attr( $class ),
-			esc_html( $label )
+			esc_html( Ability_Handler::get_provider_label( $provider ) )
 		);
 	}
 

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -206,11 +206,13 @@ class Ability_Table extends \WP_List_Table {
 	public function column_provider( $item ): string {
 		$provider = $item['provider'];
 		$class    = 'ability-provider ability-provider-' . strtolower( $provider );
+		$labels   = Ability_Handler::get_provider_labels();
+		$label    = $labels[ $provider ] ?? $provider;
 
 		return sprintf(
 			'<span class="%s">%s</span>',
 			esc_attr( $class ),
-			esc_html( $provider )
+			esc_html( $label )
 		);
 	}
 

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -200,8 +200,7 @@ class Admin_Page {
 					<tr>
 						<th><?php esc_html_e( 'Provider', 'ai' ); ?></th>
 						<?php
-						$provider_labels = Ability_Handler::get_provider_labels();
-						$provider_label  = $provider_labels[ $ability['provider'] ] ?? $ability['provider'];
+						$provider_label = Ability_Handler::get_provider_label( $ability['provider'] );
 						?>
 						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( $provider_label ); ?></span></td>
 					</tr>

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -199,10 +199,7 @@ class Admin_Page {
 				<table class="ability-detail-table">
 					<tr>
 						<th><?php esc_html_e( 'Provider', 'ai' ); ?></th>
-						<?php
-						$provider_label = Ability_Handler::get_provider_label( $ability['provider'] );
-						?>
-						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( $provider_label ); ?></span></td>
+						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( Ability_Handler::get_provider_label( $ability['provider'] ) ); ?></span></td>
 					</tr>
 				</table>
 			</div>

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -194,7 +194,11 @@ class Admin_Page {
 				<table class="ability-detail-table">
 					<tr>
 						<th><?php esc_html_e( 'Provider', 'ai' ); ?></th>
-						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( $ability['provider'] ); ?></span></td>
+						<?php
+						$provider_labels = Ability_Handler::get_provider_labels();
+						$provider_label  = $provider_labels[ $ability['provider'] ] ?? $ability['provider'];
+						?>
+						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( $provider_label ); ?></span></td>
 					</tr>
 				</table>
 			</div>

--- a/src/experiments/abilities-explorer/index.scss
+++ b/src/experiments/abilities-explorer/index.scss
@@ -55,9 +55,11 @@
 
 /* Provider Badges - Using WordPress notice colors */
 .ability-provider {
-	display: inline-block;
-	padding: 4px 8px;
-	border-radius: 3px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 2px 8px;
+	border-radius: 2px;
 	font-size: 12px;
 	font-weight: 500;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Makes ability provider labels translatable by implementing a label mapping system. Also updated the badge dimensions to be in line with the [badge component](https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Provider labels for abilities (Plugin, Theme, Core) were hardcoded and not translatable. Since we use the keys for filtering and other logic, we need to separate the display labels from the internal keys. That's why the mapping.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

Added a label mapping function that translates provider keys to translatable labels.

## Testing Instructions

1. Go to the Abilities Explorer page
2. Verify the provider labels display correctly (plugin, theme, core)
3. If testing with another locale, confirm labels are translated
4. Verify filtering still works correctly with the provider keys

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-247-011b08246a64714c222db922aa88051dbcea2fea.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->