### PR TITLE
Add preferred version for WordPress in PR preview action

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -84,7 +84,7 @@ jobs:
 
           const blueprint = {
             preferredVersions: {
-              wp: "beta",
+              wp: 'beta',
             },
             steps: [
               {

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -84,7 +84,7 @@ jobs:
 
           const blueprint = {
             "preferredVersions": {
-              "wp": "beta"
+              "wp": "beta",
             },
             steps: [
               {

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -83,6 +83,9 @@ jobs:
           }
 
           const blueprint = {
+            "preferredVersions": {
+              "wp": "beta"
+            },
             steps: [
               {
                 step: 'installPlugin',

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -83,8 +83,8 @@ jobs:
           }
 
           const blueprint = {
-            "preferredVersions": {
-              "wp": "beta",
+            preferredVersions: {
+              wp: "beta",
             },
             steps: [
               {


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #365

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently, the Playground preview is loading WordPress version 6.9.4. Because the WordPress AI plugin requires at least version 7.0 to run properly, the preview environment is currently broken.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I updated the GitHub Action configuration to set the WordPress version to `beta`. This ensures that the Playground environment loads the latest WordPress 7.0 Release Candidate (RC), making the plugin compatible again.

<!-- If you are using AI tools, you must adhere to the AI Guidelines: https://make.wordpress.org/ai/handbook/ai-guidelines/ -->

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Let the GitHub Action run on this PR.
2. Click the generated "Preview" button.
3. Verify that the Playground loads WordPress 7.0 (Beta/RC).
4. Verify that the AI plugin activates and runs successfully.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-366-1327465f7644a05c66304012f63fbc3bc548ebf9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->