### PR TITLE
[Fix]: Issue 264 | Anthropic with Title Gen

### DIFF
--- a/includes/Abilities/Title_Generation/Title_Generation.php
+++ b/includes/Abilities/Title_Generation/Title_Generation.php
@@ -24,15 +24,6 @@ use function WordPress\AI\normalize_content;
 class Title_Generation extends Abstract_Ability {
 
 	/**
-	 * The default number of candidates to generate.
-	 *
-	 * @since 0.1.0
-	 *
-	 * @var int
-	 */
-	protected const CANDIDATES_DEFAULT = 3;
-
-	/**
 	 * {@inheritDoc}
 	 *
 	 * @since 0.1.0
@@ -41,23 +32,15 @@ class Title_Generation extends Abstract_Ability {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'content'    => array(
+				'content' => array(
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'description'       => esc_html__( 'Content to generate title suggestions for.', 'ai' ),
 				),
-				'context'    => array(
+				'context' => array(
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 					'description'       => esc_html__( 'Additional context to use when generating title suggestions. This can either be a string of additional context or can be a post ID that will then be used to get context from that post (if it exists). If no content is provided but a valid post ID is used here, the content from that post will be used.', 'ai' ),
-				),
-				'candidates' => array(
-					'type'              => 'integer',
-					'minimum'           => 1,
-					'maximum'           => 10,
-					'default'           => self::CANDIDATES_DEFAULT,
-					'sanitize_callback' => 'absint',
-					'description'       => esc_html__( 'Number of titles to generate', 'ai' ),
 				),
 			),
 		);
@@ -93,9 +76,8 @@ class Title_Generation extends Abstract_Ability {
 		$args = wp_parse_args(
 			$input,
 			array(
-				'content'    => null,
-				'context'    => null,
-				'candidates' => self::CANDIDATES_DEFAULT,
+				'content' => null,
+				'context' => null,
 			),
 		);
 
@@ -134,7 +116,7 @@ class Title_Generation extends Abstract_Ability {
 		}
 
 		// Generate the titles.
-		$result = $this->generate_titles( $content, $context, $args['candidates'] );
+		$result = $this->generate_titles( $content, $context );
 
 		// If we have an error, return it.
 		if ( is_wp_error( $result ) ) {
@@ -229,10 +211,9 @@ class Title_Generation extends Abstract_Ability {
 	 *
 	 * @param string $content The content to generate title suggestions for.
 	 * @param string|array<string, string> $context Additional context to use.
-	 * @param int $candidates The number of titles to generate.
-	 * @return array<string>|\WP_Error The generated titles, or a WP_Error if there was an error.
+	 * @return array<string>|\WP_Error The generated title wrapped in an array, or a WP_Error if there was an error.
 	 */
-	protected function generate_titles( string $content, $context, int $candidates = 1 ) {
+	protected function generate_titles( string $content, $context ) {
 		// Convert the context to a string if it's an array.
 		if ( is_array( $context ) ) {
 			$context = implode(
@@ -258,12 +239,17 @@ class Title_Generation extends Abstract_Ability {
 			$content .= "\n\n<additional-context>" . $context . '</additional-context>';
 		}
 
-		// Generate the titles using the AI client.
-		return wp_ai_client_prompt( $content )
+		// Generate the title using the AI client.
+		$result = wp_ai_client_prompt( $content )
 			->using_system_instruction( $this->get_system_instruction() )
 			->using_temperature( 0.7 )
-			->using_candidate_count( (int) $candidates )
 			->using_model_preference( ...get_preferred_models_for_text_generation() )
-			->generate_texts();
+			->generate_text();
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return array( $result );
 	}
 }

--- a/includes/Abilities/Title_Generation/Title_Generation.php
+++ b/includes/Abilities/Title_Generation/Title_Generation.php
@@ -55,12 +55,9 @@ class Title_Generation extends Abstract_Ability {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'titles' => array(
-					'type'        => 'array',
-					'description' => esc_html__( 'Generated title suggestions.', 'ai' ),
-					'items'       => array(
-						'type' => 'string',
-					),
+				'title' => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'Generated title suggestion.', 'ai' ),
 				),
 			),
 		);
@@ -115,30 +112,25 @@ class Title_Generation extends Abstract_Ability {
 			);
 		}
 
-		// Generate the titles.
-		$result = $this->generate_titles( $content, $context );
+		// Generate the title.
+		$result = $this->generate_title( $content, $context );
 
 		// If we have an error, return it.
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
 
