### PR TITLE
Ability test page: Better i18n, add copy functionality.

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -335,7 +335,10 @@ class Admin_Page {
 			<?php if ( ! empty( $ability['input_schema'] ) ) : ?>
 				<div class="ability-test-schema">
 					<h3><?php esc_html_e( 'Input Schema Reference', 'ai' ); ?></h3>
-					<pre><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					<div class="ability-schema-wrapper">
+						<button type="button" class="button button-small ability-copy-btn" data-copy="test-input-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
+						<pre class="ability-schema-display" id="test-input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					</div>
 				</div>
 			<?php endif; ?>
 		</div>

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -300,10 +300,12 @@ class Admin_Page {
 					<div class="notice notice-info inline" style="margin: 10px 0;">
 						<p>
 							<strong><?php esc_html_e( 'How to test:', 'ai' ); ?></strong><br>
-							1. <?php esc_html_e( 'Edit the JSON input below with your test data', 'ai' ); ?><br>
-							2. <?php esc_html_e( 'Click "Validate Input" to check your JSON is correct', 'ai' ); ?><br>
-							3. <?php esc_html_e( 'Click "Invoke Ability" to execute the ability with your input', 'ai' ); ?><br>
-							4. <?php esc_html_e( 'View the results below', 'ai' ); ?>
+							<ol>
+								<li><?php esc_html_e( 'Edit the JSON input below with your test data', 'ai' ); ?></li>
+								<li><?php esc_html_e( 'Click "Validate Input" to check your JSON is correct', 'ai' ); ?></li>
+								<li><?php esc_html_e( 'Click "Invoke Ability" to execute the ability with your input', 'ai' ); ?></li>
+								<li><?php esc_html_e( 'View the results below', 'ai' ); ?></li>
+							</ol>
 						</p>
 					</div>
 				<?php endif; ?>

--- a/src/experiments/abilities-explorer/index.scss
+++ b/src/experiments/abilities-explorer/index.scss
@@ -179,8 +179,12 @@
 		font-size: 16px;
 		width: 16px;
 		height: 16px;
-		vertical-align: middle;
 	}
+}
+
+.wp-core-ui .button.ability-copy-btn .dashicons {
+	vertical-align: middle;
+	line-height: .95;
 }
 
 /* Test Runner */


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Experiments Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Adding a few UX improvements to the single ability test page. Wrapping the list in proper HTML element, adds copy functionality for the schema reference, and fixes icon alignment within the copy button (since the reskin).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Lists weren't wrapped in proper HTML, making i18n and accessibility harder. Also adding the copy button to make it easier to copy contents and adding cohesion with the other screens.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

- Wrapped list items in `<ol>` tag for proper semantic structure and better i18n support
- Added copy button functionality to Input Schema Reference section
- Adjusted dashicon vertical alignment in copy buttons

## Testing Instructions

Testing Instructions

1. Go to a single ability test page (Tools > Abilities explorer > pick any and click test)
2. Verify the list displays correctly with proper numbering
3. Test the copy button on the Input Schema Reference
4. Verify the dashicon in the copy button is properly aligned vertically

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="3360" height="2582" alt="abilities-test-before" src="https://github.com/user-attachments/assets/38d11354-05b1-4eaa-9178-a5e52325c46b" />|<img width="3360" height="2642" alt="abilities-test-after" src="https://github.com/user-attachments/assets/eb4da5ed-a374-46c8-ad85-3e92fc6118e4" />|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-256-857ccef5b8fb4c12dd990df34289c4bad7aae1e2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->