### PR TITLE
feat: add category filtering and tagging for abilities in Ability Table

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -132,7 +132,6 @@ class Ability_Handler {
 		$ability_name = end( $parts );
 		$namespace    = $parts[0] ?? '';
 
-
 		/**
 		 * Filters the keyword-to-category map used when auto-tagging abilities.
 		 *
@@ -141,7 +140,7 @@ class Ability_Handler {
 		 * UI; each value is an array of slug substrings that trigger that category.
 		 *
 		 * Example:
-		 *   add_filter( 'ai_ability_category_map', function( $map ) {
+		 *   add_filter( 'wpai_ability_category_map', function( $map ) {
 		 *       $map['WooCommerce'] = [ 'product', 'order', 'cart' ];
 		 *       $map['SEO']         = [ 'meta', 'seo', 'sitemap' ];
 		 *       return $map;
@@ -152,16 +151,16 @@ class Ability_Handler {
 		 * @param array<string, array<string>> $map Category label => keyword slugs.
 		 */
 		$tag_keywords = apply_filters(
-			'ai_ability_category_map',
-			[
-				'Image'     => [ 'image', 'alt-text' ],
-				'Editorial' => [ 'summariz', 'excerpt', 'title', 'review' ],
-				'Content'   => [ 'post', 'terms', 'taxonomy', 'page' ],
-				'System'    => [ 'environment', 'diagnostic', 'debug' ],
-			]
+			'wpai_ability_category_map',
+			array(
+				'Image'     => array( 'image', 'alt-text' ),
+				'Editorial' => array( 'summariz', 'excerpt', 'title', 'review' ),
+				'Content'   => array( 'post', 'terms', 'taxonomy', 'page' ),
+				'System'    => array( 'environment', 'diagnostic', 'debug' ),
+			)
 		);
 
-		$tags = [];
+		$tags = array();
 		foreach ( $tag_keywords as $tag => $keywords ) {
 			foreach ( $keywords as $keyword ) {
 				if ( false !== strpos( $ability_name, $keyword ) ) {
@@ -172,14 +171,14 @@ class Ability_Handler {
 		}
 
 		// Core abilities always get System tag.
-		if ( in_array( $namespace, [ 'wordpress', 'wp', 'core' ], true ) ) {
+		if ( in_array( $namespace, array( 'wordpress', 'wp', 'core' ), true ) ) {
 			if ( ! in_array( 'System', $tags, true ) ) {
 				$tags[] = 'System';
 			}
 		}
 
 		$unique = array_unique( $tags );
-		$unique = ! empty( $unique ) ? $unique : [ 'Other' ];
+		$unique = ! empty( $unique ) ? $unique : array( 'Other' );
 
 		/**
 		 * Filters the final resolved category tags for a specific ability.
@@ -188,7 +187,7 @@ class Ability_Handler {
 		 * specific ability slug, bypassing keyword matching entirely.
 		 *
 		 * Example:
-		 *   add_filter( 'ai_ability_tags', function( $tags, $slug ) {
+		 *   add_filter( 'wpai_ability_tags', function( $tags, $slug ) {
 		 *       if ( 'my-plugin/generate-meta-description' === $slug ) {
 		 *           return array( 'SEO' );
 		 *       }
@@ -200,7 +199,7 @@ class Ability_Handler {
 		 * @param array<string> $tags Resolved category tags for this ability.
 		 * @param string        $slug The full ability slug, e.g. 'my-plugin/do-thing'.
 		 */
-		return (array) apply_filters( 'ai_ability_tags', $unique, $slug );
+		return (array) apply_filters( 'wpai_ability_tags', $unique, $slug );
 	}
 
 	/**
@@ -212,7 +211,7 @@ class Ability_Handler {
 	 */
 	public static function get_all_tags(): array {
 		$abilities = self::get_all_abilities();
-		$tags      = [];
+		$tags      = array();
 
 		foreach ( $abilities as $ability ) {
 			$tags = array_merge( $tags, $ability['tags'] );

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -105,7 +105,7 @@ class Ability_Handler {
 			'name'          => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'provider'      => self::detect_provider( $name, $meta ),
-			'tags'          => self::get_ability_tags( $ability ),
+			'categories'    => self::get_ability_categories( $ability ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
 			'raw_data'      => array(
@@ -120,14 +120,14 @@ class Ability_Handler {
 	}
 
 	/**
-	 * Get tags for an ability.
+	 * Get categories for an ability.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param \WP_Ability $ability Ability object.
-	 * @return array<string> Tags for the ability.
+	 * @return array<string> Categories for the ability.
 	 */
-	public static function get_ability_tags( \WP_Ability $ability ): array {
+	public static function get_ability_categories( \WP_Ability $ability ): array {
 		$slug          = $ability->get_name();
 		$category_slug = $ability->get_category();
 
@@ -142,46 +142,46 @@ class Ability_Handler {
 		$unique = array( $category_label );
 
 		/**
-		 * Filters the final resolved category tags for a specific ability.
+		 * Filters the final resolved categories for a specific ability.
 		 *
 		 * Use this hook to explicitly override or append categories for a
 		 * specific ability slug, bypassing keyword matching entirely.
 		 *
 		 * Example:
-		 *   add_filter( 'wpai_ability_tags', function( $tags, $slug ) {
+		 *   add_filter( 'wpai_ability_categories', function( $categories, $slug ) {
 		 *       if ( 'my-plugin/generate-meta-description' === $slug ) {
 		 *           return array( 'SEO' );
 		 *       }
-		 *       return $tags;
+		 *       return $categories;
 		 *   }, 10, 2 );
 		 *
 		 * @since x.x.x
 		 *
-		 * @param array<string> $tags Resolved category tags for this ability.
-		 * @param string        $slug The full ability slug, e.g. 'my-plugin/do-thing'.
+		 * @param array<string> $categories Resolved categories for this ability.
+		 * @param string        $slug       The full ability slug, e.g. 'my-plugin/do-thing'.
 		 */
-		return (array) apply_filters( 'wpai_ability_tags', $unique, $slug );
+		return (array) apply_filters( 'wpai_ability_categories', $unique, $slug );
 	}
 
 	/**
-	 * Get all unique tags across all abilities.
+	 * Get all unique categories across all abilities.
 	 *
 	 * @since x.x.x
 	 *
-	 * @return array<string> Sorted list of all unique tags.
+	 * @return array<string> Sorted list of all unique categories.
 	 */
-	public static function get_all_tags(): array {
-		$abilities = self::get_all_abilities();
-		$tags      = array();
+	public static function get_all_categories(): array {
+		$abilities  = self::get_all_abilities();
+		$categories = array();
 
 		foreach ( $abilities as $ability ) {
-			$tags = array_merge( $tags, $ability['tags'] );
+			$categories = array_merge( $categories, $ability['categories'] );
 		}
 
-		$tags = array_unique( $tags );
-		sort( $tags );
+		$categories = array_unique( $categories );
+		sort( $categories );
 
-		return $tags;
+		return $categories;
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -139,7 +139,7 @@ class Ability_Handler {
 			}
 		}
 
-		$unique = array( $category_label );
+		$categories = array( $category_label );
 
 		/**
 		 * Filters the final resolved categories for a specific ability.
@@ -160,7 +160,7 @@ class Ability_Handler {
 		 * @param array<string> $categories Resolved categories for this ability.
 		 * @param string        $slug       The full ability slug, e.g. 'my-plugin/do-thing'.
 		 */
-		return (array) apply_filters( 'wpai_ability_categories', $unique, $slug );
+		return (array) apply_filters( 'wpai_ability_categories', $categories, $slug );
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -105,7 +105,7 @@ class Ability_Handler {
 			'name'          => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'provider'      => self::detect_provider( $name, $meta ),
-			'tags'          => self::get_ability_tags( $name ),
+			'tags'          => self::get_ability_tags( $ability ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
 			'raw_data'      => array(
@@ -120,65 +120,18 @@ class Ability_Handler {
 	}
 
 	/**
-	 * Get tags for an ability based on its slug.
+	 * Get tags for an ability.
 	 *
-	 * @since 0.6.0
+	 * @since x.x.x
 	 *
-	 * @param string $slug Ability slug.
+	 * @param \WP_Ability $ability Ability object.
 	 * @return array<string> Tags for the ability.
 	 */
-	public static function get_ability_tags( string $slug ): array {
-		$parts        = explode( '/', $slug );
-		$ability_name = end( $parts );
-		$namespace    = $parts[0] ?? '';
+	public static function get_ability_tags( \WP_Ability $ability ): array {
+		$slug     = $ability->get_name();
+		$category = $ability->get_category();
 
-		/**
-		 * Filters the keyword-to-category map used when auto-tagging abilities.
-		 *
-		 * Third-party plugins can add new categories or extend existing ones by
-		 * hooking into this filter. Each key is the category label shown in the
-		 * UI; each value is an array of slug substrings that trigger that category.
-		 *
-		 * Example:
-		 *   add_filter( 'wpai_ability_category_map', function( $map ) {
-		 *       $map['WooCommerce'] = [ 'product', 'order', 'cart' ];
-		 *       $map['SEO']         = [ 'meta', 'seo', 'sitemap' ];
-		 *       return $map;
-		 *   } );
-		 *
-		 * @since 0.6.0
-		 *
-		 * @param array<string, array<string>> $map Category label => keyword slugs.
-		 */
-		$tag_keywords = apply_filters(
-			'wpai_ability_category_map',
-			array(
-				'Image'     => array( 'image', 'alt-text' ),
-				'Editorial' => array( 'summariz', 'excerpt', 'title', 'review' ),
-				'Content'   => array( 'post', 'terms', 'taxonomy', 'page' ),
-				'System'    => array( 'environment', 'diagnostic', 'debug' ),
-			)
-		);
-
-		$tags = array();
-		foreach ( $tag_keywords as $tag => $keywords ) {
-			foreach ( $keywords as $keyword ) {
-				if ( false !== strpos( $ability_name, $keyword ) ) {
-					$tags[] = $tag;
-					break;
-				}
-			}
-		}
-
-		// Core abilities always get System tag.
-		if ( in_array( $namespace, array( 'wordpress', 'wp', 'core' ), true ) ) {
-			if ( ! in_array( 'System', $tags, true ) ) {
-				$tags[] = 'System';
-			}
-		}
-
-		$unique = array_unique( $tags );
-		$unique = ! empty( $unique ) ? $unique : array( 'Other' );
+		$unique = ! empty( $category ) ? array( $category ) : array( 'Other' );
 
 		/**
 		 * Filters the final resolved category tags for a specific ability.
@@ -194,7 +147,7 @@ class Ability_Handler {
 		 *       return $tags;
 		 *   }, 10, 2 );
 		 *
-		 * @since 0.6.0
+		 * @since x.x.x
 		 *
 		 * @param array<string> $tags Resolved category tags for this ability.
 		 * @param string        $slug The full ability slug, e.g. 'my-plugin/do-thing'.
@@ -205,7 +158,7 @@ class Ability_Handler {
 	/**
 	 * Get all unique tags across all abilities.
 	 *
-	 * @since 0.6.0
+	 * @since x.x.x
 	 *
 	 * @return array<string> Sorted list of all unique tags.
 	 */

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -105,6 +105,7 @@ class Ability_Handler {
 			'name'          => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'provider'      => self::detect_provider( $name, $meta ),
+			'tags'          => self::get_ability_tags( $name ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
 			'raw_data'      => array(
@@ -116,6 +117,111 @@ class Ability_Handler {
 				'meta'          => $meta,
 			),
 		);
+	}
+
+	/**
+	 * Get tags for an ability based on its slug.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param string $slug Ability slug.
+	 * @return array<string> Tags for the ability.
+	 */
+	public static function get_ability_tags( string $slug ): array {
+		$parts        = explode( '/', $slug );
+		$ability_name = end( $parts );
+		$namespace    = $parts[0] ?? '';
+
+
+		/**
+		 * Filters the keyword-to-category map used when auto-tagging abilities.
+		 *
+		 * Third-party plugins can add new categories or extend existing ones by
+		 * hooking into this filter. Each key is the category label shown in the
+		 * UI; each value is an array of slug substrings that trigger that category.
+		 *
+		 * Example:
+		 *   add_filter( 'ai_ability_category_map', function( $map ) {
+		 *       $map['WooCommerce'] = [ 'product', 'order', 'cart' ];
+		 *       $map['SEO']         = [ 'meta', 'seo', 'sitemap' ];
+		 *       return $map;
+		 *   } );
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array<string, array<string>> $map Category label => keyword slugs.
+		 */
+		$tag_keywords = apply_filters(
+			'ai_ability_category_map',
+			[
+				'Image'     => [ 'image', 'alt-text' ],
+				'Editorial' => [ 'summariz', 'excerpt', 'title', 'review' ],
+				'Content'   => [ 'post', 'terms', 'taxonomy', 'page' ],
+				'System'    => [ 'environment', 'diagnostic', 'debug' ],
+			]
+		);
+
+		$tags = [];
+		foreach ( $tag_keywords as $tag => $keywords ) {
+			foreach ( $keywords as $keyword ) {
+				if ( false !== strpos( $ability_name, $keyword ) ) {
+					$tags[] = $tag;
+					break;
+				}
+			}
+		}
+
+		// Core abilities always get System tag.
+		if ( in_array( $namespace, [ 'wordpress', 'wp', 'core' ], true ) ) {
+			if ( ! in_array( 'System', $tags, true ) ) {
+				$tags[] = 'System';
+			}
+		}
+
+		$unique = array_unique( $tags );
+		$unique = ! empty( $unique ) ? $unique : [ 'Other' ];
+
+		/**
+		 * Filters the final resolved category tags for a specific ability.
+		 *
+		 * Use this hook to explicitly override or append categories for a
+		 * specific ability slug, bypassing keyword matching entirely.
+		 *
+		 * Example:
+		 *   add_filter( 'ai_ability_tags', function( $tags, $slug ) {
+		 *       if ( 'my-plugin/generate-meta-description' === $slug ) {
+		 *           return array( 'SEO' );
+		 *       }
+		 *       return $tags;
+		 *   }, 10, 2 );
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array<string> $tags Resolved category tags for this ability.
+		 * @param string        $slug The full ability slug, e.g. 'my-plugin/do-thing'.
+		 */
+		return (array) apply_filters( 'ai_ability_tags', $unique, $slug );
+	}
+
+	/**
+	 * Get all unique tags across all abilities.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @return array<string> Sorted list of all unique tags.
+	 */
+	public static function get_all_tags(): array {
+		$abilities = self::get_all_abilities();
+		$tags      = [];
+
+		foreach ( $abilities as $ability ) {
+			$tags = array_merge( $tags, $ability['tags'] );
+		}
+
+		$tags = array_unique( $tags );
+		sort( $tags );
+
+		return $tags;
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -105,7 +105,7 @@ class Ability_Handler {
 			'name'          => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'provider'      => self::detect_provider( $name, $meta ),
-			'categories'    => self::get_ability_categories( $ability ),
+			'category'      => self::get_ability_category( $ability ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
 			'raw_data'      => array(
@@ -120,14 +120,14 @@ class Ability_Handler {
 	}
 
 	/**
-	 * Get categories for an ability.
+	 * Get the category for an ability.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param \WP_Ability $ability Ability object.
-	 * @return array<string> Categories for the ability.
+	 * @return string Category for the ability.
 	 */
-	public static function get_ability_categories( \WP_Ability $ability ): array {
+	public static function get_ability_category( \WP_Ability $ability ): string {
 		$slug          = $ability->get_name();
 		$category_slug = $ability->get_category();
 
@@ -139,49 +139,26 @@ class Ability_Handler {
 			}
 		}
 
-		$categories = array( $category_label );
-
 		/**
-		 * Filters the final resolved categories for a specific ability.
+		 * Filters the final resolved category for a specific ability.
 		 *
-		 * Use this hook to explicitly override or append categories for a
-		 * specific ability slug, bypassing keyword matching entirely.
+		 * Use this hook to explicitly override the category for a
+		 * specific ability slug.
 		 *
 		 * Example:
-		 *   add_filter( 'wpai_ability_categories', function( $categories, $slug ) {
+		 *   add_filter( 'wpai_ability_category', function( $category, $slug ) {
 		 *       if ( 'my-plugin/generate-meta-description' === $slug ) {
-		 *           return array( 'SEO' );
+		 *           return 'SEO';
 		 *       }
-		 *       return $categories;
+		 *       return $category;
 		 *   }, 10, 2 );
 		 *
 		 * @since x.x.x
 		 *
-		 * @param array<string> $categories Resolved categories for this ability.
-		 * @param string        $slug       The full ability slug, e.g. 'my-plugin/do-thing'.
+		 * @param string $category Resolved category for this ability.
+		 * @param string $slug     The full ability slug, e.g. 'my-plugin/do-thing'.
 		 */
-		return (array) apply_filters( 'wpai_ability_categories', $categories, $slug );
-	}
-
-	/**
-	 * Get all unique categories across all abilities.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return array<string> Sorted list of all unique categories.
-	 */
-	public static function get_all_categories(): array {
-		$abilities  = self::get_all_abilities();
-		$categories = array();
-
-		foreach ( $abilities as $ability ) {
-			$categories = array_merge( $categories, $ability['categories'] );
-		}
-
-		$categories = array_unique( $categories );
-		sort( $categories );
-
-		return $categories;
+		return (string) apply_filters( 'wpai_ability_category', $category_label, $slug );
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -128,10 +128,18 @@ class Ability_Handler {
 	 * @return array<string> Tags for the ability.
 	 */
 	public static function get_ability_tags( \WP_Ability $ability ): array {
-		$slug     = $ability->get_name();
-		$category = $ability->get_category();
+		$slug          = $ability->get_name();
+		$category_slug = $ability->get_category();
 
-		$unique = ! empty( $category ) ? array( $category ) : array( 'Other' );
+		$category_label = 'Other';
+		if ( ! empty( $category_slug ) && function_exists( 'wp_get_ability_category' ) ) {
+			$category_obj = wp_get_ability_category( $category_slug );
+			if ( $category_obj ) {
+				$category_label = $category_obj->get_label();
+			}
+		}
+
+		$unique = array( $category_label );
 
 		/**
 		 * Filters the final resolved category tags for a specific ability.

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -131,7 +131,7 @@ class Ability_Handler {
 		$slug          = $ability->get_name();
 		$category_slug = $ability->get_category();
 
-		$category_label = 'Other';
+		$category_label = esc_html__( 'Other', 'ai' );
 		if ( ! empty( $category_slug ) && function_exists( 'wp_get_ability_category' ) ) {
 			$category_obj = wp_get_ability_category( $category_slug );
 			if ( $category_obj ) {

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -124,7 +124,7 @@ class Ability_Table extends \WP_List_Table {
 			$abilities = array_filter(
 				$abilities,
 				static function ( $ability ) use ( $category_filter ) {
-					return in_array( $category_filter, $ability['categories'] ?? array(), true );
+					return ( $ability['category'] ?? '' ) === $category_filter;
 				}
 			);
 		}
@@ -173,29 +173,17 @@ class Ability_Table extends \WP_List_Table {
 		$categories = array();
 
 		foreach ( $this->all_abilities as $ability ) {
-			$categories = array_merge( $categories, $ability['categories'] ?? array() );
+			if ( empty( $ability['category'] ) ) {
+				continue;
+			}
+
+			$categories[] = $ability['category'];
 		}
 
 		$categories = array_unique( $categories );
 		sort( $categories );
 
 		return $categories;
-	}
-
-	/**
-	 * {@inheritDoc}
-	 *
-	 * Adds data-categories attribute so the JS category filter can work client-side.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param array<string,mixed> $item Item data.
-	 */
-	public function single_row( $item ): void {
-		$categories = implode( ',', $item['categories'] ?? array() );
-		echo '<tr data-categories="' . esc_attr( $categories ) . '">';
-		$this->single_row_columns( $item );
-		echo '</tr>';
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -32,7 +32,7 @@ class Ability_Table extends \WP_List_Table {
 	/**
 	 * Full list of abilities before pagination, used to derive filter options.
 	 *
-	 * @since 0.6.0
+	 * @since x.x.x
 	 *
 	 * @var array<array<string,mixed>>
 	 */
@@ -124,7 +124,7 @@ class Ability_Table extends \WP_List_Table {
 			$abilities = array_filter(
 				$abilities,
 				static function ( $ability ) use ( $category_filter ) {
-					return in_array( $category_filter, $ability['tags'] ?? array(), true );
+					return in_array( $category_filter, $ability['categories'] ?? array(), true );
 				}
 			);
 		}
@@ -163,37 +163,37 @@ class Ability_Table extends \WP_List_Table {
 	}
 
 	/**
-	 * Get sorted unique tags derived from the already-fetched ability list.
+	 * Get sorted unique categories derived from the already-fetched ability list.
 	 *
 	 * @since 0.6.0
 	 *
 	 * @return array<string>
 	 */
-	public function get_unique_tags(): array {
-		$tags = array();
+	public function get_unique_categories(): array {
+		$categories = array();
 
 		foreach ( $this->all_abilities as $ability ) {
-			$tags = array_merge( $tags, $ability['tags'] ?? array() );
+			$categories = array_merge( $categories, $ability['categories'] ?? array() );
 		}
 
-		$tags = array_unique( $tags );
-		sort( $tags );
+		$categories = array_unique( $categories );
+		sort( $categories );
 
-		return $tags;
+		return $categories;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 *
-	 * Adds data-tags attribute so the JS category filter can work client-side.
+	 * Adds data-categories attribute so the JS category filter can work client-side.
 	 *
 	 * @since 0.6.0
 	 *
 	 * @param array<string,mixed> $item Item data.
 	 */
 	public function single_row( $item ): void {
-		$tags = implode( ',', $item['tags'] ?? array() );
-		echo '<tr data-tags="' . esc_attr( $tags ) . '">';
+		$categories = implode( ',', $item['categories'] ?? array() );
+		echo '<tr data-categories="' . esc_attr( $categories ) . '">';
 		$this->single_row_columns( $item );
 		echo '</tr>';
 	}
@@ -313,8 +313,8 @@ class Ability_Table extends \WP_List_Table {
 
 			<select name="category" id="filter-by-category">
 				<option value="all" <?php selected( $category_filter, 'all' ); ?>><?php esc_html_e( 'All Categories', 'ai' ); ?></option>
-				<?php foreach ( $this->get_unique_tags() as $tag ) : ?>
-					<option value="<?php echo esc_attr( $tag ); ?>" <?php selected( $category_filter, $tag ); ?>><?php echo esc_html( $tag ); ?></option>
+				<?php foreach ( $this->get_unique_categories() as $category ) : ?>
+					<option value="<?php echo esc_attr( $category ); ?>" <?php selected( $category_filter, $category ); ?>><?php echo esc_html( $category ); ?></option>
 				<?php endforeach; ?>
 			</select>
 

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -36,7 +36,7 @@ class Ability_Table extends \WP_List_Table {
 	 *
 	 * @var array<array<string,mixed>>
 	 */
-	private array $all_abilities = [];
+	private array $all_abilities = array();
 
 	/**
 	 * Constructor.
@@ -91,8 +91,8 @@ class Ability_Table extends \WP_List_Table {
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
 		// Get abilities once and store the full list for filter option derivation.
-		$abilities            = Ability_Handler::get_all_abilities();
-		$this->all_abilities  = $abilities;
+		$abilities           = Ability_Handler::get_all_abilities();
+		$this->all_abilities = $abilities;
 
 		// Apply search filter.
 		$search = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -124,7 +124,7 @@ class Ability_Table extends \WP_List_Table {
 			$abilities = array_filter(
 				$abilities,
 				static function ( $ability ) use ( $category_filter ) {
-					return in_array( $category_filter, $ability['tags'] ?? [], true );
+					return in_array( $category_filter, $ability['tags'] ?? array(), true );
 				}
 			);
 		}
@@ -173,7 +173,7 @@ class Ability_Table extends \WP_List_Table {
 		$tags = array();
 
 		foreach ( $this->all_abilities as $ability ) {
-			$tags = array_merge( $tags, $ability['tags'] ?? [] );
+			$tags = array_merge( $tags, $ability['tags'] ?? array() );
 		}
 
 		$tags = array_unique( $tags );
@@ -192,7 +192,7 @@ class Ability_Table extends \WP_List_Table {
 	 * @param array<string,mixed> $item Item data.
 	 */
 	public function single_row( $item ): void {
-		$tags = implode( ',', $item['tags'] ?? [] );
+		$tags = implode( ',', $item['tags'] ?? array() );
 		echo '<tr data-tags="' . esc_attr( $tags ) . '">';
 		$this->single_row_columns( $item );
 		echo '</tr>';

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -165,7 +165,7 @@ class Ability_Table extends \WP_List_Table {
 	/**
 	 * Get sorted unique categories derived from the already-fetched ability list.
 	 *
-	 * @since 0.6.0
+	 * @since x.x.x
 	 *
 	 * @return array<string>
 	 */
@@ -187,7 +187,7 @@ class Ability_Table extends \WP_List_Table {
 	 *
 	 * Adds data-categories attribute so the JS category filter can work client-side.
 	 *
-	 * @since 0.6.0
+	 * @since x.x.x
 	 *
 	 * @param array<string,mixed> $item Item data.
 	 */

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -30,6 +30,15 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 class Ability_Table extends \WP_List_Table {
 
 	/**
+	 * Full list of abilities before pagination, used to derive filter options.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @var array<array<string,mixed>>
+	 */
+	private array $all_abilities = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.2.0
@@ -81,8 +90,9 @@ class Ability_Table extends \WP_List_Table {
 
 		$this->_column_headers = array( $columns, $hidden, $sortable );
 
-		// Get abilities.
-		$abilities = Ability_Handler::get_all_abilities();
+		// Get abilities once and store the full list for filter option derivation.
+		$abilities            = Ability_Handler::get_all_abilities();
+		$this->all_abilities  = $abilities;
 
 		// Apply search filter.
 		$search = isset( $_REQUEST['s'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['s'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -104,6 +114,17 @@ class Ability_Table extends \WP_List_Table {
 				$abilities,
 				static function ( $ability ) use ( $provider_filter ) {
 					return $ability['provider'] === $provider_filter;
+				}
+			);
+		}
+
+		// Apply category filter.
+		$category_filter = isset( $_REQUEST['category'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['category'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $category_filter ) && 'all' !== $category_filter ) {
+			$abilities = array_filter(
+				$abilities,
+				static function ( $ability ) use ( $category_filter ) {
+					return in_array( $category_filter, $ability['tags'] ?? [], true );
 				}
 			);
 		}
@@ -139,6 +160,42 @@ class Ability_Table extends \WP_List_Table {
 		);
 
 		$this->items = array_slice( $abilities, ( $current_page - 1 ) * $per_page, $per_page );
+	}
+
+	/**
+	 * Get sorted unique tags derived from the already-fetched ability list.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @return array<string>
+	 */
+	public function get_unique_tags(): array {
+		$tags = array();
+
+		foreach ( $this->all_abilities as $ability ) {
+			$tags = array_merge( $tags, $ability['tags'] ?? [] );
+		}
+
+		$tags = array_unique( $tags );
+		sort( $tags );
+
+		return $tags;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Adds data-tags attribute so the JS category filter can work client-side.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array<string,mixed> $item Item data.
+	 */
+	public function single_row( $item ): void {
+		$tags = implode( ',', $item['tags'] ?? [] );
+		echo '<tr data-tags="' . esc_attr( $tags ) . '">';
+		$this->single_row_columns( $item );
+		echo '</tr>';
 	}
 
 	/**
@@ -243,6 +300,7 @@ class Ability_Table extends \WP_List_Table {
 		}
 
 		$provider_filter = isset( $_REQUEST['provider'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$category_filter = isset( $_REQUEST['category'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['category'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		?>
 		<div class="alignleft actions">
@@ -251,6 +309,13 @@ class Ability_Table extends \WP_List_Table {
 				<option value="Core" <?php selected( $provider_filter, 'Core' ); ?>><?php esc_html_e( 'Core', 'ai' ); ?></option>
 				<option value="Plugin" <?php selected( $provider_filter, 'Plugin' ); ?>><?php esc_html_e( 'Plugins', 'ai' ); ?></option>
 				<option value="Theme" <?php selected( $provider_filter, 'Theme' ); ?>><?php esc_html_e( 'Theme', 'ai' ); ?></option>
+			</select>
+
+			<select name="category" id="filter-by-category">
+				<option value="all" <?php selected( $category_filter, 'all' ); ?>><?php esc_html_e( 'All Categories', 'ai' ); ?></option>
+				<?php foreach ( $this->get_unique_tags() as $tag ) : ?>
+					<option value="<?php echo esc_attr( $tag ); ?>" <?php selected( $category_filter, $tag ); ?>><?php echo esc_html( $tag ); ?></option>
+				<?php endforeach; ?>
 			</select>
 
 			<?php submit_button( __( 'Filter', 'ai' ), '', 'filter_action', false ); ?>

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -541,17 +541,19 @@ import './index.scss';
 		},
 	};
 
-	// Don't render if disabled.
-	if ( ! aiAbilityExplorer?.enabled ) {
-		return null;
+	function initWhenReady( fn ) {
+		if ( document.readyState === 'loading' ) {
+			document.addEventListener( 'DOMContentLoaded', fn );
+		} else {
+			fn();
+		}
 	}
 
-	// Initialize on document ready.
-	if ( document.readyState === 'loading' ) {
-		document.addEventListener( 'DOMContentLoaded', function () {
-			AiAbilityExplorer.init();
-		} );
-	} else {
-		AiAbilityExplorer.init();
-	}
+	initWhenReady( function () {
+		if ( aiAbilityExplorer?.enabled ) {
+			AiAbilityExplorer.initTestRunner();
+			AiAbilityExplorer.initCopyButtons();
+			AiAbilityExplorer.initValidation();
+		}
+	} );
 } )();

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -551,9 +551,7 @@ import './index.scss';
 
 	initWhenReady( function () {
 		if ( aiAbilityExplorer?.enabled ) {
-			AiAbilityExplorer.initTestRunner();
-			AiAbilityExplorer.initCopyButtons();
-			AiAbilityExplorer.initValidation();
+			AiAbilityExplorer.init();
 		}
 	} );
 } )();

--- a/tests/e2e/specs/experiments/abilities-explorer.spec.js
+++ b/tests/e2e/specs/experiments/abilities-explorer.spec.js
@@ -57,6 +57,76 @@ test.describe( 'Abilities Explorer Experiment', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Category filter dropdown renders on the Abilities Explorer list page', async ( {
+		admin,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Abilities Explorer Experiment.
+		await enableExperiment( admin, page, 'abilities-explorer' );
+
+		// Visit the Abilities Explorer page.
+		await admin.visitAdminPage( 'tools.php?page=ai-abilities-explorer' );
+
+		// Ensure the category filter dropdown is visible.
+		await expect( page.locator( '#filter-by-category' ) ).toBeVisible();
+
+		// Ensure the dropdown contains the "All Categories" option.
+		await expect(
+			page.locator( '#filter-by-category option[value="all"]' )
+		).toHaveText( 'All Categories' );
+	} );
+
+	test( 'Category filter dropdown filters abilities by category', async ( {
+		admin,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Abilities Explorer Experiment.
+		await enableExperiment( admin, page, 'abilities-explorer' );
+
+		// Visit the Abilities Explorer page.
+		await admin.visitAdminPage( 'tools.php?page=ai-abilities-explorer' );
+
+		// Get the initial row count.
+		const allRows = page.locator( '.wp-list-table tbody tr' );
+		const initialCount = await allRows.count();
+
+		// Get the first non-"all" option from the category dropdown (if one exists).
+		const firstOption = page.locator(
+			'#filter-by-category option:not([value="all"])'
+		);
+		const optionCount = await firstOption.count();
+
+		if ( optionCount > 0 ) {
+			const categoryValue = await firstOption
+				.first()
+				.getAttribute( 'value' );
+
+			// Select that category from the dropdown.
+			await page.selectOption( '#filter-by-category', categoryValue );
+
+			// Submit the filter form.
+			await page.click( '#filter_action' );
+			await page.waitForLoadState( 'load' );
+
+			// The filtered row count should be less than or equal to the initial count.
+			const filteredCount = await page
+				.locator( '.wp-list-table tbody tr' )
+				.count();
+			expect( filteredCount ).toBeLessThanOrEqual( initialCount );
+
+			// The category dropdown should show the selected value.
+			await expect( page.locator( '#filter-by-category' ) ).toHaveValue(
+				categoryValue
+			);
+		}
+	} );
+
 	test( 'Can access the Abilities Explorer detail page when enabled', async ( {
 		admin,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #344

<!-- In a few words, what is the PR actually doing? -->

Adds a Category filter to the Abilities Explorer, allowing users to filter abilities by functional area (e.g., Image, Editorial, Content).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The Abilities Explorer currently only allows filtering by Provider (Core, Plugin, Theme), which makes it difficult to find abilities based on what they do, especially in large lists. This PR addresses the need for functional filtering by introducing a Category filter, making it easier to discover abilities by their purpose (e.g., image handling, content editing).
References: [Original issue] (summarize: lack of functional filtering in Abilities Explorer).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds a Category filter dropdown to the Abilities Explorer UI. Categories are auto-derived from ability slugs using keyword matching, and can be extended or overridden by third-party plugins via the ai_ability_category_map and ai_ability_tags filter hooks. The filter works identically to the Provider dropdown: it is server-side, persists in the URL, and is submitted via the same Filter button.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to the Abilities Explorer in the admin interface.
2. Observe the new Category filter dropdown next to the Provider filter.
3. Select a category (e.g., Image, Editorial, Content) and click the Filter button.
4. Confirm that the list of abilities updates to show only those matching the selected category.
5. Change the Provider filter and verify that both filters work together as expected.
6. Check that the selected filters persist in the URL and after page reload.

## Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

1. Tab to the Category filter dropdown.
2. Use arrow keys to navigate and select a category.
3. Tab to the Filter button and press Enter.
4. Verify that the filtered results are accessible and that focus order is logical.
5. Tab through the Provider filter and ensure all controls are reachable and operable via keyboard.

## Screenshots or screencast <!-- if applicable -->
https://www.awesomescreenshot.com/video/50968973?key=5acd67e6e7dc53b4aa9d85fe075a9709

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-355-0126bf0e80a02d0e8e21ce8925e596bfb6ce1205.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->