### PR TITLE
Fix failing and flaky E2E tests

### DIFF
--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -57,21 +57,22 @@ test.describe( 'Plugin settings', () => {
 
 		await visitConnectorsPage( admin );
 
+		const openAIConnector = page.locator( '[role="listitem"]', {
+			has: page.getByRole( 'heading', { name: 'OpenAI', exact: true } ),
+		} );
+
 		// Add dummy credentials for OpenAI.
-		await page
-			.locator( '.connector-item--ai-provider-for-openai button' )
+		await openAIConnector
+			.getByRole( 'button', { name: /Set up|Edit/i } )
 			.click();
-		await page
-			.locator(
-				'.connector-item--ai-provider-for-openai input[type="text"]'
-			)
+		await openAIConnector
+			.getByRole( 'textbox' )
+			.first()
 			.fill( 'valid-api-key' );
 
 		// Save the credentials.
-		await page
-			.locator(
-				'.connector-item--ai-provider-for-openai .connector-settings button'
-			)
+		await openAIConnector
+			.getByRole( 'button', { name: /Save|Update/i } )
 			.click();
 	} );
 

--- a/tests/e2e/specs/experiments/image-editing.spec.js
+++ b/tests/e2e/specs/experiments/image-editing.spec.js
@@ -391,7 +391,7 @@ test.describe( 'Image Editing Experiment', () => {
 		);
 		await expect( startOverBtn ).toBeVisible();
 
-		startOverBtn.click();
+		await startOverBtn.click();
 
 		// Add a prompt and generate the image.
 		await page
@@ -495,7 +495,7 @@ test.describe( 'Image Editing Experiment', () => {
 		);
 		await expect( startOverBtn ).toBeVisible();
 
-		startOverBtn.click();
+		await startOverBtn.click();
 
 		// Find the Remove Item button and click on it.
 		const removeItemBtn = page
@@ -573,12 +573,17 @@ test.describe( 'Image Editing Experiment', () => {
 		);
 		await expect( generateAnotherBtn ).toBeVisible();
 
-		generateAnotherBtn.click();
+		await generateAnotherBtn.click();
 
 		// Ensure the images are visible in the modal.
 		await expect(
 			page.locator( '.ai-media-library-editor__preview-image' )
 		).toHaveCount( 2 );
+
+		// Ensure generation has completed and history is updated.
+		await expect(
+			page.locator( '.ai-image-history-nav__counter' )
+		).toHaveText( '2 / 2' );
 
 		// Click the previous image navigation arrow.
 		let previousImgBtn = page

--- a/tests/e2e/specs/experiments/image-editing.spec.js
+++ b/tests/e2e/specs/experiments/image-editing.spec.js
@@ -35,21 +35,22 @@ test.describe( 'Image Editing Experiment', () => {
 
 		await visitConnectorsPage( admin );
 
+		const googleConnector = page.locator( '[role="listitem"]', {
+			has: page.getByRole( 'heading', { name: 'Google', exact: true } ),
+		} );
+
 		// Add dummy credentials for Google.
-		await page
-			.locator( '.connector-item--ai-provider-for-google button' )
+		await googleConnector
+			.getByRole( 'button', { name: /Set up|Edit/i } )
 			.click();
-		await page
-			.locator(
-				'.connector-item--ai-provider-for-google input[type="text"]'
-			)
+		await googleConnector
+			.getByRole( 'textbox' )
+			.first()
 			.fill( 'valid-api-key' );
 
 		// Save the credentials.
-		await page
-			.locator(
-				'.connector-item--ai-provider-for-google .connector-settings button'
-			)
+		await googleConnector
+			.getByRole( 'button', { name: /Save|Update/i } )
 			.click();
 	} );
 

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -37,7 +37,6 @@ const clearConnectorFromItem = async ( connectorItem: Locator ) => {
 	const candidate = connectorItem.getByRole( 'button', { name: /Remove/i } );
 	if ( ( await candidate.count() ) > 0 ) {
 		await candidate.first().click();
-		return;
 	}
 };
 

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -1,12 +1,45 @@
 /**
  * External dependencies
  */
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 /**
  * WordPress dependencies
  */
 import { type Admin, expect } from '@wordpress/e2e-test-utils-playwright';
+
+const CONNECTOR_LABELS: Record< string, string > = {
+	'ai-provider-for-openai': 'OpenAI',
+	'ai-provider-for-google': 'Google',
+	'ai-provider-for-anthropic': 'Anthropic',
+};
+
+const getConnectorItem = ( page: Page, connectorId: string ) => {
+	const label = CONNECTOR_LABELS[ connectorId ];
+
+	if ( ! label ) {
+		return null;
+	}
+
+	return page.locator( '[role="listitem"]', {
+		has: page.getByRole( 'heading', { name: label, exact: true } ),
+	} );
+};
+
+const clearConnectorFromItem = async ( connectorItem: Locator ) => {
+	const editBtn = connectorItem.getByRole( 'button', { name: 'Edit' } );
+	if ( ( await editBtn.count() ) === 0 ) {
+		return;
+	}
+
+	await editBtn.click();
+
+	const candidate = connectorItem.getByRole( 'button', { name: /Remove/i } );
+	if ( ( await candidate.count() ) > 0 ) {
+		await candidate.first().click();
+		return;
+	}
+};
 
 /**
  * Visits a specific admin page.
@@ -55,20 +88,10 @@ export const clearConnectors = async ( admin: Admin, page: Page ) => {
 	];
 
 	for ( const provider of providers ) {
-		const editBtn = page.locator( `.connector-item--${ provider } button`, {
-			hasText: 'Edit',
-		} );
-
-		if ( ( await editBtn.count() ) === 0 ) {
-			continue;
+		const connectorItem = getConnectorItem( page, provider );
+		if ( connectorItem ) {
+			await clearConnectorFromItem( connectorItem );
 		}
-
-		await editBtn.click();
-		await page
-			.locator(
-				`.connector-item--${ provider } .connector-settings button`
-			)
-			.click();
 	}
 
 	// Wait for save.
@@ -92,20 +115,10 @@ export const clearConnector = async (
 	// Wait for page to fully load before finding button
 	await page.waitForTimeout( 1000 );
 
-	const editBtn = page.locator( `.connector-item--${ connectorId } button`, {
-		hasText: 'Edit',
-	} );
-
-	if ( ( await editBtn.count() ) === 0 ) {
-		return;
+	const connectorItem = getConnectorItem( page, connectorId );
+	if ( connectorItem ) {
+		await clearConnectorFromItem( connectorItem );
 	}
-
-	await editBtn.click();
-	await page
-		.locator(
-			`.connector-item--${ connectorId } .connector-settings button`
-		)
-		.click();
 
 	// Wait for save.
 	await page.waitForTimeout( 1000 );


### PR DESCRIPTION
## What?

Fixes flaky E2E image edit tests. Also updates some tests based on the new Connectors markup that's in WordPress `trunk`

## Why?

Some of the image edit E2E tests tend to be flaky, sometimes passing, sometimes not. Seems to be most flaky in our pipeline runs.

Also have some tests that started failing due to markup changes to the Connectors screen recently merged into WordPress `trunk`

## How?

Ensure we wait properly for click events to happen. Update our selectors

### Use of AI Tools

Used Cursor running GPT-5.3 Codex to investigate and fix the issue. Ran E2E tests myself locally multiple times to verify the fix

## Testing Instructions

n/a. Just ensure E2E tests pass

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-360-ab87dba5d1018e9b1c5e29cdde72b828eed4bc27.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->