### PR TITLE
Split Available Experiments into Editor and Admin sections

### DIFF
--- a/includes/Abstracts/Abstract_Experiment.php
+++ b/includes/Abstracts/Abstract_Experiment.php
@@ -46,6 +46,14 @@ abstract class Abstract_Experiment implements Experiment {
 	protected string $description;
 
 	/**
+	 * Experiment category.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	protected string $category;
+
+	/**
 	 * Cache for this experiment's enabled status.
 	 *
 	 * @since 0.1.0
@@ -86,16 +94,17 @@ abstract class Abstract_Experiment implements Experiment {
 		$this->id          = $metadata['id'];
 		$this->label       = $metadata['label'];
 		$this->description = $metadata['description'];
+		$this->category    = $metadata['category'] ?? 'editor';
 	}
 
 	/**
 	 * Loads experiment metadata.
 	 *
-	 * Must return an array with keys: id, label, description.
+	 * Must return an array with keys: id, label, description, and optionally category.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return array{id: string, label: string, description: string} Experiment metadata.
+	 * @return array{id: string, label: string, description: string, category?: string} Experiment metadata.
 	 */
 	abstract protected function load_experiment_metadata(): array;
 
@@ -130,6 +139,17 @@ abstract class Abstract_Experiment implements Experiment {
 	 */
 	public function get_description(): string {
 		return $this->description;
+	}
+
+	/**
+	 * Gets the experiment category.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Experiment category slug.
+	 */
+	public function get_category(): string {
+		return $this->category;
 	}
 
 	/**

--- a/includes/Contracts/Experiment.php
+++ b/includes/Contracts/Experiment.php
@@ -51,6 +51,18 @@ interface Experiment {
 	public function get_description(): string;
 
 	/**
+	 * Gets the experiment category.
+	 *
+	 * Returns a category slug used to group experiments in the settings UI.
+	 * Built-in categories are 'editor' and 'admin'.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string Experiment category slug.
+	 */
+	public function get_category(): string;
+
+	/**
 	 * Registers the experiment's hooks and functionality.
 	 *
 	 * This method is called when the experiment is initialized.

--- a/includes/Experiment_Loader.php
+++ b/includes/Experiment_Loader.php
@@ -104,12 +104,14 @@ final class Experiment_Loader {
 	 */
 	private function get_default_experiments(): array {
 		$experiment_classes = array(
-			\WordPress\AI\Experiments\Abilities_Explorer\Abilities_Explorer::class,
-			\WordPress\AI\Experiments\Excerpt_Generation\Excerpt_Generation::class,
-			\WordPress\AI\Experiments\Alt_Text_Generation\Alt_Text_Generation::class,
-			\WordPress\AI\Experiments\Image_Generation\Image_Generation::class,
-			\WordPress\AI\Experiments\Summarization\Summarization::class,
+			// Editor experiments.
 			\WordPress\AI\Experiments\Title_Generation\Title_Generation::class,
+			\WordPress\AI\Experiments\Excerpt_Generation\Excerpt_Generation::class,
+			\WordPress\AI\Experiments\Summarization\Summarization::class,
+			\WordPress\AI\Experiments\Image_Generation\Image_Generation::class,
+			\WordPress\AI\Experiments\Alt_Text_Generation\Alt_Text_Generation::class,
+			// Admin experiments.
+			\WordPress\AI\Experiments\Abilities_Explorer\Abilities_Explorer::class,
 		);
 
 		/**

--- a/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
+++ b/includes/Experiments/Abilities_Explorer/Abilities_Explorer.php
@@ -37,6 +37,7 @@ class Abilities_Explorer extends Abstract_Experiment {
 			'id'          => 'abilities-explorer',
 			'label'       => __( 'Abilities Explorer', 'ai' ),
 			'description' => __( 'Discover, inspect, test, and document all abilities registered via the WordPress Abilities API.', 'ai' ),
+			'category'    => 'admin',
 		);
 	}
 

--- a/includes/Experiments/Alt_Text_Generation/Alt_Text_Generation.php
+++ b/includes/Experiments/Alt_Text_Generation/Alt_Text_Generation.php
@@ -44,6 +44,7 @@ class Alt_Text_Generation extends Abstract_Experiment {
 			'id'          => 'alt-text-generation',
 			'label'       => __( 'Alt Text Generation', 'ai' ),
 			'description' => __( 'Generates descriptive alt text for images using AI vision models.', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Experiments/Example_Experiment/Example_Experiment.php
+++ b/includes/Experiments/Example_Experiment/Example_Experiment.php
@@ -31,6 +31,7 @@ class Example_Experiment extends Abstract_Experiment {
 			'id'          => 'example-experiment',
 			'label'       => __( 'Example Experiment', 'ai' ),
 			'description' => __( 'Demonstrates the AI experiment system with example hooks and functionality.', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
+++ b/includes/Experiments/Excerpt_Generation/Excerpt_Generation.php
@@ -34,6 +34,7 @@ class Excerpt_Generation extends Abstract_Experiment {
 			'id'          => 'excerpt-generation',
 			'label'       => __( 'Excerpt Generation', 'ai' ),
 			'description' => __( 'Generates excerpt suggestions from content', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Experiments/Image_Generation/Image_Generation.php
+++ b/includes/Experiments/Image_Generation/Image_Generation.php
@@ -39,6 +39,7 @@ class Image_Generation extends Abstract_Experiment {
 			'id'          => 'image-generation',
 			'label'       => __( 'Image Generation', 'ai' ),
 			'description' => __( 'Generates a featured image from a generated image prompt', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Experiments/Summarization/Summarization.php
+++ b/includes/Experiments/Summarization/Summarization.php
@@ -37,6 +37,7 @@ class Summarization extends Abstract_Experiment {
 			'id'          => 'summarization',
 			'label'       => __( 'Content Summarization', 'ai' ),
 			'description' => __( 'Summarizes long-form content into digestible overviews', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Experiments/Title_Generation/Title_Generation.php
+++ b/includes/Experiments/Title_Generation/Title_Generation.php
@@ -36,6 +36,7 @@ class Title_Generation extends Abstract_Experiment {
 			'id'          => 'title-generation',
 			'label'       => __( 'Title Generation', 'ai' ),
 			'description' => __( 'Generates title suggestions from content', 'ai' ),
+			'category'    => 'editor',
 		);
 	}
 

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace WordPress\AI\Settings;
 
 use WordPress\AI\Asset_Loader;
+use WordPress\AI\Contracts\Experiment;
 use WordPress\AI\Experiment_Registry;
 
 use function WordPress\AI\has_ai_credentials;
@@ -158,6 +159,22 @@ class Settings_Page {
 			<form method="post" action="options.php" id="ai-experiments-form">
 				<?php
 				settings_fields( Settings_Registration::OPTION_GROUP );
+
+				$all_experiments = $this->registry->get_all_experiments();
+
+				$editor_experiments = array_filter(
+					$all_experiments,
+					static function ( $experiment ) {
+						return 'editor' === $experiment->get_category();
+					}
+				);
+
+				$admin_experiments = array_filter(
+					$all_experiments,
+					static function ( $experiment ) {
+						return 'admin' === $experiment->get_category();
+					}
+				);
 				?>
 
 				<div class="ai-experiments">
@@ -188,13 +205,13 @@ class Settings_Page {
 						</div>
 					</div>
 
-					<!-- Individual Experiments Section -->
-					<?php if ( ! empty( $this->registry->get_all_experiments() ) ) : ?>
-						<div class="ai-experiments__card" role="region" aria-labelledby="ai-experiments-list-heading">
+					<!-- Editor Experiments Section -->
+					<?php if ( ! empty( $editor_experiments ) ) : ?>
+						<div class="ai-experiments__card" role="region" aria-labelledby="ai-experiments-editor-heading">
 							<div class="ai-experiments__card-heading">
-								<h2 id="ai-experiments-list-heading"><?php esc_html_e( 'Available Experiments', 'ai' ); ?></h2>
-								<p class="description" id="ai-experiments-list-desc">
-									<?php esc_html_e( 'Try out the following experiments to see how AI can help your site.', 'ai' ); ?>
+								<h2 id="ai-experiments-editor-heading"><?php esc_html_e( 'Editor Experiments', 'ai' ); ?></h2>
+								<p class="description" id="ai-experiments-editor-desc">
+									<?php esc_html_e( 'Try out the following experiments to see how AI can help in the editor.', 'ai' ); ?>
 								</p>
 
 								<?php if ( ! $global_enabled ) : ?>
@@ -205,61 +222,26 @@ class Settings_Page {
 							</div>
 
 							<ul class="ai-experiments__list">
-								<?php foreach ( $this->registry->get_all_experiments() as $experiment ) : ?>
-									<?php
-									$experiment_id      = $experiment->get_id();
-									$experiment_option  = "ai_experiment_{$experiment_id}_enabled";
-									$experiment_enabled = (bool) get_option( $experiment_option, false );
-									$disabled_class     = ! $global_enabled ? 'ai-experiments__item--disabled' : '';
-									$desc_id            = "ai-experiment-{$experiment_id}-desc";
-									?>
-									<li class="ai-experiments__item <?php echo esc_attr( $disabled_class ); ?>">
-										<div class="ai-experiments__item-header">
-											<label class="components-toggle-control" for="<?php echo esc_attr( $experiment_option ); ?>">
-												<input
-													type="checkbox"
-													name="<?php echo esc_attr( $experiment_option ); ?>"
-													id="<?php echo esc_attr( $experiment_option ); ?>"
-													value="1"
-													<?php checked( $experiment_enabled ); ?>
-													<?php disabled( ! $global_enabled ); ?>
-													<?php if ( $experiment->get_description() ) : ?>
-														aria-describedby="<?php echo esc_attr( $desc_id ); ?>"
-													<?php endif; ?>
-												/>
-												<span>
-													<strong><?php echo esc_html( $experiment->get_label() ); ?></strong>
-												</span>
-											</label>
-										</div>
-										<?php if ( $experiment->get_description() ) : ?>
-											<p class="description" id="<?php echo esc_attr( $desc_id ); ?>">
-												<?php
-												echo wp_kses(
-													$experiment->get_description(),
-													array(
-														'a'      => array(
-															'href'   => array(),
-															'title'  => array(),
-															'target' => array(),
-															'rel'    => array(),
-														),
-														'b'      => array(),
-														'strong' => array(),
-														'em'     => array(),
-														'i'      => array(),
-													)
-												);
-												?>
-											</p>
-										<?php endif; ?>
-										<?php
-										// Allow experiments to render their own custom settings fields.
-										if ( method_exists( $experiment, 'render_settings_fields' ) ) {
-											$experiment->render_settings_fields();
-										}
-										?>
-									</li>
+								<?php foreach ( $editor_experiments as $experiment ) : ?>
+									<?php $this->render_experiment_item( $experiment, $global_enabled ); ?>
+								<?php endforeach; ?>
+							</ul>
+						</div>
+					<?php endif; ?>
+
+					<!-- Admin Experiments Section -->
+					<?php if ( ! empty( $admin_experiments ) ) : ?>
+						<div class="ai-experiments__card" role="region" aria-labelledby="ai-experiments-admin-heading">
+							<div class="ai-experiments__card-heading">
+								<h2 id="ai-experiments-admin-heading"><?php esc_html_e( 'Admin Experiments', 'ai' ); ?></h2>
+								<p class="description" id="ai-experiments-admin-desc">
+									<?php esc_html_e( 'Try out the following experiments for site administration, exploration, or developer experience.', 'ai' ); ?>
+								</p>
+							</div>
+
+							<ul class="ai-experiments__list">
+								<?php foreach ( $admin_experiments as $experiment ) : ?>
+									<?php $this->render_experiment_item( $experiment, $global_enabled ); ?>
 								<?php endforeach; ?>
 							</ul>
 						</div>
@@ -292,6 +274,73 @@ class Settings_Page {
 				})();
 			</script>
 		</div>
+		<?php
+	}
+
+	/**
+	 * Renders a single experiment item in the settings list.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WordPress\AI\Contracts\Experiment $experiment      The experiment instance.
+	 * @param bool                               $global_enabled Whether experiments are globally enabled.
+	 *
+	 * @return void
+	 */
+	private function render_experiment_item( Experiment $experiment, bool $global_enabled ): void {
+		$experiment_id      = $experiment->get_id();
+		$experiment_option  = "ai_experiment_{$experiment_id}_enabled";
+		$experiment_enabled = (bool) get_option( $experiment_option, false );
+		$disabled_class     = ! $global_enabled ? 'ai-experiments__item--disabled' : '';
+		$desc_id            = "ai-experiment-{$experiment_id}-desc";
+		?>
+		<li class="ai-experiments__item <?php echo esc_attr( $disabled_class ); ?>">
+			<div class="ai-experiments__item-header">
+				<label class="components-toggle-control" for="<?php echo esc_attr( $experiment_option ); ?>">
+					<input
+						type="checkbox"
+						name="<?php echo esc_attr( $experiment_option ); ?>"
+						id="<?php echo esc_attr( $experiment_option ); ?>"
+						value="1"
+						<?php checked( $experiment_enabled ); ?>
+						<?php disabled( ! $global_enabled ); ?>
+						<?php if ( $experiment->get_description() ) : ?>
+							aria-describedby="<?php echo esc_attr( $desc_id ); ?>"
+						<?php endif; ?>
+					/>
+					<span>
+						<strong><?php echo esc_html( $experiment->get_label() ); ?></strong>
+					</span>
+				</label>
+			</div>
+			<?php if ( $experiment->get_description() ) : ?>
+				<p class="description" id="<?php echo esc_attr( $desc_id ); ?>">
+					<?php
+					echo wp_kses(
+						$experiment->get_description(),
+						array(
+							'a'      => array(
+								'href'   => array(),
+								'title'  => array(),
+								'target' => array(),
+								'rel'    => array(),
+							),
+							'b'      => array(),
+							'strong' => array(),
+							'em'     => array(),
+							'i'      => array(),
+						)
+					);
+					?>
+				</p>
+			<?php endif; ?>
+			<?php
+			// Allow experiments to render their own custom settings fields.
+			if ( method_exists( $experiment, 'render_settings_fields' ) ) {
+				$experiment->render_settings_fields();
+			}
+			?>
+		</li>
 		<?php
 	}
 }


### PR DESCRIPTION
## Summary

Closes #218

- Add a `category` field (`'editor'` or `'admin'`) to experiment metadata via the `Experiment` interface and `Abstract_Experiment` base class
- Split the single "Available Experiments" section into two distinct sections: **Editor Experiments** and **Admin Experiments**
- Reorder experiments to match the proposed structure in the issue
- Extract experiment item rendering into a reusable `render_experiment_item()` private method to avoid duplication

## Screenshot

_Screenshot will be added in a comment below._

## Test plan

- [ ] Visit **Settings > AI Experiments** and verify experiments are grouped into "Editor Experiments" and "Admin Experiments" sections
- [ ] Verify Editor Experiments appear in order: Title Generation, Excerpt Generation, Content Summarization, Image Generation, Alt Text Generation
- [ ] Verify Admin Experiments shows: Abilities Explorer
- [ ] Toggle global experiments off and verify the disabled notice appears in the Editor section
- [ ] Enable/disable individual experiments and save — verify settings persist correctly
- [ ] Run `composer lint` and `composer phpstan` to verify coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-263-12ded43c99794bfac95c0df092be57c6c1b6c74e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->