### PR TITLE
Update our preferred models

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -143,7 +143,11 @@ function get_preferred_models_for_text_generation(): array {
 	$preferred_models = array(
 		array(
 			'anthropic',
-			'claude-haiku-4-5',
+			'claude-sonnet-4-6',
+		),
+		array(
+			'google',
+			'gemini-3-flash-preview',
 		),
 		array(
 			'google',
@@ -151,11 +155,11 @@ function get_preferred_models_for_text_generation(): array {
 		),
 		array(
 			'openai',
-			'gpt-4o-mini',
+			'gpt-5.4-mini',
 		),
 		array(
 			'openai',
-			'gpt-4.1',
+			'gpt-4.1-mini',
 		),
 	);
 
@@ -237,15 +241,7 @@ function get_preferred_image_models(): array {
 		),
 		array(
 			'openai',
-			'gpt-image-1',
-		),
-		array(
-			'openai',
 			'gpt-image-1-mini',
-		),
-		array(
-			'openai',
-			'dall-e-3',
 		),
 	);
 
@@ -271,7 +267,11 @@ function get_preferred_vision_models(): array {
 	$preferred_models = array(
 		array(
 			'anthropic',
-			'claude-haiku-4-5-20251001',
+			'claude-sonnet-4-6',
+		),
+		array(
+			'google',
+			'gemini-3-flash-preview',
 		),
 		array(
 			'google',
@@ -279,7 +279,11 @@ function get_preferred_vision_models(): array {
 		),
 		array(
 			'openai',
-			'gpt-5-nano',
+			'gpt-5.4-mini',
+		),
+		array(
+			'openai',
+			'gpt-4.1-mini',
 		),
 	);
 

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -280,31 +280,37 @@ class HelpersTest extends WP_UnitTestCase {
 	public function test_get_preferred_models_for_text_generation_returns_default_models() {
 		$result = \WordPress\AI\get_preferred_models_for_text_generation();
 
-		$this->assertCount( 4, $result, 'Should have 4 preferred models' );
+		$this->assertCount( 5, $result, 'Should have 5 preferred models' );
 
 		// Check first model (anthropic).
 		$this->assertIsArray( $result[0], 'First model should be an array' );
 		$this->assertCount( 2, $result[0], 'First model should have 2 elements' );
 		$this->assertEquals( 'anthropic', $result[0][0], 'First model provider should be anthropic' );
-		$this->assertEquals( 'claude-haiku-4-5', $result[0][1], 'First model name should be claude-haiku-4-5' );
+		$this->assertEquals( 'claude-sonnet-4-6', $result[0][1], 'First model name should be claude-sonnet-4-6' );
 
 		// Check second model (google).
 		$this->assertIsArray( $result[1], 'Second model should be an array' );
 		$this->assertCount( 2, $result[1], 'Second model should have 2 elements' );
 		$this->assertEquals( 'google', $result[1][0], 'Second model provider should be google' );
-		$this->assertEquals( 'gemini-2.5-flash', $result[1][1], 'Second model name should be gemini-2.5-flash' );
+		$this->assertEquals( 'gemini-3-flash-preview', $result[1][1], 'Second model name should be gemini-3-flash-preview' );
 
-		// Check third model (openai).
+		// Check third model (google).
 		$this->assertIsArray( $result[2], 'Third model should be an array' );
 		$this->assertCount( 2, $result[2], 'Third model should have 2 elements' );
-		$this->assertEquals( 'openai', $result[2][0], 'Third model provider should be openai' );
-		$this->assertEquals( 'gpt-4o-mini', $result[2][1], 'Third model name should be gpt-4o-mini' );
+		$this->assertEquals( 'google', $result[2][0], 'Third model provider should be google' );
+		$this->assertEquals( 'gemini-2.5-flash', $result[2][1], 'Third model name should be gemini-2.5-flash' );
 
 		// Check fourth model (openai).
 		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
 		$this->assertCount( 2, $result[3], 'Fourth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[3][0], 'Fourth model provider should be openai' );
-		$this->assertEquals( 'gpt-4.1', $result[3][1], 'Fourth model name should be gpt-4.1' );
+		$this->assertEquals( 'gpt-5.4-mini', $result[3][1], 'Fourth model name should be gpt-5.4-mini' );
+
+		// Check fifth model (openai).
+		$this->assertIsArray( $result[4], 'Fifth model should be an array' );
+		$this->assertCount( 2, $result[4], 'Fifth model should have 2 elements' );
+		$this->assertEquals( 'openai', $result[4][0], 'Fifth model provider should be openai' );
+		$this->assertEquals( 'gpt-4.1-mini', $result[4][1], 'Fifth model name should be gpt-4.1-mini' );
 	}
 
 	/**
@@ -327,9 +333,9 @@ class HelpersTest extends WP_UnitTestCase {
 
 		$result = \WordPress\AI\get_preferred_models_for_text_generation();
 
-		$this->assertCount( 5, $result, 'Should have 5 models after filter' );
-		$this->assertEquals( 'custom', $result[4][0], 'Fifth model provider should be custom' );
-		$this->assertEquals( 'custom-model', $result[4][1], 'Fifth model name should be custom-model' );
+		$this->assertCount( 6, $result, 'Should have 6 models after filter' );
+		$this->assertEquals( 'custom', $result[5][0], 'Sixth model provider should be custom' );
+		$this->assertEquals( 'custom-model', $result[5][1], 'Sixth model name should be custom-model' );
 
 		remove_all_filters( 'wpai_preferred_text_models' );
 	}
@@ -382,7 +388,7 @@ class HelpersTest extends WP_UnitTestCase {
 	public function test_get_preferred_image_models_returns_default_models() {
 		$result = \WordPress\AI\get_preferred_image_models();
 
-		$this->assertCount( 8, $result, 'Should have 7 preferred image models' );
+		$this->assertCount( 6, $result, 'Should have 6 preferred image models' );
 
 		// Check first model (google).
 		$this->assertIsArray( $result[0], 'First model should be an array' );
@@ -418,19 +424,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[5], 'Sixth model should be an array' );
 		$this->assertCount( 2, $result[5], 'Sixth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[5][0], 'Sixth model provider should be openai' );
-		$this->assertEquals( 'gpt-image-1', $result[5][1], 'Sixth model name should be gpt-image-1' );
-
-		// Check seventh model (openai).
-		$this->assertIsArray( $result[6], 'Seventh model should be an array' );
-		$this->assertCount( 2, $result[6], 'Seventh model should have 2 elements' );
-		$this->assertEquals( 'openai', $result[6][0], 'Seventh model provider should be openai' );
-		$this->assertEquals( 'gpt-image-1-mini', $result[6][1], 'Seventh model name should be gpt-image-1-mini' );
-
-		// Check eight model (openai).
-		$this->assertIsArray( $result[7], 'Eighth model should be an array' );
-		$this->assertCount( 2, $result[7], 'Eighth model should have 2 elements' );
-		$this->assertEquals( 'openai', $result[7][0], 'Eighth model provider should be openai' );
-		$this->assertEquals( 'dall-e-3', $result[7][1], 'Eighth model name should be dall-e-3' );
+		$this->assertEquals( 'gpt-image-1-mini', $result[5][1], 'Sixth model name should be gpt-image-1' );
 	}
 
 	/**
@@ -453,9 +447,9 @@ class HelpersTest extends WP_UnitTestCase {
 
 		$result = \WordPress\AI\get_preferred_image_models();
 
-		$this->assertCount( 9, $result, 'Should have 9 models after filter' );
-		$this->assertEquals( 'custom', $result[8][0], 'Ninth model provider should be custom' );
-		$this->assertEquals( 'custom-image-model', $result[8][1], 'Ninth model name should be custom-image-model' );
+		$this->assertCount( 7, $result, 'Should have 7 models after filter' );
+		$this->assertEquals( 'custom', $result[6][0], 'Seventh model provider should be custom' );
+		$this->assertEquals( 'custom-image-model', $result[6][1], 'Seventh model name should be custom-image-model' );
 
 		remove_all_filters( 'wpai_preferred_image_models' );
 	}
@@ -508,22 +502,32 @@ class HelpersTest extends WP_UnitTestCase {
 	public function test_get_preferred_vision_models_returns_default_models() {
 		$result = \WordPress\AI\get_preferred_vision_models();
 
-		$this->assertCount( 3, $result, 'Should have 3 preferred vision models' );
+		$this->assertCount( 5, $result, 'Should have 5 preferred vision models' );
 
 		$this->assertIsArray( $result[0], 'First model should be an array' );
 		$this->assertCount( 2, $result[0], 'First model should have 2 elements' );
 		$this->assertEquals( 'anthropic', $result[0][0], 'First model provider should be anthropic' );
-		$this->assertEquals( 'claude-haiku-4-5-20251001', $result[0][1], 'First model name should be claude-haiku-4-5-20251001' );
+		$this->assertEquals( 'claude-sonnet-4-6', $result[0][1], 'First model name should be claude-sonnet-4-6' );
 
 		$this->assertIsArray( $result[1], 'Second model should be an array' );
 		$this->assertCount( 2, $result[1], 'Second model should have 2 elements' );
 		$this->assertEquals( 'google', $result[1][0], 'Second model provider should be google' );
-		$this->assertEquals( 'gemini-2.5-flash', $result[1][1], 'Second model name should be gemini-2.5-flash' );
+		$this->assertEquals( 'gemini-3-flash-preview', $result[1][1], 'Second model name should be gemini-3-flash-preview' );
 
 		$this->assertIsArray( $result[2], 'Third model should be an array' );
 		$this->assertCount( 2, $result[2], 'Third model should have 2 elements' );
-		$this->assertEquals( 'openai', $result[2][0], 'Third model provider should be openai' );
-		$this->assertEquals( 'gpt-5-nano', $result[2][1], 'Third model name should be gpt-5-nano' );
+		$this->assertEquals( 'google', $result[2][0], 'Third model provider should be google' );
+		$this->assertEquals( 'gemini-2.5-flash', $result[2][1], 'Third model name should be gemini-2.5-flash' );
+
+		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
+		$this->assertCount( 2, $result[3], 'Fourth model should have 2 elements' );
+		$this->assertEquals( 'openai', $result[3][0], 'Fourth model provider should be openai' );
+		$this->assertEquals( 'gpt-5.4-mini', $result[3][1], 'Fourth model name should be gpt-5.4-mini' );
+
+		$this->assertIsArray( $result[4], 'Fifth model should be an array' );
+		$this->assertCount( 2, $result[4], 'Fifth model should have 2 elements' );
+		$this->assertEquals( 'openai', $result[4][0], 'Fifth model provider should be openai' );
+		$this->assertEquals( 'gpt-4.1-mini', $result[4][1], 'Fifth model name should be gpt-4.1-mini' );
 	}
 
 	/**
@@ -545,9 +549,9 @@ class HelpersTest extends WP_UnitTestCase {
 
 		$result = \WordPress\AI\get_preferred_vision_models();
 
-		$this->assertCount( 4, $result, 'Should have 4 models after filter' );
-		$this->assertEquals( 'custom', $result[3][0], 'Fourth model provider should be custom' );
-		$this->assertEquals( 'custom-vision-model', $result[3][1], 'Fourth model name should be custom-vision-model' );
+		$this->assertCount( 6, $result, 'Should have 6 models after filter' );
+		$this->assertEquals( 'custom', $result[5][0], 'Sixth model provider should be custom' );
+		$this->assertEquals( 'custom-vision-model', $result[5][1], 'Sixth model name should be custom-vision-model' );
 
 		remove_all_filters( 'wpai_preferred_vision_models' );
 	}


### PR DESCRIPTION
## What?

Updates our preferred models to more recent ones for the three default providers

## Why?

We maintain a list of our preferred models for text generation, image generation and vision handling. This allows us to be more confident that when someone uses one of our features with the three default providers, things will work (even if new models are released).

This does mean we need to maintain that list and periodically update it, which is what this PR does. Some providers (like OpenAI) have lots of models to choose from and while they often provide guidance on which models to choose, there is still some room for individual opinions here. I made my best judgement on the models to use but open to other opinions here.

## How?

Updates our preferred model list with the most recent suggested models

### Use of AI Tools

None

## Testing Instructions

We're updating the text generation and vision models in this PR so need to test experiments that use those, ideally with the three default AI provider plugins

1. Pull these changes down
2. Activate one of the three default AI provider plugins
3. Enable Title Generation, alt text generation and image generation
4. Test all three and ensure they work
5. Run tests again with the other default AI providers

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-361-c1c4dab15661feeb41f36490a71b18a18799d779.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->