### PR TITLE
Fix system instruction loading failing on repeated calls

### DIFF
--- a/includes/Abstracts/Abstract_Ability.php
+++ b/includes/Abstracts/Abstract_Ability.php
@@ -159,7 +159,7 @@ abstract class Abstract_Ability extends WP_Ability {
 
 			if ( file_exists( $file_path ) && is_readable( $file_path ) ) {
 				// PHP files should return a string directly.
-				$content = require_once $file_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
+				$content = require $file_path; // phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingVariable
 
 				return is_string( $content ) ? esc_html( $content ) : '';
 			}

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -231,7 +231,11 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	private function create_system_instruction_file( string $filename, string $content ): void {
 		$path               = trailingslashit( $this->feature_dir ) . $filename;
 		$this->temp_files[] = $path;
-		file_put_contents( $path, $content );
+		$result             = @file_put_contents( $path, $content );
+
+		if ( false === $result ) {
+			$this->fail( sprintf( 'Failed to create system instruction file at path: %s', $path ) );
+		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -410,6 +410,54 @@ PHP;
 	}
 
 	/**
+	 * Test that get_system_instruction() returns the instruction on consecutive calls with the same file.
+	 *
+	 * Surfaces an issue: require_once on line 162 of Abstract_Ability returns true (not the string)
+	 * on the second call, causing the method to silently return an empty string.
+	 *
+	 * @since 0.1.0
+	 */
+	public function test_get_system_instruction_returns_instruction_on_consecutive_calls() {
+		$experiment = new Test_Ability_Experiment();
+		$ability    = new Test_Ability(
+			'test-ability',
+			array(
+				'label'       => $experiment->get_label(),
+				'description' => $experiment->get_description(),
+			)
+		);
+
+		// Get the test ability's directory using reflection.
+		$reflection  = new \ReflectionClass( $ability );
+		$file_name   = $reflection->getFileName();
+		$feature_dir = dirname( $file_name );
+
+		// Create a temporary system instruction file.
+		$test_file    = trailingslashit( $feature_dir ) . 'test-system-instruction-consecutive.php';
+		$test_content = <<<'PHP'
+<?php
+// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
+return <<<INSTRUCTION
+You are a test assistant for consecutive calls.
+INSTRUCTION;
+PHP;
+		file_put_contents( $test_file, $test_content );
+
+		try {
+			$first_result  = $ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
+			$second_result = $ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
+
+			$this->assertNotEmpty( $first_result, 'First call should return the instruction' );
+			$this->assertNotEmpty( $second_result, 'Second call should also return the instruction, but require_once causes it to return empty' );
+			$this->assertSame( $first_result, $second_result, 'Both calls should return the same instruction' );
+		} finally {
+			if ( file_exists( $test_file ) ) {
+				wp_delete_file( $test_file );
+			}
+		}
+	}
+
+	/**
 	 * Test that get_system_instruction() with empty data array works correctly.
 	 *
 	 * @since 0.1.0

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -384,10 +384,11 @@ PHP
 	}
 
 	/**
-	 * Test that get_system_instruction() returns the instruction on consecutive calls with the same file.
+	 * Regression test: get_system_instruction() must return the instruction on every call with the same file.
 	 *
-	 * Surfaces an issue: require_once on line 162 of Abstract_Ability returns true (not the string)
-	 * on the second call, causing the method to silently return an empty string.
+	 * Previously, the implementation used require_once for explicit filenames, which returns true
+	 * (not the file's return value) on subsequent calls, causing the method to silently return an
+	 * empty string. This test ensures that consecutive calls always return the correct string.
 	 *
 	 * @since 0.1.0
 	 */
@@ -407,7 +408,7 @@ PHP
 		$second_result = $this->ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
 
 		$this->assertNotEmpty( $first_result, 'First call should return the instruction' );
-		$this->assertNotEmpty( $second_result, 'Second call should also return the instruction, but require_once causes it to return empty' );
+		$this->assertNotEmpty( $second_result, 'Second call should also return the instruction' );
 		$this->assertSame( $first_result, $second_result, 'Both calls should return the same instruction' );
 	}
 

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -149,25 +149,32 @@ class Test_Ability_Experiment extends Abstract_Feature {
 class Abstract_AbilityTest extends WP_UnitTestCase {
 
 	/**
+	 * Test experiment instance.
+	 *
+	 * @var Test_Ability_Experiment
+	 */
+	private Test_Ability_Experiment $experiment;
+
+	/**
 	 * Test ability instance.
 	 *
 	 * @var Test_Ability
 	 */
-	private $ability;
+	private Test_Ability $ability;
 
 	/**
 	 * Directory where the Test_Ability class file resides.
 	 *
 	 * @var string
 	 */
-	private $feature_dir;
+	private string $feature_dir;
 
 	/**
 	 * Temporary files created during tests, cleaned up in tearDown.
 	 *
 	 * @var string[]
 	 */
-	private $temp_files = array();
+	private array $temp_files = array();
 
 	/**
 	 * Set up test case.
@@ -183,12 +190,12 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 		// Mock has_valid_ai_credentials to return true for tests.
 		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 
-		$experiment    = new Test_Ability_Experiment();
-		$this->ability = new Test_Ability(
+		$this->experiment = new Test_Ability_Experiment();
+		$this->ability    = new Test_Ability(
 			'test-ability',
 			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
+				'label'       => $this->experiment->get_label(),
+				'description' => $this->experiment->get_description(),
 			)
 		);
 
@@ -233,6 +240,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_constructor_sets_up_ability() {
+		$this->assertSame( $this->experiment->get_label(), $this->ability->get_label(), 'Label should be stored in ability' );
 		$this->assertSame( 'Test Ability Experiment', $this->ability->get_label(), 'Label should be stored in ability' );
 	}
 
@@ -242,6 +250,8 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_constructor_calls_parent_with_properties() {
+		// Verify the ability was registered with WordPress Abilities API.
+		// We can't directly test parent::__construct, but we can verify the ability exists.
 		$this->assertInstanceOf( Abstract_Ability::class, $this->ability, 'Ability should be instance of Abstract_Ability' );
 	}
 
@@ -258,6 +268,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 
 		$result = $method->invoke( $this->ability );
 
+		$this->assertEquals( $this->experiment->get_label(), $result, 'Label should match experiment label' );
 		$this->assertEquals( 'Test Ability Experiment', $result, 'Label should be correct' );
 	}
 
@@ -274,6 +285,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 
 		$result = $method->invoke( $this->ability );
 
+		$this->assertEquals( $this->experiment->get_description(), $result, 'Description should match experiment description' );
 		$this->assertEquals( 'A test experiment for ability testing', $result, 'Description should be correct' );
 	}
 

--- a/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_AbilityTest.php
@@ -149,6 +149,27 @@ class Test_Ability_Experiment extends Abstract_Feature {
 class Abstract_AbilityTest extends WP_UnitTestCase {
 
 	/**
+	 * Test ability instance.
+	 *
+	 * @var Test_Ability
+	 */
+	private $ability;
+
+	/**
+	 * Directory where the Test_Ability class file resides.
+	 *
+	 * @var string
+	 */
+	private $feature_dir;
+
+	/**
+	 * Temporary files created during tests, cleaned up in tearDown.
+	 *
+	 * @var string[]
+	 */
+	private $temp_files = array();
+
+	/**
 	 * Set up test case.
 	 *
 	 * @since 0.1.0
@@ -161,6 +182,19 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 
 		// Mock has_valid_ai_credentials to return true for tests.
 		add_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
+
+		$experiment    = new Test_Ability_Experiment();
+		$this->ability = new Test_Ability(
+			'test-ability',
+			array(
+				'label'       => $experiment->get_label(),
+				'description' => $experiment->get_description(),
+			)
+		);
+
+		$reflection       = new \ReflectionClass( $this->ability );
+		$file_name        = $reflection->getFileName();
+		$this->feature_dir = dirname( $file_name );
 	}
 
 	/**
@@ -169,9 +203,28 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function tearDown(): void {
+		foreach ( $this->temp_files as $file ) {
+			if ( file_exists( $file ) ) {
+				wp_delete_file( $file );
+			}
+		}
+		$this->temp_files = array();
+
 		delete_option( 'wp_ai_client_provider_credentials' );
 		remove_filter( 'wpai_pre_has_valid_credentials_check', '__return_true' );
 		parent::tearDown();
+	}
+
+	/**
+	 * Creates a temporary system instruction file and registers it for cleanup.
+	 *
+	 * @param string $filename The filename to create inside the feature directory.
+	 * @param string $content  The PHP file content.
+	 */
+	private function create_system_instruction_file( string $filename, string $content ): void {
+		$path               = trailingslashit( $this->feature_dir ) . $filename;
+		$this->temp_files[] = $path;
+		file_put_contents( $path, $content );
 	}
 
 	/**
@@ -180,16 +233,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_constructor_sets_up_ability() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		$this->assertSame( $experiment->get_label(), $ability->get_label(), 'Label should be stored in ability' );
+		$this->assertSame( 'Test Ability Experiment', $this->ability->get_label(), 'Label should be stored in ability' );
 	}
 
 	/**
@@ -198,18 +242,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_constructor_calls_parent_with_properties() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		// Verify the ability was registered with WordPress Abilities API.
-		// We can't directly test parent::__construct, but we can verify the ability exists.
-		$this->assertInstanceOf( Abstract_Ability::class, $ability, 'Ability should be instance of Abstract_Ability' );
+		$this->assertInstanceOf( Abstract_Ability::class, $this->ability, 'Ability should be instance of Abstract_Ability' );
 	}
 
 	/**
@@ -218,23 +251,13 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_label_delegates_to_experiment() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
 		// Use reflection to test protected method.
-		$reflection = new \ReflectionClass( $ability );
+		$reflection = new \ReflectionClass( $this->ability );
 		$method     = $reflection->getMethod( 'get_label' );
 		$method->setAccessible( true );
 
-		$result = $method->invoke( $ability );
+		$result = $method->invoke( $this->ability );
 
-		$this->assertEquals( $experiment->get_label(), $result, 'Label should match experiment label' );
 		$this->assertEquals( 'Test Ability Experiment', $result, 'Label should be correct' );
 	}
 
@@ -244,23 +267,13 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_description_delegates_to_experiment() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
 		// Use reflection to test protected method.
-		$reflection = new \ReflectionClass( $ability );
+		$reflection = new \ReflectionClass( $this->ability );
 		$method     = $reflection->getMethod( 'get_description' );
 		$method->setAccessible( true );
 
-		$result = $method->invoke( $ability );
+		$result = $method->invoke( $this->ability );
 
-		$this->assertEquals( $experiment->get_description(), $result, 'Description should match experiment description' );
 		$this->assertEquals( 'A test experiment for ability testing', $result, 'Description should be correct' );
 	}
 
@@ -283,16 +296,7 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_get_system_instruction_returns_empty_when_no_file() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		$system_instruction = $ability->get_system_instruction();
+		$system_instruction = $this->ability->get_system_instruction();
 
 		// Test ability doesn't have a system instruction file, so should return empty string.
 		$this->assertIsString( $system_instruction, 'System instruction should be a string' );
@@ -305,23 +309,9 @@ class Abstract_AbilityTest extends WP_UnitTestCase {
 	 * @since 0.1.0
 	 */
 	public function test_get_system_instruction_with_data_parameter() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		// Get the test ability's directory using reflection.
-		$reflection  = new \ReflectionClass( $ability );
-		$file_name   = $reflection->getFileName();
-		$feature_dir = dirname( $file_name );
-
-		// Create a temporary system instruction file that uses data variables.
-		$test_file    = trailingslashit( $feature_dir ) . 'test-system-instruction.php';
-		$test_content = <<<'PHP'
+		$this->create_system_instruction_file(
+			'test-system-instruction.php',
+			<<<'PHP'
 <?php
 // Process the length variable if provided.
 $length_desc = 'medium length';
@@ -337,30 +327,21 @@ if ( isset( $length ) ) {
 return <<<INSTRUCTION
 You are a test assistant. The length is {$length_desc} and the tone is {$tone}. Max words: {$max_words}.
 INSTRUCTION;
-PHP;
-		file_put_contents( $test_file, $test_content );
+PHP
+		);
 
-		try {
-			// Test with data parameter.
-			$data = array(
-				'length'    => 'short',
-				'tone'      => 'professional',
-				'max_words' => 100,
-			);
+		$data = array(
+			'length'    => 'short',
+			'tone'      => 'professional',
+			'max_words' => 100,
+		);
 
-			$system_instruction = $ability->get_system_instruction( 'test-system-instruction.php', $data );
+		$system_instruction = $this->ability->get_system_instruction( 'test-system-instruction.php', $data );
 
-			// Verify the data was interpolated into the system instruction.
-			$this->assertIsString( $system_instruction, 'System instruction should be a string' );
-			$this->assertStringContainsString( 'short length', $system_instruction, 'System instruction should contain processed length value' );
-			$this->assertStringContainsString( 'professional', $system_instruction, 'System instruction should contain tone value' );
-			$this->assertStringContainsString( '100', $system_instruction, 'System instruction should contain max_words value' );
-		} finally {
-			// Clean up the test file.
-			if ( file_exists( $test_file ) ) {
-				wp_delete_file( $test_file );
-			}
-		}
+		$this->assertIsString( $system_instruction, 'System instruction should be a string' );
+		$this->assertStringContainsString( 'short length', $system_instruction, 'System instruction should contain processed length value' );
+		$this->assertStringContainsString( 'professional', $system_instruction, 'System instruction should contain tone value' );
+		$this->assertStringContainsString( '100', $system_instruction, 'System instruction should contain max_words value' );
 	}
 
 	/**
@@ -369,44 +350,21 @@ PHP;
 	 * @since 0.1.0
 	 */
 	public function test_get_system_instruction_without_data_parameter() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		// Get the test ability's directory using reflection.
-		$reflection  = new \ReflectionClass( $ability );
-		$file_name   = $reflection->getFileName();
-		$feature_dir = dirname( $file_name );
-
-		// Create a temporary system instruction file without using data variables.
-		$test_file    = trailingslashit( $feature_dir ) . 'test-system-instruction-simple.php';
-		$test_content = <<<'PHP'
+		$this->create_system_instruction_file(
+			'test-system-instruction-simple.php',
+			<<<'PHP'
 <?php
 // phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
 return <<<INSTRUCTION
 You are a test assistant without data variables.
 INSTRUCTION;
-PHP;
-		file_put_contents( $test_file, $test_content );
+PHP
+		);
 
-		try {
-			// Test without data parameter (should still work).
-			$system_instruction = $ability->get_system_instruction( 'test-system-instruction-simple.php' );
+		$system_instruction = $this->ability->get_system_instruction( 'test-system-instruction-simple.php' );
 
-			// Verify it returns the content.
-			$this->assertIsString( $system_instruction, 'System instruction should be a string' );
-			$this->assertStringContainsString( 'test assistant', $system_instruction, 'System instruction should contain expected content' );
-		} finally {
-			// Clean up the test file.
-			if ( file_exists( $test_file ) ) {
-				wp_delete_file( $test_file );
-			}
-		}
+		$this->assertIsString( $system_instruction, 'System instruction should be a string' );
+		$this->assertStringContainsString( 'test assistant', $system_instruction, 'System instruction should contain expected content' );
 	}
 
 	/**
@@ -418,43 +376,23 @@ PHP;
 	 * @since 0.1.0
 	 */
 	public function test_get_system_instruction_returns_instruction_on_consecutive_calls() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		// Get the test ability's directory using reflection.
-		$reflection  = new \ReflectionClass( $ability );
-		$file_name   = $reflection->getFileName();
-		$feature_dir = dirname( $file_name );
-
-		// Create a temporary system instruction file.
-		$test_file    = trailingslashit( $feature_dir ) . 'test-system-instruction-consecutive.php';
-		$test_content = <<<'PHP'
+		$this->create_system_instruction_file(
+			'test-system-instruction-consecutive.php',
+			<<<'PHP'
 <?php
 // phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
 return <<<INSTRUCTION
 You are a test assistant for consecutive calls.
 INSTRUCTION;
-PHP;
-		file_put_contents( $test_file, $test_content );
+PHP
+		);
 
-		try {
-			$first_result  = $ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
-			$second_result = $ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
+		$first_result  = $this->ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
+		$second_result = $this->ability->get_system_instruction( 'test-system-instruction-consecutive.php' );
 
-			$this->assertNotEmpty( $first_result, 'First call should return the instruction' );
-			$this->assertNotEmpty( $second_result, 'Second call should also return the instruction, but require_once causes it to return empty' );
-			$this->assertSame( $first_result, $second_result, 'Both calls should return the same instruction' );
-		} finally {
-			if ( file_exists( $test_file ) ) {
-				wp_delete_file( $test_file );
-			}
-		}
+		$this->assertNotEmpty( $first_result, 'First call should return the instruction' );
+		$this->assertNotEmpty( $second_result, 'Second call should also return the instruction, but require_once causes it to return empty' );
+		$this->assertSame( $first_result, $second_result, 'Both calls should return the same instruction' );
 	}
 
 	/**
@@ -463,43 +401,20 @@ PHP;
 	 * @since 0.1.0
 	 */
 	public function test_get_system_instruction_with_empty_data_array() {
-		$experiment = new Test_Ability_Experiment();
-		$ability    = new Test_Ability(
-			'test-ability',
-			array(
-				'label'       => $experiment->get_label(),
-				'description' => $experiment->get_description(),
-			)
-		);
-
-		// Get the test ability's directory using reflection.
-		$reflection  = new \ReflectionClass( $ability );
-		$file_name   = $reflection->getFileName();
-		$feature_dir = dirname( $file_name );
-
-		// Create a temporary system instruction file.
-		$test_file    = trailingslashit( $feature_dir ) . 'test-system-instruction-empty.php';
-		$test_content = <<<'PHP'
+		$this->create_system_instruction_file(
+			'test-system-instruction-empty.php',
+			<<<'PHP'
 <?php
 // phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
 return <<<INSTRUCTION
 You are a test assistant.
 INSTRUCTION;
-PHP;
-		file_put_contents( $test_file, $test_content );
+PHP
+		);
 
-		try {
-			// Test with empty data array.
-			$system_instruction = $ability->get_system_instruction( 'test-system-instruction-empty.php', array() );
+		$system_instruction = $this->ability->get_system_instruction( 'test-system-instruction-empty.php', array() );
 
-			// Verify it returns the content.
-			$this->assertIsString( $system_instruction, 'System instruction should be a string' );
-			$this->assertStringContainsString( 'test assistant', $system_instruction, 'System instruction should contain expected content' );
-		} finally {
-			// Clean up the test file.
-			if ( file_exists( $test_file ) ) {
-				wp_delete_file( $test_file );
-			}
-		}
+		$this->assertIsString( $system_instruction, 'System instruction should be a string' );
+		$this->assertStringContainsString( 'test assistant', $system_instruction, 'System instruction should contain expected content' );
 	}
 }


### PR DESCRIPTION
## What?

Fix `load_system_instruction_from_file()` silently returning an empty string when `get_system_instruction()` is called more than once with the same explicit filename in a single request.

## Why?

The method used `require_once` to load instruction files. On the first call, PHP returns the file's return value (the instruction string). On subsequent calls, `require_once` returns `true` instead, causing `is_string($content)` to fail and the method to silently return `''`.

## How?

- Changed `require_once` to `require`, consistent with the automatic detection path which already uses `require`
- Added a regression test that calls `get_system_instruction()` twice with the same file and asserts both calls return the instruction
- Reduced duplication in `Abstract_AbilityTest` by extracting shared setup into `setUp()` and a temp file helper

## Testing Instructions

1. Pull this branch down and run `composer install`
2. Run `npm run test:php -- --filter='Abstract_AbilityTest'` — all 10 tests should pass
3. Run the full test suite with `npm run test:php` — all tests should pass

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-358-e283cd66232974998563d303d953ab2c840ecb9b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->