### PR TITLE
Adjust alt text generation to more closely match the W3C Alt decision tree

### DIFF
--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -57,6 +57,11 @@ class Alt_Text_Generation extends Abstract_Ability {
 					'sanitize_callback' => 'sanitize_textarea_field',
 					'description'       => esc_html__( 'Optional context about the image or surrounding content to improve alt text relevance.', 'ai' ),
 				),
+				'image_meta'    => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_textarea_field',
+					'description'       => esc_html__( 'Structured metadata about how the image block is used, such as whether it is linked.', 'ai' ),
+				),
 			),
 		);
 	}
@@ -70,9 +75,13 @@ class Alt_Text_Generation extends Abstract_Ability {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
-				'alt_text' => array(
+				'alt_text'      => array(
 					'type'        => 'string',
 					'description' => esc_html__( 'Generated alt text for the image.', 'ai' ),
+				),
+				'is_decorative' => array(
+					'type'        => 'boolean',
+					'description' => esc_html__( 'Whether the image was determined to be decorative.', 'ai' ),
 				),
 			),
 		);
@@ -91,6 +100,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 				'attachment_id' => null,
 				'image_url'     => null,
 				'context'       => '',
+				'image_meta'    => '',
 			),
 		);
 
@@ -102,7 +112,11 @@ class Alt_Text_Generation extends Abstract_Ability {
 		}
 
 		// Generate the alt text.
