### PR TITLE
When getting content for a post, ensure we're always getting the most recent version

### DIFF
--- a/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
+++ b/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, select, useDispatch } from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
@@ -54,9 +54,13 @@ export function useExcerptGeneration(): {
 	hasExcerpt: boolean;
 	handleGenerate: () => Promise< void >;
 } {
-	const postId = select( editorStore ).getCurrentPostId();
-	const content = select( editorStore ).getEditedPostContent();
-	const excerpt = select( editorStore ).getEditedPostAttribute( 'excerpt' );
+	const { postId, content, excerpt } = useSelect( ( select ) => {
+		return {
+			postId: select( editorStore ).getCurrentPostId(),
+			content: select( editorStore ).getEditedPostContent(),
+			excerpt: select( editorStore ).getEditedPostAttribute( 'excerpt' ),
+		};
+	} );
 	const { editPost } = useDispatch( editorStore );
 	const [ isGenerating, setIsGenerating ] = useState< boolean >( false );
 

--- a/src/experiments/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/experiments/image-generation/components/GenerateFeaturedImage.tsx
@@ -25,7 +25,6 @@ export default function GenerateFeaturedImage(): JSX.Element {
 	const { editPost } = useDispatch( editorStore );
 
 	const content = select( editorStore ).getEditedPostContent();
-	const postId = select( editorStore ).getCurrentPostId();
 	const featuredImage =
 		select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
@@ -49,11 +48,9 @@ export default function GenerateFeaturedImage(): JSX.Element {
 		);
 
 		try {
-			const generatedImageData = await generateImage(
-				postId as number,
-				content,
-				{ onProgress: setProgressMessage }
-			);
+			const generatedImageData = await generateImage( content, {
+				onProgress: setProgressMessage,
+			} );
 			const importedImage = await uploadImage( generatedImageData, {
 				onProgress: setProgressMessage,
 			} );

--- a/src/experiments/image-generation/functions/generate-image.ts
+++ b/src/experiments/image-generation/functions/generate-image.ts
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
+import { select } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { formatContext } from './format-context';
-import { getContext } from './get-context';
 import { generatePrompt } from './generate-prompt';
 import { runAbility } from '../../../utils/run-ability';
 import type {
@@ -20,28 +21,21 @@ import type {
 /**
  * Generates an image for the given post ID and content.
  *
- * @param {number}   postId             The ID of the post to generate a featured image for.
  * @param {string}   content            The content of the post to generate an image for.
  * @param {Object}   options            Optional settings.
  * @param {Function} options.onProgress Callback invoked with progress messages.
  * @return {Promise<GeneratedImageData>} A promise that resolves to the generated image data.
  */
 export async function generateImage(
-	postId: number,
 	content: string,
 	options?: { onProgress?: ImageProgressCallback }
 ): Promise< GeneratedImageData > {
 	const onProgress = options?.onProgress;
 
-	let context: PostContext;
-
-	try {
-		context = ( await getContext( postId ) ) as PostContext;
-	} catch ( error: any ) {
-		throw new Error(
-			`Failed to get post context: ${ error.message || error }`
-		);
-	}
+	const context: PostContext = {
+		title: select( editorStore ).getEditedPostAttribute( 'title' ),
+		type: select( editorStore ).getEditedPostAttribute( 'type' ),
+	};
 
 	let prompt: string;
 

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -159,7 +159,6 @@ async function generateTitles(
  */
 export default function TitleToolbar(): JSX.Element | null {
 	const postId = select( editorStore ).getCurrentPostId();
-	const content = select( editorStore ).getEditedPostContent();
 	const title = select( editorStore ).getEditedPostAttribute( 'title' );
 
 	const { editPost } = useDispatch( editorStore );
@@ -183,6 +182,7 @@ export default function TitleToolbar(): JSX.Element | null {
 	 * Handles the generate/re-generate button click.
 	 */
 	const handleGenerate = async () => {
+		const content = select( editorStore ).getEditedPostContent();
 		setIsGenerating( true );
 		( dispatch( noticesStore ) as any ).removeNotice(
 			'ai_title_generation_error'


### PR DESCRIPTION
## What?

When content about a post is needed when an experiment is triggered, ensure we always grab the most recent version.

## Why?

There was a bug report around the Title Generation Experiment and how they added some post content that was about one topic and then changed that content to be about a completely different topic. When generating titles, the titles reflected the first content, not the second.

The issue here is we grab the content from the editor at page load so if the content is changed and the page isn't refreshed, we have the old version of the content stored. Instead we should pull the content fresh each time title generation is triggered.

I audited all of our other Experiments and found similar problems with Excerpt Generation and Featured Image Generation (in particular, generating the image prompt). All of those are fixed now. All other Experiments were working correctly.

## How?

- Grab the post content from the editor when title generation is triggered instead of when the component is loaded
- Switch to using the `useSelect` hook to get the post content and excerpt when Excerpt Generation is triggered to ensure we always have the freshest data
- For the context we send to our Image Prompt Generation Ability, switch away from using our `get-post-details` Ability and instead directly grab the post title and post type. This ensures we always have the most up-to-date title instead of the latest version stored in the database

### Use of AI Tools

None

## Testing Instructions

1. Checkout this PR and run `npm i && npm run build`
2. Turn on Title Generation, Excerpt Generation and Image Generation
3. Create a new post and add a title and some content
4. Ensure all three of those Experiments work
5. Modify the title and content significantly. Don't save or reload
6. Run all three Experiments again and ensure they still work

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-367-a15dd320b354769075b9c771785a2bbc79691b1d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->