-		// If we have no results, return an error.
+		// If we have no result, return an error.
 		if ( empty( $result ) ) {
 			return new WP_Error(
 				'no_results',
-				esc_html__( 'No title suggestions were generated.', 'ai' )
+				esc_html__( 'No title suggestion was generated.', 'ai' )
 			);
 		}
 
-		// Return the titles in the format the Ability expects.
+		// Return the title in the format the Ability expects.
 		return array(
-			'titles' => array_map(
-				static function ( $title ) {
-					return sanitize_text_field( trim( $title, ' "\'' ) );
-				},
-				$result
-			),
+			'title' => sanitize_text_field( trim( $result, ' "\'' ) ),
 		);
 	}
 
@@ -205,15 +197,15 @@ class Title_Generation extends Abstract_Ability {
 	}
 
 	/**
-	 * Generates title suggestions from the given content.
+	 * Generates a title suggestion from the given content.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $content The content to generate title suggestions for.
+	 * @param string                       $content The content to generate a title suggestion for.
 	 * @param string|array<string, string> $context Additional context to use.
-	 * @return array<string>|\WP_Error The generated title wrapped in an array, or a WP_Error if there was an error.
+	 * @return string|\WP_Error The generated title, or a WP_Error if there was an error.
 	 */
-	protected function generate_titles( string $content, $context ) {
+	protected function generate_title( string $content, $context ) {
 		// Convert the context to a string if it's an array.
 		if ( is_array( $context ) ) {
 			$context = implode(
@@ -250,6 +242,6 @@ class Title_Generation extends Abstract_Ability {
 			return $result;
 		}
 
-		return array( $result );
+		return $result;
 	}
 }

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -17,10 +17,7 @@ import { store as noticesStore } from '@wordpress/notices';
  * Internal dependencies
  */
 import { runAbility } from '../../../utils/run-ability';
-import type {
-	TitleGenerationAbilityInput,
-	GeneratedTitlesData,
-} from '../types';
+import type { TitleGenerationAbilityInput, GeneratedTitleData } from '../types';
 
 const { aiTitleGenerationData } = window as any;
 
@@ -40,7 +37,7 @@ async function generateTitle(
 		content,
 	};
 
-	const response = await runAbility< GeneratedTitlesData >(
+	const response = await runAbility< GeneratedTitleData >(
 		'ai/title-generation',
 		params
 	);
@@ -48,14 +45,14 @@ async function generateTitle(
 	if (
 		response &&
 		typeof response === 'object' &&
-		'titles' in response &&
-		Array.isArray( response.titles ) &&
-		response.titles.length > 0
+		'title' in response &&
+		typeof response.title === 'string' &&
+		response.title.length > 0
 	) {
-		return response.titles[ 0 ] as string;
+		return response.title;
 	}
 
-	throw new Error( __( 'No title suggestions were generated.', 'ai' ) );
+	throw new Error( __( 'No title suggestion was generated.', 'ai' ) );
 }
 
 /**

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -5,15 +5,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	Flex,
-	FlexItem,
-	Modal,
-	TextareaControl,
-	ToolbarGroup,
-	ToolbarButton,
-} from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 import { dispatch, select, useDispatch } from '@wordpress/data';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
@@ -33,121 +25,37 @@ import type {
 const { aiTitleGenerationData } = window as any;
 
 /**
- * Renders a single title option.
+ * Generates a title for the given post ID and content.
  *
- * @param {Object}   props          Component props.
- * @param {string}   props.title    The title value to display.
- * @param {number}   props.index    The index of this title in the array.
- * @param {Function} props.onChange Callback to update this title's value.
- * @param {Function} props.onSelect Callback when this title is selected.
- * @return {JSX.Element} The rendered title option.
+ * @param {number} postId  The ID of the post to generate a title for.
+ * @param {string} content The content of the post to generate a title for.
+ * @return {Promise<string>} A promise that resolves to the generated title.
  */
-function TitleOption( {
-	title,
-	index,
-	onChange,
-	onSelect,
-}: {
-	title: string;
-	index: number;
-	onChange: ( value: string ) => void;
-	onSelect: ( title: string, index: number ) => void;
-} ): JSX.Element {
-	return (
-		<FlexItem className="ai-title">
-			<TextareaControl
-				rows={ 2 }
-				label={ __( 'Generated title', 'ai' ) }
-				hideLabelFromVision
-				value={ title }
-				onChange={ onChange }
-				__nextHasNoMarginBottom
-			/>
-			<Button
-				variant="secondary"
-				style={ { marginTop: '15px' } }
-				onClick={ () => onSelect( title, index ) }
-			>
-				{ __( 'Select', 'ai' ) }
-			</Button>
-		</FlexItem>
-	);
-}
-
-/**
- * Renders the generated title data with editable textareas.
- *
- * @param {Object}   props               Component props.
- * @param {string[]} props.titles        The array of titles to render.
- * @param {Function} props.onTitleChange Callback to update the title array.
- * @param {Function} props.onSelect      Callback when a title is selected.
- * @return {JSX.Element | null} The rendered titles.
- */
-function TitleOptionsList( {
-	titles: titlesToRender,
-	onTitleChange,
-	onSelect,
-}: {
-	titles: string[];
-	onTitleChange: ( newTitle: string[] ) => void;
-	onSelect: ( title: string, index: number ) => void;
-} ): JSX.Element | null {
-	if ( ! titlesToRender || titlesToRender.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<Flex gap="5" wrap direction="column">
-			{ titlesToRender.map( ( title: string, i: number ) => (
-				<TitleOption
-					key={ `title-${ i }` }
-					title={ title }
-					index={ i }
-					onChange={ ( value: string ) => {
-						onTitleChange(
-							titlesToRender.map( ( item, index ) =>
-								index === i ? value : item
-							)
-						);
-					} }
-					onSelect={ onSelect }
-				/>
-			) ) }
-		</Flex>
-	);
-}
-
-/**
- * Generates titles for the given post ID and content.
- *
- * @param {number} postId  The ID of the post to generate titles for.
- * @param {string} content The content of the post to generate titles for.
- * @return {Promise<string[]>} A promise that resolves to the generated titles.
- */
-async function generateTitles(
+async function generateTitle(
 	postId: number,
 	content: string
-): Promise< string[] > {
+): Promise< string > {
 	const params: TitleGenerationAbilityInput = {
 		context: postId.toString(),
 		content,
 	};
 
-	return runAbility< GeneratedTitlesData >( 'ai/title-generation', params )
-		.then( ( response ) => {
-			if (
-				response &&
-				typeof response === 'object' &&
-				'titles' in response
-			) {
-				return response.titles as string[];
-			}
+	const response = await runAbility< GeneratedTitlesData >(
+		'ai/title-generation',
+		params
+	);
 
-			return [];
-		} )
-		.catch( ( error ) => {
-			throw new Error( `Error generating titles: ${ error.message }` );
-		} );
+	if (
+		response &&
+		typeof response === 'object' &&
+		'titles' in response &&
+		Array.isArray( response.titles ) &&
+		response.titles.length > 0
+	) {
+		return response.titles[ 0 ] as string;
+	}
+
+	throw new Error( __( 'No title suggestions were generated.', 'ai' ) );
 }
 
 /**
@@ -165,14 +73,6 @@ export default function TitleToolbar(): JSX.Element | null {
 	const { editPost } = useDispatch( editorStore );
 
 	const [ isGenerating, setIsGenerating ] = useState< boolean >( false );
-	const [ isOpen, setOpen ] = useState< boolean >( false );
-	const [ titles, setTitles ] = useState< string[] >( [] );
-
-	const openModal = () => setOpen( true );
-	const closeModal = () => {
-		setOpen( false );
-		setTitles( [] );
-	};
 
 	const hasTitle = title.trim().length > 0;
 	const buttonLabel = hasTitle
@@ -189,33 +89,19 @@ export default function TitleToolbar(): JSX.Element | null {
 		);
 
 		try {
-			const generatedTitles = await generateTitles(
+			const generatedTitle = await generateTitle(
 				postId as number,
 				content
 			);
-			setTitles( generatedTitles );
-			openModal();
+			editPost( { title: generatedTitle } );
 		} catch ( error: any ) {
 			( dispatch( noticesStore ) as any ).createErrorNotice( error, {
 				id: 'ai_title_generation_error',
 				isDismissible: true,
 			} );
-			setTitles( [] );
 		} finally {
 			setIsGenerating( false );
 		}
-	};
-
-	/**
-	 * Handles selecting a title.
-	 *
-	 * @param {string} selectedTitle The selected title.
-	 */
-	const handleSelectTitle = async ( selectedTitle: string ) => {
-		editPost( {
-			title: selectedTitle,
-		} );
-		closeModal();
 	};
 
 	// Don't render if disabled.
@@ -224,37 +110,18 @@ export default function TitleToolbar(): JSX.Element | null {
 	}
 
 	return (
-		<>
-			<PostTypeSupportCheck supportKeys="title">
-				<ToolbarGroup>
-					<ToolbarButton
-						icon={ update }
-						label={ buttonLabel }
-						onClick={ handleGenerate }
-						disabled={ isGenerating }
-						isBusy={ isGenerating }
-					>
-						{ buttonLabel }
-					</ToolbarButton>
-				</ToolbarGroup>
-			</PostTypeSupportCheck>
-			{ isOpen && (
-				<Modal
-					title={ __( 'Select a title', 'ai' ) }
-					onRequestClose={ closeModal }
-					isFullScreen={ false }
-					size="medium"
-					className="ai-title-generation-modal"
+		<PostTypeSupportCheck supportKeys="title">
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ update }
+					label={ buttonLabel }
+					onClick={ handleGenerate }
+					disabled={ isGenerating }
+					isBusy={ isGenerating }
 				>
-					{ titles && (
-						<TitleOptionsList
-							titles={ titles }
-							onTitleChange={ setTitles }
-							onSelect={ handleSelectTitle }
-						/>
-					) }
-				</Modal>
-			) }
-		</>
+					{ buttonLabel }
+				</ToolbarButton>
+			</ToolbarGroup>
+		</PostTypeSupportCheck>
 	);
 }

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -92,7 +92,11 @@ export default function TitleToolbar(): JSX.Element | null {
 			);
 			editPost( { title: generatedTitle } );
 		} catch ( error: any ) {
-			( dispatch( noticesStore ) as any ).createErrorNotice( error, {
+			const message =
+				typeof error === 'string'
+					? error
+					: error?.message ?? __( 'Failed to generate title.', 'ai' );
+			( dispatch( noticesStore ) as any ).createErrorNotice( message, {
 				id: 'ai_title_generation_error',
 				isDismissible: true,
 			} );

--- a/src/experiments/title-generation/types.ts
+++ b/src/experiments/title-generation/types.ts
@@ -14,6 +14,6 @@ export interface TitleGenerationAbilityInput {
 /**
  * Response from the ai/title-generation ability.
  */
-export interface GeneratedTitlesData {
-	titles: string[];
+export interface GeneratedTitleData {
+	title: string;
 }

--- a/tests/Integration/Includes/Abilities/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Title_GenerationTest.php
@@ -150,10 +150,8 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertIsArray( $schema, 'Output schema should be an array' );
 		$this->assertEquals( 'object', $schema['type'], 'Schema type should be object' );
 		$this->assertArrayHasKey( 'properties', $schema, 'Schema should have properties' );
-		$this->assertArrayHasKey( 'titles', $schema['properties'], 'Schema should have titles property' );
-		$this->assertEquals( 'array', $schema['properties']['titles']['type'], 'Titles should be array type' );
-		$this->assertArrayHasKey( 'items', $schema['properties']['titles'], 'Titles should have items' );
-		$this->assertEquals( 'string', $schema['properties']['titles']['items']['type'], 'Title items should be string type' );
+		$this->assertArrayHasKey( 'title', $schema['properties'], 'Schema should have title property' );
+		$this->assertEquals( 'string', $schema['properties']['title']['type'], 'Title should be string type' );
 	}
 
 	/**
@@ -197,9 +195,8 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		}
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
-		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 1, $result['titles'], 'Should have 1 title' );
+		$this->assertArrayHasKey( 'title', $result, 'Result should have title key' );
+		$this->assertIsString( $result['title'], 'Title should be a string' );
 	}
 
 	/**
@@ -238,9 +235,8 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		}
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
-		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 1, $result['titles'], 'Should have 1 title' );
+		$this->assertArrayHasKey( 'title', $result, 'Result should have title key' );
+		$this->assertIsString( $result['title'], 'Title should be a string' );
 	}
 
 	/**
@@ -307,9 +303,8 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		}
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
-		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 1, $result['titles'], 'Should have 1 title by default' );
+		$this->assertArrayHasKey( 'title', $result, 'Result should have title key' );
+		$this->assertIsString( $result['title'], 'Title should be a string' );
 	}
 
 	/**
@@ -349,10 +344,10 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		}
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
-		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		// The feature's generate_titles uses the post content, verified by titles being generated.
-		$this->assertNotEmpty( $result['titles'], 'Should generate titles from post content' );
+		$this->assertArrayHasKey( 'title', $result, 'Result should have title key' );
+		$this->assertIsString( $result['title'], 'Title should be a string' );
+		// The feature's generate_title uses the post content, verified by a title being generated.
+		$this->assertNotEmpty( $result['title'], 'Should generate a title from post content' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Title_GenerationTest.php
@@ -126,8 +126,6 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'properties', $schema, 'Schema should have properties' );
 		$this->assertArrayHasKey( 'content', $schema['properties'], 'Schema should have content property' );
 		$this->assertArrayHasKey( 'context', $schema['properties'], 'Schema should have context property' );
-		$this->assertArrayHasKey( 'candidates', $schema['properties'], 'Schema should have candidates property' );
-
 		// Verify content property.
 		$this->assertEquals( 'string', $schema['properties']['content']['type'], 'Content should be string type' );
 		$this->assertEquals( 'sanitize_text_field', $schema['properties']['content']['sanitize_callback'], 'Content should use sanitize_text_field' );
@@ -135,11 +133,6 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		// Verify context property (can be string or numeric post ID).
 		$this->assertEquals( 'string', $schema['properties']['context']['type'], 'Context should be string type' );
 		$this->assertEquals( 'sanitize_text_field', $schema['properties']['context']['sanitize_callback'], 'Context should use sanitize_text_field' );
-
-		// Verify candidates property.
-		$this->assertEquals( 'integer', $schema['properties']['candidates']['type'], 'candidates should be integer type' );
-		$this->assertEquals( 1, $schema['properties']['candidates']['minimum'], 'candidates minimum should be 1' );
-		$this->assertEquals( 10, $schema['properties']['candidates']['maximum'], 'candidates maximum should be 10' );
 	}
 
 	/**
@@ -187,8 +180,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		$input = array(
-			'content'    => 'This is some test content.',
-			'candidates' => 3,
+			'content' => 'This is some test content.',
 		);
 
 		try {
@@ -207,7 +199,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'Result should be an array' );
 		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
 		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 3, $result['titles'], 'Should have 3 titles' );
+		$this->assertCount( 1, $result['titles'], 'Should have 1 title' );
 	}
 
 	/**
@@ -229,8 +221,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		);
 
 		$input = array(
-			'context'    => $post_id,
-			'candidates' => 2,
+			'context' => $post_id,
 		);
 
 		try {
@@ -249,7 +240,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'Result should be an array' );
 		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
 		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 2, $result['titles'], 'Should have 2 titles' );
+		$this->assertCount( 1, $result['titles'], 'Should have 1 title' );
 	}
 
 	/**
@@ -318,7 +309,7 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'Result should be an array' );
 		$this->assertArrayHasKey( 'titles', $result, 'Result should have titles key' );
 		$this->assertIsArray( $result['titles'], 'Titles should be an array' );
-		$this->assertCount( 3, $result['titles'], 'Should have 3 titles by default' );
+		$this->assertCount( 1, $result['titles'], 'Should have 1 title by default' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
@@ -74,6 +74,18 @@ class Title_GenerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that register() adds the expected hooks.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_register_adds_hooks() {
+		$experiment = new Title_Generation();
+		$experiment->register();
+		$this->assertIsInt( has_action( 'wp_abilities_api_init', array( $experiment, 'register_abilities' ) ), 'Should register abilities hook' );
+		$this->assertIsInt( has_action( 'admin_enqueue_scripts', array( $experiment, 'enqueue_assets' ) ), 'Should register assets hook' );
+	}
+
+	/**
 	 * Test that enqueue_assets() returns early for non-post screens.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Title_Generation/Title_GenerationTest.php
@@ -72,4 +72,44 @@ class Title_GenerationTest extends WP_UnitTestCase {
 		$this->assertEquals( Experiment_Category::EDITOR, $experiment->get_category() );
 		$this->assertTrue( $experiment->is_enabled() );
 	}
+
+	/**
+	 * Test that enqueue_assets() returns early for non-post screens.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_enqueue_assets_returns_early_for_non_post_screens() {
+		$experiment = new Title_Generation();
+
+		// Should not enqueue for a non-post screen.
+		$experiment->enqueue_assets( 'options-general.php' );
+
+		$this->assertFalse( wp_script_is( 'ai-experiments-title_generation', 'enqueued' ), 'Should not enqueue on options page' );
+	}
+
+	/**
+	 * Test that the experiment is not enabled when globally disabled.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_experiment_not_enabled_when_globally_disabled() {
+		update_option( 'wpai_features_enabled', false );
+
+		$experiment = new Title_Generation();
+
+		$this->assertFalse( $experiment->is_enabled(), 'Should not be enabled when global toggle is off' );
+	}
+
+	/**
+	 * Test that the experiment is not enabled when individually disabled.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_experiment_not_enabled_when_individually_disabled() {
+		update_option( 'wpai_feature_title-generation_enabled', false );
+
+		$experiment = new Title_Generation();
+
+		$this->assertFalse( $experiment->is_enabled(), 'Should not be enabled when feature toggle is off' );
+	}
 }

--- a/tests/e2e/specs/experiments/title-generation.spec.js
+++ b/tests/e2e/specs/experiments/title-generation.spec.js
@@ -50,7 +50,7 @@ test.describe( 'Title Generation Experiment', () => {
 		// Click into the title field.
 		await editor.canvas.locator( '.editor-post-title__input' ).click();
 
-		// Ensure the title toolbar is visible.
+		// Ensure the title toolbar is visible with "Generate" label.
 		await expect(
 			editor.canvas.locator( '.ai-title-toolbar-container', {
 				hasText: 'Generate',
@@ -62,33 +62,12 @@ test.describe( 'Title Generation Experiment', () => {
 			.locator( '.ai-title-toolbar-container button' )
 			.click();
 
-		// Ensure the title modal is visible.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).toBeVisible();
-
-		// Ensure there is one title option.
-		await expect(
-			page.locator( '.ai-title-generation-modal .ai-title textarea' )
-		).toHaveCount( 1 );
-
-		// Click the first title option.
-		await page
-			.locator(
-				'.ai-title-generation-modal .ai-title:first-child button'
-			)
-			.click();
-
-		// Ensure the title modal is closed.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).not.toBeVisible();
-
-		// Ensure the title is updated.
+		// Ensure the title is updated directly (no modal).
 		await expect(
 			editor.canvas.locator( '.editor-post-title__input' )
 		).toHaveText(
-			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure'
+			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
+			{ timeout: 10000 }
 		);
 
 		// Save the post.
@@ -120,7 +99,7 @@ test.describe( 'Title Generation Experiment', () => {
 		// Click into the title field.
 		await editor.canvas.locator( '.editor-post-title__input' ).click();
 
-		// Ensure the title toolbar is visible.
+		// Ensure the title toolbar is visible with "Re-generate" label.
 		await expect(
 			editor.canvas.locator( '.ai-title-toolbar-container', {
 				hasText: 'Re-generate',
@@ -132,33 +111,12 @@ test.describe( 'Title Generation Experiment', () => {
 			.locator( '.ai-title-toolbar-container button' )
 			.click();
 
-		// Ensure the title modal is visible.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).toBeVisible();
-
-		// Ensure there is one title option.
-		await expect(
-			page.locator( '.ai-title-generation-modal .ai-title textarea' )
-		).toHaveCount( 1 );
-
-		// Click the first title option.
-		await page
-			.locator(
-				'.ai-title-generation-modal .ai-title:first-child button'
-			)
-			.click();
-
-		// Ensure the title modal is closed.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).not.toBeVisible();
-
-		// Ensure the title is updated.
+		// Ensure the title is updated directly (no modal).
 		await expect(
 			editor.canvas.locator( '.editor-post-title__input' )
 		).toHaveText(
-			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure'
+			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
+			{ timeout: 10000 }
 		);
 
 		// Save the post.


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #264 

<!-- In a few words, what is the PR actually doing? -->
This PR removes the multiple candidates from the Title Generation experiment and makes it return only one. All E2E and unit tests updated accordingly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As described in https://github.com/WordPress/ai/issues/264 -- Anthropic and OpenAI no longer support multiple candidate responses. This PR ensures the title generation logic continues to work even if only one of those models is currently connected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove all references to candidates within the Title Generation experiment. With the removal of multiple candidates per response, the modal UI has been removed and titles are just inserted into the post directly. Editors can then regenerate the title as needed using the existing toolbar button.

<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
* **AI Assistance:** Yes
* **Tool(s):** Claude Code (Opus 4.6)
* **Used for:**
    * Outlining everywhere candidates were referenced and used
    * Update E2E and Unit Tests accordingly

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Ensure the "Title Generation" experiment is enabled.
2. Ensure only an Anthropic connector is active.
3. Navigate to a post and click the "Regenerate" button.
4. Confirm a title is generated and inserted into the post title field.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-341-5290d7c5064dc81fd5344d07a21d76fd77eb68e8.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->