### PR TITLE
Allow has_ai_credentials() filter fallback for non-API-key connectors

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -331,7 +331,7 @@ function has_ai_credentials(): bool {
 	 * Allows third-party plugins to declare credential availability for
 	 * connectors that do not rely on API key settings.
 	 *
-	 * @since 0.6.1
+	 * @since x.x.x
 	 *
 	 * @param bool  $has_credentials Whether AI credentials are available.
 	 * @param array $connectors      The registered connectors.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -308,6 +308,8 @@ function has_ai_credentials(): bool {
 
 	$connectors = wp_get_connectors();
 
+	$has_credentials = false;
+
 	foreach ( $connectors as $connector_data ) {
 		if ( 'ai_provider' !== $connector_data['type'] ) {
 			continue;
@@ -322,7 +324,8 @@ function has_ai_credentials(): bool {
 			continue;
 		}
 
-		return true;
+		$has_credentials = true;
+		break;
 	}
 
 	/**
@@ -336,7 +339,7 @@ function has_ai_credentials(): bool {
 	 * @param bool  $has_credentials Whether AI credentials are available.
 	 * @param array $connectors      The registered connectors.
 	 */
-	return (bool) apply_filters( 'wpai_has_ai_credentials', false, $connectors );
+	return (bool) apply_filters( 'wpai_has_ai_credentials', $has_credentials, $connectors );
 }
 
 /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -306,7 +306,9 @@ function has_ai_credentials(): bool {
 		return false;
 	}
 
-	foreach ( wp_get_connectors() as $connector_data ) {
+	$connectors = wp_get_connectors();
+
+	foreach ( $connectors as $connector_data ) {
 		if ( 'ai_provider' !== $connector_data['type'] ) {
 			continue;
 		}
@@ -323,7 +325,18 @@ function has_ai_credentials(): bool {
 		return true;
 	}
 
-	return false;
+	/**
+	 * Filters whether AI credentials are available.
+	 *
+	 * Allows third-party plugins to declare credential availability for
+	 * connectors that do not rely on API key settings.
+	 *
+	 * @since 0.6.1
+	 *
+	 * @param bool  $has_credentials Whether AI credentials are available.
+	 * @param array $connectors      The registered connectors.
+	 */
+	return (bool) apply_filters( 'wpai_has_ai_credentials', false, $connectors );
 }
 
 /**


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/ai/issues/336

Adds a filter-based fallback to `has_ai_credentials()` so third-party/local providers that do not use API keys can still mark credentials as configured.

## Why?
The current configured-state check only returns `true` when an `ai_provider` connector uses `authentication.method = api_key` and the related setting is non-empty. Local/self-hosted connectors (for example connectors using `authentication.method = none`) can be fully usable but still fail this configured check, which triggers the settings notice and blocks expected behavior.

## How?
1. Cache registered connectors in `$connectors = wp_get_connectors()`.
2. Keep existing `api_key` logic unchanged.
3. If no API-key credential is found, call:
   `apply_filters( 'wpai_has_ai_credentials', false, $connectors )`
4. Update the filter docs to reflect the second argument is the full connectors array.

### Use of AI Tools
Drafting and implementation assistance was done with GitHub Copilot (GPT-5.3-Codex). All changes were reviewed and validated before submission.

## Testing Instructions
1. Check out this PR branch.
2. Ensure no AI provider API key options are set.
3. Register an `ai_provider` connector that does not use API-key auth (for example auth method `none`).
4. Add a filter callback to `wpai_has_ai_credentials` returning `true` when that connector is present.
5. Verify `\WordPress\AI\has_ai_credentials()` returns `true`.
6. Verify AI settings no longer show the "requires a valid AI Connector" configured-state notice in this scenario.
7. Remove the filter and verify behavior returns to previous default (`false` without API-key credentials).

### Testing Instructions for Keyboard
1. Open the AI settings page using keyboard navigation only.
2. Verify focus order and controls are unchanged.
3. Confirm the configured-state notice visibility changes only based on credential/filter state, with no keyboard regressions.

## Screenshots or screencast
N/A (no UI/layout changes; behavior-only change).

|Before|After|
|-|-|
|Configured check could not be overridden with connector context for non-API-key providers.|Configured check can be overridden via `wpai_has_ai_credentials` with access to registered connectors.|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-337-4c5d711c42cff2aac36924b2dcab08d8ea69cbe2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->