### PR TITLE
[Feature] Implement plugin permissions management system

### DIFF
--- a/ai.php
+++ b/ai.php
@@ -32,3 +32,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'WPAI_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once WPAI_DIR . 'includes/bootstrap.php';
+// add_action( 'wpai_register_plugins', function( $registry ) {
+//     $registry->register_plugin( 'my-plugin', array(
+//         'name'        => 'My Plugin',
+//         'description' => 'Uses AI for content generation.',
+//     ) );
+// } );

--- a/ai.php
+++ b/ai.php
@@ -32,9 +32,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'WPAI_DIR', plugin_dir_path( __FILE__ ) );
 
 require_once WPAI_DIR . 'includes/bootstrap.php';
-// add_action( 'wpai_register_plugins', function( $registry ) {
-//     $registry->register_plugin( 'my-plugin', array(
-//         'name'        => 'My Plugin',
-//         'description' => 'Uses AI for content generation.',
-//     ) );
-// } );

--- a/includes/Permissions/Permissions_Manager.php
+++ b/includes/Permissions/Permissions_Manager.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Manages plugin-level permissions for AI provider access.
- * Its final class to prevent extension, ensuring a single 
+ * Its final class to prevent extension, ensuring a single
  * source of truth for plugin permissions logic.
  *
  * Provides a central point for:

--- a/includes/Permissions/Permissions_Manager.php
+++ b/includes/Permissions/Permissions_Manager.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * Permissions Manager for AI access control.
+ *
+ * @package WordPress\AI\Permissions
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Permissions;
+
+use WordPress\AI\Settings\Settings_Registration;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages plugin-level permissions for AI provider access.
+ * Its final class to prevent extension, ensuring a single 
+ * source of truth for plugin permissions logic.
+ *
+ * Provides a central point for:
+ * - Checking whether a plugin is authorized to use AI providers.
+ * - Storing and retrieving per-plugin provider routing preferences.
+ *
+ * @since 1.0.0
+ */
+final class Permissions_Manager {
+
+	/**
+	 * Option name prefix for plugin access settings.
+	 *
+	 * Full option name: `wpai_plugin_access_{sanitized_plugin_id}`.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const PLUGIN_ACCESS_OPTION_PREFIX = 'wpai_plugin_access_';
+
+	/**
+	 * Option name prefix for plugin provider routing preferences.
+	 *
+	 * Full option name: `wpai_plugin_providers_{sanitized_plugin_id}`.
+	 * Stores a comma-separated list of allowed provider slugs (e.g. "anthropic,google").
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	public const PLUGIN_PROVIDER_OPTION_PREFIX = 'wpai_plugin_providers_';
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @since 1.0.0
+	 * @var \WordPress\AI\Permissions\Permissions_Manager|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Plugin registry instance.
+	 *
+	 * @since 1.0.0
+	 * @var \WordPress\AI\Permissions\Plugin_Registry
+	 */
+	private Plugin_Registry $plugin_registry;
+
+	/**
+	 * Whether the manager has been initialized.
+	 *
+	 * @since 1.0.0
+	 * @var bool
+	 */
+	private bool $initialized = false;
+
+	/**
+	 * Private constructor — use {@see Permissions_Manager::get_instance()} instead.
+	 *
+	 * @since 1.0.0
+	 */
+	private function __construct() {
+		$this->plugin_registry = new Plugin_Registry();
+	}
+
+	/**
+	 * Returns the singleton instance.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return \WordPress\AI\Permissions\Permissions_Manager The singleton instance.
+	 */
+	public static function get_instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Initializes the permissions system.
+	 *
+	 * Fires the `wpai_register_plugins` action, allowing third-party plugins to register
+	 * themselves as AI consumers. Should be called once during plugin initialization.
+	 *
+	 * Third-party plugins should hook into `wpai_register_plugins` at `init` priority 14
+	 * or earlier to ensure their registration is processed in time.
+	 *
+	 * Example:
+	 * ```php
+	 * add_action( 'wpai_register_plugins', function( $registry ) {
+	 *     $registry->register_plugin( 'my-plugin', array(
+	 *         'name'        => 'My Plugin',
+	 *         'description' => 'Uses AI for content generation.',
+	 *     ) );
+	 * } );
+	 * ```
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	public function initialize(): void {
+		if ( $this->initialized ) {
+			return;
+		}
+
+		/**
+		 * Fires to allow third-party plugins to register as AI consumers.
+		 *
+		 * Plugins must register before the site admin can grant or revoke their
+		 * access to connected AI providers. Registrations should be added at
+		 * `init` priority 14 or earlier.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param \WordPress\AI\Permissions\Plugin_Registry $registry The plugin registry instance.
+		 */
+		do_action( 'wpai_register_plugins', $this->plugin_registry );
+
+		$this->initialized = true;
+	}
+
+	/**
+	 * Returns the plugin registry.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return \WordPress\AI\Permissions\Plugin_Registry The plugin registry instance.
+	 */
+	public function get_plugin_registry(): Plugin_Registry {
+		return $this->plugin_registry;
+	}
+
+	/**
+	 * Checks if a plugin has been granted access to connected AI providers.
+	 *
+	 * Also checks the global AI features toggle — if AI is globally disabled,
+	 * this returns false regardless of the plugin's individual access setting.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id The plugin identifier.
+	 * @return bool True if the plugin is allowed to use AI providers, false otherwise.
+	 */
+	public function plugin_has_access( string $plugin_id ): bool {
+		// Unregistered plugins are always denied.
+		if ( ! $this->plugin_registry->has_plugin( $plugin_id ) ) {
+			return false;
+		}
+
+		// Respect the global AI features toggle.
+		$global_enabled = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
+		if ( ! $global_enabled ) {
+			return false;
+		}
+
+		$option_name = self::PLUGIN_ACCESS_OPTION_PREFIX . $this->sanitize_option_key( $plugin_id );
+		$has_access  = (bool) get_option( $option_name, false );
+
+		/**
+		 * Filters whether a specific plugin has access to AI providers.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param bool   $has_access Whether the plugin has been granted access.
+		 * @param string $plugin_id  The plugin identifier.
+		 */
+		return (bool) apply_filters( 'wpai_plugin_ai_access', $has_access, $plugin_id );
+	}
+
+	/**
+	 * Returns the provider routing preferences for a specific plugin.
+	 *
+	 * Returns an empty array if no preferences are configured, which means the
+	 * plugin should use the global provider preferences.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id The plugin identifier.
+	 * @return list<string> Ordered list of allowed provider slugs (e.g. ['anthropic', 'google']).
+	 */
+	public function get_plugin_provider_preferences( string $plugin_id ): array {
+		$option_name = self::PLUGIN_PROVIDER_OPTION_PREFIX . $this->sanitize_option_key( $plugin_id );
+		$stored      = get_option( $option_name, '' );
+
+		if ( ! is_string( $stored ) || '' === $stored ) {
+			$preferences = array();
+		} else {
+			$preferences = array_values(
+				array_filter(
+					array_map( 'trim', explode( ',', $stored ) )
+				)
+			);
+		}
+
+		/**
+		 * Filters the provider routing preferences for a specific plugin.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param list<string> $preferences Ordered list of provider slugs. Empty means use global.
+		 * @param string       $plugin_id   The plugin identifier.
+		 */
+		return (array) apply_filters( 'wpai_plugin_provider_preferences', $preferences, $plugin_id );
+	}
+
+	/**
+	 * Sanitizes a plugin ID for use as an option key suffix.
+	 *
+	 * Lowercases the string and replaces any character that is not a-z, 0-9,
+	 * or underscore with an underscore.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id The plugin identifier.
+	 * @return string The sanitized key, safe for use in option names.
+	 */
+	public function sanitize_option_key( string $plugin_id ): string {
+		return preg_replace( '/[^a-z0-9_]/', '_', strtolower( $plugin_id ) ) ?? '';
+	}
+}