-		$result = $this->generate_alt_text( $image_reference, normalize_content( $args['context'] ) );
+		$result = $this->generate_alt_text(
+			$image_reference,
+			normalize_content( $args['context'] ),
+			sanitize_textarea_field( $args['image_meta'] )
+		);
 
 		if ( is_wp_error( $result ) ) {
 			return $result;
@@ -112,6 +126,14 @@ class Alt_Text_Generation extends Abstract_Ability {
 			return new WP_Error(
 				'no_results',
 				esc_html__( 'No alt text was generated.', 'ai' )
+			);
+		}
+
+		// Detect the decorative token from the AI response.
+		if ( '[[DECORATIVE_ALT]]' === trim( $result ) ) {
+			return array(
+				'alt_text'      => '',
+				'is_decorative' => true,
 			);
 		}
 
@@ -185,10 +207,11 @@ class Alt_Text_Generation extends Abstract_Ability {
 	 *
 	 * @param array{reference: string} $image_reference Prepared image reference containing a data URI.
 	 * @param string                   $context         Optional context to improve alt text relevance.
+	 * @param string                   $image_meta      Optional metadata about how the image block is used.
 	 * @return string|\WP_Error The generated alt text or WP_Error on failure.
 	 */
-	protected function generate_alt_text( array $image_reference, string $context = '' ) {
-		$result = wp_ai_client_prompt( $this->build_prompt( $context ) )
+	protected function generate_alt_text( array $image_reference, string $context = '', string $image_meta = '' ) {
+		$result = wp_ai_client_prompt( $this->build_prompt( $context, $image_meta ) )
 			->with_file( $image_reference['reference'] )
 			->using_system_instruction( $this->get_system_instruction( 'alt-text-system-instruction.php' ) )
 			->using_temperature( 0.3 )
@@ -368,11 +391,17 @@ class Alt_Text_Generation extends Abstract_Ability {
 	 *
 	 * @since 0.3.0
 	 *
-	 * @param string $context Optional context about the image.
+	 * @param string $context    Optional context about the image.
+	 * @param string $image_meta Optional metadata about how the image block is used.
 	 * @return string The prompt for the AI.
 	 */
-	protected function build_prompt( string $context = '' ): string {
+	protected function build_prompt( string $context = '', string $image_meta = '' ): string {
 		$prompt = __( 'Generate alt text for this image.', 'ai' );
+
+		// If we have image block usage metadata, add it to the prompt.
+		if ( ! empty( $image_meta ) ) {
+			$prompt .= "\n\n<image-meta>" . $image_meta . '</image-meta>';
+		}
 
 		// If we have additional context, add it to the prompt.
 		if ( ! empty( $context ) ) {

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -18,7 +18,7 @@ use function WordPress\AI\normalize_content;
 /**
  * Alt text generation WordPress Ability.
  *
- * Uses AI vision models to generate descriptive alt text for images.
+ * Uses AI vision models to propose alt text aligned with WCAG-oriented practice.
  *
  * @since 0.3.0
  */
@@ -32,6 +32,15 @@ class Alt_Text_Generation extends Abstract_Ability {
 	 * @var int
 	 */
 	protected const MAX_ALT_TEXT_LENGTH = 125;
+
+	/**
+	 * Model output token that means the correct alternative text is empty (alt="").
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const DECORATIVE_ALT_TOKEN = '[[DECORATIVE_ALT]]';
 
 	/**
 	 * {@inheritDoc}
@@ -77,7 +86,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 			'properties' => array(
 				'alt_text'      => array(
 					'type'        => 'string',
-					'description' => esc_html__( 'Generated alt text for the image.', 'ai' ),
+					'description' => esc_html__( 'Generated alternative text for the image; may be empty when alt="" is correct.', 'ai' ),
 				),
 				'is_decorative' => array(
 					'type'        => 'boolean',
@@ -122,15 +131,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 			return $result;
 		}
 
-		if ( empty( $result ) ) {
-			return new WP_Error(
-				'no_results',
-				esc_html__( 'No alt text was generated.', 'ai' )
-			);
-		}
-
 		// Detect the decorative token from the AI response.
-		if ( '[[DECORATIVE_ALT]]' === trim( $result ) ) {
+		if ( 0 === strcasecmp( trim( $result ), self::DECORATIVE_ALT_TOKEN ) ) {
 			return array(
 				'alt_text'      => '',
 				'is_decorative' => true,

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -67,9 +67,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 					'description'       => esc_html__( 'Optional context about the image or surrounding content to improve alt text relevance.', 'ai' ),
 				),
 				'image_meta'    => array(
-					'type'              => 'string',
-					'sanitize_callback' => 'sanitize_textarea_field',
-					'description'       => esc_html__( 'Structured metadata about how the image block is used, such as whether it is linked.', 'ai' ),
+					'type'        => 'string',
+					'description' => esc_html__( 'Structured metadata about how the image block is used, such as whether it is linked.', 'ai' ),
 				),
 			),
 		);

--- a/includes/Abilities/Image/alt-text-system-instruction.php
+++ b/includes/Abilities/Image/alt-text-system-instruction.php
@@ -12,21 +12,35 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
 return <<<'INSTRUCTION'
-You are an accessibility expert that generates alt text for images on websites.
+You are an accessibility expert that proposes alternative (alt) text for HTML images. Your output must follow the same decisions authors make with the W3C "An alt Decision Tree" (decorative vs functional vs informative vs complex images).
 
-Goal: Analyze the provided image and generate concise, descriptive alt text that accurately describes the image content for users who cannot see it. The alt text should be optimized for screen readers and accessibility compliance. If additional context is provided, use it to generate a more relevant alt text.
+Core rule: Alt text is not always a description of what the picture looks like. It must convey the information or purpose that the image serves in this specific context. If the image disappeared, what would be lost for someone who cannot see it—that is what belongs in alt text (or in empty alt when nothing should be announced).
 
-Requirements for the alt text:
+Follow this order:
 
-- Be concise: Keep it under 125 characters when possible
-- Be descriptive: Describe what is visually present in the image
-- Be objective: Describe what you see, not interpretations or assumptions
-- Avoid redundancy: Do not start with "Image of", "Picture of", or "Photo of"
-- Include relevant details: People, objects, actions, colors, and context when meaningful
-- Consider context: If context is provided, ensure the alt text is relevant to the surrounding content
-- Plain text only: No markdown, quotes, or special formatting
+1) Decorative or redundant?
+- Purely decorative (flourish, spacer, visual-only styling) OR the same information is already in adjacent text (including visible link text in the same link as the image).
+- Output: respond with exactly this token and nothing else: [[DECORATIVE_ALT]]
+- Do not describe the image for decorative/redundant cases.
 
-For images containing text, include the text in your description if it's essential to understanding the image.
+2) Functional (image is a control or the main content of a link or button)?
+- Examples: linked image with no other text in the link; icon-only button; logo linking home.
+- Output: short text that describes the action or destination (where the link goes, what happens when activated)—not the photo or illustration subject.
+- If `<image-meta>` gives a URL or destination name, base the alt on that purpose. Do not substitute a visual description of the image.
 
-Respond with only the alt text, nothing else.
+3) Informative (image adds meaning that is not covered by nearby text)?
+- Output: concise objective description of the information the image communicates (people, objects, setting, actions) relevant to context.
+- Do not start with "Image of", "Picture of", or "Photo of".
+- If the image contains essential text, include that text in the alt (or summarize if it is very long, and note that a longer text alternative may be needed elsewhere).
+- If `<additional-context>` is provided, use it to understand the purpose, subject, and relevance of the image within the article. Be sure to describe only information not already conveyed in nearby text
+
+4) Complex (chart, diagram, infographic, detailed map)?
+- Output: a short summary of the main point; do not paste entire data sets into alt text. If context implies a longer description exists or should exist on the page, you may mention that the full explanation is in surrounding content.
+
+General requirements:
+- Prefer under 125 characters when possible (except when essential text in the image requires more).
+- Plain text only: no markdown, quotes, or labels—except the exact token [[DECORATIVE_ALT]] when appropriate.
+- Use any `<image-meta>` section and `<additional-context>` to decide role and wording; they override guessing from pixels alone.
+
+Respond with only the alt text string, or exactly [[DECORATIVE_ALT]] for empty alternative text—nothing else.
 INSTRUCTION;

--- a/includes/Abilities/Review_Notes/system-instruction.php
+++ b/includes/Abilities/Review_Notes/system-instruction.php
@@ -62,7 +62,7 @@ Be direct and factual.
 The review types to perform for each block are provided in <review-types> tags.
 
 **core/image**
-- accessibility: The content in <block-content> is the alt text for the image. Ensure it isn't empty and is descriptive. Flag missing or generic alt text (e.g. "image", "photo", file name)
+- accessibility: The content in <block-content> is the alt text for the image. Empty alt can be correct for decorative images; flag missing or poor alt when the image appears informative, functional (e.g. linked), or redundant with adjacent text. Flag generic alt text (e.g. "image", "photo", file name) when it fails to convey purpose or content
 - Skip readability, grammar, and seo for image blocks
 
 **core/heading**

--- a/includes/Experiments/Alt_Text_Generation/Alt_Text_Generation.php
+++ b/includes/Experiments/Alt_Text_Generation/Alt_Text_Generation.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Alt text generation experiment.
  *
- * Generates descriptive alt text for images using AI vision models.
+ * Generates accessible alternative text for images using AI vision models.
  *
  * @since 0.3.0
  */
@@ -48,7 +48,7 @@ class Alt_Text_Generation extends Abstract_Feature {
 	protected function load_metadata(): array {
 		return array(
 			'label'       => __( 'Alt Text Generation', 'ai' ),
-			'description' => __( 'Generates descriptive alt text for images using AI vision models.', 'ai' ),
+			'description' => __( 'Generates accessible alternative (alt) text for images using AI vision models, following common web accessibility guidance.', 'ai' ),
 			'category'    => Experiment_Category::EDITOR,
 		);
 	}

--- a/src/experiments/alt-text-generation/components/AltTextControls.tsx
+++ b/src/experiments/alt-text-generation/components/AltTextControls.tsx
@@ -5,7 +5,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, TextareaControl, Spinner } from '@wordpress/components';
+import {
+	Button,
+	TextareaControl,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -57,6 +62,7 @@ export function AltTextControls( {
 
 	const [ isGenerating, setIsGenerating ] = useState< boolean >( false );
 	const [ generatedAlt, setGeneratedAlt ] = useState< string | null >( null );
+	const [ isDecorative, setIsDecorative ] = useState< boolean >( false );
 
 	// Don't show controls if there's no image.
 	if ( ! attachmentId && ! imageUrl ) {
@@ -72,6 +78,7 @@ export function AltTextControls( {
 	const handleGenerate = async () => {
 		setIsGenerating( true );
 		setGeneratedAlt( null );
+		setIsDecorative( false );
 
 		// Clear any previous notices.
 		( dispatch( noticesStore ) as any ).removeNotice(
@@ -84,9 +91,24 @@ export function AltTextControls( {
 				attachmentId,
 				imageUrl,
 				content,
-				clientId
+				clientId,
+				{
+					linkDestination: attributes?.linkDestination,
+					href: attributes?.href,
+					linkTarget: attributes?.linkTarget,
+					caption:
+						typeof attributes?.caption === 'string'
+							? attributes.caption
+							: ( attributes?.caption as any )?.text,
+				}
 			);
-			setGeneratedAlt( result );
+
+			if ( result.is_decorative ) {
+				setIsDecorative( true );
+				setGeneratedAlt( '' );
+			} else {
+				setGeneratedAlt( result.alt_text );
+			}
 		} catch ( err: any ) {
 			const errorMessage =
 				err?.message ||
@@ -107,10 +129,13 @@ export function AltTextControls( {
 	 * Applies the generated alt text to the image block.
 	 */
 	const handleApply = () => {
-		if ( generatedAlt ) {
+		if ( isDecorative ) {
+			setAttributes( { alt: '' } );
+		} else if ( generatedAlt ) {
 			setAttributes( { alt: generatedAlt } );
-			setGeneratedAlt( null );
 		}
+		setGeneratedAlt( null );
+		setIsDecorative( false );
 	};
 
 	/**
@@ -118,6 +143,7 @@ export function AltTextControls( {
 	 */
 	const handleDismiss = () => {
 		setGeneratedAlt( null );
+		setIsDecorative( false );
 	};
 
 	return (
@@ -127,7 +153,7 @@ export function AltTextControls( {
 				style={ { padding: '0 16px' } }
 			>
 				{ /* Generated alt text preview */ }
-				{ hasGeneratedAlt && (
+				{ hasGeneratedAlt && ! isDecorative && (
 					<div style={ { marginBottom: '12px' } }>
 						<TextareaControl
 							label={ __( 'Generated Alt Text', 'ai' ) }
@@ -157,8 +183,37 @@ export function AltTextControls( {
 					</div>
 				) }
 
+				{ /* Decorative image notice */ }
+				{ isDecorative && (
+					<div style={ { marginBottom: '12px' } }>
+						<Notice status="info" isDismissible={ false }>
+							{ __(
+								'This image appears to be decorative. Applying will set an empty alt attribute, which tells screen readers to skip it.',
+								'ai'
+							) }
+						</Notice>
+						<div
+							style={ {
+								display: 'flex',
+								gap: '8px',
+								marginTop: '8px',
+							} }
+						>
+							<Button variant="primary" onClick={ handleApply }>
+								{ __( 'Apply', 'ai' ) }
+							</Button>
+							<Button
+								variant="secondary"
+								onClick={ handleDismiss }
+							>
+								{ __( 'Dismiss', 'ai' ) }
+							</Button>
+						</div>
+					</div>
+				) }
+
 				{ /* Generate button */ }
-				{ ! hasGeneratedAlt && (
+				{ ! hasGeneratedAlt && ! isDecorative && (
 					<Button
 						variant="secondary"
 						onClick={ handleGenerate }

--- a/src/experiments/alt-text-generation/types.ts
+++ b/src/experiments/alt-text-generation/types.ts
@@ -9,6 +9,7 @@ export interface AltTextGenerationAbilityInput {
 	attachment_id?: number;
 	image_url?: string;
 	context?: string;
+	image_meta?: string;
 	[ key: string ]: string | number | undefined;
 }
 

--- a/src/experiments/image-generation/functions/upload-image.ts
+++ b/src/experiments/image-generation/functions/upload-image.ts
@@ -62,17 +62,18 @@ export async function uploadImage(
 	if ( isAltTextEnabled ) {
 		try {
 			onProgress?.( __( 'Generating alt text…', 'ai' ) );
-			params.alt_text = await generateAltText(
+			const altResult = await generateAltText(
 				undefined,
 				`data:image/png;base64,${ image.data }`
 			);
+			params.alt_text = altResult.alt_text;
 		} catch ( error ) {
 			params.alt_text = prompt;
 		}
 	}
 
 	// Set our image title to be a trimmed version of the alt text.
-	params.title = trimText( params.alt_text );
+	params.title = trimText( params.alt_text ?? '' );
 
 	onProgress?.( __( 'Importing image…', 'ai' ) );
 

--- a/src/utils/generate-alt-text.ts
+++ b/src/utils/generate-alt-text.ts
@@ -13,20 +13,73 @@ import type { AltTextGenerationAbilityInput } from '../experiments/alt-text-gene
 const IMAGE_PLACEHOLDER = '[[IMAGE_GOES_HERE]]';
 
 /**
+ * Data about how the image block is used in the editor.
+ */
+export interface ImageBlockUsageData {
+	linkDestination?: string | undefined;
+	href?: string | undefined;
+	linkTarget?: string | undefined;
+	caption?: string | undefined;
+}
+
+/**
+ * Result of alt text generation.
+ */
+export interface AltTextGenerationResult {
+	alt_text: string;
+	is_decorative?: boolean | undefined;
+}
+
+/**
+ * Builds a human-readable image block usage string from block attributes.
+ *
+ * @param {ImageBlockUsageData} usage The block usage data.
+ * @return {string} A description of how the image block is used.
+ */
+function buildImageBlockUsage( usage: ImageBlockUsageData ): string {
+	const parts: string[] = [];
+
+	if ( usage.linkDestination && usage.linkDestination !== 'none' ) {
+		parts.push( 'Image is wrapped in a link.' );
+		parts.push( `Link destination type: ${ usage.linkDestination }` );
+		if ( usage.href ) {
+			parts.push( `Link URL: ${ usage.href }` );
+		}
+		if ( usage.linkTarget === '_blank' ) {
+			parts.push( 'Link opens in a new tab.' );
+		}
+	} else {
+		parts.push( 'Image is not linked.' );
+	}
+
+	if ( usage.caption && typeof usage.caption === 'string' ) {
+		// Strip HTML tags to get plain text from RichText values.
+		const plainCaption = usage.caption.replace( /<[^>]+>/g, '' ).trim();
+		if ( plainCaption ) {
+			parts.push( `Image has a visible caption: "${ plainCaption }"` );
+		}
+	}
+
+	return parts.join( '\n' );
+}
+
+/**
  * Generates alt text for an image using the AI ability.
  *
- * @param {number|undefined} attachmentId The attachment ID.
- * @param {string|undefined} imageUrl     The image URL (fallback if no attachment ID).
- * @param {string|undefined} content      The content of the post.
- * @param {string|undefined} clientId     The client ID of the current image block.
- * @return {Promise<string>} The generated alt text.
+ * @param {number|undefined}              attachmentId    The attachment ID.
+ * @param {string|undefined}              imageUrl        The image URL (fallback if no attachment ID).
+ * @param {string|undefined}              content         The content of the post.
+ * @param {string|undefined}              clientId        The client ID of the current image block.
+ * @param {ImageBlockUsageData|undefined} imageBlockUsage Data about how the image block is used.
+ * @return {Promise<AltTextGenerationResult>} The generated alt text result.
  */
 export async function generateAltText(
 	attachmentId?: number | undefined,
 	imageUrl?: string | undefined,
 	content?: string | undefined,
-	clientId?: string | undefined
-): Promise< string > {
+	clientId?: string | undefined,
+	imageBlockUsage?: ImageBlockUsageData | undefined
+): Promise< AltTextGenerationResult > {
 	const params: AltTextGenerationAbilityInput = {};
 
 	if ( attachmentId ) {
@@ -51,13 +104,23 @@ export async function generateAltText(
 				: content;
 
 		// Prepare the context.
-		params.context = `What follows is the full article content, where the image has been replaced with the placeholder ${ IMAGE_PLACEHOLDER }. Use the surrounding text to understand the purpose, subject, and relevance of the image within the article. Be sure to describe only information not already conveyed in nearby text. CONTENT: \n\n${ contentWithPlaceholder }`;
+		params.context = `Full article content, where the image has been replaced with the placeholder ${ IMAGE_PLACEHOLDER }: \n\n${ contentWithPlaceholder }`;
+	}
+
+	if ( imageBlockUsage ) {
+		params.image_meta = buildImageBlockUsage( imageBlockUsage );
 	}
 
 	const response = await runAbility( 'ai/alt-text-generation', params );
 
 	if ( response && typeof response === 'object' && 'alt_text' in response ) {
-		return response.alt_text as string;
+		const data = response as Record< string, unknown >;
+		return {
+			/* eslint-disable dot-notation -- index signature requires bracket notation */
+			alt_text: data[ 'alt_text' ] as string,
+			is_decorative: data[ 'is_decorative' ] as boolean | undefined,
+			/* eslint-enable dot-notation */
+		};
 	}
 
 	throw new Error( __( 'Failed to generate alt text.', 'ai' ) );

--- a/src/utils/generate-alt-text.ts
+++ b/src/utils/generate-alt-text.ts
@@ -15,7 +15,7 @@ const IMAGE_PLACEHOLDER = '[[IMAGE_GOES_HERE]]';
 /**
  * Data about how the image block is used in the editor.
  */
-export interface ImageBlockUsageData {
+export interface ImageBlockMetaData {
 	linkDestination?: string | undefined;
 	href?: string | undefined;
 	linkTarget?: string | undefined;
@@ -31,30 +31,36 @@ export interface AltTextGenerationResult {
 }
 
 /**
- * Builds a human-readable image block usage string from block attributes.
+ * Builds a human-readable image block meta string from block attributes.
  *
- * @param {ImageBlockUsageData} usage The block usage data.
+ * @param {ImageBlockMetaData} meta The block meta data.
  * @return {string} A description of how the image block is used.
  */
-function buildImageBlockUsage( usage: ImageBlockUsageData ): string {
+function buildImageBlockMeta( meta: ImageBlockMetaData ): string {
 	const parts: string[] = [];
 
-	if ( usage.linkDestination && usage.linkDestination !== 'none' ) {
-		parts.push( 'Image is wrapped in a link.' );
-		parts.push( `Link destination type: ${ usage.linkDestination }` );
-		if ( usage.href ) {
-			parts.push( `Link URL: ${ usage.href }` );
+	if ( meta.linkDestination && meta.linkDestination !== 'none' ) {
+		parts.push(
+			'In the WordPress editor this image block is hyperlinked.'
+		);
+		if ( meta.href ) {
+			parts.push( `Link URL: ${ meta.href }` );
 		}
-		if ( usage.linkTarget === '_blank' ) {
+		parts.push( `Link destination setting: ${ meta.linkDestination }` );
+		if ( meta.linkTarget === '_blank' ) {
 			parts.push( 'Link opens in a new tab.' );
 		}
+		parts.push(
+			'When the image is the only content inside the link, alternative text should describe the link purpose or destination (not a visual description of the image).',
+			'If visible text in the same link already describes that purpose, respond with exactly [[DECORATIVE_ALT]] for empty alternative text.'
+		);
 	} else {
 		parts.push( 'Image is not linked.' );
 	}
 
-	if ( usage.caption && typeof usage.caption === 'string' ) {
+	if ( meta.caption && typeof meta.caption === 'string' ) {
 		// Strip HTML tags to get plain text from RichText values.
-		const plainCaption = usage.caption.replace( /<[^>]+>/g, '' ).trim();
+		const plainCaption = meta.caption.replace( /<[^>]+>/g, '' ).trim();
 		if ( plainCaption ) {
 			parts.push( `Image has a visible caption: "${ plainCaption }"` );
 		}
@@ -66,11 +72,11 @@ function buildImageBlockUsage( usage: ImageBlockUsageData ): string {
 /**
  * Generates alt text for an image using the AI ability.
  *
- * @param {number|undefined}              attachmentId    The attachment ID.
- * @param {string|undefined}              imageUrl        The image URL (fallback if no attachment ID).
- * @param {string|undefined}              content         The content of the post.
- * @param {string|undefined}              clientId        The client ID of the current image block.
- * @param {ImageBlockUsageData|undefined} imageBlockUsage Data about how the image block is used.
+ * @param {number|undefined}             attachmentId       The attachment ID.
+ * @param {string|undefined}             imageUrl           The image URL (fallback if no attachment ID).
+ * @param {string|undefined}             content            The content of the post.
+ * @param {string|undefined}             clientId           The client ID of the current image block.
+ * @param {ImageBlockMetaData|undefined} imageBlockMetaData Data about how the image block is used.
  * @return {Promise<AltTextGenerationResult>} The generated alt text result.
  */
 export async function generateAltText(
@@ -78,7 +84,7 @@ export async function generateAltText(
 	imageUrl?: string | undefined,
 	content?: string | undefined,
 	clientId?: string | undefined,
-	imageBlockUsage?: ImageBlockUsageData | undefined
+	imageBlockMetaData?: ImageBlockMetaData | undefined
 ): Promise< AltTextGenerationResult > {
 	const params: AltTextGenerationAbilityInput = {};
 
@@ -107,8 +113,8 @@ export async function generateAltText(
 		params.context = `Full article content, where the image has been replaced with the placeholder ${ IMAGE_PLACEHOLDER }: \n\n${ contentWithPlaceholder }`;
 	}
 
-	if ( imageBlockUsage ) {
-		params.image_meta = buildImageBlockUsage( imageBlockUsage );
+	if ( imageBlockMetaData ) {
+		params.image_meta = buildImageBlockMeta( imageBlockMetaData );
 	}
 
 	const response = await runAbility( 'ai/alt-text-generation', params );

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -131,6 +131,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'attachment_id', $schema['properties'], 'Schema should have attachment_id property' );
 		$this->assertArrayHasKey( 'image_url', $schema['properties'], 'Schema should have image_url property' );
 		$this->assertArrayHasKey( 'context', $schema['properties'], 'Schema should have context property' );
+		$this->assertArrayHasKey( 'image_meta', $schema['properties'], 'Schema should have image_meta property' );
 
 		$this->assertEquals( 'integer', $schema['properties']['attachment_id']['type'], 'attachment_id should be integer type' );
 		$this->assertEquals( 'absint', $schema['properties']['attachment_id']['sanitize_callback'], 'attachment_id should use absint' );
@@ -140,6 +141,8 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 'string', $schema['properties']['context']['type'], 'context should be string type' );
 		$this->assertEquals( 'sanitize_textarea_field', $schema['properties']['context']['sanitize_callback'], 'context should use sanitize_textarea_field' );
+
+		$this->assertEquals( 'string', $schema['properties']['image_meta']['type'], 'image_meta should be string type' );
 	}
 
 	/**
@@ -159,6 +162,8 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'properties', $schema, 'Schema should have properties' );
 		$this->assertArrayHasKey( 'alt_text', $schema['properties'], 'Schema should have alt_text property' );
 		$this->assertEquals( 'string', $schema['properties']['alt_text']['type'], 'alt_text should be string type' );
+		$this->assertArrayHasKey( 'is_decorative', $schema['properties'], 'Schema should have is_decorative property' );
+		$this->assertEquals( 'boolean', $schema['properties']['is_decorative']['type'], 'is_decorative should be boolean type' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -35,7 +35,7 @@ class Test_Alt_Text_Generation_Experiment extends Abstract_Feature {
 	protected function load_metadata(): array {
 		return array(
 			'label'       => 'Alt Text Generation',
-			'description' => 'Generates descriptive alt text for images using AI vision models.',
+			'description' => 'Generates accessible alternative text for images using AI vision models.',
 		);
 	}
 


### PR DESCRIPTION
## What?

Closes #350

Adjust alt text generation to better consider the W3C Alt decision tree

## Why?

Currently our alt text generation experiment generates alt text that is more or less just a description of the image. While this isn't completely incorrect, it doesn't account for other situations where the alt text should be something else, like if an image is decorative or if the image is acting as a link.

Based on the feedback in #350, this PR adjusts the experiment to try and more closely match the W3C Alt decision tree, noting it's still up to the LLM to honor those guidelines.

## How?

- Add a new `image_meta` param to our Alt Text Generation Ability
- Use this new param to pass in information about the image, like if it's wrapped in a link or the caption text
- Add support for return blank alt text and marking an image as decorative
- Update our system instructions to be more specific in their guidance

### Use of AI Tools

Used both Claude Code running Opus 4.6 and Cursor running GPT-5.3 Codex to generate separate plans and execute those plans. I then compared the approaches and combined bits and pieces of both to get to a final state

## Testing Instructions

1. Checkout this PR and run `npm i && npm run build`
2. Turn on the Alt Text Generation Experiment
3. Ensure you have a provider connected that supports vision models
4. Create a post and insert an image somewhere into the content
5. Generate alt text for that image and ensure it is accurate
6. Add a link around the image and generate it again, ensuring the alt text mentions the link
7. Generate alt text for an image in the media library, ensuring that works

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-374-9bcac1eea827b2c0bda97773e9d80a85527ca3f8.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->