### PR TITLE
Switch to the new `wp_get_connectors` function

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -302,11 +302,11 @@ function get_preferred_vision_models(): array {
  * @return bool True if we have AI credentials, false otherwise.
  */
 function has_ai_credentials(): bool {
-	if ( ! function_exists( '_wp_connectors_get_connector_settings' ) || ! function_exists( '_wp_connectors_get_real_api_key' ) ) {
+	if ( ! function_exists( 'wp_get_connectors' ) ) {
 		return false;
 	}
 
-	foreach ( _wp_connectors_get_connector_settings() as $connector_data ) {
+	foreach ( wp_get_connectors() as $connector_data ) {
 		if ( 'ai_provider' !== $connector_data['type'] ) {
 			continue;
 		}
@@ -316,8 +316,7 @@ function has_ai_credentials(): bool {
 			continue;
 		}
 
-		$api_key = _wp_connectors_get_real_api_key( $auth['setting_name'], '_wp_connectors_mask_api_key' );
-		if ( '' === $api_key ) {
+		if ( '' === get_option( $auth['setting_name'], '' ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
## What?

Switches to the new `wp_get_connectors` function and away from private functions

## Why?

While adding support for the new Connectors experience coming in 7.0, we needed a new approach to get all stored AI connectors, so we can alert users when they don't have any connectors in place. I copied the approach that was in WordPress at the time which required the use of some private functions (prefixed with `_`).

There's now a new [`wp_get_connectors` function](https://core.trac.wordpress.org/changeset/61943) we can use instead, as well as it looks like one of the private functions we were using [will be removed](https://github.com/WordPress/wordpress-develop/pull/11227), so nice to move away from that.

## How?

- Switches from using `_wp_connectors_get_connector_settings` to `wp_get_connectors`
- Switches from using `_wp_connectors_get_real_api_key` to just doing a direct `get_option` call, as we don't care if the API key is valid in this check, just if it exists

### Use of AI Tools

None

## Testing Instructions

1. Install the latest `trunk` version of WordPress (as the `wp_get_connectors` function only exists there at the time of this writing)
2. Go to `Settings > Connectors` and ensure you have at least on Connector installed and an API key in place
3. Go to `Settings > AI Experiments` and ensure you don't see any error message at the top of the page about a missing AI connector
4. Switch to WP 7.0-beta4 and do the same steps
5. You should see an error message now at `Settings > AI Experiments` but should not get any fatal errors as well as all functionality should still work

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-301-ac3c4d9dc40026d856003c5cffb3d5684e37617e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->