### PR TITLE
Only add the Generate Alt Text button to selected image blocks

### DIFF
--- a/src/experiments/alt-text-generation/index.tsx
+++ b/src/experiments/alt-text-generation/index.tsx
@@ -35,24 +35,22 @@ const { aiAltTextGenerationData } = window as AltTextGenerationData;
  */
 const withAltTextGeneration = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props: BlockEditProps ) => {
-		// Only add controls to the selected image block.
-		if ( props.name !== 'core/image' || ! props.isSelected ) {
-			return <BlockEdit { ...props } />;
-		}
-
-		// Don't render if disabled.
-		if ( ! aiAltTextGenerationData?.enabled ) {
-			return <BlockEdit { ...props } />;
-		}
+		// Only show controls if we have a selected image block and the experiment is enabled.
+		const showControls =
+			props.name === 'core/image' &&
+			props.isSelected &&
+			aiAltTextGenerationData?.enabled;
 
 		return (
 			<>
 				<BlockEdit { ...props } />
-				<AltTextControls
-					clientId={ props.clientId }
-					attributes={ props.attributes }
-					setAttributes={ props.setAttributes }
-				/>
+				{ showControls && (
+					<AltTextControls
+						clientId={ props.clientId }
+						attributes={ props.attributes }
+						setAttributes={ props.setAttributes }
+					/>
+				) }
 			</>
 		);
 	};

--- a/src/experiments/alt-text-generation/index.tsx
+++ b/src/experiments/alt-text-generation/index.tsx
@@ -17,6 +17,7 @@ import type { ImageBlockAttributes } from './types';
 interface BlockEditProps {
 	clientId: string;
 	name: string;
+	isSelected: boolean;
 	attributes: ImageBlockAttributes;
 	setAttributes: ( attributes: Partial< ImageBlockAttributes > ) => void;
 }
@@ -34,8 +35,8 @@ const { aiAltTextGenerationData } = window as AltTextGenerationData;
  */
 const withAltTextGeneration = createHigherOrderComponent( ( BlockEdit ) => {
 	return ( props: BlockEditProps ) => {
-		// Only add controls to the image block.
-		if ( props.name !== 'core/image' ) {
+		// Only add controls to the selected image block.
+		if ( props.name !== 'core/image' || ! props.isSelected ) {
 			return <BlockEdit { ...props } />;
 		}
 


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/ai-provider-for-openai/issues/16

Ensure we add the alt text generation controls only to selected image blocks

## Why?

As reported in the above issue, if you have an image block within a pattern and you toggle back and forth between the image and another block in the pattern, the alt text generation button ends up displaying weird (that issue mentions it duplicating but I wasn't able to reproduce that).

To fix this, we just need to ensure we only show our controls on **selected** image blocks.

## How?

Instead of checking if the current block is an image, we also add a check to ensure that block is currently selected

### Use of AI Tools

None

## Testing Instructions

1. Pull this branch down and run `npm i && npm run build`
2. Turn on the Alt Text Generation Experiment
3. Add an image into a post and with it selected, ensure you see a button in the sidebar to generate alt text
4. Insert a pattern
5. Ensure there's an image block within the pattern
6. Select that image block and ensure you see the same button in the sidebar
7. Using the Content controls in the pattern sidebar, click into another block within the pattern
8. Ensure you no longer see the alt text controls
9. Click back into the image block and ensure it shows again

## Screenshots

|Before|After|
|-|-|
| <img width="284" height="613" alt="Alt text controls showing in the pattern editor when they shouldn't" src="https://github.com/user-attachments/assets/03ed54eb-5e8f-4853-9006-86a788396b65" /> | <img width="329" height="594" alt="Alt text controls not showing in the pattern editor" src="https://github.com/user-attachments/assets/b0969798-957a-4536-a069-10398187110b" /> |

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-356-04555a045d3962143ffbbd933a0af71d46561017.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->