### PR TITLE
Generate summary: Update button to match the styling of other buttons.

### DIFF
--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -58,6 +58,7 @@ export default function SummarizationPlugin() {
 						disabled={ isSummarizing }
 						isBusy={ isSummarizing }
 						__next40pxDefaultSize
+						style={ { width: '100%', justifyContent: 'center' } }
 					>
 						{ buttonLabel }
 					</Button>

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -51,6 +51,7 @@ export default function SummarizationPlugin() {
 			>
 				<FlexItem>
 					<Button
+						className="ai-summarization-plugin-button"
 						variant="secondary"
 						label={ buttonLabel }
 						icon={ update }
@@ -58,7 +59,6 @@ export default function SummarizationPlugin() {
 						disabled={ isSummarizing }
 						isBusy={ isSummarizing }
 						__next40pxDefaultSize
-						style={ { width: '100%', justifyContent: 'center' } }
 					>
 						{ buttonLabel }
 					</Button>

--- a/src/experiments/summarization/index.scss
+++ b/src/experiments/summarization/index.scss
@@ -1,4 +1,9 @@
 .ai-summarization-plugin-container {
+	.components-button.ai-summarization-plugin-button {
+		width: 100%;
+		justify-content: center;
+	}
+
 	.description {
 		color: #757575;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Updating the "Generate AI Summary" button to match the styling of other buttons in the interface, making it feel more connected.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The button had inconsistent styling compared to other buttons in the same area.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

Setting button width to 100%, centering the content alignment.

## Testing Instructions

1. Create a page.
2. Check the "Generate AI summary" in the page controls.
3. Confirm the width and the content alignment matches the other buttons in the same area.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="3930" height="2060" alt="Screenshot 2026-02-23 at 22-50-14 Edit Page “WordPress in the AI era ” ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/3c5e3f36-14a9-4e11-92a8-57b02d15d451" />|<img width="3930" height="2060" alt="Screenshot 2026-02-23 at 22-49-40 Edit Page “WordPress in the AI era ” ‹ Stories® — WordPress" src="https://github.com/user-attachments/assets/6d1b4388-0229-469f-8c8e-fe0ce4f7b688" />|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-253-eab59a061a64d6f844774af40c87f332a44732d8.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->