### PR TITLE
dev: rename hook prefixes in helpers.php

### DIFF
--- a/docs/experiments/excerpt-generation.md
+++ b/docs/experiments/excerpt-generation.md
@@ -282,13 +282,13 @@ The `normalize_content()` helper function processes content before sending it to
 
 ```php
 // Filter content before normalization
-add_filter( 'ai_experiments_pre_normalize_content', function( $content ) {
+add_filter( 'wpai_pre_normalize_content', function( $content ) {
     // Custom preprocessing
     return $content;
 } );
 
 // Filter content after normalization
-add_filter( 'ai_experiments_normalize_content', function( $content ) {
+add_filter( 'wpai_normalize_content', function( $content ) {
     // Custom post-processing
     return $content;
 } );

--- a/docs/experiments/image-generation.md
+++ b/docs/experiments/image-generation.md
@@ -681,10 +681,10 @@ This instruction tells the AI how to create image generation prompts from post c
 
 ### Filtering Preferred Image Models
 
-You can filter which AI image models are used for image generation using the `ai_experiments_preferred_image_models` filter:
+You can filter which AI image models are used for image generation using the `wpai_preferred_image_models` filter:
 
 ```php
-add_filter( 'ai_experiments_preferred_image_models', function( $models ) {
+add_filter( 'wpai_preferred_image_models', function( $models ) {
     // Prefer specific image models
     return array(
         array( 'openai', 'dall-e-3' ),

--- a/docs/experiments/summarization.md
+++ b/docs/experiments/summarization.md
@@ -330,13 +330,13 @@ The `normalize_content()` helper function processes content before sending it to
 
 ```php
 // Filter content before normalization
-add_filter( 'ai_experiments_pre_normalize_content', function( $content ) {
+add_filter( 'wpai_pre_normalize_content', function( $content ) {
     // Custom preprocessing
     return $content;
 } );
 
 // Filter content after normalization
-add_filter( 'ai_experiments_normalize_content', function( $content ) {
+add_filter( 'wpai_normalize_content', function( $content ) {
     // Custom post-processing
     return $content;
 } );

--- a/includes/Deprecated.php
+++ b/includes/Deprecated.php
@@ -71,7 +71,7 @@ final class Deprecated {
 
 				$models = (array) apply_filters_deprecated(
 					'ai_experiments_preferred_models_for_text_generation',
-					array( $models, '' ),
+					array( $models ),
 					'x.x.x',
 					'wpai_preferred_models_for_text_generation',
 					esc_html__( 'This filter will be removed in v1.0', 'ai' )
@@ -90,7 +90,7 @@ final class Deprecated {
 
 				$models = (array) apply_filters_deprecated(
 					'ai_experiments_preferred_image_models',
-					array( $models, array() ),
+					array( $models ),
 					'x.x.x',
 					'wpai_preferred_image_models',
 					esc_html__( 'This filter will be removed in v1.0', 'ai' )
@@ -109,7 +109,7 @@ final class Deprecated {
 
 				$models = (array) apply_filters_deprecated(
 					'ai_experiments_preferred_vision_models',
-					array( $models, array() ),
+					array( $models ),
 					'x.x.x',
 					'wpai_preferred_vision_models',
 					esc_html__( 'This filter will be removed in v1.0', 'ai' )
@@ -126,7 +126,7 @@ final class Deprecated {
 					return $valid;
 				}
 
-				$valid = (bool) apply_filters_deprecated(
+				$valid = apply_filters_deprecated(
 					'ai_experiments_pre_has_valid_credentials_check',
 					array( $valid ),
 					'x.x.x',

--- a/includes/Deprecated.php
+++ b/includes/Deprecated.php
@@ -63,7 +63,7 @@ final class Deprecated {
 
 		// @todo remove in v1.0.
 		add_filter(
-			'wpai_preferred_models_for_text_generation',
+			'wpai_preferred_text_models',
 			static function ( $models ) {
 				if ( ! has_filter( 'ai_experiments_preferred_models_for_text_generation' ) ) {
 					return $models;
@@ -73,7 +73,7 @@ final class Deprecated {
 					'ai_experiments_preferred_models_for_text_generation',
 					array( $models ),
 					'x.x.x',
-					'wpai_preferred_models_for_text_generation',
+					'wpai_preferred_text_models',
 					esc_html__( 'This filter will be removed in v1.0', 'ai' )
 				);
 				return $models;

--- a/includes/Deprecated.php
+++ b/includes/Deprecated.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Handle deprecated code.
+ *
+ * @package WordPress\AI
+ *
+ * @since x.x.x
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI;
+
+/**
+ * Handle deprecated code.
+ *
+ * @internal
+ *
+ * @since x.x.x
+ */
+final class Deprecated {
+	/**
+	 * Initialize the class.
+	 */
+	public function init(): void {
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_pre_normalize_content',
+			static function ( $content ) {
+				if ( ! has_filter( 'ai_experiments_pre_normalize_content' ) ) {
+					return $content;
+				}
+
+				$content = (string) apply_filters_deprecated(
+					'ai_experiments_pre_normalize_content',
+					array( $content ),
+					'x.x.x',
+					'wpai_pre_normalize_content',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $content;
+			}
+		);
+
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_normalize_content',
+			static function ( $content ) {
+				if ( ! has_filter( 'ai_experiments_normalize_content' ) ) {
+					return $content;
+				}
+
+				$content = (string) apply_filters_deprecated(
+					'ai_experiments_normalize_content',
+					array( $content ),
+					'x.x.x',
+					'wpai_normalize_content',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $content;
+			},
+		);
+
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_preferred_models_for_text_generation',
+			static function ( $models ) {
+				if ( ! has_filter( 'ai_experiments_preferred_models_for_text_generation' ) ) {
+					return $models;
+				}
+
+				$models = (array) apply_filters_deprecated(
+					'ai_experiments_preferred_models_for_text_generation',
+					array( $models, '' ),
+					'x.x.x',
+					'wpai_preferred_models_for_text_generation',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $models;
+			}
+		);
+
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_preferred_image_models',
+			static function ( $models ) {
+				if ( ! has_filter( 'ai_experiments_preferred_image_models' ) ) {
+					return $models;
+				}
+
+				$models = (array) apply_filters_deprecated(
+					'ai_experiments_preferred_image_models',
+					array( $models, array() ),
+					'x.x.x',
+					'wpai_preferred_image_models',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $models;
+			}
+		);
+
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_preferred_vision_models',
+			static function ( $models ) {
+				if ( ! has_filter( 'ai_experiments_preferred_vision_models' ) ) {
+					return $models;
+				}
+
+				$models = (array) apply_filters_deprecated(
+					'ai_experiments_preferred_vision_models',
+					array( $models, array() ),
+					'x.x.x',
+					'wpai_preferred_vision_models',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $models;
+			}
+		);
+
+		// @todo remove in v1.0.
+		add_filter(
+			'wpai_pre_has_valid_credentials_check',
+			static function ( $valid ) {
+				if ( ! has_filter( 'ai_experiments_pre_has_valid_credentials_check' ) ) {
+					return $valid;
+				}
+
+				$valid = (bool) apply_filters_deprecated(
+					'ai_experiments_pre_has_valid_credentials_check',
+					array( $valid ),
+					'x.x.x',
+					'wpai_pre_has_valid_credentials_check',
+					esc_html__( 'This filter will be removed in v1.0', 'ai' )
+				);
+				return $valid;
+			}
+		);
+	}
+}

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -173,6 +173,9 @@ function load(): void {
 	// Run any pending migrations.
 	( new Credential_Migration() )->run();
 
+	// Handle deprecated code.
+	( new Deprecated() )->init();
+
 	$loaded = true;
 
 	// Add plugin action links.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -167,7 +167,7 @@ function get_preferred_models_for_text_generation(): array {
 	 * @param array<int, array{string, string}> $preferred_models The preferred models for text generation.
 	 * @return array<int, array{string, string}> The filtered preferred models.
 	 */
-	return (array) apply_filters( 'wpai_preferred_models_for_text_generation', $preferred_models );
+	return (array) apply_filters( 'wpai_preferred_text_models', $preferred_models );
 }
 
 /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -42,7 +42,7 @@ function normalize_content( string $content ): string {
 	 *
 	 * @return string The filtered Post content.
 	 */
-	$content = (string) apply_filters( 'ai_experiments_pre_normalize_content', $content );
+	$content = (string) apply_filters( 'wpai_pre_normalize_content', $content );
 
 	// Strip HTML entities.
 	$content = preg_replace( '/&#?[a-z0-9]{2,8};/i', '', $content ) ?? $content;
@@ -68,7 +68,7 @@ function normalize_content( string $content ): string {
 	 *
 	 * @return string The filtered normalized content.
 	 */
-	$content = (string) apply_filters( 'ai_experiments_normalize_content', (string) $content );
+	$content = (string) apply_filters( 'wpai_normalize_content', (string) $content );
 
 	return trim( $content );
 }
@@ -167,7 +167,7 @@ function get_preferred_models_for_text_generation(): array {
 	 * @param array<int, array{string, string}> $preferred_models The preferred models for text generation.
 	 * @return array<int, array{string, string}> The filtered preferred models.
 	 */
-	return (array) apply_filters( 'ai_experiments_preferred_models_for_text_generation', $preferred_models );
+	return (array) apply_filters( 'wpai_preferred_models_for_text_generation', $preferred_models );
 }
 
 /**
@@ -257,7 +257,7 @@ function get_preferred_image_models(): array {
 	 * @param array<int, array{string, string}> $preferred_models The preferred image models.
 	 * @return array<int, array{string, string}> The filtered preferred image models.
 	 */
-	return (array) apply_filters( 'ai_experiments_preferred_image_models', $preferred_models );
+	return (array) apply_filters( 'wpai_preferred_image_models', $preferred_models );
 }
 
 /**
@@ -291,7 +291,7 @@ function get_preferred_vision_models(): array {
 	 * @param array<int, array{string, string}> $preferred_models The preferred vision models.
 	 * @return array<int, array{string, string}> The filtered preferred vision models.
 	 */
-	return (array) apply_filters( 'ai_experiments_preferred_vision_models', $preferred_models );
+	return (array) apply_filters( 'wpai_preferred_vision_models', $preferred_models );
 }
 
 /**
@@ -349,7 +349,7 @@ function has_valid_ai_credentials(): bool {
 	 * @param bool|null $has_valid_credentials Whether valid credentials are available. Return null to use default check.
 	 * @return bool|null True if valid credentials are available, false otherwise, or null to use default check.
 	 */
-	$valid = apply_filters( 'ai_experiments_pre_has_valid_credentials_check', null );
+	$valid = apply_filters( 'wpai_pre_has_valid_credentials_check', null );
 	if ( null !== $valid ) {
 		return (bool) $valid;
 	}

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -152,7 +152,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 	}
 
 	/**
@@ -162,7 +162,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiment_LoaderTest.php
+++ b/tests/Integration/Includes/Experiment_LoaderTest.php
@@ -111,7 +111,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		$this->registry = new Experiment_Registry();
 		$this->loader   = new Experiment_Loader( $this->registry );
@@ -124,7 +124,7 @@ class Experiment_LoaderTest extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiment_RegistryTest.php
+++ b/tests/Integration/Includes/Experiment_RegistryTest.php
@@ -68,7 +68,7 @@ class Experiment_Registry_Test extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		$this->registry = new Experiment_Registry();
 	}
@@ -80,7 +80,7 @@ class Experiment_Registry_Test extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Abilities_ExplorerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Abilities_ExplorerTest.php
@@ -45,7 +45,7 @@ class Abilities_ExplorerTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -65,7 +65,7 @@ class Abilities_ExplorerTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_abilities-explorer_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Alt_Text_Generation/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Alt_Text_Generation/Alt_Text_GenerationTest.php
@@ -28,7 +28,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		update_option( 'ai_experiments_enabled', true );
 		update_option( 'ai_experiment_alt-text-generation_enabled', true );
@@ -55,7 +55,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_alt-text-generation_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
+++ b/tests/Integration/Includes/Experiments/Example_Experiment/Example_ExperimentTest.php
@@ -31,7 +31,7 @@ class Example_ExperimentTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -61,7 +61,7 @@ class Example_ExperimentTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_example-experiment_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Excerpt_Generation/Excerpt_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Excerpt_Generation/Excerpt_GenerationTest.php
@@ -29,7 +29,7 @@ class Excerpt_GenerationTest extends WP_UnitTestCase {
 		parent::setUp();
 
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		update_option( 'ai_experiments_enabled', true );
 		update_option( 'ai_experiment_excerpt-generation_enabled', true );
@@ -56,7 +56,7 @@ class Excerpt_GenerationTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_excerpt-generation_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Image_Generation/Image_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Image_Generation/Image_GenerationTest.php
@@ -31,7 +31,7 @@ class Image_GenerationTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -56,7 +56,7 @@ class Image_GenerationTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_image-generation_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Review_Notes/Review_NotesTest.php
+++ b/tests/Integration/Includes/Experiments/Review_Notes/Review_NotesTest.php
@@ -40,7 +40,7 @@ class Review_NotesTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -67,7 +67,7 @@ class Review_NotesTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_review-notes_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Summarization/SummarizationTest.php
+++ b/tests/Integration/Includes/Experiments/Summarization/SummarizationTest.php
@@ -31,7 +31,7 @@ class SummarizationTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -56,7 +56,7 @@ class SummarizationTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_summarization_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
@@ -31,7 +31,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		update_option( 'wp_ai_client_provider_credentials', array( 'openai' => 'test-api-key' ) );
 
 		// Mock has_valid_ai_credentials to return true for tests.
-		add_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
 		// Enable experiments globally and individually.
 		update_option( 'ai_experiments_enabled', true );
@@ -55,7 +55,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_title-generation_enabled' );
 		delete_option( 'wp_ai_client_provider_credentials' );
-		remove_filter( 'ai_experiments_pre_has_valid_credentials_check', '__return_true' );
+		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
 	}
 

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -311,7 +311,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_for_text_generation_applies_filter() {
 		add_filter(
-			'wpai_preferred_models_for_text_generation',
+			'wpai_preferred_text_models',
 			function( $models ) {
 				// Add a custom model.
 				$models[] = array(
@@ -328,7 +328,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'custom', $result[4][0], 'Fifth model provider should be custom' );
 		$this->assertEquals( 'custom-model', $result[4][1], 'Fifth model name should be custom-model' );
 
-		remove_all_filters( 'wpai_preferred_models_for_text_generation' );
+		remove_all_filters( 'wpai_preferred_text_models' );
 	}
 
 	/**
@@ -338,7 +338,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_for_text_generation_filter_can_replace_models() {
 		add_filter(
-			'wpai_preferred_models_for_text_generation',
+			'wpai_preferred_text_models',
 			function( $models ) {
 				// Replace with a single model.
 				return array(
@@ -356,7 +356,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'test', $result[0][0], 'Model provider should be test' );
 		$this->assertEquals( 'test-model', $result[0][1], 'Model name should be test-model' );
 
-		remove_all_filters( 'wpai_preferred_models_for_text_generation' );
+		remove_all_filters( 'wpai_preferred_text_models' );
 	}
 
 	/**

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -134,7 +134,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_normalize_content_applies_filters() {
-		add_filter( 'ai_experiments_pre_normalize_content', function( $content ) {
+		add_filter( 'wpai_pre_normalize_content', function( $content ) {
 			return 'Filtered: ' . $content;
 		} );
 
@@ -142,7 +142,7 @@ class HelpersTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'Filtered:', $result, 'Should apply pre-normalize filter' );
 
-		remove_all_filters( 'ai_experiments_pre_normalize_content' );
+		remove_all_filters( 'wpai_pre_normalize_content' );
 	}
 
 	/**
@@ -311,7 +311,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_for_text_generation_applies_filter() {
 		add_filter(
-			'ai_experiments_preferred_models_for_text_generation',
+			'wpai_preferred_models_for_text_generation',
 			function( $models ) {
 				// Add a custom model.
 				$models[] = array(
@@ -328,7 +328,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'custom', $result[4][0], 'Fifth model provider should be custom' );
 		$this->assertEquals( 'custom-model', $result[4][1], 'Fifth model name should be custom-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_models_for_text_generation' );
+		remove_all_filters( 'wpai_preferred_models_for_text_generation' );
 	}
 
 	/**
@@ -338,7 +338,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_models_for_text_generation_filter_can_replace_models() {
 		add_filter(
-			'ai_experiments_preferred_models_for_text_generation',
+			'wpai_preferred_models_for_text_generation',
 			function( $models ) {
 				// Replace with a single model.
 				return array(
@@ -356,7 +356,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'test', $result[0][0], 'Model provider should be test' );
 		$this->assertEquals( 'test-model', $result[0][1], 'Model name should be test-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_models_for_text_generation' );
+		remove_all_filters( 'wpai_preferred_models_for_text_generation' );
 	}
 
 	/**
@@ -437,7 +437,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_image_models_applies_filter() {
 		add_filter(
-			'ai_experiments_preferred_image_models',
+			'wpai_preferred_image_models',
 			function( $models ) {
 				// Add a custom model.
 				$models[] = array(
@@ -454,7 +454,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'custom', $result[8][0], 'Ninth model provider should be custom' );
 		$this->assertEquals( 'custom-image-model', $result[8][1], 'Ninth model name should be custom-image-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_image_models' );
+		remove_all_filters( 'wpai_preferred_image_models' );
 	}
 
 	/**
@@ -464,7 +464,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_image_models_filter_can_replace_models() {
 		add_filter(
-			'ai_experiments_preferred_image_models',
+			'wpai_preferred_image_models',
 			function( $models ) {
 				// Replace with a single model.
 				return array(
@@ -482,7 +482,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'test', $result[0][0], 'Model provider should be test' );
 		$this->assertEquals( 'test-image-model', $result[0][1], 'Model name should be test-image-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_image_models' );
+		remove_all_filters( 'wpai_preferred_image_models' );
 	}
 
 	/**
@@ -530,7 +530,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_vision_models_applies_filter() {
 		add_filter(
-			'ai_experiments_preferred_vision_models',
+			'wpai_preferred_vision_models',
 			function( $models ) {
 				$models[] = array(
 					'custom',
@@ -546,7 +546,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'custom', $result[3][0], 'Fourth model provider should be custom' );
 		$this->assertEquals( 'custom-vision-model', $result[3][1], 'Fourth model name should be custom-vision-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_vision_models' );
+		remove_all_filters( 'wpai_preferred_vision_models' );
 	}
 
 	/**
@@ -556,7 +556,7 @@ class HelpersTest extends WP_UnitTestCase {
 	 */
 	public function test_get_preferred_vision_models_filter_can_replace_models() {
 		add_filter(
-			'ai_experiments_preferred_vision_models',
+			'wpai_preferred_vision_models',
 			function( $models ) {
 				return array(
 					array(
@@ -573,6 +573,6 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertEquals( 'test', $result[0][0], 'Model provider should be test' );
 		$this->assertEquals( 'test-vision-model', $result[0][1], 'Model name should be test-vision-model' );
 
-		remove_all_filters( 'ai_experiments_preferred_vision_models' );
+		remove_all_filters( 'wpai_preferred_vision_models' );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Part of #234 

Migrates the functions in `helpers.php` to use `wpai_*` prefixed hooks. Old hooks are deprecated via a new `WordPress\AI\Deprecated` class

Specifically:

- `ai_experiments_pre_normalize_content` -> `wpai_pre_normalize_content`
- `ai_experiments_normalize_content` -> `wpai_normalize_content`
- `ai_experiments_preferred_models_for_text_generation` -> `wpai_preferred_models_for_text_generation`
- `ai_experiments_preferred_image_models` -> `wpai_preferred_image_models`
- `ai_experiments_preferred_vision_models` -> `wpai_preferred_vision_models`
- `ai_experiments_pre_has_valid_credentials_check` -> `wpai_pre_has_valid_credentials_check`

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Isolated from #309 , these renames won't cause conflicts with the namespace.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

A new `Deprecated.php` checks for use of the old filters and if so adds an `apply_filter_deprecated`. This keeps the diff of the main files uninterrupted for when we're ready to remove.

<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

Copilot Autocomplete.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-315-5fd13a7b56267801e25431fb276c83078875155e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->