### PR TITLE
Add AGENTS.md for contributor onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ build-types/
 # AI files
 .gemini/
 .claude/
-AGENTS.md
 GEMINI.md
 CLAUDE.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AI Agent Instructions
+
+WordPress AI Experiments plugin — canonical WordPress plugin for testing AI capabilities.
+
+## References
+
+Read these before making changes:
+
+- [CONTRIBUTING.md](CONTRIBUTING.md) — setup, coding standards, naming conventions, PHPDoc rules, quality checks
+- [docs/DEVELOPER_GUIDE.md](docs/DEVELOPER_GUIDE.md) — creating experiments, plugin API, asset loading
+- [docs/ARCHITECTURE_OVERVIEW.md](docs/ARCHITECTURE_OVERVIEW.md) — plugin architecture
+- [docs/TESTING.md](docs/TESTING.md) — testing strategy
+- [docs/TESTING_REST_API.md](docs/TESTING_REST_API.md) — REST API testing
+- [docs/EXPERIMENT_LIFECYCLE.md](docs/EXPERIMENT_LIFECYCLE.md) — how experiments graduate toward core
+
+## Workflow
+
+- All npm scripts wrap `wp-env` — prefer `npm run` over direct `composer`/`vendor` calls.
+- Run `npm run lint:php`, `npm run lint:php:stan`, `npm run lint:js`, and `npm run typecheck` before submitting PRs.
+- Use `npm run lint:php:fix` and `npm run lint:js:fix` to auto-fix.
+
+## Helping Contributors Get Started
+
+When a contributor asks for help getting started:
+
+1. Read the relevant doc from the references list based on their topic. If no topic is given, read `CONTRIBUTING.md` and walk them through setup, dev environment, and first experiment creation.
+2. Give a concise, actionable answer with exact commands.
+3. When asked to set up the project, run: `composer install`, `npm i`, `npm run build`, and `npm run test:e2e:env:start`. Run independent steps in parallel where possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Read these before making changes:
 
 ## Workflow
 
-- All npm scripts wrap `wp-env` — prefer `npm run` over direct `composer`/`vendor` calls.
+- PHP-related npm scripts wrap `wp-env`; some JavaScript/tooling scripts call `wp-scripts`/`tsc` directly. Prefer `npm run` over direct `composer`, `vendor/bin`, or `wp-env` calls.
 - Run `npm run lint:php`, `npm run lint:php:stan`, `npm run lint:js`, and `npm run typecheck` before submitting PRs.
 - Use `npm run lint:php:fix` and `npm run lint:js:fix` to auto-fix.
 


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` — a concise reference file that routes contributors (and AI coding tools) to the right docs for setup, architecture, testing, and workflow rules
- Removes `AGENTS.md` from `.gitignore` so it is tracked in the repo

Closes #307

## Context

New contributors currently need to discover and read multiple docs before they can start working. `AGENTS.md` acts as a quick-start routing table — it doesn't duplicate existing docs, it links to them and codifies workflow rules (e.g., use `npm run` scripts instead of direct `composer` calls).

The file is agent-agnostic and works with any AI coding tool (Copilot, Cursor, Claude Code, Windsurf, etc.) as well as being a useful human-readable reference.

## Test plan

- [ ] Verify `AGENTS.md` is no longer gitignored
- [ ] Verify all doc links in `AGENTS.md` resolve correctly
- [ ] Try asking an AI coding tool "how do I start contributing?" with the file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-308-286e09889328e3f600bf11db81f9d48a5b42d57c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->