### PR TITLE
Move the Generate Alt Text button to the new Content tab 

### DIFF
--- a/src/experiments/alt-text-generation/components/AltTextControls.tsx
+++ b/src/experiments/alt-text-generation/components/AltTextControls.tsx
@@ -130,8 +130,11 @@ export function AltTextControls( {
 	};
 
 	return (
-		<InspectorControls>
-			<div className="ai-alt-text-controls" style={ { padding: '16px' } }>
+		<InspectorControls group="content">
+			<div
+				className="ai-alt-text-controls"
+				style={ { padding: '0 16px' } }
+			>
 				<h3 style={ { marginTop: 0, marginBottom: '8px' } }>
 					{ __( 'AI Alternative Text', 'ai' ) }
 				</h3>

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -166,14 +166,6 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			.first()
 			.fill( '' );
 
-		// Click into the block settings sidebar.
-		const blockSettingsBtn = page
-			.locator( '.block-editor-block-inspector__tabs' )
-			.getByRole( 'tab', {
-				name: 'Settings',
-			} );
-		await blockSettingsBtn.click();
-
 		// Ensure the Generate button is visible in the sidebar.
 		await expect(
 			page.locator( '.ai-alt-text-controls button', {
@@ -194,21 +186,12 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			.locator( '.ai-alt-text-controls button', { hasText: 'Apply' } )
 			.click();
 
-		// Click back to the block content sidebar.
-		const blockContentBtn = page
-			.locator( '.block-editor-block-inspector__tabs' )
-			.getByRole( 'tab', {
-				name: 'Content',
-			} );
-		await blockContentBtn.click();
-
 		// Ensure the generated alt text shows in the textarea.
 		await expect(
 			page.locator( '.components-tools-panel textarea' ).first()
 		).toHaveValue( /Edit or Delete Your First WordPress Post/ );
 
 		// Ensure the generate button text is updated.
-		await blockSettingsBtn.click();
 		await expect(
 			page.locator( '.ai-alt-text-controls button', {
 				hasText: 'Regenerate Alt Text',
@@ -216,14 +199,12 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		).toBeVisible();
 
 		// Remove alt text.
-		await blockContentBtn.click();
 		await page
 			.locator( '.components-tools-panel textarea' )
 			.first()
 			.fill( '' );
 
 		// Ensure the generate button text is updated.
-		await blockSettingsBtn.click();
 		await expect(
 			page.locator( '.ai-alt-text-controls button', {
 				hasText: 'Generate Alt Text',
@@ -239,7 +220,6 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			.click();
 
 		// Ensure the generated alt text is not visible.
-		await blockContentBtn.click();
 		await expect(
 			page.locator( '.ai-alt-text-controls textarea' )
 		).not.toBeVisible();
@@ -304,7 +284,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			.locator( '.media-frame-content ul.attachments li:first-child' )
 			.click();
 
-		// Ensure the alt text generation button is visible and says Generate
+		// Ensure the alt text generation button is not visible.
 		await expect(
 			page.locator( '#ai-alt-text-generate-button' )
 		).not.toBeVisible();
@@ -378,7 +358,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			.locator( '.media-frame-content ul.attachments li:first-child' )
 			.click();
 
-		// Ensure the alt text generation button is visible and says Generate
+		// Ensure the alt text generation button is not visible.
 		await expect(
 			page.locator( '#ai-alt-text-generate-button' )
 		).not.toBeVisible();


### PR DESCRIPTION

## What?
Closes #252

Moves the Generate Alt Text button and other components to the Content tab instead of the Settings tab

## Why?

It appears in WordPress 7.0, block settings are now in three tabs: Content, Settings, Styles. If you don't specify the tab you want, it defaults to Settings.

For our Alt Text Generation Experiment, this meant the process of generating alt text happens in a tab separate from the actual alt text field, which isn't ideal. This PR updates our code to ensure it loads in the Content tab instead.

## How?

- Add `group="content"` to our `InspectorControls` component
- Remove some unneeded extra top spacing
- Fix tests

### Use of AI Tools

Claude Code running Sonnet 4.6 investigated what changed in WP 7.0 and put together the plan. I then executed that plan as it was just a simple one line change.

## Testing Instructions

1. Checkout this branch and run `npm i && npm run build`
2. Setup a proper connector with credentials
3. Turn on the alt text generation experiment
4. Create a new post and insert an image block, selecting or uploading an image
5. Once inserted into the editor, find the block settings in the sidebar
6. Ensure you see a `Generate Alt Text` button in the same panel as the actual alt text field
7. If desired, ensure generating alt text still works as expected, though that isn't changed in this PR


## Screenshots

<img width="290" height="579" alt="Generate alt text button showing in the image block settings content tab" src="https://github.com/user-attachments/assets/6da1da94-96b1-45d1-8230-d156e3ebb71b" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-306-d36884344319c2df6e350fa44780eaa075d1c138.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->