--- a/includes/Permissions/Permissions_Manager.php
+++ b/includes/Permissions/Permissions_Manager.php
@@ -49,6 +49,23 @@ final class Permissions_Manager {
 	public const PLUGIN_PROVIDER_OPTION_PREFIX = 'wpai_plugin_providers_';
 
 	/**
+	 * Known AI capabilities that plugins may request.
+	 *
+	 * @since 1.0.0
+	 * @var list<string>
+	 */
+	public const KNOWN_CAPABILITIES = array(
+		'text_generation',
+		'chat_history',
+		'image_generation',
+		'embedding_generation',
+		'text_to_speech_conversion',
+		'speech_generation',
+		'music_generation',
+		'video_generation',
+	);
+
+	/**
 	 * Singleton instance.
 	 *
 	 * @since 1.0.0
@@ -156,12 +173,20 @@ final class Permissions_Manager {
 	 * Also checks the global AI features toggle — if AI is globally disabled,
 	 * this returns false regardless of the plugin's individual access setting.
 	 *
+	 * When a capability is specified, the method additionally verifies that
+	 * the plugin explicitly registered that capability during plugin registration.
+	 * This mirrors how OAuth scopes work: a plugin must declare what it intends
+	 * to use, and the admin grants blanket access, but the system still enforces
+	 * that only declared capabilities are consumable.
+	 *
 	 * @since 1.0.0
 	 *
-	 * @param string $plugin_id The plugin identifier.
-	 * @return bool True if the plugin is allowed to use AI providers, false otherwise.
+	 * @param string $plugin_id  The plugin identifier.
+	 * @param string $capability Optional. A specific AI capability to check (e.g. 'text_generation').
+	 *                           If empty, only the general access check is performed.
+	 * @return bool True if the plugin is allowed to use AI providers (and the requested capability), false otherwise.
 	 */
-	public function plugin_has_access( string $plugin_id ): bool {
+	public function plugin_has_access( string $plugin_id, string $capability = '' ): bool {
 		// Unregistered plugins are always denied.
 		if ( ! $this->plugin_registry->has_plugin( $plugin_id ) ) {
 			return false;
@@ -181,10 +206,30 @@ final class Permissions_Manager {
 		 *
 		 * @since 1.0.0
 		 *
-		 * @param bool   $has_access Whether the plugin has been granted access.
-		 * @param string $plugin_id  The plugin identifier.
+		 * @param bool   $has_access  Whether the plugin has been granted access.
+		 * @param string $plugin_id   The plugin identifier.
+		 * @param string $capability  The requested capability (empty string if none).
 		 */
-		return (bool) apply_filters( 'wpai_plugin_ai_access', $has_access, $plugin_id );
+		$has_access = (bool) apply_filters( 'wpai_plugin_ai_access', $has_access, $plugin_id, $capability );
+
+		if ( ! $has_access ) {
+			return false;
+		}
+
+		// If a specific capability was requested, verify the plugin declared it.
+		if ( '' !== $capability ) {
+			$plugin = $this->plugin_registry->get_plugin( $plugin_id );
+			if ( null === $plugin || empty( $plugin['capabilities'] ) ) {
+				// Plugin registered without capabilities — allow for backward compatibility.
+				return true;
+			}
+
+			if ( ! in_array( $capability, $plugin['capabilities'], true ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/includes/Permissions/Permissions_Manager.php
+++ b/includes/Permissions/Permissions_Manager.php
@@ -49,21 +49,16 @@ final class Permissions_Manager {
 	public const PLUGIN_PROVIDER_OPTION_PREFIX = 'wpai_plugin_providers_';
 
 	/**
-	 * Known AI capabilities that plugins may request.
+	 * Option name prefix for per-capability admin toggles.
+	 *
+	 * Full option name: `wpai_plugin_cap_{sanitized_plugin_id}_{capability}`.
+	 * Defaults to true — all declared capabilities are enabled unless an admin explicitly disables one.
 	 *
 	 * @since 1.0.0
-	 * @var list<string>
+	 * @var string
 	 */
-	public const KNOWN_CAPABILITIES = array(
-		'text_generation',
-		'chat_history',
-		'image_generation',
-		'embedding_generation',
-		'text_to_speech_conversion',
-		'speech_generation',
-		'music_generation',
-		'video_generation',
-	);
+	public const PLUGIN_CAPABILITY_OPTION_PREFIX = 'wpai_plugin_cap_';
+
 
 	/**
 	 * Singleton instance.
@@ -216,7 +211,7 @@ final class Permissions_Manager {
 			return false;
 		}
 
-		// If a specific capability was requested, verify the plugin declared it.
+		// If a specific capability was requested, verify the plugin declared it and the admin has not disabled it.
 		if ( '' !== $capability ) {
 			$plugin = $this->plugin_registry->get_plugin( $plugin_id );
 			if ( null === $plugin || empty( $plugin['capabilities'] ) ) {
@@ -225,6 +220,14 @@ final class Permissions_Manager {
 			}
 
 			if ( ! in_array( $capability, $plugin['capabilities'], true ) ) {
+				return false;
+			}
+
+			// Check whether the admin has explicitly disabled this specific capability.
+			// Defaults to true so all declared capabilities are on when a plugin is first granted access.
+			$cap_option = self::PLUGIN_CAPABILITY_OPTION_PREFIX
+				. $this->sanitize_option_key( $plugin_id ) . '_' . $capability;
+			if ( ! (bool) get_option( $cap_option, true ) ) {
 				return false;
 			}
 		}

--- a/includes/Permissions/Plugin_Registry.php
+++ b/includes/Permissions/Plugin_Registry.php
@@ -37,7 +37,7 @@ final class Plugin_Registry {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @var array<string, array{id: string, name: string, description: string}>
+	 * @var array<string, array{id: string, name: string, description: string, capabilities: list<string>}>
 	 */
 	private array $plugins = array();
 
@@ -49,11 +49,13 @@ final class Plugin_Registry {
 	 * @since 1.0.0
 	 *
 	 * @param string $plugin_id Unique plugin identifier (e.g. 'my-plugin').
-	 * @param array{name?: string, description?: string} $args {
+	 * @param array{name?: string, description?: string, capabilities?: list<string>} $args {
 	 *     Optional plugin arguments.
 	 *
-	 *     @type string $name        Human-readable plugin name. Defaults to the plugin ID.
-	 *     @type string $description Brief description of how AI is used by this plugin.
+	 *     @type string       $name         Human-readable plugin name. Defaults to the plugin ID.
+	 *     @type string       $description  Brief description of how AI is used by this plugin.
+	 *     @type list<string> $capabilities List of AI capability slugs this plugin requires
+	 *                                      (e.g. 'text_generation', 'image_generation'). Defaults to empty.
 	 * }
 	 * @return void
 	 */
@@ -62,10 +64,20 @@ final class Plugin_Registry {
 			return;
 		}
 
+		$capabilities = array();
+		if ( isset( $args['capabilities'] ) && is_array( $args['capabilities'] ) ) {
+			$capabilities = array_values(
+				array_filter(
+					array_map( 'sanitize_key', $args['capabilities'] )
+				)
+			);
+		}
+
 		$this->plugins[ $plugin_id ] = array(
-			'id'          => $plugin_id,
-			'name'        => sanitize_text_field( $args['name'] ?? $plugin_id ),
-			'description' => sanitize_textarea_field( $args['description'] ?? '' ),
+			'id'           => $plugin_id,
+			'name'         => sanitize_text_field( $args['name'] ?? $plugin_id ),
+			'description'  => sanitize_textarea_field( $args['description'] ?? '' ),
+			'capabilities' => $capabilities,
 		);
 	}
 
@@ -74,7 +86,7 @@ final class Plugin_Registry {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array<string, array{id: string, name: string, description: string}>
+	 * @return array<string, array{id: string, name: string, description: string, capabilities: list<string>}>
 	 */
 	public function get_all_plugins(): array {
 		return $this->plugins;
@@ -86,7 +98,7 @@ final class Plugin_Registry {
 	 * @since 1.0.0
 	 *
 	 * @param string $plugin_id The plugin identifier.
-	 * @return array{id: string, name: string, description: string}|null Plugin data, or null if not found.
+	 * @return array{id: string, name: string, description: string, capabilities: list<string>}|null Plugin data, or null if not found.
 	 */
 	public function get_plugin( string $plugin_id ): ?array {
 		return $this->plugins[ $plugin_id ] ?? null;

--- a/includes/Permissions/Plugin_Registry.php
+++ b/includes/Permissions/Plugin_Registry.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Plugin Registry for AI access control.
+ *
+ * @package WordPress\AI\Permissions
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Permissions;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registry for plugins that have declared themselves as AI consumers.
+ *
+ * Third-party plugins register themselves via the `wpai_register_plugins` action hook.
+ * Site admins can then grant or revoke AI provider access per plugin via the settings page.
+ *
+ * Example usage:
+ * ```php
+ * add_action( 'wpai_register_plugins', function( $registry ) {
+ *     $registry->register_plugin( 'my-plugin', array(
+ *         'name'        => 'My Plugin',
+ *         'description' => 'Uses AI for content generation.',
+ *     ) );
+ * } );
+ * ```
+ *
+ * @since 1.0.0
+ */
+final class Plugin_Registry {
+
+	/**
+	 * Registered plugins.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @var array<string, array{id: string, name: string, description: string}>
+	 */
+	private array $plugins = array();
+
+	/**
+	 * Registers a plugin as an AI consumer.
+	 *
+	 * If a plugin with the same ID is already registered, this call is a no-op.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id Unique plugin identifier (e.g. 'my-plugin').
+	 * @param array{name?: string, description?: string} $args {
+	 *     Optional plugin arguments.
+	 *
+	 *     @type string $name        Human-readable plugin name. Defaults to the plugin ID.
+	 *     @type string $description Brief description of how AI is used by this plugin.
+	 * }
+	 * @return void
+	 */
+	public function register_plugin( string $plugin_id, array $args = array() ): void {
+		if ( isset( $this->plugins[ $plugin_id ] ) ) {
+			return;
+		}
+
+		$this->plugins[ $plugin_id ] = array(
+			'id'          => $plugin_id,
+			'name'        => sanitize_text_field( $args['name'] ?? $plugin_id ),
+			'description' => sanitize_textarea_field( $args['description'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Returns all registered plugins.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array<string, array{id: string, name: string, description: string}>
+	 */
+	public function get_all_plugins(): array {
+		return $this->plugins;
+	}
+
+	/**
+	 * Returns a single registered plugin by ID.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id The plugin identifier.
+	 * @return array{id: string, name: string, description: string}|null Plugin data, or null if not found.
+	 */
+	public function get_plugin( string $plugin_id ): ?array {
+		return $this->plugins[ $plugin_id ] ?? null;
+	}
+
+	/**
+	 * Checks whether a plugin is registered.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $plugin_id The plugin identifier.
+	 * @return bool True if the plugin is registered, false otherwise.
+	 */
+	public function has_plugin( string $plugin_id ): bool {
+		return isset( $this->plugins[ $plugin_id ] );
+	}
+}

--- a/includes/Services/AI_Service.php
+++ b/includes/Services/AI_Service.php
@@ -173,7 +173,7 @@ class AI_Service {
 	public function create_textgen_prompt_for_plugin( string $plugin_id, ?string $prompt = null, array $options = array() ) {
 		$permissions = Permissions_Manager::get_instance();
 
-		if ( ! $permissions->plugin_has_access( $plugin_id ) ) {
+		if ( ! $permissions->plugin_has_access( $plugin_id, 'text_generation' ) ) {
 			return null;
 		}
 

--- a/includes/Services/AI_Service.php
+++ b/includes/Services/AI_Service.php
@@ -11,8 +11,8 @@ declare( strict_types=1 );
 
 namespace WordPress\AI\Services;
 
+use WordPress\AI\Permissions\Permissions_Manager;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
-
 use function WordPress\AI\get_preferred_models_for_text_generation;
 
 /**
@@ -131,6 +131,73 @@ class AI_Service {
 		}
 
 		// Apply options via ModelConfig if any are provided.
+		if ( ! empty( $options ) ) {
+			$config_array = $this->map_options_to_config( $options );
+			if ( ! empty( $config_array ) ) {
+				$config  = ModelConfig::fromArray( $config_array );
+				$builder = $builder->using_model_config( $config );
+			}
+		}
+
+		return $builder;
+	}
+
+	/**
+	 * Creates a text generation prompt builder scoped to a specific plugin.
+	 *
+	 * Performs an access check for the plugin before creating the prompt builder.
+	 * Returns null if the plugin has not been granted AI access by the site admin,
+	 * so callers should check the return value before proceeding.
+	 *
+	 * If the site admin has configured provider routing preferences for the plugin,
+	 * the prompt builder will be limited to those providers. Otherwise it falls back
+	 * to the global preferred models list.
+	 *
+	 * Example usage:
+	 * ```php
+	 * $service = WordPress\AI\get_ai_service();
+	 * $builder = $service->create_textgen_prompt_for_plugin( 'my-plugin', 'Summarize this' );
+	 * if ( null === $builder ) {
+	 *     return new WP_Error( 'ai_access_denied', 'AI access is not enabled for this plugin.' );
+	 * }
+	 * $text = $builder->generate_text();
+	 * ```
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $plugin_id The plugin identifier used during registration.
+	 * @param string|null          $prompt    Optional. Initial prompt content.
+	 * @param array<string, mixed> $options   Optional. Same options as {@see AI_Service::create_textgen_prompt()}.
+	 * @return \WP_AI_Client_Prompt_Builder|null The configured prompt builder, or null if access is denied.
+	 */
+	public function create_textgen_prompt_for_plugin( string $plugin_id, ?string $prompt = null, array $options = array() ) {
+		$permissions = Permissions_Manager::get_instance();
+
+		if ( ! $permissions->plugin_has_access( $plugin_id ) ) {
+			return null;
+		}
+
+		$builder = wp_ai_client_prompt( $prompt );
+
+		// Use plugin-specific provider preferences, or fall back to global.
+		$provider_prefs = $permissions->get_plugin_provider_preferences( $plugin_id );
+		if ( ! empty( $provider_prefs ) ) {
+			$all_models = get_preferred_models_for_text_generation();
+			$filtered   = array_values(
+				array_filter(
+					$all_models,
+					static fn( array $m ): bool => in_array( $m[0], $provider_prefs, true )
+				)
+			);
+			$models     = ! empty( $filtered ) ? $filtered : $all_models;
+		} else {
+			$models = get_preferred_models_for_text_generation();
+		}
+
+		if ( ! empty( $models ) ) {
+			$builder = $builder->using_model_preference( ...$models );
+		}
+
 		if ( ! empty( $options ) ) {
 			$config_array = $this->map_options_to_config( $options );
 			if ( ! empty( $config_array ) ) {

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -341,6 +341,24 @@ class Settings_Page {
 							</p>
 						<?php endif; ?>
 
+					<?php if ( ! empty( $plugin['capabilities'] ) ) : ?>
+						<p class="description ai-plugin-capabilities">
+							<strong><?php esc_html_e( 'Requested capabilities:', 'ai' ); ?></strong>
+							<?php
+							$capability_labels = array_map(
+								static function ( string $cap ): string {
+									return '<code>' . esc_html( $cap ) . '</code>';
+								},
+								$plugin['capabilities']
+							);
+							echo wp_kses(
+								implode( ', ', $capability_labels ),
+								array( 'code' => array() )
+							);
+							?>
+						</p>
+					<?php endif; ?>
+
 						<div class="ai-plugin-provider-routing">
 							<label for="<?php echo esc_attr( $providers_id ); ?>">
 								<?php esc_html_e( 'Limit to providers (optional)', 'ai' ); ?>

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -15,6 +15,8 @@ use WordPress\AI\Asset_Loader;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\Features\Feature_Category;
 use WordPress\AI\Features\Registry;
+use WordPress\AI\Permissions\Permissions_Manager;
+use function WordPress\AI\get_preferred_models_for_text_generation;
 use function WordPress\AI\has_ai_credentials;
 use function WordPress\AI\has_valid_ai_credentials;
 
@@ -190,16 +192,18 @@ class Settings_Page {
 						</div>
 					</div>
 
-					<?php
+					<?php $this->render_plugin_permissions_section( $global_enabled ); ?>
+
+				<?php
 					// Group experiments by category, normalizing unknown categories to OTHER.
 					$known_categories        = array( Experiment_Category::EDITOR, Experiment_Category::ADMIN );
 					$experiments_by_category = array();
-					foreach ( $this->registry->get_all_features() as $experiment ) {
-						$category                               = in_array( $experiment->get_category(), $known_categories, true )
-							? $experiment->get_category()
-							: Feature_Category::OTHER;
-						$experiments_by_category[ $category ][] = $experiment;
-					}
+				foreach ( $this->registry->get_all_features() as $experiment ) {
+					$category                               = in_array( $experiment->get_category(), $known_categories, true )
+						? $experiment->get_category()
+						: Feature_Category::OTHER;
+					$experiments_by_category[ $category ][] = $experiment;
+				}
 
 					$this->render_experiments_section(
 						'ai-experiments-editor-heading',
@@ -224,7 +228,7 @@ class Settings_Page {
 						$experiments_by_category[ Feature_Category::OTHER ] ?? array(),
 						$global_enabled
 					);
-					?>
+				?>
 				</div>
 
 				<?php submit_button(); ?>
@@ -253,6 +257,120 @@ class Settings_Page {
 				})();
 			</script>
 		</div>
+		<?php
+	}
+
+	/**
+	 * Renders the plugin permissions section.
+	 *
+	 * Displays a card allowing site admins to grant or revoke AI provider access
+	 * for each third-party plugin that has registered via `wpai_register_plugins`.
+	 * Also allows configuring per-plugin provider routing preferences.
+	 *
+	 * The section is hidden if no plugins have registered themselves.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param bool $global_enabled Whether the global AI toggle is currently on.
+	 * @return void
+	 */
+	private function render_plugin_permissions_section( bool $global_enabled ): void {
+		$permissions_manager = Permissions_Manager::get_instance();
+		$plugins             = $permissions_manager->get_plugin_registry()->get_all_plugins();
+
+		if ( empty( $plugins ) ) {
+			return;
+		}
+
+		// Build the list of available provider slugs from the global preferences.
+		$known_providers = array_unique(
+			array_column( get_preferred_models_for_text_generation(), 0 )
+		);
+		?>
+
+		<div class="ai-experiments__card" role="region" aria-labelledby="ai-plugin-permissions-heading">
+			<div class="ai-experiments__card-heading">
+				<h2 id="ai-plugin-permissions-heading"><?php esc_html_e( 'Plugin Permissions', 'ai' ); ?></h2>
+				<p class="description">
+					<?php esc_html_e( 'Control which plugins are allowed to use connected AI providers. Only plugins that have declared their intent to use AI appear here.', 'ai' ); ?>
+				</p>
+
+				<?php if ( ! $global_enabled ) : ?>
+					<div class="notice notice-info inline ai-experiments__notice" role="status" aria-live="polite">
+						<p><?php esc_html_e( 'Enable AI above to configure plugin permissions.', 'ai' ); ?></p>
+					</div>
+				<?php endif; ?>
+			</div>
+
+			<ul class="ai-experiments__list">
+				<?php foreach ( $plugins as $plugin ) : ?>
+					<?php
+					$plugin_key       = $permissions_manager->sanitize_option_key( $plugin['id'] );
+					$access_option    = Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key;
+					$providers_option = Permissions_Manager::PLUGIN_PROVIDER_OPTION_PREFIX . $plugin_key;
+					$plugin_access    = (bool) get_option( $access_option, false );
+					$plugin_providers = (string) get_option( $providers_option, '' );
+					$disabled_class   = ! $global_enabled ? 'ai-experiments__item--disabled' : '';
+					$desc_id          = 'ai-plugin-' . esc_attr( $plugin_key ) . '-desc';
+					$providers_id     = 'ai-plugin-' . esc_attr( $plugin_key ) . '-providers';
+					?>
+
+					<li class="ai-experiments__item <?php echo esc_attr( $disabled_class ); ?>">
+						<div class="ai-experiments__item-header">
+							<label class="components-toggle-control" for="<?php echo esc_attr( $access_option ); ?>">
+								<input
+									type="checkbox"
+									name="<?php echo esc_attr( $access_option ); ?>"
+									id="<?php echo esc_attr( $access_option ); ?>"
+									value="1"
+									<?php checked( $plugin_access ); ?>
+									<?php disabled( ! $global_enabled ); ?>
+									<?php if ( ! empty( $plugin['description'] ) ) : ?>
+										aria-describedby="<?php echo esc_attr( $desc_id ); ?>"
+									<?php endif; ?>
+								/>
+								<span>
+									<strong><?php echo esc_html( $plugin['name'] ); ?></strong>
+								</span>
+							</label>
+						</div>
+
+						<?php if ( ! empty( $plugin['description'] ) ) : ?>
+							<p class="description" id="<?php echo esc_attr( $desc_id ); ?>">
+								<?php echo esc_html( $plugin['description'] ); ?>
+							</p>
+						<?php endif; ?>
+
+						<div class="ai-plugin-provider-routing">
+							<label for="<?php echo esc_attr( $providers_id ); ?>">
+								<?php esc_html_e( 'Limit to providers (optional)', 'ai' ); ?>
+							</label>
+							<input
+								type="text"
+								name="<?php echo esc_attr( $providers_option ); ?>"
+								id="<?php echo esc_attr( $providers_id ); ?>"
+								value="<?php echo esc_attr( $plugin_providers ); ?>"
+								placeholder="<?php echo esc_attr( implode( ', ', $known_providers ) ); ?>"
+								<?php disabled( ! $global_enabled ); ?>
+								class="regular-text"
+							/>
+							<p class="description">
+								<?php
+								echo esc_html(
+									sprintf(
+										/* translators: %s: comma-separated list of available provider slugs. */
+										__( 'Comma-separated list of provider slugs this plugin may use (e.g. %s). Leave empty to allow all configured providers.', 'ai' ),
+										implode( ', ', $known_providers )
+									)
+								);
+								?>
+							</p>
+						</div>
+					</li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+
 		<?php
 	}
 

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -16,7 +16,7 @@ use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\Features\Feature_Category;
 use WordPress\AI\Features\Registry;
 use WordPress\AI\Permissions\Permissions_Manager;
-use function WordPress\AI\get_preferred_models_for_text_generation;
+use function WordPress\AI\get_available_ai_providers;
 use function WordPress\AI\has_ai_credentials;
 use function WordPress\AI\has_valid_ai_credentials;
 
@@ -132,6 +132,15 @@ class Settings_Page {
 		}
 
 		$global_enabled = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
+		$has_plugins    = ! empty( Permissions_Manager::get_instance()->get_plugin_registry()->get_all_plugins() );
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$active_tab = isset( $_GET['tab'] ) ? sanitize_key( $_GET['tab'] ) : 'general';
+		$valid_tabs = $has_plugins ? array( 'general', 'plugin-permissions' ) : array( 'general' );
+		if ( ! in_array( $active_tab, $valid_tabs, true ) ) {
+			$active_tab = 'general';
+		}
+		$general_tab_url     = admin_url( 'options-general.php?page=' . self::PAGE_SLUG );
+		$permissions_tab_url = admin_url( 'options-general.php?page=' . self::PAGE_SLUG . '&tab=plugin-permissions' );
 		?>
 		<div class="wrap">
 			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
@@ -159,80 +168,115 @@ class Settings_Page {
 
 			<?php settings_errors( 'ai_experiments' ); ?>
 
-			<form method="post" action="options.php" id="ai-experiments-form">
-				<?php
-				settings_fields( Settings_Registration::OPTION_GROUP );
-				?>
+			<nav class="nav-tab-wrapper wp-clearfix" aria-label="<?php esc_attr_e( 'AI settings tabs', 'ai' ); ?>">
+				<a
+					href="<?php echo esc_url( $general_tab_url ); ?>"
+					class="nav-tab <?php echo 'general' === $active_tab ? 'nav-tab-active' : ''; ?>"
+				>
+					<?php esc_html_e( 'General', 'ai' ); ?>
+				</a>
+				<?php if ( $has_plugins ) : ?>
+					<a
+						href="<?php echo esc_url( $permissions_tab_url ); ?>"
+						class="nav-tab <?php echo 'plugin-permissions' === $active_tab ? 'nav-tab-active' : ''; ?>"
+					>
+						<?php esc_html_e( 'Plugin Permissions', 'ai' ); ?>
+					</a>
+				<?php endif; ?>
+			</nav>
 
-				<div class="ai-experiments">
-					<!-- Global Toggle Section -->
-					<div class="ai-experiments__card ai-experiments__card--global">
-						<div class="ai-experiments__card-heading">
-							<h2><?php esc_html_e( 'General Settings', 'ai' ); ?></h2>
-							<p class="description" id="ai-experiments-global-desc">
-								<?php esc_html_e( 'Control whether AI is enabled for your site. When disabled, all features and experiments will be inactive regardless of their individual settings.', 'ai' ); ?>
-							</p>
+			<form method="post" action="options.php" id="ai-experiments-form">
+				<?php settings_fields( Settings_Registration::OPTION_GROUP ); ?>
+
+				<!-- General tab -->
+				<div class="ai-tab-panel <?php echo 'general' === $active_tab ? 'ai-tab-panel--active' : ''; ?>">
+					<div class="ai-experiments">
+						<!-- Global Toggle Section -->
+						<div class="ai-experiments__card ai-experiments__card--global">
+							<div class="ai-experiments__card-heading">
+								<h2><?php esc_html_e( 'General Settings', 'ai' ); ?></h2>
+								<p class="description" id="ai-experiments-global-desc">
+									<?php esc_html_e( 'Control whether AI is enabled for your site. When disabled, all features and experiments will be inactive regardless of their individual settings.', 'ai' ); ?>
+								</p>
+							</div>
+
+							<div class="ai-experiments__toggle">
+								<input
+									type="hidden"
+									name="<?php echo esc_attr( Settings_Registration::GLOBAL_OPTION ); ?>"
+									id="ai-experiments-enabled"
+									value="<?php echo $global_enabled ? '1' : '0'; ?>"
+								/>
+								<button
+									type="button"
+									class="button <?php echo $global_enabled ? 'button-secondary' : 'button-primary'; ?> ai-experiments__toggle-button"
+									data-ai-toggle-global="<?php echo $global_enabled ? '0' : '1'; ?>"
+									aria-describedby="ai-experiments-global-desc"
+								>
+									<?php echo $global_enabled ? esc_html__( 'Disable AI', 'ai' ) : esc_html__( 'Enable AI', 'ai' ); ?>
+								</button>
+							</div>
 						</div>
 
-						<div class="ai-experiments__toggle">
-							<input
-								type="hidden"
-								name="<?php echo esc_attr( Settings_Registration::GLOBAL_OPTION ); ?>"
-								id="ai-experiments-enabled"
-								value="<?php echo $global_enabled ? '1' : '0'; ?>"
-							/>
-							<button
-								type="button"
-								class="button <?php echo $global_enabled ? 'button-secondary' : 'button-primary'; ?> ai-experiments__toggle-button"
-								data-ai-toggle-global="<?php echo $global_enabled ? '0' : '1'; ?>"
-								aria-describedby="ai-experiments-global-desc"
-							>
-								<?php echo $global_enabled ? esc_html__( 'Disable AI', 'ai' ) : esc_html__( 'Enable AI', 'ai' ); ?>
-							</button>
+						<?php
+						// Group experiments by category, normalizing unknown categories to OTHER.
+						$known_categories        = array( Experiment_Category::EDITOR, Experiment_Category::ADMIN );
+						$experiments_by_category = array();
+						foreach ( $this->registry->get_all_features() as $experiment ) {
+							$category                               = in_array( $experiment->get_category(), $known_categories, true )
+								? $experiment->get_category()
+								: Feature_Category::OTHER;
+							$experiments_by_category[ $category ][] = $experiment;
+						}
+
+						$this->render_experiments_section(
+							'ai-experiments-editor-heading',
+							__( 'Editor Experiments', 'ai' ),
+							__( 'AI-powered experiments for the block editor, including content generation and enhancement tools.', 'ai' ),
+							$experiments_by_category[ Experiment_Category::EDITOR ] ?? array(),
+							$global_enabled
+						);
+
+						$this->render_experiments_section(
+							'ai-experiments-admin-heading',
+							__( 'Admin Experiments', 'ai' ),
+							__( 'AI-powered experiments for the WordPress admin area, including exploration and testing tools.', 'ai' ),
+							$experiments_by_category[ Experiment_Category::ADMIN ] ?? array(),
+							$global_enabled
+						);
+
+						$this->render_experiments_section(
+							'ai-experiments-other-heading',
+							__( 'Other Experiments', 'ai' ),
+							__( 'Additional experiments that do not fit into a specific category.', 'ai' ),
+							$experiments_by_category[ Feature_Category::OTHER ] ?? array(),
+							$global_enabled
+						);
+						?>
+					</div>
+				</div>
+
+				<!-- Plugin Permissions tab -->
+				<?php if ( $has_plugins ) : ?>
+					<div class="ai-tab-panel <?php echo 'plugin-permissions' === $active_tab ? 'ai-tab-panel--active' : ''; ?>">
+						<div class="ai-experiments">
+							<?php $this->render_plugin_permissions_section( $global_enabled ); ?>
 						</div>
 					</div>
-
-					<?php $this->render_plugin_permissions_section( $global_enabled ); ?>
-
-				<?php
-					// Group experiments by category, normalizing unknown categories to OTHER.
-					$known_categories        = array( Experiment_Category::EDITOR, Experiment_Category::ADMIN );
-					$experiments_by_category = array();
-				foreach ( $this->registry->get_all_features() as $experiment ) {
-					$category                               = in_array( $experiment->get_category(), $known_categories, true )
-						? $experiment->get_category()
-						: Feature_Category::OTHER;
-					$experiments_by_category[ $category ][] = $experiment;
-				}
-
-					$this->render_experiments_section(
-						'ai-experiments-editor-heading',
-						__( 'Editor Experiments', 'ai' ),
-						__( 'AI-powered experiments for the block editor, including content generation and enhancement tools.', 'ai' ),
-						$experiments_by_category[ Experiment_Category::EDITOR ] ?? array(),
-						$global_enabled
-					);
-
-					$this->render_experiments_section(
-						'ai-experiments-admin-heading',
-						__( 'Admin Experiments', 'ai' ),
-						__( 'AI-powered experiments for the WordPress admin area, including exploration and testing tools.', 'ai' ),
-						$experiments_by_category[ Experiment_Category::ADMIN ] ?? array(),
-						$global_enabled
-					);
-
-					$this->render_experiments_section(
-						'ai-experiments-other-heading',
-						__( 'Other Experiments', 'ai' ),
-						__( 'Additional experiments that do not fit into a specific category.', 'ai' ),
-						$experiments_by_category[ Feature_Category::OTHER ] ?? array(),
-						$global_enabled
-					);
-				?>
-				</div>
+				<?php endif; ?>
 
 				<?php submit_button(); ?>
 			</form>
+
+			<style>
+				.ai-tab-panel { display: none; }
+				.ai-tab-panel--active { display: block; }
+				.nav-tab-wrapper { margin-bottom: 0; }
+				.nav-tab-wrapper + form .ai-experiments { margin-top: 20px; }
+				.ai-provider-select { min-width: 220px; height: auto; min-height: 80px; }
+				.ai-plugin-provider-routing { margin-top: 10px; }
+				.ai-plugin-provider-routing > label { display: block; margin-bottom: 4px; font-weight: 600; }
+			</style>
 
 			<script>
 				(function() {
@@ -253,6 +297,17 @@ class Settings_Page {
 						}
 
 						form.submit();
+					});
+
+					// Sync each provider multi-select to its hidden input on change.
+					document.querySelectorAll('.ai-provider-select').forEach(function(select) {
+						function syncToHidden() {
+							const hiddenInput = document.getElementById(select.dataset.hiddenInput);
+							if (!hiddenInput) return;
+							const selected = Array.from(select.selectedOptions).map(function(o) { return o.value; });
+							hiddenInput.value = selected.join(',');
+						}
+						select.addEventListener('change', syncToHidden);
 					});
 				})();
 			</script>
@@ -282,10 +337,8 @@ class Settings_Page {
 			return;
 		}
 
-		// Build the list of available provider slugs from the global preferences.
-		$known_providers = array_unique(
-			array_column( get_preferred_models_for_text_generation(), 0 )
-		);
+		// Build the list of available providers from the live connector registry.
+		$available_providers = get_available_ai_providers();
 		?>
 
 		<div class="ai-experiments__card" role="region" aria-labelledby="ai-plugin-permissions-heading">
@@ -297,7 +350,7 @@ class Settings_Page {
 
 				<?php if ( ! $global_enabled ) : ?>
 					<div class="notice notice-info inline ai-experiments__notice" role="status" aria-live="polite">
-						<p><?php esc_html_e( 'Enable AI above to configure plugin permissions.', 'ai' ); ?></p>
+						<p><?php esc_html_e( 'Enable AI on the General tab to configure plugin permissions.', 'ai' ); ?></p>
 					</div>
 				<?php endif; ?>
 			</div>
@@ -342,47 +395,75 @@ class Settings_Page {
 						<?php endif; ?>
 
 					<?php if ( ! empty( $plugin['capabilities'] ) ) : ?>
-						<p class="description ai-plugin-capabilities">
-							<strong><?php esc_html_e( 'Requested capabilities:', 'ai' ); ?></strong>
-							<?php
-							$capability_labels = array_map(
-								static function ( string $cap ): string {
-									return '<code>' . esc_html( $cap ) . '</code>';
-								},
-								$plugin['capabilities']
-							);
-							echo wp_kses(
-								implode( ', ', $capability_labels ),
-								array( 'code' => array() )
-							);
-							?>
-						</p>
+						<fieldset class="ai-plugin-capabilities">
+							<legend class="description">
+								<strong><?php esc_html_e( 'Permitted capabilities:', 'ai' ); ?></strong>
+							</legend>
+							<ul>
+								<?php foreach ( $plugin['capabilities'] as $capability ) : ?>
+									<?php
+									$cap_option  = Permissions_Manager::PLUGIN_CAPABILITY_OPTION_PREFIX . $plugin_key . '_' . $capability;
+									$cap_enabled = (bool) get_option( $cap_option, true );
+									$cap_id      = 'ai-plugin-' . esc_attr( $plugin_key ) . '-cap-' . esc_attr( $capability );
+									?>
+									<li>
+										<label for="<?php echo esc_attr( $cap_id ); ?>">
+											<input
+												type="checkbox"
+												name="<?php echo esc_attr( $cap_option ); ?>"
+												id="<?php echo esc_attr( $cap_id ); ?>"
+												value="1"
+												<?php checked( $cap_enabled ); ?>
+												<?php disabled( ! $global_enabled ); ?>
+											/>
+											<code><?php echo esc_html( $capability ); ?></code>
+										</label>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+						</fieldset>
 					<?php endif; ?>
 
+						<?php
+						$selected_providers = array_filter( array_map( 'trim', explode( ',', $plugin_providers ) ) );
+						$hidden_id          = $providers_id . '_hidden';
+						?>
 						<div class="ai-plugin-provider-routing">
 							<label for="<?php echo esc_attr( $providers_id ); ?>">
 								<?php esc_html_e( 'Limit to providers (optional)', 'ai' ); ?>
 							</label>
+							<!-- Hidden input holds the comma-separated value that gets submitted -->
 							<input
-								type="text"
+								type="hidden"
 								name="<?php echo esc_attr( $providers_option ); ?>"
-								id="<?php echo esc_attr( $providers_id ); ?>"
+								id="<?php echo esc_attr( $hidden_id ); ?>"
 								value="<?php echo esc_attr( $plugin_providers ); ?>"
-								placeholder="<?php echo esc_attr( implode( ', ', $known_providers ) ); ?>"
-								<?php disabled( ! $global_enabled ); ?>
-								class="regular-text"
 							/>
-							<p class="description">
-								<?php
-								echo esc_html(
-									sprintf(
-										/* translators: %s: comma-separated list of available provider slugs. */
-										__( 'Comma-separated list of provider slugs this plugin may use (e.g. %s). Leave empty to allow all configured providers.', 'ai' ),
-										implode( ', ', $known_providers )
-									)
-								);
-								?>
-							</p>
+							<?php if ( ! empty( $available_providers ) ) : ?>
+								<select
+									multiple
+									id="<?php echo esc_attr( $providers_id ); ?>"
+									data-hidden-input="<?php echo esc_attr( $hidden_id ); ?>"
+									class="ai-provider-select"
+									<?php disabled( ! $global_enabled ); ?>
+								>
+									<?php foreach ( $available_providers as $slug => $display_name ) : ?>
+										<option
+											value="<?php echo esc_attr( $slug ); ?>"
+											<?php selected( in_array( $slug, $selected_providers, true ) ); ?>
+										>
+											<?php echo esc_html( $display_name ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+								<p class="description">
+									<?php esc_html_e( 'Select one or more providers this plugin may use. Leave all unselected to allow all configured providers.', 'ai' ); ?>
+								</p>
+							<?php else : ?>
+								<p class="description">
+									<?php esc_html_e( 'No AI providers are currently connected.', 'ai' ); ?>
+								</p>
+							<?php endif; ?>
 						</div>
 					</li>
 				<?php endforeach; ?>

--- a/includes/Settings/Settings_Registration.php
+++ b/includes/Settings/Settings_Registration.php
@@ -153,6 +153,20 @@ class Settings_Registration {
 					'sanitize_callback' => array( $this, 'sanitize_provider_preferences' ),
 				)
 			);
+
+			// Register a boolean toggle for each declared capability.
+			// Defaults to true — capabilities are on when a plugin is first granted access.
+			foreach ( $plugin['capabilities'] as $capability ) {
+				register_setting(
+					self::OPTION_GROUP,
+					Permissions_Manager::PLUGIN_CAPABILITY_OPTION_PREFIX . $plugin_key . '_' . $capability,
+					array(
+						'type'              => 'boolean',
+						'default'           => true,
+						'sanitize_callback' => 'rest_sanitize_boolean',
+					)
+				);
+			}
 		}
 	}
 

--- a/includes/Settings/Settings_Registration.php
+++ b/includes/Settings/Settings_Registration.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace WordPress\AI\Settings;
 
 use WordPress\AI\Features\Registry;
+use WordPress\AI\Permissions\Permissions_Manager;
 
 /**
  * Handles registration of settings for the AI plugin.
@@ -110,5 +111,72 @@ class Settings_Registration {
 
 			$feature->register_settings();
 		}
+
+		// Register plugin permission settings.
+		$this->register_plugin_permission_settings();
+	}
+
+	/**
+	 * Registers settings options for each plugin that has declared itself as an AI consumer.
+	 *
+	 * Two options are registered per plugin:
+	 * - A boolean access toggle (`wpai_plugin_access_{key}`).
+	 * - A string of comma-separated provider slugs for routing (`wpai_plugin_providers_{key}`).
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return void
+	 */
+	private function register_plugin_permission_settings(): void {
+		$permissions_manager = Permissions_Manager::get_instance();
+		$plugin_registry     = $permissions_manager->get_plugin_registry();
+
+		foreach ( $plugin_registry->get_all_plugins() as $plugin ) {
+			$plugin_key = $permissions_manager->sanitize_option_key( $plugin['id'] );
+
+			register_setting(
+				self::OPTION_GROUP,
+				Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key,
+				array(
+					'type'              => 'boolean',
+					'default'           => false,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+				)
+			);
+
+			register_setting(
+				self::OPTION_GROUP,
+				Permissions_Manager::PLUGIN_PROVIDER_OPTION_PREFIX . $plugin_key,
+				array(
+					'type'              => 'string',
+					'default'           => '',
+					'sanitize_callback' => array( $this, 'sanitize_provider_preferences' ),
+				)
+			);
+		}
+	}
+
+	/**
+	 * Sanitizes a comma-separated list of provider slugs.
+	 *
+	 * Each provider slug is sanitized with `sanitize_key()`. Empty values are discarded.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param mixed $value The raw submitted value.
+	 * @return string A sanitized, comma-separated list of provider slugs.
+	 */
+	public function sanitize_provider_preferences( $value ): string {
+		if ( empty( $value ) || ! is_string( $value ) ) {
+			return '';
+		}
+
+		$providers = array_values(
+			array_filter(
+				array_map( 'sanitize_key', explode( ',', $value ) )
+			)
+		);
+
+		return implode( ',', $providers );
 	}
 }

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -17,6 +17,7 @@ use WordPress\AI\Admin\Upgrades;
 use WordPress\AI\Experiments\Experiments;
 use WordPress\AI\Features\Loader;
 use WordPress\AI\Features\Registry;
+use WordPress\AI\Permissions\Permissions_Manager;
 use WordPress\AI\Settings\Settings_Page;
 use WordPress\AI\Settings\Settings_Registration;
 
@@ -204,6 +205,10 @@ function initialize_features(): void {
 		$loader   = new Loader( $registry );
 		$loader->register_features();
 		$loader->initialize_features();
+
+		// Initialize plugin permissions registry.
+		$permissions_manager = Permissions_Manager::get_instance();
+		$permissions_manager->initialize();
 
 		// Initialize settings registration.
 		$settings_registration = new Settings_Registration( $registry );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace WordPress\AI;
 
 use Throwable;
+use WordPress\AI\Permissions\Permissions_Manager;
 use WordPress\AI\Services\AI_Service;
 
 /**
@@ -292,6 +293,31 @@ function get_preferred_vision_models(): array {
 	 * @return array<int, array{string, string}> The filtered preferred vision models.
 	 */
 	return (array) apply_filters( 'wpai_preferred_vision_models', $preferred_models );
+}
+
+/**
+ * Checks whether a plugin has been granted access to connected AI providers.
+ *
+ * Plugins must first register themselves via the `wpai_register_plugins` action hook.
+ * Site admins can then grant or revoke access per plugin on the AI settings page.
+ *
+ * This also checks the global AI features toggle — if AI is globally disabled,
+ * this returns false regardless of the plugin's individual access setting.
+ *
+ * Example usage:
+ * ```php
+ * if ( ! WordPress\AI\plugin_has_ai_access( 'my-plugin' ) ) {
+ *     return new WP_Error( 'ai_access_denied', 'AI access is not enabled for this plugin.' );
+ * }
+ * ```
+ *
+ * @since 1.0.0
+ *
+ * @param string $plugin_id The plugin identifier used during registration.
+ * @return bool True if the plugin has been granted AI access, false otherwise.
+ */
+function plugin_has_ai_access( string $plugin_id ): bool {
+	return Permissions_Manager::get_instance()->plugin_has_access( $plugin_id );
 }
 
 /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -296,6 +296,69 @@ function get_preferred_vision_models(): array {
 }
 
 /**
+ * Returns the available AI provider slugs registered as connectors.
+ *
+ * Reads the live connector registry so the list always reflects what is
+ * actually configured on the site. Third-party provider plugins that register
+ * via `wp_connectors_init` are included automatically.
+ *
+ * Use the `wpai_available_providers` filter to add custom provider slugs that
+ * are not registered as WordPress connectors (e.g. a self-hosted provider).
+ *
+ * Example usage:
+ * ```php
+ * add_filter( 'wpai_available_providers', function( array $providers ): array {
+ *     $providers['my-provider'] = 'My Custom Provider';
+ *     return $providers;
+ * } );
+ * ```
+ *
+ * @since 1.0.0
+ *
+ * @return array<string, string> Provider slugs mapped to display names (e.g. ['anthropic' => 'Anthropic']).
+ */
+function get_available_ai_providers(): array {
+	$providers = array();
+
+	if ( function_exists( 'wp_get_connectors' ) ) {
+		foreach ( wp_get_connectors() as $connector_id => $connector_data ) {
+			if ( 'ai_provider' !== ( $connector_data['type'] ?? '' ) ) {
+				continue;
+			}
+			$providers[ $connector_id ] = $connector_data['name'] ?? $connector_id;
+		}
+	}
+
+	/**
+	 * Filters the list of available AI providers shown in the Plugin Permissions settings.
+	 *
+	 * Add entries for custom or self-hosted providers that are not registered as
+	 * WordPress connectors. The array keys are provider slugs used in routing
+	 * (e.g. 'anthropic') and the values are human-readable display names.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, string> $providers Provider slugs mapped to display names.
+	 * @return array<string, string>
+	 */
+	return (array) apply_filters( 'wpai_available_providers', $providers );
+}
+
+/**
+ * Returns the preferred models for image generation.
+ *
+ * Alias of {@see get_preferred_image_models()} following the consistent
+ * `get_preferred_models_for_{capability}` naming convention.
+ *
+ * @since 1.0.0
+ *
+ * @return array<int, array{string, string}> The preferred models for image generation.
+ */
+function get_preferred_models_for_image_generation(): array {
+	return get_preferred_image_models();
+}
+
+/**
  * Checks whether a plugin has been granted access to connected AI providers.
  *
  * Plugins must first register themselves via the `wpai_register_plugins` action hook.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -304,20 +304,30 @@ function get_preferred_vision_models(): array {
  * This also checks the global AI features toggle — if AI is globally disabled,
  * this returns false regardless of the plugin's individual access setting.
  *
+ * When a capability is specified, the check additionally verifies that the
+ * plugin declared that capability during registration. Plugins that registered
+ * without listing any capabilities are allowed for backward compatibility.
+ *
  * Example usage:
  * ```php
  * if ( ! WordPress\AI\plugin_has_ai_access( 'my-plugin' ) ) {
  *     return new WP_Error( 'ai_access_denied', 'AI access is not enabled for this plugin.' );
  * }
+ *
+ * // Check for a specific capability.
+ * if ( ! WordPress\AI\plugin_has_ai_access( 'my-plugin', 'image_generation' ) ) {
+ *     return new WP_Error( 'ai_scope_denied', 'This plugin has not been granted image generation access.' );
+ * }
  * ```
  *
  * @since 1.0.0
  *
- * @param string $plugin_id The plugin identifier used during registration.
- * @return bool True if the plugin has been granted AI access, false otherwise.
+ * @param string $plugin_id  The plugin identifier used during registration.
+ * @param string $capability Optional. A specific AI capability to check (e.g. 'text_generation').
+ * @return bool True if the plugin has been granted AI access (and the requested capability), false otherwise.
  */
-function plugin_has_ai_access( string $plugin_id ): bool {
-	return Permissions_Manager::get_instance()->plugin_has_access( $plugin_id );
+function plugin_has_ai_access( string $plugin_id, string $capability = '' ): bool {
+	return Permissions_Manager::get_instance()->plugin_has_access( $plugin_id, $capability );
 }
 
 /**

--- a/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
+++ b/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
@@ -80,14 +80,13 @@ class Permissions_ManagerTest extends WP_UnitTestCase {
 	 */
 	public function test_initialize_fires_register_plugins_action(): void {
 		$received = null;
-		add_action(
-			'wpai_register_plugins',
-			static function ( $registry ) use ( &$received ): void {
-				$received = $registry;
-			}
-		);
+		$callback = function ( $registry ) use ( &$received ): void {
+			$received = $registry;
+		};
 
+		add_action( 'wpai_register_plugins', $callback );
 		$this->manager->initialize();
+		remove_action( 'wpai_register_plugins', $callback );
 
 		$this->assertInstanceOf(
 			\WordPress\AI\Permissions\Plugin_Registry::class,
@@ -103,15 +102,14 @@ class Permissions_ManagerTest extends WP_UnitTestCase {
 	 */
 	public function test_initialize_is_idempotent(): void {
 		$call_count = 0;
-		add_action(
-			'wpai_register_plugins',
-			static function () use ( &$call_count ): void {
-				$call_count++;
-			}
-		);
+		$callback   = function () use ( &$call_count ): void {
+			$call_count++;
+		};
 
+		add_action( 'wpai_register_plugins', $callback );
 		$this->manager->initialize();
 		$this->manager->initialize();
+		remove_action( 'wpai_register_plugins', $callback );
 
 		$this->assertSame( 1, $call_count );
 	}

--- a/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
+++ b/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
@@ -1,0 +1,330 @@
+<?php
+/**
+ * Tests for the Permissions_Manager class.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Permissions
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Permissions;
+
+use WP_UnitTestCase;
+use WordPress\AI\Permissions\Permissions_Manager;
+use WordPress\AI\Settings\Settings_Registration;
+
+/**
+ * Permissions_Manager test case.
+ *
+ * @covers \WordPress\AI\Permissions\Permissions_Manager
+ * @since 1.0.0
+ */
+class Permissions_ManagerTest extends WP_UnitTestCase {
+
+	/**
+	 * Permissions manager instance under test.
+	 *
+	 * @since 1.0.0
+	 * @var \WordPress\AI\Permissions\Permissions_Manager
+	 */
+	private Permissions_Manager $manager;
+
+	/**
+	 * Sets up a fresh manager instance before each test.
+	 *
+	 * @since 1.0.0
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->manager = Permissions_Manager::get_instance();
+	}
+
+	/**
+	 * Resets singleton state and cleans up options after each test.
+	 *
+	 * @since 1.0.0
+	 */
+	public function tearDown(): void {
+		$reflection = new \ReflectionClass( Permissions_Manager::class );
+		$prop       = $reflection->getProperty( 'instance' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+
+		delete_option( Settings_Registration::GLOBAL_OPTION );
+
+		parent::tearDown();
+	}
+
+	// -------------------------------------------------------------------------
+	// Singleton
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that get_instance returns the same object on repeated calls.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_instance_returns_singleton(): void {
+		$a = Permissions_Manager::get_instance();
+		$b = Permissions_Manager::get_instance();
+
+		$this->assertSame( $a, $b );
+	}
+
+	// -------------------------------------------------------------------------
+	// initialize / wpai_register_plugins action
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that initialize() fires the wpai_register_plugins action with the registry.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_initialize_fires_register_plugins_action(): void {
+		$received = null;
+		add_action(
+			'wpai_register_plugins',
+			static function ( $registry ) use ( &$received ): void {
+				$received = $registry;
+			}
+		);
+
+		$this->manager->initialize();
+
+		$this->assertInstanceOf(
+			\WordPress\AI\Permissions\Plugin_Registry::class,
+			$received,
+			'wpai_register_plugins must receive a Plugin_Registry instance.'
+		);
+	}
+
+	/**
+	 * Tests that calling initialize() a second time does not fire the action again.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_initialize_is_idempotent(): void {
+		$call_count = 0;
+		add_action(
+			'wpai_register_plugins',
+			static function () use ( &$call_count ): void {
+				$call_count++;
+			}
+		);
+
+		$this->manager->initialize();
+		$this->manager->initialize();
+
+		$this->assertSame( 1, $call_count );
+	}
+
+	// -------------------------------------------------------------------------
+	// plugin_has_access — global toggle
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that plugin_has_access returns false when the global toggle is off.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_returns_false_when_global_disabled(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, false );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		$plugin_key = $this->manager->sanitize_option_key( 'test-plugin' );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+
+		$this->assertFalse( $this->manager->plugin_has_access( 'test-plugin' ) );
+	}
+
+	/**
+	 * Tests that plugin_has_access returns false for an unregistered plugin.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_returns_false_for_unregistered_plugin(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$this->assertFalse( $this->manager->plugin_has_access( 'unregistered-plugin' ) );
+	}
+
+	/**
+	 * Tests that plugin_has_access defaults to false when the plugin has not been explicitly granted access.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_returns_false_when_not_granted(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		$this->assertFalse( $this->manager->plugin_has_access( 'test-plugin' ) );
+	}
+
+	/**
+	 * Tests that plugin_has_access returns true when global is on and the plugin option is granted.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_returns_true_when_granted(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		$plugin_key = $this->manager->sanitize_option_key( 'test-plugin' );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+
+		$this->assertTrue( $this->manager->plugin_has_access( 'test-plugin' ) );
+	}
+
+	/**
+	 * Tests that the wpai_plugin_ai_access filter can override the access decision.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_respects_filter_override(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		add_filter( 'wpai_plugin_ai_access', '__return_true' );
+		$result = $this->manager->plugin_has_access( 'test-plugin' );
+		remove_filter( 'wpai_plugin_ai_access', '__return_true' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Tests that the wpai_plugin_ai_access filter receives the plugin_id as the second argument.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_filter_receives_plugin_id(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		$received_id = null;
+		$callback    = static function ( bool $access, string $plugin_id ) use ( &$received_id ): bool {
+			$received_id = $plugin_id;
+			return $access;
+		};
+
+		add_filter( 'wpai_plugin_ai_access', $callback, 10, 2 );
+		$this->manager->plugin_has_access( 'test-plugin' );
+		remove_filter( 'wpai_plugin_ai_access', $callback, 10 );
+
+		$this->assertSame( 'test-plugin', $received_id );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_plugin_provider_preferences
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that get_plugin_provider_preferences returns an empty array when no preference is stored.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_provider_preferences_returns_empty_by_default(): void {
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( 'test-plugin' );
+
+		$this->assertSame( array(), $this->manager->get_plugin_provider_preferences( 'test-plugin' ) );
+	}
+
+	/**
+	 * Tests that get_plugin_provider_preferences returns stored provider slugs as an ordered list.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_provider_preferences_returns_stored_slugs(): void {
+		$plugin_key = $this->manager->sanitize_option_key( 'test-plugin' );
+		update_option( Permissions_Manager::PLUGIN_PROVIDER_OPTION_PREFIX . $plugin_key, 'anthropic,google' );
+
+		$prefs = $this->manager->get_plugin_provider_preferences( 'test-plugin' );
+
+		$this->assertSame( array( 'anthropic', 'google' ), $prefs );
+	}
+
+	/**
+	 * Tests that slugs with surrounding whitespace are trimmed.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_provider_preferences_trims_whitespace(): void {
+		$plugin_key = $this->manager->sanitize_option_key( 'test-plugin' );
+		update_option( Permissions_Manager::PLUGIN_PROVIDER_OPTION_PREFIX . $plugin_key, ' anthropic , google ' );
+
+		$prefs = $this->manager->get_plugin_provider_preferences( 'test-plugin' );
+
+		$this->assertSame( array( 'anthropic', 'google' ), $prefs );
+	}
+
+	/**
+	 * Tests that empty comma-separated segments are discarded.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_provider_preferences_discards_empty_segments(): void {
+		$plugin_key = $this->manager->sanitize_option_key( 'test-plugin' );
+		update_option( Permissions_Manager::PLUGIN_PROVIDER_OPTION_PREFIX . $plugin_key, 'anthropic,,google' );
+
+		$prefs = $this->manager->get_plugin_provider_preferences( 'test-plugin' );
+
+		$this->assertSame( array( 'anthropic', 'google' ), $prefs );
+	}
+
+	/**
+	 * Tests that the wpai_plugin_provider_preferences filter can override the preferences.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_provider_preferences_respects_filter(): void {
+		$callback = static function ( array $prefs, string $plugin_id ): array {
+			return array( 'openai' );
+		};
+		add_filter( 'wpai_plugin_provider_preferences', $callback, 10, 2 );
+
+		$prefs = $this->manager->get_plugin_provider_preferences( 'test-plugin' );
+
+		remove_filter( 'wpai_plugin_provider_preferences', $callback, 10 );
+
+		$this->assertSame( array( 'openai' ), $prefs );
+	}
+
+	// -------------------------------------------------------------------------
+	// sanitize_option_key
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that sanitize_option_key lowercases the input string.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_sanitize_option_key_lowercases(): void {
+		$this->assertSame( 'my_plugin', $this->manager->sanitize_option_key( 'My_Plugin' ) );
+	}
+
+	/**
+	 * Tests that sanitize_option_key replaces hyphens and non-alphanumeric characters with underscores.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_sanitize_option_key_replaces_special_chars(): void {
+		$this->assertSame( 'my_plugin_v2', $this->manager->sanitize_option_key( 'my-plugin/v2' ) );
+	}
+
+	/**
+	 * Tests that sanitize_option_key preserves alphanumeric characters and underscores.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_sanitize_option_key_preserves_valid_chars(): void {
+		$this->assertSame( 'my_plugin_123', $this->manager->sanitize_option_key( 'my_plugin_123' ) );
+	}
+}

--- a/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
+++ b/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
@@ -325,4 +325,116 @@ class Permissions_ManagerTest extends WP_UnitTestCase {
 	public function test_sanitize_option_key_preserves_valid_chars(): void {
 		$this->assertSame( 'my_plugin_123', $this->manager->sanitize_option_key( 'my_plugin_123' ) );
 	}
+
+	// -------------------------------------------------------------------------
+	// plugin_has_access — capability scopes
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Helper to register a plugin with access granted and the global toggle on.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $plugin_id    The plugin identifier.
+	 * @param array<string, mixed> $args         Registration arguments.
+	 */
+	private function grant_plugin_access( string $plugin_id, array $args = array() ): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$registry = $this->manager->get_plugin_registry();
+		$registry->register_plugin( $plugin_id, $args );
+
+		$plugin_key = $this->manager->sanitize_option_key( $plugin_id );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+	}
+
+	/**
+	 * Tests that a plugin with a declared capability is granted access for that capability.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_allows_declared_capability(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation', 'image_generation' ),
+		) );
+
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin', 'text_generation' ) );
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin', 'image_generation' ) );
+	}
+
+	/**
+	 * Tests that a plugin is denied access for a capability it did not declare.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_denies_undeclared_capability(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation' ),
+		) );
+
+		$this->assertFalse( $this->manager->plugin_has_access( 'cap-plugin', 'image_generation' ) );
+	}
+
+	/**
+	 * Tests backward compatibility: a plugin registered without capabilities is allowed for any capability.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_allows_any_capability_when_none_declared(): void {
+		$this->grant_plugin_access( 'legacy-plugin' );
+
+		$this->assertTrue( $this->manager->plugin_has_access( 'legacy-plugin', 'text_generation' ) );
+		$this->assertTrue( $this->manager->plugin_has_access( 'legacy-plugin', 'image_generation' ) );
+	}
+
+	/**
+	 * Tests that calling plugin_has_access without a capability still performs only the general check.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_without_capability_skips_scope_check(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation' ),
+		) );
+
+		// General access check (no capability) should pass.
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin' ) );
+	}
+
+	/**
+	 * Tests that the wpai_plugin_ai_access filter receives the capability as the third argument.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_filter_receives_capability(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation' ),
+		) );
+
+		$received_cap = null;
+		$callback     = static function ( bool $access, string $plugin_id, string $capability ) use ( &$received_cap ): bool {
+			$received_cap = $capability;
+			return $access;
+		};
+
+		add_filter( 'wpai_plugin_ai_access', $callback, 10, 3 );
+		$this->manager->plugin_has_access( 'cap-plugin', 'text_generation' );
+		remove_filter( 'wpai_plugin_ai_access', $callback, 10 );
+
+		$this->assertSame( 'text_generation', $received_cap );
+	}
+
+	/**
+	 * Tests that KNOWN_CAPABILITIES constant is defined and contains expected entries.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_known_capabilities_constant_contains_expected_values(): void {
+		$caps = Permissions_Manager::KNOWN_CAPABILITIES;
+
+		$this->assertContains( 'text_generation', $caps );
+		$this->assertContains( 'image_generation', $caps );
+		$this->assertContains( 'embedding_generation', $caps );
+		$this->assertGreaterThanOrEqual( 5, count( $caps ) );
+	}
 }

--- a/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
+++ b/tests/Integration/Includes/Permissions/Permissions_ManagerTest.php
@@ -437,4 +437,74 @@ class Permissions_ManagerTest extends WP_UnitTestCase {
 		$this->assertContains( 'embedding_generation', $caps );
 		$this->assertGreaterThanOrEqual( 5, count( $caps ) );
 	}
+
+	// -------------------------------------------------------------------------
+	// plugin_has_access — per-capability admin toggles
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that a declared capability is allowed when no per-capability option has been set (default on).
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_capability_defaults_to_enabled(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation' ),
+		) );
+
+		// No per-capability option set — should default to true.
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin', 'text_generation' ) );
+	}
+
+	/**
+	 * Tests that an admin can disable a specific declared capability.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_denies_capability_when_admin_disabled_it(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation', 'image_generation' ),
+		) );
+
+		$plugin_key = $this->manager->sanitize_option_key( 'cap-plugin' );
+		update_option( Permissions_Manager::PLUGIN_CAPABILITY_OPTION_PREFIX . $plugin_key . '_image_generation', false );
+
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin', 'text_generation' ) );
+		$this->assertFalse( $this->manager->plugin_has_access( 'cap-plugin', 'image_generation' ) );
+	}
+
+	/**
+	 * Tests that re-enabling a previously disabled capability restores access.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_restores_capability_when_admin_re_enables_it(): void {
+		$this->grant_plugin_access( 'cap-plugin', array(
+			'capabilities' => array( 'text_generation' ),
+		) );
+
+		$plugin_key = $this->manager->sanitize_option_key( 'cap-plugin' );
+		$option     = Permissions_Manager::PLUGIN_CAPABILITY_OPTION_PREFIX . $plugin_key . '_text_generation';
+
+		update_option( $option, false );
+		$this->assertFalse( $this->manager->plugin_has_access( 'cap-plugin', 'text_generation' ) );
+
+		update_option( $option, true );
+		$this->assertTrue( $this->manager->plugin_has_access( 'cap-plugin', 'text_generation' ) );
+	}
+
+	/**
+	 * Tests that per-capability toggles are ignored for plugins without declared capabilities (backward compat).
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_plugin_has_access_capability_toggle_ignored_for_legacy_plugins(): void {
+		$this->grant_plugin_access( 'legacy-plugin' );
+
+		// Even if someone sets the cap option to false, legacy plugins are unaffected.
+		$plugin_key = $this->manager->sanitize_option_key( 'legacy-plugin' );
+		update_option( Permissions_Manager::PLUGIN_CAPABILITY_OPTION_PREFIX . $plugin_key . '_text_generation', false );
+
+		$this->assertTrue( $this->manager->plugin_has_access( 'legacy-plugin', 'text_generation' ) );
+	}
 }

--- a/tests/Integration/Includes/Permissions/Plugin_RegistryTest.php
+++ b/tests/Integration/Includes/Permissions/Plugin_RegistryTest.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Tests for the Plugin_Registry class.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Permissions
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Permissions;
+
+use WP_UnitTestCase;
+use WordPress\AI\Permissions\Plugin_Registry;
+
+/**
+ * Plugin_Registry test case.
+ *
+ * @covers \WordPress\AI\Permissions\Plugin_Registry
+ * @since 1.0.0
+ */
+class Plugin_RegistryTest extends WP_UnitTestCase {
+
+	/**
+	 * Registry instance under test.
+	 *
+	 * @since 1.0.0
+	 * @var \WordPress\AI\Permissions\Plugin_Registry
+	 */
+	private Plugin_Registry $registry;
+
+	/**
+	 * Sets up a fresh registry before each test.
+	 *
+	 * @since 1.0.0
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->registry = new Plugin_Registry();
+	}
+
+	// -------------------------------------------------------------------------
+	// register_plugin
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that a freshly registered plugin is retrievable by ID.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_stores_plugin(): void {
+		$this->registry->register_plugin( 'my-plugin', array( 'name' => 'My Plugin' ) );
+
+		$this->assertTrue( $this->registry->has_plugin( 'my-plugin' ) );
+	}
+
+	/**
+	 * Tests that registered plugin data contains the correct id, name, and description.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_stores_correct_data(): void {
+		$this->registry->register_plugin(
+			'my-plugin',
+			array(
+				'name'        => 'My Plugin',
+				'description' => 'Uses AI for content.',
+			)
+		);
+
+		$plugin = $this->registry->get_plugin( 'my-plugin' );
+
+		$this->assertSame( 'my-plugin', $plugin['id'] );
+		$this->assertSame( 'My Plugin', $plugin['name'] );
+		$this->assertSame( 'Uses AI for content.', $plugin['description'] );
+	}
+
+	/**
+	 * Tests that the plugin ID is used as the name when no name is provided.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_defaults_name_to_id(): void {
+		$this->registry->register_plugin( 'my-plugin' );
+
+		$plugin = $this->registry->get_plugin( 'my-plugin' );
+
+		$this->assertSame( 'my-plugin', $plugin['name'] );
+	}
+
+	/**
+	 * Tests that the description defaults to an empty string when not provided.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_defaults_description_to_empty_string(): void {
+		$this->registry->register_plugin( 'my-plugin' );
+
+		$plugin = $this->registry->get_plugin( 'my-plugin' );
+
+		$this->assertSame( '', $plugin['description'] );
+	}
+
+	/**
+	 * Tests that registering a duplicate plugin ID is a no-op and the first registration wins.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_duplicate_id_is_noop(): void {
+		$this->registry->register_plugin( 'my-plugin', array( 'name' => 'Original' ) );
+		$this->registry->register_plugin( 'my-plugin', array( 'name' => 'Duplicate' ) );
+
+		$plugin = $this->registry->get_plugin( 'my-plugin' );
+
+		$this->assertSame( 'Original', $plugin['name'] );
+	}
+
+	/**
+	 * Tests that the plugin name is sanitized via sanitize_text_field.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_register_plugin_sanitizes_name(): void {
+		$this->registry->register_plugin( 'my-plugin', array( 'name' => '<script>alert(1)</script>My Plugin' ) );
+
+		$plugin = $this->registry->get_plugin( 'my-plugin' );
+
+		$this->assertStringNotContainsString( '<script>', $plugin['name'] );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_all_plugins
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that get_all_plugins returns an empty array when nothing is registered.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_all_plugins_empty_by_default(): void {
+		$this->assertSame( array(), $this->registry->get_all_plugins() );
+	}
+
+	/**
+	 * Tests that get_all_plugins returns all registered plugins keyed by ID.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_all_plugins_returns_all(): void {
+		$this->registry->register_plugin( 'plugin-a', array( 'name' => 'Plugin A' ) );
+		$this->registry->register_plugin( 'plugin-b', array( 'name' => 'Plugin B' ) );
+
+		$all = $this->registry->get_all_plugins();
+
+		$this->assertCount( 2, $all );
+		$this->assertArrayHasKey( 'plugin-a', $all );
+		$this->assertArrayHasKey( 'plugin-b', $all );
+	}
+
+	// -------------------------------------------------------------------------
+	// get_plugin
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that get_plugin returns null for an unknown plugin ID.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_get_plugin_returns_null_for_unknown_id(): void {
+		$this->assertNull( $this->registry->get_plugin( 'unknown' ) );
+	}
+
+	// -------------------------------------------------------------------------
+	// has_plugin
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that has_plugin returns false before a plugin is registered.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_has_plugin_returns_false_before_registration(): void {
+		$this->assertFalse( $this->registry->has_plugin( 'my-plugin' ) );
+	}
+
+	/**
+	 * Tests that has_plugin returns true after a plugin is registered.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_has_plugin_returns_true_after_registration(): void {
+		$this->registry->register_plugin( 'my-plugin' );
+
+		$this->assertTrue( $this->registry->has_plugin( 'my-plugin' ) );
+	}
+}

--- a/tests/Integration/Includes/Services/AI_ServiceTest.php
+++ b/tests/Integration/Includes/Services/AI_ServiceTest.php
@@ -8,7 +8,9 @@
 namespace WordPress\AI\Tests\Integration\Includes\Services;
 
 use WP_UnitTestCase;
+use WordPress\AI\Permissions\Permissions_Manager;
 use WordPress\AI\Services\AI_Service;
+use WordPress\AI\Settings\Settings_Registration;
 
 use function WordPress\AI\get_ai_service;
 
@@ -37,11 +39,19 @@ class AI_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Teardown test case.
+	 * Resets permission state and cleans up options after each test.
 	 *
 	 * @since 0.2.1
 	 */
 	public function tearDown(): void {
+		// Reset the Permissions_Manager singleton so permission state does not bleed between tests.
+		$reflection = new \ReflectionClass( Permissions_Manager::class );
+		$prop       = $reflection->getProperty( 'instance' );
+		$prop->setAccessible( true );
+		$prop->setValue( null, null );
+
+		delete_option( Settings_Registration::GLOBAL_OPTION );
+
 		parent::tearDown();
 	}
 
@@ -104,6 +114,101 @@ class AI_Service_Test extends WP_UnitTestCase {
 			$builder,
 			'Should return WP_AI_Client_Prompt_Builder instance with options applied'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// create_textgen_prompt_for_plugin
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Tests that create_textgen_prompt_for_plugin returns null when the plugin is not registered.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_create_textgen_prompt_for_plugin_returns_null_for_unregistered_plugin(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$builder = $this->service->create_textgen_prompt_for_plugin( 'unregistered-plugin', 'Hello' );
+
+		$this->assertNull( $builder );
+	}
+
+	/**
+	 * Tests that create_textgen_prompt_for_plugin returns null when global AI is disabled.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_create_textgen_prompt_for_plugin_returns_null_when_global_disabled(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, false );
+
+		$manager  = Permissions_Manager::get_instance();
+		$registry = $manager->get_plugin_registry();
+		$registry->register_plugin( 'my-plugin' );
+
+		$plugin_key = $manager->sanitize_option_key( 'my-plugin' );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+
+		$builder = $this->service->create_textgen_prompt_for_plugin( 'my-plugin', 'Hello' );
+
+		$this->assertNull( $builder );
+	}
+
+	/**
+	 * Tests that create_textgen_prompt_for_plugin returns null when the plugin has not been granted access.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_create_textgen_prompt_for_plugin_returns_null_when_access_not_granted(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$manager  = Permissions_Manager::get_instance();
+		$registry = $manager->get_plugin_registry();
+		$registry->register_plugin( 'my-plugin' );
+
+		// Access option deliberately NOT set (defaults to false).
+		$builder = $this->service->create_textgen_prompt_for_plugin( 'my-plugin', 'Hello' );
+
+		$this->assertNull( $builder );
+	}
+
+	/**
+	 * Tests that create_textgen_prompt_for_plugin returns a prompt builder when the plugin has been granted access.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_create_textgen_prompt_for_plugin_returns_builder_when_access_granted(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$manager  = Permissions_Manager::get_instance();
+		$registry = $manager->get_plugin_registry();
+		$registry->register_plugin( 'my-plugin' );
+
+		$plugin_key = $manager->sanitize_option_key( 'my-plugin' );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+
+		$builder = $this->service->create_textgen_prompt_for_plugin( 'my-plugin', 'Hello' );
+
+		$this->assertInstanceOf( \WP_AI_Client_Prompt_Builder::class, $builder );
+	}
+
+	/**
+	 * Tests that create_textgen_prompt_for_plugin accepts a null prompt argument.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_create_textgen_prompt_for_plugin_accepts_null_prompt(): void {
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+
+		$manager  = Permissions_Manager::get_instance();
+		$registry = $manager->get_plugin_registry();
+		$registry->register_plugin( 'my-plugin' );
+
+		$plugin_key = $manager->sanitize_option_key( 'my-plugin' );
+		update_option( Permissions_Manager::PLUGIN_ACCESS_OPTION_PREFIX . $plugin_key, true );
+
+		$builder = $this->service->create_textgen_prompt_for_plugin( 'my-plugin' );
+
+		$this->assertInstanceOf( \WP_AI_Client_Prompt_Builder::class, $builder );
 	}
 
 	/**


### PR DESCRIPTION
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #342 

## Why?
The plugin-level permissions and provider routing feature introduced three new production classes (`Permissions_Manager`, `Plugin_Registry`) and extended `AI_Service`, `Settings_Page`, `Settings_Registration`, `bootstrap.php`, and `helpers.php` with no test coverage. Without tests, regressions in access control logic e.g. the global toggle blocking all access, the opt-in default, provider preference filtering would go undetected.

---

## What changed?

### Production code
- **`includes/Permissions/Permissions_Manager.php`** _(new)_ Singleton that gates plugin AI access (`plugin_has_access()`), stores and retrieves per-plugin provider routing preferences (`get_plugin_provider_preferences()`), and sanitizes plugin IDs for use as option-name suffixes (`sanitize_option_key()`). Fires the `wpai_register_plugins` action on `initialize()`.

- **`includes/Permissions/Plugin_Registry.php`** _(new)_ In-memory registry for plugins that declare themselves as AI consumers via `wpai_register_plugins`. Exposes `register_plugin()` (no-op on duplicate), `get_all_plugins()`, `get_plugin()`, and `has_plugin()`.

- **`includes/Services/AI_Service.php`** Added `create_textgen_prompt_for_plugin()`: performs an access check via `Permissions_Manager`, then builds a prompt scoped to the plugin's provider preferences (falls back to global if none configured).

- **`includes/Settings/Settings_Page.php`** Added `render_plugin_permissions_section()`: renders an admin UI card with per-plugin access toggles and provider routing text inputs. Section is hidden when no plugins are registered; inputs are disabled when the global AI toggle is off.

- **`includes/Settings/Settings_Registration.php`** Added `register_plugin_permission_settings()` (registers `wpai_plugin_access_*` and `wpai_plugin_providers_*` options per plugin) and `sanitize_provider_preferences()`
(sanitizes comma-separated provider slug lists via `sanitize_key()`).

- **`includes/bootstrap.php`** Calls `Permissions_Manager::get_instance()->initialize()` during plugin load so registrations via `wpai_register_plugins` are processed in time.

- **`includes/helpers.php`** Added the public helper `plugin_has_ai_access( $plugin_id )` as a thin wrapper around `Permissions_Manager::plugin_has_access()`.

### Tests
Added two new integration test files and extended the existing `AI_ServiceTest`:
- **`tests/Integration/Includes/Permissions/Plugin_RegistryTest.php`** 11 tests covering `register_plugin()` (data storage, name/description defaults, duplicate no-op, XSS sanitization via `sanitize_text_field`/`sanitize_textarea_field`), `get_all_plugins()`, `get_plugin()`, and `has_plugin()`.

- **`tests/Integration/Includes/Permissions/Permissions_ManagerTest.php`** 17 tests covering the singleton (`get_instance()`), `initialize()` idempotency and action firing, `plugin_has_access()` (global toggle off, unregistered plugin, not granted, granted, filter override, filter receives correct plugin ID), `get_plugin_provider_preferences()` (empty default, stored slugs, whitespace trimming, empty segment pruning, filter override), and `sanitize_option_key()` (lowercasing, special-character replacement, valid-character preservation).

- **`tests/Integration/Includes/Services/AI_ServiceTest.php`**  5 new tests for `create_textgen_prompt_for_plugin()` covering all denial paths (unregistered plugin, global AI disabled, access not granted) and the success paths (access granted with prompt string, access granted with null prompt).

- All tests follow the project's `WP_UnitTestCase` conventions: WordPress `update_option`/`delete_option` for state, `@covers` tags, `@since 1.0.0` aligned with the production code, and action/filter hooks cleaned up after each assertion to ensure determinism.

---

## Testing Instructions

1. Ensure the WordPress test environment is configured (`WP_TESTS_DIR` or equivalent).
2. Run the PHP integration test suite:
   ```
   composer test
   ```
3. Confirm all new tests in `tests/Integration/Includes/Permissions/` pass with no
   failures or warnings.
4. Confirm no regressions in `tests/Integration/Includes/Services/AI_ServiceTest.php`.

---

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Used for:** Initial test scaffolding (method names, assertion structure,
setUp/tearDown shape). Final tests were reviewed line-by-line, corrected for hook
cleanup (leaked `add_action` callbacks replaced with stored references +
`remove_action`), docblock style aligned to project conventions (`Tests that…`
descriptions, `@covers`, third-person setUp/tearDown descriptions), and verified
against all production source files before submission.


------------------ 
### Testing Instructions for Keyboard 
N/A no UI changes.

## Screenshots or screencast
N/A test-only change.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-343-b50c582eae718c5e3f03d5e60631aa326d78a0da.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->