### PR TITLE
Update length type from enum to string in summarization ability

### DIFF
--- a/docs/experiments/summarization.md
+++ b/docs/experiments/summarization.md
@@ -64,7 +64,7 @@ The ability can be called directly via REST API, making it useful for automation
      - Allows regenerating the summary from the block toolbar
 
 3. **Ability Execution:**
-   - Accepts `content` (string), `context` (string or post ID), and `length` (enum: 'short', 'medium', 'long') as input
+   - Accepts `content` (string), `context` (string or post ID), and `length` (string: 'short', 'medium', 'long') as input
    - If `context` is numeric, treats it as a post ID and fetches post content using `get_post_context()`
    - Normalizes content using `normalize_content()` helper
    - Sends content to AI client with system instruction for summarization (length-aware)
@@ -89,7 +89,7 @@ array(
             'description'       => 'Additional context to use when summarizing the content. Can be a string of additional context or a post ID (as string) that will be used to get context from that post. If no content is provided but a valid post ID is used, the content from that post will be used.',
         ),
         'length'  => array(
-            'type'        => 'enum',
+            'type'        => 'string',
             'enum'        => array( 'short', 'medium', 'long' ),
             'default'     => 'medium',
             'description' => 'The length of the summary.',

--- a/includes/Abilities/Summarization/Summarization.php
+++ b/includes/Abilities/Summarization/Summarization.php
@@ -52,7 +52,7 @@ class Summarization extends Abstract_Ability {
 					'description'       => esc_html__( 'Additional context to use when summarizing the content. This can either be a string of additional context or can be a post ID that will then be used to get context from that post (if it exists). If no content is provided but a valid post ID is used here, the content from that post will be used.', 'ai' ),
 				),
 				'length'  => array(
-					'type'        => 'enum',
+					'type'        => 'string',
 					'enum'        => array( 'short', 'medium', 'long' ),
 					'default'     => self::LENGTH_DEFAULT,
 					'description' => esc_html__( 'The length of the summary.', 'ai' ),

--- a/tests/Integration/Includes/Abilities/SummarizationTest.php
+++ b/tests/Integration/Includes/Abilities/SummarizationTest.php
@@ -137,7 +137,7 @@ class SummarizationTest extends WP_UnitTestCase {
 		$this->assertEquals( 'sanitize_text_field', $schema['properties']['context']['sanitize_callback'], 'Context should use sanitize_text_field' );
 
 		// Verify length property.
-		$this->assertEquals( 'enum', $schema['properties']['length']['type'], 'Length should be enum type' );
+		$this->assertEquals( 'string', $schema['properties']['length']['type'], 'Length should be string type' );
 		$this->assertEquals( array( 'short', 'medium', 'long' ), $schema['properties']['length']['enum'], 'Length should be enum with values short, medium, long' );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
Corrects the type value for the summarization ability because enum is no type.

## Why?
Ensures part of #346 is fixed.

## How?
Replaces 'enum' with 'string'.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-347-6f193ba51ac70af4a5577312e1dbede315fedca1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->