### PR TITLE
fix: preserve experiment settings when ai is globally disabled

### DIFF
--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -306,9 +306,29 @@ class Settings_Page {
 					<li class="ai-experiments__item <?php echo esc_attr( $disabled_class ); ?>">
 						<div class="ai-experiments__item-header">
 							<label class="components-toggle-control" for="<?php echo esc_attr( $experiment_option ); ?>">
+								<?php
+								// Disabled checkboxes are omitted from POST; hidden fields keep per-feature values when AI is off.
+								if ( $global_enabled ) {
+									?>
+								<input
+									type="hidden"
+									name="<?php echo esc_attr( $experiment_option ); ?>"
+									value="0"
+								/>
+									<?php
+								} else {
+									?>
+								<input
+									type="hidden"
+									name="<?php echo esc_attr( $experiment_option ); ?>"
+									value="<?php echo $experiment_enabled ? '1' : '0'; ?>"
+								/>
+									<?php
+								}
+								?>
 								<input
 									type="checkbox"
-									name="<?php echo esc_attr( $experiment_option ); ?>"
+									<?php echo $global_enabled ? 'name="' . esc_attr( $experiment_option ) . '"' : ''; ?>
 									id="<?php echo esc_attr( $experiment_option ); ?>"
 									value="1"
 									<?php checked( $experiment_enabled ); ?>

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -9,6 +9,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const {
 	clearConnectors,
 	disableExperiments,
+	enableExperiment,
 	enableExperiments,
 	visitConnectorsPage,
 	visitSettingsPage,
@@ -116,5 +117,21 @@ test.describe( 'Plugin settings', () => {
 				}
 			)
 		).toHaveCount( 1 );
+	} );
+
+	test( 'Per-experiment settings persist after disabling and re-enabling AI', async ( {
+		admin,
+		page,
+	} ) => {
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'title-generation' );
+
+		await disableExperiments( admin, page );
+		await enableExperiments( admin, page );
+
+		await visitSettingsPage( admin );
+		await expect(
+			page.locator( '#wpai_feature_title-generation_enabled' )
+		).toBeChecked();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->
## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/352
Ensures per-experiment enable/disable settings are **not cleared** when the site admin uses **Disable AI** and saves, so **Enable AI** restores the same feature toggles as before.
## Why?
With AI globally off, experiment checkboxes are **disabled**. Disabled fields are **not submitted** with the form. `options.php` still updates every option registered for the settings page; when a key is missing from `POST`, the saved value becomes empty/null, which **wiped** each `wpai_feature_{id}_enabled` option. After re-enabling AI, every experiment appeared off until configured again.
## How?
- When **AI is on**: keep the usual pattern of a hidden `0` plus the checkbox (`1`) so unchecked experiments still save as off.
- When **AI is off**: output a **hidden input** per experiment carrying the **current stored** value, and render the visible checkbox **without a `name`** (still disabled, same `id` for the label) so only the hidden value is submitted and options stay intact.
Adds an **e2e** test: enable Title Generation, toggle global AI off then on, assert the Title Generation checkbox remains checked.
<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->
### Use of AI Tools
<!-- You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>. -->
- **Tooling:** [e.g. Cursor / Copilot / ChatGPT — fill in what you used]
- **Extent:** [e.g. implementation suggested for the hidden-field approach and e2e scenario; human reviewed, tested, and adjusted as needed]
## Testing Instructions
1. Go to **Settings → AI** (with valid connectors so the page loads as usual).
2. Turn **AI** on. Enable several experiments (e.g. Title Generation, Alt Text), click **Save Changes**, confirm success.
3. Click **Disable AI** (form auto-submits). Confirm AI is off and experiment checkboxes are disabled.
4. Click **Enable AI** again.
5. Confirm the same experiments are still **checked** as in step 2 (no need to re-check each one).
6. Optional: uncheck one experiment, save, disable/enable AI again, confirm only your intentional change persists.
### Testing Instructions for Keyboard
1. Tab to **Disable AI** / **Enable AI** and activate with **Enter** or **Space**; confirm the form submits and focus returns to a sensible place after reload.
2. With AI enabled, tab to experiment checkboxes, toggle with **Space**, save with **Submit** / **Save Changes**; confirm behavior matches before (no regression).
3. With AI disabled, tab past experiment rows; confirm disabled controls are still in tab order (or skipped per browser) as before—no new traps or focus loops.
## Screenshots or screencast <!-- if applicable -->
<!-- Optional: short screencast of disable → enable showing checkboxes unchanged. -->
n/a

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-353-4df6db96040a1295fcd54febe19e37d46ea201e9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->