### PR TITLE
Replace the error message the AI Client returns with a more specific one if image requests fail

### DIFF
--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -185,7 +185,10 @@ class Generate_Image extends Abstract_Ability {
 
 		if ( is_wp_error( $result ) ) {
 			// Update the error message if trying to edit an image.
-			if ( null !== $reference_image && str_contains( $result->get_error_message(), 'No models found that support image_generation' ) ) {
+			if (
+				null !== $reference_image &&
+				false !== strpos( $result->get_error_message(), 'No models found that support image_generation' )
+			) {
 				$result = new WP_Error(
 					$result->get_error_code(),
 					esc_html__( 'Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.', 'ai' )

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -185,10 +185,7 @@ class Generate_Image extends Abstract_Ability {
 
 		if ( is_wp_error( $result ) ) {
 			// Update the error message if trying to edit an image.
-			if (
-				null !== $reference_image &&
-				false !== strpos( $result->get_error_message(), 'No models found that support image_generation' )
-			) {
+			if ( null !== $reference_image ) {
 				$result = new WP_Error(
 					$result->get_error_code(),
 					esc_html__( 'Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.', 'ai' )
@@ -254,6 +251,14 @@ class Generate_Image extends Abstract_Ability {
 			->using_request_options( $request_options )
 			->as_output_file_type( FileTypeEnum::inline() )
 			->using_model_preference( ...get_preferred_image_models() );
+
+		// Return a more specific error if there isn't a model that supports image generation.
+		if ( ! $prompt_builder->is_supported_for_image_generation() ) {
+			return new WP_Error(
+				'unsupported_model',
+				esc_html__( 'Image generation failed. Please ensure you have a connected provider that supports image generation.', 'ai' )
+			);
+		}
 
 		if ( null !== $reference_image ) {
 			try {

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -252,14 +252,6 @@ class Generate_Image extends Abstract_Ability {
 			->as_output_file_type( FileTypeEnum::inline() )
 			->using_model_preference( ...get_preferred_image_models() );
 
-		// Return a more specific error if there isn't a model that supports image generation.
-		if ( ! $prompt_builder->is_supported_for_image_generation() ) {
-			return new WP_Error(
-				'unsupported_model',
-				esc_html__( 'Image generation failed. Please ensure you have a connected provider that supports image generation.', 'ai' )
-			);
-		}
-
 		if ( null !== $reference_image ) {
 			try {
 				$file           = new File( $reference_image );
@@ -270,6 +262,14 @@ class Generate_Image extends Abstract_Ability {
 					esc_html__( 'The reference image is not valid base64-encoded data.', 'ai' )
 				);
 			}
+		}
+
+		// Return a more specific error if there isn't a model that supports image generation.
+		if ( ! $prompt_builder->is_supported_for_image_generation() ) {
+			return new WP_Error(
+				'unsupported_model',
+				esc_html__( 'Image generation failed. Please ensure you have a connected provider that supports image generation.', 'ai' )
+			);
 		}
 
 		return $prompt_builder;

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -184,14 +184,6 @@ class Generate_Image extends Abstract_Ability {
 		$result = $prompt_builder->generate_image_result();
 
 		if ( is_wp_error( $result ) ) {
-			// Update the error message if trying to edit an image.
-			if ( null !== $reference_image ) {
-				$result = new WP_Error(
-					$result->get_error_code(),
-					esc_html__( 'Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.', 'ai' )
-				);
-			}
-
 			return $result;
 		}
 
@@ -266,10 +258,13 @@ class Generate_Image extends Abstract_Ability {
 
 		// Return a more specific error if there isn't a model that supports image generation.
 		if ( ! $prompt_builder->is_supported_for_image_generation() ) {
-			return new WP_Error(
-				'unsupported_model',
-				esc_html__( 'Image generation failed. Please ensure you have a connected provider that supports image generation.', 'ai' )
-			);
+			$error_message = esc_html__( 'Image generation failed. Please ensure you have a connected provider that supports image generation.', 'ai' );
+
+			if ( null !== $reference_image ) {
+				$error_message = esc_html__( 'Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.', 'ai' );
+			}
+
+			return new WP_Error( 'unsupported_model', $error_message );
 		}
 
 		return $prompt_builder;

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -184,6 +184,14 @@ class Generate_Image extends Abstract_Ability {
 		$result = $prompt_builder->generate_image_result();
 
 		if ( is_wp_error( $result ) ) {
+			// Update the error message if trying to edit an image.
+			if ( null !== $reference_image && str_contains( $result->get_error_message(), 'No models found that support image_generation' ) ) {
+				$result = new WP_Error(
+					$result->get_error_code(),
+					esc_html__( 'Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.', 'ai' )
+				);
+			}
+
 			return $result;
 		}
 


### PR DESCRIPTION
## What?

Ensure we show a more understandable error message if image generation / refinement / editing fails.

## Why?

At the moment, image generation is supported by the Google and OpenAI provider plugins but image editing / refinement is only supported by Google. If you only have OpenAI connected, you can generate an image but if you then try and refine that image, you'll receive an error message.

Also, if you have no providers connected that support image generation and you turn on the image generation experiment, the UI is still available to use (which this is how all of our experiments currently work). If you try and generate an image you will get an error message.

These messages come from the AI Client and we just capture and display them. But the error messages aren't super specific and don't make it completely clear what the actual problem is, so this PR replaces those errors with more specific ones.

## How?

If an error happens when we make an image generation request, replace the error message the AI Client returns from:

`No models found that support image_generation for this prompt.`

to

`Image generation failed. Please ensure you have a connected provider that supports image generation.`

If an error happens when we make an image edit request, replace the error message the AI Client returns from:

`No models found that support image_generation for this prompt.`

to

`Image refinement failed. Please ensure you have a connected provider that supports image refinement, not just image generation.`

### Use of AI Tools

None

## Testing Instructions

1. Check out this PR
2. Install the OpenAI Provider plugin
3. Activate that and configure it properly
4. Turn on image generation and generate an image
5. Click the Refine button after generating and enter a refinement prompt
6. Ensure you get the more specific error message now
7. Disable the OpenAI Provider
8. Try and generate an image
9. Ensure you get a specific error message

## Screenshots

<img width="1012" height="350" alt="Error message that shows when a provider doesn't support image generation" src="https://github.com/user-attachments/assets/4a4630df-354d-41bf-939e-ef91351208cd" />

<img width="977" height="273" alt="Error message that shows when a provider doesn't support image editing" src="https://github.com/user-attachments/assets/eeeb8698-f974-42d8-aa28-cf106dd76ccd" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-332-c39db2c7360f30675f63344b74a6da59d9ba0b8a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->