### PR TITLE
Use toggle UI, auto-save, and inline DataForm settings for experiments

### DIFF
--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -217,6 +217,52 @@ abstract class Abstract_Feature implements Feature {
 	}
 
 	/**
+	 * Gets the field definitions for feature-specific settings.
+	 *
+	 * Override this method in child classes to declare custom settings fields
+	 * that will be rendered as a DataForm on the settings page. Each field
+	 * should use the short option name (e.g. 'strategy'), not the full
+	 * namespaced option name.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<int, array{
+	 *   id: string,
+	 *   label: string,
+	 *   type: string,
+	 *   default?: mixed,
+	 *   elements?: list<array{value: string, label: string}>,
+	 * }> Array of field definitions.
+	 */
+	public function get_settings_fields(): array {
+		return array();
+	}
+
+	/**
+	 * Gets field definitions with fully resolved option names.
+	 *
+	 * Transforms the short field IDs from get_settings_fields() into
+	 * full WordPress option names suitable for the REST API and frontend.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<int, array{
+	 *   id: string,
+	 *   label: string,
+	 *   type: string,
+	 *   default?: mixed,
+	 *   elements?: list<array{value: string, label: string}>,
+	 * }> Array of field definitions with full option names.
+	 */
+	public function get_settings_fields_metadata(): array {
+		$fields = $this->get_settings_fields();
+		foreach ( $fields as &$field ) {
+			$field['id'] = $this->get_field_option_name( $field['id'] );
+		}
+		return $fields;
+	}
+
+	/**
 	 * Gets the option name for a custom feature setting field.
 	 *
 	 * Generates a properly namespaced option name for feature-specific settings.

--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -232,7 +232,8 @@ abstract class Abstract_Feature implements Feature {
 	 *   type: string,
 	 *   default?: mixed,
 	 *   elements?: list<array{value: string, label: string}>,
-	 * }> Array of field definitions.
+	 *   isValid?: array{min?: int, max?: int},
+	 * }> Array of field definitions matching the DataForm Field shape.
 	 */
 	public function get_settings_fields(): array {
 		return array();
@@ -252,6 +253,7 @@ abstract class Abstract_Feature implements Feature {
 	 *   type: string,
 	 *   default?: mixed,
 	 *   elements?: list<array{value: string, label: string}>,
+	 *   isValid?: array{min?: int, max?: int},
 	 * }> Array of field definitions with full option names.
 	 */
 	public function get_settings_fields_metadata(): array {

--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -259,6 +259,7 @@ abstract class Abstract_Feature implements Feature {
 		foreach ( $fields as &$field ) {
 			$field['id'] = $this->get_field_option_name( $field['id'] );
 		}
+		unset( $field );
 		return $fields;
 	}
 

--- a/includes/Contracts/Feature.php
+++ b/includes/Contracts/Feature.php
@@ -88,4 +88,21 @@ interface Feature {
 	 * @return bool True if enabled, false otherwise.
 	 */
 	public function is_enabled(): bool;
+
+	/**
+	 * Gets field definitions with fully resolved option names.
+	 *
+	 * Returns an empty array when the feature has no custom settings.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<int, array{
+	 *   id: string,
+	 *   label: string,
+	 *   type: string,
+	 *   default?: mixed,
+	 *   elements?: list<array{value: string, label: string}>,
+	 * }> Array of field definitions with full option names.
+	 */
+	public function get_settings_fields_metadata(): array;
 }

--- a/includes/Contracts/Feature.php
+++ b/includes/Contracts/Feature.php
@@ -102,6 +102,7 @@ interface Feature {
 	 *   type: string,
 	 *   default?: mixed,
 	 *   elements?: list<array{value: string, label: string}>,
+	 *   isValid?: array{min?: int, max?: int},
 	 * }> Array of field definitions with full option names.
 	 */
 	public function get_settings_fields_metadata(): array;

--- a/includes/Experiments/Content_Classification/Content_Classification.php
+++ b/includes/Experiments/Content_Classification/Content_Classification.php
@@ -153,6 +153,12 @@ class Content_Classification extends Abstract_Feature {
 				'type'              => 'string',
 				'default'           => self::STRATEGY_EXISTING_ONLY,
 				'sanitize_callback' => array( $this, 'sanitize_strategy' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( self::STRATEGY_EXISTING_ONLY, self::STRATEGY_ALLOW_NEW ),
+					),
+				),
 			)
 		);
 
@@ -163,65 +169,45 @@ class Content_Classification extends Abstract_Feature {
 				'type'              => 'integer',
 				'default'           => self::DEFAULT_MAX_SUGGESTIONS,
 				'sanitize_callback' => array( $this, 'sanitize_max_suggestions' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'    => 'integer',
+						'minimum' => 1,
+						'maximum' => 10,
+					),
+				),
 			)
 		);
 	}
 
 	/**
-	 * Renders experiment-specific settings fields.
-	 *
-	 * @since x.x.x
+	 * {@inheritDoc}
 	 */
-	public function render_settings_fields(): void {
-		$strategy_option        = $this->get_field_option_name( 'strategy' );
-		$max_suggestions_option = $this->get_field_option_name( 'max_suggestions' );
-		$current_strategy       = get_option( $this->get_field_option_name( 'strategy' ), self::STRATEGY_EXISTING_ONLY );
-		$current_max            = get_option( $this->get_field_option_name( 'max_suggestions' ), self::DEFAULT_MAX_SUGGESTIONS );
-		?>
-		<fieldset class="ai-experiments__item-fields">
-			<legend class="screen-reader-text"><?php esc_html_e( 'Content Classification Settings', 'ai' ); ?></legend>
-			<table class="ai-experiments__settings-table" role="presentation">
-				<tr>
-					<td>
-						<label for="<?php echo esc_attr( $strategy_option ); ?>">
-							<?php esc_html_e( 'Taxonomy strategy:', 'ai' ); ?>
-						</label>
-					</td>
-					<td>
-						<select
-							id="<?php echo esc_attr( $strategy_option ); ?>"
-							name="<?php echo esc_attr( $strategy_option ); ?>"
-						>
-							<option value="<?php echo esc_attr( self::STRATEGY_EXISTING_ONLY ); ?>" <?php selected( $current_strategy, self::STRATEGY_EXISTING_ONLY ); ?>>
-								<?php esc_html_e( 'Only suggest existing terms', 'ai' ); ?>
-							</option>
-							<option value="<?php echo esc_attr( self::STRATEGY_ALLOW_NEW ); ?>" <?php selected( $current_strategy, self::STRATEGY_ALLOW_NEW ); ?>>
-								<?php esc_html_e( 'Suggest new terms based on context', 'ai' ); ?>
-							</option>
-						</select>
-					</td>
-				</tr>
-				<tr>
-					<td>
-						<label for="<?php echo esc_attr( $max_suggestions_option ); ?>">
-							<?php esc_html_e( 'Maximum suggestions:', 'ai' ); ?>
-						</label>
-					</td>
-					<td>
-						<input
-							type="number"
-							id="<?php echo esc_attr( $max_suggestions_option ); ?>"
-							name="<?php echo esc_attr( $max_suggestions_option ); ?>"
-							value="<?php echo esc_attr( (string) $current_max ); ?>"
-							min="1"
-							max="10"
-							step="1"
-						/>
-					</td>
-				</tr>
-			</table>
-		</fieldset>
-		<?php
+	public function get_settings_fields(): array {
+		return array(
+			array(
+				'id'       => 'strategy',
+				'label'    => __( 'Taxonomy strategy', 'ai' ),
+				'type'     => 'string',
+				'default'  => self::STRATEGY_EXISTING_ONLY,
+				'elements' => array(
+					array(
+						'value' => self::STRATEGY_EXISTING_ONLY,
+						'label' => __( 'Only suggest existing terms', 'ai' ),
+					),
+					array(
+						'value' => self::STRATEGY_ALLOW_NEW,
+						'label' => __( 'Suggest new terms based on context', 'ai' ),
+					),
+				),
+			),
+			array(
+				'id'      => 'max_suggestions',
+				'label'   => __( 'Maximum suggestions', 'ai' ),
+				'type'    => 'integer',
+				'default' => self::DEFAULT_MAX_SUGGESTIONS,
+			),
+		);
 	}
 
 	/**

--- a/includes/Experiments/Content_Classification/Content_Classification.php
+++ b/includes/Experiments/Content_Classification/Content_Classification.php
@@ -188,7 +188,7 @@ class Content_Classification extends Abstract_Feature {
 			array(
 				'id'       => 'strategy',
 				'label'    => __( 'Taxonomy strategy', 'ai' ),
-				'type'     => 'string',
+				'type'     => 'text',
 				'default'  => self::STRATEGY_EXISTING_ONLY,
 				'elements' => array(
 					array(
@@ -206,6 +206,10 @@ class Content_Classification extends Abstract_Feature {
 				'label'   => __( 'Maximum suggestions', 'ai' ),
 				'type'    => 'integer',
 				'default' => self::DEFAULT_MAX_SUGGESTIONS,
+				'isValid' => array(
+					'min' => 1,
+					'max' => 10,
+				),
 			),
 		);
 	}

--- a/includes/Experiments/Content_Classification/Content_Classification.php
+++ b/includes/Experiments/Content_Classification/Content_Classification.php
@@ -57,6 +57,24 @@ class Content_Classification extends Abstract_Feature {
 	public const DEFAULT_MAX_SUGGESTIONS = 5;
 
 	/**
+	 * The minimum allowed number of suggestions.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	public const MIN_SUGGESTIONS = 1;
+
+	/**
+	 * The maximum allowed number of suggestions.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	public const MAX_SUGGESTIONS = 10;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public static function get_id(): string {
@@ -172,8 +190,8 @@ class Content_Classification extends Abstract_Feature {
 				'show_in_rest'      => array(
 					'schema' => array(
 						'type'    => 'integer',
-						'minimum' => 1,
-						'maximum' => 10,
+						'minimum' => self::MIN_SUGGESTIONS,
+						'maximum' => self::MAX_SUGGESTIONS,
 					),
 				),
 			)
@@ -207,8 +225,8 @@ class Content_Classification extends Abstract_Feature {
 				'type'    => 'integer',
 				'default' => self::DEFAULT_MAX_SUGGESTIONS,
 				'isValid' => array(
-					'min' => 1,
-					'max' => 10,
+					'min' => self::MIN_SUGGESTIONS,
+					'max' => self::MAX_SUGGESTIONS,
 				),
 			),
 		);
@@ -239,7 +257,7 @@ class Content_Classification extends Abstract_Feature {
 	public function sanitize_max_suggestions( $value ): int {
 		$value = absint( $value );
 
-		return max( 1, min( 10, $value ) );
+		return max( self::MIN_SUGGESTIONS, min( self::MAX_SUGGESTIONS, $value ) );
 	}
 
 	/**

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -224,13 +224,18 @@ function get_settings_feature_metadata( Registry $registry ): array {
 			);
 		}
 
+		$settings_fields = method_exists( $feature, 'get_settings_fields_metadata' )
+			? $feature->get_settings_fields_metadata()
+			: array();
+
 		$categories_in_use[ $category ] = true;
 		$features[]                     = array(
-			'id'          => $feature_id,
-			'settingName' => "wpai_feature_{$feature_id}_enabled",
-			'label'       => $feature->get_label(),
-			'description' => wp_strip_all_tags( $feature->get_description() ),
-			'category'    => $category,
+			'id'             => $feature_id,
+			'settingName'    => "wpai_feature_{$feature_id}_enabled",
+			'label'          => $feature->get_label(),
+			'description'    => wp_strip_all_tags( $feature->get_description() ),
+			'category'       => $category,
+			'settingsFields' => $settings_fields,
 		);
 	}
 

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -224,8 +224,6 @@ function get_settings_feature_metadata( Registry $registry ): array {
 			);
 		}
 
-		$settings_fields = $feature->get_settings_fields_metadata();
-
 		$categories_in_use[ $category ] = true;
 		$features[]                     = array(
 			'id'             => $feature_id,
@@ -233,7 +231,7 @@ function get_settings_feature_metadata( Registry $registry ): array {
 			'label'          => $feature->get_label(),
 			'description'    => wp_strip_all_tags( $feature->get_description() ),
 			'category'       => $category,
-			'settingsFields' => $settings_fields,
+			'settingsFields' => $feature->get_settings_fields_metadata(),
 		);
 	}
 

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -224,9 +224,7 @@ function get_settings_feature_metadata( Registry $registry ): array {
 			);
 		}
 
-		$settings_fields = method_exists( $feature, 'get_settings_fields_metadata' )
-			? $feature->get_settings_fields_metadata()
-			: array();
+		$settings_fields = $feature->get_settings_fields_metadata();
 
 		$categories_in_use[ $category ] = true;
 		$features[]                     = array(

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -2,17 +2,12 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import {
-	Button,
-	CheckboxControl,
-	Notice,
-	Spinner,
-} from '@wordpress/components';
+import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
 import { useCallback, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 
@@ -188,19 +183,17 @@ const GLOBAL_FIELD: Field< AISettings > = {
 	id: GLOBAL_FIELD_ID,
 	label: __( 'Enable AI', 'ai' ),
 	type: 'boolean',
+	Edit: 'toggle',
 };
 
-function DisabledCheckbox( {
-	field,
-	data,
-}: DataFormControlProps< AISettings > ) {
+function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	return (
-		<CheckboxControl
+		<ToggleControl
 			__nextHasNoMarginBottom
 			label={ field.label }
 			help={ field.description }
 			checked={ !! field.getValue( { item: data } ) }
-			// No-op handler required to satisfy React's controlled-component warning; the checkbox is disabled.
+			// No-op handler required to satisfy React's controlled-component warning; the toggle is disabled.
 			onChange={ () => {} }
 			disabled
 		/>
@@ -208,30 +201,19 @@ function DisabledCheckbox( {
 }
 
 function AISettingsPage() {
-	const { siteSettings, hasEdits, isSaving, isLoading } = useSelect(
-		( select ) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
-			const store: any = select( coreStore );
-			return {
-				siteSettings: store.getEditedEntityRecord( 'root', 'site' ) as
-					| Record< string, unknown >
-					| undefined,
-				hasEdits: store.hasEditsForEntityRecord(
-					'root',
-					'site'
-				) as boolean,
-				isSaving: store.isSavingEntityRecord(
-					'root',
-					'site'
-				) as boolean,
-				isLoading: ! store.hasFinishedResolution( 'getEntityRecord', [
-					'root',
-					'site',
-				] ) as boolean,
-			};
-		},
-		[]
-	);
+	const { siteSettings, isLoading } = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
+		const store: any = select( coreStore );
+		return {
+			siteSettings: store.getEditedEntityRecord( 'root', 'site' ) as
+				| Record< string, unknown >
+				| undefined,
+			isLoading: ! store.hasFinishedResolution( 'getEntityRecord', [
+				'root',
+				'site',
+			] ) as boolean,
+		};
+	}, [] );
 
 	const { editEntityRecord, saveEditedEntityRecord } =
 		useDispatch( coreStore );
@@ -309,9 +291,7 @@ function AISettingsPage() {
 				label: feature.label,
 				description: feature.description,
 				type: 'boolean' as const,
-				Edit: globalEnabled
-					? ( 'checkbox' as const )
-					: DisabledCheckbox,
+				Edit: globalEnabled ? ( 'toggle' as const ) : DisabledToggle,
 			} ) ),
 		],
 		[ featureDefinitions, globalEnabled ]
@@ -392,26 +372,50 @@ function AISettingsPage() {
 	}, [ featureDefinitions, featureGroups ] );
 
 	const handleChange = useCallback(
-		( edits: Record< string, unknown > ) => {
+		async ( edits: Record< string, unknown > ) => {
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
 			editEntityRecord( 'root', 'site', undefined, edits );
-		},
-		[ editEntityRecord ]
-	);
 
-	const handleSave = useCallback( async () => {
-		try {
-			// @ts-expect-error -- core-data types don't expose saveEditedEntityRecord for 'root'/'site' args.
-			await saveEditedEntityRecord( 'root', 'site' );
-			createSuccessNotice( __( 'Settings saved.', 'ai' ), {
-				type: 'snackbar',
-			} );
-		} catch {
-			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
-				type: 'snackbar',
-			} );
-		}
-	}, [ saveEditedEntityRecord, createSuccessNotice, createErrorNotice ] );
+			const entry = Object.entries( edits )[ 0 ];
+			let message: string;
+			if ( ! entry ) {
+				message = __( 'Settings saved.', 'ai' );
+			} else if ( entry[ 0 ] === GLOBAL_FIELD_ID ) {
+				message = entry[ 1 ]
+					? __( 'AI enabled.', 'ai' )
+					: __( 'AI disabled.', 'ai' );
+			} else {
+				const feature = featureDefinitions.find(
+					( f ) => f.settingName === entry[ 0 ]
+				);
+				const label = feature?.label ?? entry[ 0 ];
+				if ( entry[ 1 ] ) {
+					// translators: %s: Feature label.
+					message = sprintf( __( '%s enabled.', 'ai' ), label );
+				} else {
+					// translators: %s: Feature label.
+					message = sprintf( __( '%s disabled.', 'ai' ), label );
+				}
+			}
+
+			try {
+				// @ts-expect-error -- core-data types don't expose saveEditedEntityRecord for 'root'/'site' args.
+				await saveEditedEntityRecord( 'root', 'site' );
+				createSuccessNotice( message, { type: 'snackbar' } );
+			} catch {
+				createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
+					type: 'snackbar',
+				} );
+			}
+		},
+		[
+			editEntityRecord,
+			saveEditedEntityRecord,
+			createSuccessNotice,
+			createErrorNotice,
+			featureDefinitions,
+		]
+	);
 
 	return (
 		<Page
@@ -471,25 +475,12 @@ function AISettingsPage() {
 				{ isLoading ? (
 					<Spinner />
 				) : (
-					<>
-						<DataForm< AISettings >
-							data={ data }
-							fields={ fields }
-							form={ form }
-							onChange={ handleChange }
-						/>
-						<div className="ai-settings-page__save">
-							<Button
-								variant="primary"
-								onClick={ handleSave }
-								isBusy={ isSaving }
-								disabled={ ! hasEdits || isSaving }
-								aria-busy={ isSaving }
-							>
-								{ __( 'Save Changes', 'ai' ) }
-							</Button>
-						</div>
-					</>
+					<DataForm< AISettings >
+						data={ data }
+						fields={ fields }
+						form={ form }
+						onChange={ handleChange }
+					/>
 				) }
 			</div>
 		</Page>

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -6,7 +6,7 @@ import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
@@ -284,7 +284,7 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 		[ feature.settingsFields ]
 	);
 
-	const { editedRecord, nonTransientEdits, isSaving } = useSelect(
+	const { editedRecord, nonTransientEdits } = useSelect(
 		( select ) => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
 			const store: any = select( coreStore );
@@ -296,14 +296,12 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 					'root',
 					'site'
 				) ?? {} ) as Record< string, unknown >,
-				isSaving: store.isSavingEntityRecord(
-					'root',
-					'site'
-				) as boolean,
 			};
 		},
 		[]
 	);
+
+	const [ isSaving, setIsSaving ] = useState( false );
 
 	const isDirty = useMemo(
 		() => fieldIds.some( ( id ) => id in nonTransientEdits ),
@@ -363,6 +361,7 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 	);
 
 	const handleSave = useCallback( async () => {
+		setIsSaving( true );
 		try {
 			await saveSpecifiedEdits( 'root', 'site', undefined, fieldIds, {
 				throwOnError: true,
@@ -380,6 +379,8 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 				type: 'snackbar',
 			} );
+		} finally {
+			setIsSaving( false );
 		}
 	}, [
 		saveSpecifiedEdits,
@@ -403,6 +404,7 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 						variant="primary"
 						onClick={ handleSave }
 						isBusy={ isSaving }
+						disabled={ isSaving }
 						size="compact"
 					>
 						{ __( 'Save', 'ai' ) }

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -516,6 +516,9 @@ function AISettingsPage() {
 
 	const globalEnabled = data[ GLOBAL_FIELD.id ];
 
+	// Guard against concurrent auto-save requests from rapid toggle clicks.
+	const savingRef = useRef( false );
+
 	// Stable references for feature edit components to prevent React remounts
 	// when siteSettings changes (which would reset InlineFeatureSettings state).
 	// Stores the feature reference alongside the component so the cache is
@@ -642,6 +645,11 @@ function AISettingsPage() {
 
 	const handleChange = useCallback(
 		async ( edits: Record< string, unknown > ) => {
+			if ( savingRef.current ) {
+				return;
+			}
+			savingRef.current = true;
+
 			// Capture previous values for rollback on failure.
 			const previousValues: Record< string, unknown > = {};
 			for ( const key of Object.keys( edits ) ) {
@@ -684,6 +692,8 @@ function AISettingsPage() {
 				createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 					type: 'snackbar',
 				} );
+			} finally {
+				savingRef.current = false;
 			}
 		},
 		[

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -71,7 +71,8 @@ function isSettingsField( value: unknown ): value is SettingsFieldData {
 	if ( ! isRecord( value ) ) {
 		return false;
 	}
-	const id = value.id;
+	// eslint-disable-next-line dot-notation
+	const id = value[ 'id' ];
 	return typeof id === 'string' && id !== '';
 }
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -547,18 +547,17 @@ function AISettingsPage() {
 				if ( ! globalEnabled ) {
 					baseField.Edit = DisabledToggle;
 				} else if ( feature.settingsFields.length > 0 ) {
-					const cached =
+					let cached =
 						editComponentsRef.current.get( feature.id );
 					if ( ! cached || cached.feature !== feature ) {
-						editComponentsRef.current.set( feature.id, {
+						cached = {
 							component:
 								createFeatureToggleWithSettings( feature ),
 							feature,
-						} );
+						};
+						editComponentsRef.current.set( feature.id, cached );
 					}
-					baseField.Edit =
-						editComponentsRef.current.get( feature.id )!
-							.component;
+					baseField.Edit = cached.component;
 				} else {
 					baseField.Edit = 'toggle' as const;
 				}

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -620,6 +620,12 @@ function AISettingsPage() {
 
 	const handleChange = useCallback(
 		async ( edits: Record< string, unknown > ) => {
+			// Capture previous values for rollback on failure.
+			const previousValues: Record< string, unknown > = {};
+			for ( const key of Object.keys( edits ) ) {
+				previousValues[ key ] = data[ key ];
+			}
+
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
 			editEntityRecord( 'root', 'site', undefined, edits );
 
@@ -650,6 +656,9 @@ function AISettingsPage() {
 				await saveEditedEntityRecord( 'root', 'site' );
 				createSuccessNotice( message, { type: 'snackbar' } );
 			} catch {
+				// Revert the optimistic edit on failure.
+				// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
+				editEntityRecord( 'root', 'site', undefined, previousValues );
 				createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 					type: 'snackbar',
 				} );
@@ -661,6 +670,7 @@ function AISettingsPage() {
 			createSuccessNotice,
 			createErrorNotice,
 			featureDefinitions,
+			data,
 		]
 	);
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -255,6 +255,10 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 /**
  * Inline sub-settings form for an experiment's custom fields.
  * Rendered below the toggle inside the same card, with its own Save button.
+ *
+ * @param {Object}                              root0              Component props.
+ * @param {FeatureData}                         root0.feature      The feature with custom settings fields.
+ * @param {Record< string, unknown >|undefined} root0.siteSettings Current site settings from core-data.
  */
 function InlineFeatureSettings( {
 	feature,
@@ -375,6 +379,9 @@ function InlineFeatureSettings( {
 /**
  * Creates a custom Edit component for a feature toggle that also renders
  * inline sub-settings when the feature is enabled.
+ *
+ * @param {FeatureData}                         feature      The feature with custom settings fields.
+ * @param {Record< string, unknown >|undefined} siteSettings Current site settings from core-data.
  */
 function createFeatureToggleWithSettings(
 	feature: FeatureData,

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -6,7 +6,13 @@ import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
@@ -278,6 +284,13 @@ function InlineFeatureSettings( {
 	const [ localEdits, setLocalEdits ] = useState< Record< string, unknown > >(
 		{}
 	);
+
+	// Clear pending edits when the feature changes (e.g. fields redefined by
+	// a filter) so stale keys from the previous definition don't persist.
+	useEffect( () => {
+		setLocalEdits( {} );
+	}, [ feature.id ] );
+
 	const isDirty = Object.keys( localEdits ).length > 0;
 	const [ isSaving, setIsSaving ] = useState( false );
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -25,17 +25,13 @@ interface FeatureGroupData {
 	description: string;
 }
 
-interface SettingsFieldElement {
-	value: string;
-	label: string;
-}
-
 interface SettingsFieldData {
 	id: string;
 	label: string;
 	type: string;
-	default: unknown;
-	elements: SettingsFieldElement[];
+	default?: unknown;
+	elements?: Array< { value: string; label: string } >;
+	isValid?: Record< string, number >;
 }
 
 interface FeatureData {
@@ -70,39 +66,12 @@ function isDefined< T >( value: T | null | undefined ): value is T {
 	return value !== null && value !== undefined;
 }
 
-function parseSettingsField( value: unknown ): SettingsFieldData | null {
-	if ( ! isRecord( value ) ) {
-		return null;
-	}
-
-	const field = value as Partial< SettingsFieldData >;
-	const id = toStringValue( field.id );
-	if ( ! id ) {
-		return null;
-	}
-
-	const rawElements = field.elements;
-
-	const type = toStringValue( field.type ) || 'string';
-
-	return {
-		id,
-		label: toStringValue( field.label ),
-		type,
-		default: field.default ?? ( type === 'integer' ? 0 : '' ),
-		elements: Array.isArray( rawElements )
-			? ( rawElements as unknown[] )
-					.filter( isRecord )
-					.map( ( el ) => {
-						const element = el as Partial< SettingsFieldElement >;
-						return {
-							value: toStringValue( element.value ),
-							label: toStringValue( element.label ),
-						};
-					} )
-					.filter( ( el ) => el.value !== '' )
-			: [],
-	};
+function isSettingsField( value: unknown ): value is SettingsFieldData {
+	return (
+		isRecord( value ) &&
+		typeof value[ 'id' ] === 'string' &&
+		value[ 'id' ] !== ''
+	);
 }
 
 function parseFeatureGroup( value: unknown ): FeatureGroupData | null {
@@ -148,7 +117,7 @@ function parseFeature( value: unknown ): FeatureData | null {
 		label: toStringValue( feature.label ) || getDefaultLabel( id ),
 		description: toStringValue( feature.description ),
 		category: toStringValue( feature.category ) || 'other',
-		settingsFields: rawFields.map( parseSettingsField ).filter( isDefined ),
+		settingsFields: ( rawFields as unknown[] ).filter( isSettingsField ),
 	};
 }
 
@@ -325,23 +294,10 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 
 	const fields = useMemo< Field< Record< string, unknown > >[] >(
 		() =>
-			feature.settingsFields.map( ( settingsField ) => {
-				const fieldDef: Field< Record< string, unknown > > = {
-					id: settingsField.id,
-					label: settingsField.label,
-				};
-
-				if ( settingsField.type === 'integer' ) {
-					fieldDef.type = 'integer';
-				} else if ( settingsField.elements.length > 0 ) {
-					fieldDef.type = 'text';
-					fieldDef.elements = settingsField.elements;
-				} else {
-					fieldDef.type = 'text';
-				}
-
-				return fieldDef;
-			} ),
+			feature.settingsFields.map(
+				( { default: _, ...fieldProps } ) =>
+					fieldProps as Field< Record< string, unknown > >
+			),
 		[ feature.settingsFields ]
 	);
 
@@ -406,6 +362,11 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 						isBusy={ isSaving }
 						disabled={ isSaving }
 						size="compact"
+						aria-label={ sprintf(
+							// translators: %s: Feature label.
+							__( 'Save %s settings', 'ai' ),
+							feature.label
+						) }
 					>
 						{ __( 'Save', 'ai' ) }
 					</Button>
@@ -415,49 +376,36 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 	);
 }
 
-/**
- * Creates a custom Edit component for a feature toggle that also renders
- * inline sub-settings when the feature is enabled.
- *
- * @param {FeatureData} feature The feature with custom settings fields.
- */
-function createFeatureToggleWithSettings( feature: FeatureData ) {
-	return function FeatureToggleWithSettings( {
-		field,
-		data,
-		onChange,
-	}: DataFormControlProps< AISettings > ) {
-		const checked = !! field.getValue( { item: data } );
+const FEATURES_BY_SETTING = new Map(
+	PAGE_DATA.features
+		.filter( ( f ) => f.settingsFields.length > 0 )
+		.map( ( f ) => [ f.settingName, f ] as const )
+);
 
-		return (
-			<div className="ai-feature-toggle-with-settings">
-				<ToggleControl
-					__nextHasNoMarginBottom
-					label={ field.label }
-					help={ field.description }
-					checked={ checked }
-					onChange={ ( value ) => {
-						onChange( { [ field.id ]: value } );
-					} }
-				/>
-				{ checked && <InlineFeatureSettings feature={ feature } /> }
-			</div>
-		);
-	};
-}
+function FeatureToggleWithSettings( {
+	field,
+	data,
+	onChange,
+}: DataFormControlProps< AISettings > ) {
+	const feature = FEATURES_BY_SETTING.get( field.id );
+	const checked = !! field.getValue( { item: data } );
 
-const featureEditComponents = new Map<
-	string,
-	ReturnType< typeof createFeatureToggleWithSettings >
->();
-
-function getFeatureEditComponent( feature: FeatureData ) {
-	let component = featureEditComponents.get( feature.id );
-	if ( ! component ) {
-		component = createFeatureToggleWithSettings( feature );
-		featureEditComponents.set( feature.id, component );
-	}
-	return component;
+	return (
+		<div className="ai-feature-toggle-with-settings">
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ field.label }
+				help={ field.description }
+				checked={ checked }
+				onChange={ ( value ) => {
+					onChange( { [ field.id ]: value } );
+				} }
+			/>
+			{ checked && feature && (
+				<InlineFeatureSettings feature={ feature } />
+			) }
+		</div>
+	);
 }
 
 function AISettingsPage() {
@@ -561,7 +509,7 @@ function AISettingsPage() {
 				if ( ! globalEnabled ) {
 					baseField.Edit = DisabledToggle;
 				} else if ( feature.settingsFields.length > 0 ) {
-					baseField.Edit = getFeatureEditComponent( feature );
+					baseField.Edit = FeatureToggleWithSettings;
 				} else {
 					baseField.Edit = 'toggle' as const;
 				}

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -329,6 +329,16 @@ function InlineFeatureSettings( {
 
 	const handleSave = useCallback( async () => {
 		setIsSaving( true );
+
+		// Capture previous values for rollback on failure.
+		const previousValues: Record< string, unknown > = {};
+		for ( const key of Object.keys( localEdits ) ) {
+			previousValues[ key ] =
+				siteSettings?.[ key ] ??
+				feature.settingsFields.find( ( f ) => f.id === key )
+					?.default;
+		}
+
 		try {
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
 			editEntityRecord( 'root', 'site', undefined, localEdits );
@@ -344,6 +354,9 @@ function InlineFeatureSettings( {
 				{ type: 'snackbar' }
 			);
 		} catch {
+			// Revert the optimistic edit on failure.
+			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
+			editEntityRecord( 'root', 'site', undefined, previousValues );
 			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 				type: 'snackbar',
 			} );
@@ -352,6 +365,8 @@ function InlineFeatureSettings( {
 		}
 	}, [
 		localEdits,
+		siteSettings,
+		feature.settingsFields,
 		editEntityRecord,
 		saveEditedEntityRecord,
 		createSuccessNotice,

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -4,15 +4,9 @@
 import { Page } from '@wordpress/admin-ui';
 import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
@@ -246,6 +240,30 @@ const GLOBAL_FIELD: Field< AISettings > = {
 	Edit: 'toggle',
 };
 
+function buildToggleMessage(
+	edits: Record< string, unknown >,
+	featureDefinitions: FeatureData[]
+): string {
+	const entry = Object.entries( edits )[ 0 ];
+	if ( ! entry ) {
+		return __( 'Settings saved.', 'ai' );
+	}
+	if ( entry[ 0 ] === GLOBAL_FIELD_ID ) {
+		return entry[ 1 ]
+			? __( 'AI enabled.', 'ai' )
+			: __( 'AI disabled.', 'ai' );
+	}
+	const feature = featureDefinitions.find(
+		( f ) => f.settingName === entry[ 0 ]
+	);
+	const label = feature?.label ?? entry[ 0 ];
+	return entry[ 1 ]
+		? // translators: %s: Feature label.
+		  sprintf( __( '%s enabled.', 'ai' ), label )
+		: // translators: %s: Feature label.
+		  sprintf( __( '%s disabled.', 'ai' ), label );
+}
+
 function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	return (
 		<ToggleControl
@@ -260,52 +278,52 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	);
 }
 
-/**
- * Inline sub-settings form for an experiment's custom fields.
- * Rendered below the toggle inside the same card, with its own Save button.
- *
- * @param {Object}      root0         Component props.
- * @param {FeatureData} root0.feature The feature with custom settings fields.
- */
-function InlineFeatureSettings( {
-	feature,
-}: {
-	feature: FeatureData;
-} ) {
-	// Read siteSettings directly from the store so this component can
-	// re-render independently without forcing its parent to recreate.
-	const siteSettings = useSelect( ( select ) => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
-		const store: any = select( coreStore );
-		return store.getEditedEntityRecord( 'root', 'site' ) as
-			| Record< string, unknown >
-			| undefined;
-	}, [] );
-	const [ localEdits, setLocalEdits ] = useState< Record< string, unknown > >(
-		{}
+function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
+	const fieldIds = useMemo(
+		() => feature.settingsFields.map( ( f ) => f.id ),
+		[ feature.settingsFields ]
 	);
 
-	// Clear pending edits when the feature changes (e.g. fields redefined by
-	// a filter) so stale keys from the previous definition don't persist.
-	useEffect( () => {
-		setLocalEdits( {} );
-	}, [ feature.id ] );
+	const { editedRecord, nonTransientEdits, isSaving } = useSelect(
+		( select ) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
+			const store: any = select( coreStore );
+			return {
+				editedRecord: store.getEditedEntityRecord( 'root', 'site' ) as
+					| Record< string, unknown >
+					| undefined,
+				nonTransientEdits: ( store.getEntityRecordNonTransientEdits(
+					'root',
+					'site'
+				) ?? {} ) as Record< string, unknown >,
+				isSaving: store.isSavingEntityRecord(
+					'root',
+					'site'
+				) as boolean,
+			};
+		},
+		[]
+	);
 
-	const isDirty = Object.keys( localEdits ).length > 0;
-	const [ isSaving, setIsSaving ] = useState( false );
+	const isDirty = useMemo(
+		() => fieldIds.some( ( id ) => id in nonTransientEdits ),
+		[ fieldIds, nonTransientEdits ]
+	);
 
-	const { editEntityRecord, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const { editEntityRecord } = useDispatch( coreStore );
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- __experimentalSaveSpecifiedEntityEdits is not in the public types.
+	const { __experimentalSaveSpecifiedEntityEdits: saveSpecifiedEdits } =
+		useDispatch( coreStore ) as any;
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
 	const data = useMemo( () => {
 		const base: Record< string, unknown > = {};
 		for ( const field of feature.settingsFields ) {
-			base[ field.id ] = siteSettings?.[ field.id ] ?? field.default;
+			base[ field.id ] = editedRecord?.[ field.id ] ?? field.default;
 		}
-		return { ...base, ...localEdits };
-	}, [ feature.settingsFields, siteSettings, localEdits ] );
+		return base;
+	}, [ feature.settingsFields, editedRecord ] );
 
 	const fields = useMemo< Field< Record< string, unknown > >[] >(
 		() =>
@@ -336,28 +354,19 @@ function InlineFeatureSettings( {
 		[ feature.settingsFields ]
 	);
 
-	const handleChange = useCallback( ( edits: Record< string, unknown > ) => {
-		setLocalEdits( ( prev ) => ( { ...prev, ...edits } ) );
-	}, [] );
+	const handleChange = useCallback(
+		( edits: Record< string, unknown > ) => {
+			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
+			editEntityRecord( 'root', 'site', undefined, edits );
+		},
+		[ editEntityRecord ]
+	);
 
 	const handleSave = useCallback( async () => {
-		setIsSaving( true );
-
-		// Capture previous values for rollback on failure.
-		const previousValues: Record< string, unknown > = {};
-		for ( const key of Object.keys( localEdits ) ) {
-			previousValues[ key ] =
-				siteSettings?.[ key ] ??
-				feature.settingsFields.find( ( f ) => f.id === key )
-					?.default;
-		}
-
 		try {
-			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
-			editEntityRecord( 'root', 'site', undefined, localEdits );
-			// @ts-expect-error -- core-data types don't expose saveEditedEntityRecord for 'root'/'site' args.
-			await saveEditedEntityRecord( 'root', 'site' );
-			setLocalEdits( {} );
+			await saveSpecifiedEdits( 'root', 'site', undefined, fieldIds, {
+				throwOnError: true,
+			} );
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: Feature label.
@@ -367,21 +376,14 @@ function InlineFeatureSettings( {
 				{ type: 'snackbar' }
 			);
 		} catch {
-			// Revert the optimistic edit on failure.
-			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
-			editEntityRecord( 'root', 'site', undefined, previousValues );
+			// Edits remain in the store — user can retry or adjust values.
 			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 				type: 'snackbar',
 			} );
-		} finally {
-			setIsSaving( false );
 		}
 	}, [
-		localEdits,
-		siteSettings,
-		feature.settingsFields,
-		editEntityRecord,
-		saveEditedEntityRecord,
+		saveSpecifiedEdits,
+		fieldIds,
 		createSuccessNotice,
 		createErrorNotice,
 		feature.label,
@@ -395,13 +397,12 @@ function InlineFeatureSettings( {
 				form={ form }
 				onChange={ handleChange }
 			/>
-			{ ( isDirty || isSaving ) && (
+			{ isDirty && (
 				<div className="ai-feature-settings-form__actions">
 					<Button
 						variant="primary"
 						onClick={ handleSave }
 						isBusy={ isSaving }
-						disabled={ isSaving }
 						size="compact"
 					>
 						{ __( 'Save', 'ai' ) }
@@ -437,20 +438,32 @@ function createFeatureToggleWithSettings( feature: FeatureData ) {
 						onChange( { [ field.id ]: value } );
 					} }
 				/>
-				{ checked && (
-					<InlineFeatureSettings feature={ feature } />
-				) }
+				{ checked && <InlineFeatureSettings feature={ feature } /> }
 			</div>
 		);
 	};
 }
 
+const featureEditComponents = new Map<
+	string,
+	ReturnType< typeof createFeatureToggleWithSettings >
+>();
+
+function getFeatureEditComponent( feature: FeatureData ) {
+	let component = featureEditComponents.get( feature.id );
+	if ( ! component ) {
+		component = createFeatureToggleWithSettings( feature );
+		featureEditComponents.set( feature.id, component );
+	}
+	return component;
+}
+
 function AISettingsPage() {
-	const { siteSettings, isLoading } = useSelect( ( select ) => {
+	const { editedRecord, isLoading } = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
 		const store: any = select( coreStore );
 		return {
-			siteSettings: store.getEditedEntityRecord( 'root', 'site' ) as
+			editedRecord: store.getEditedEntityRecord( 'root', 'site' ) as
 				| Record< string, unknown >
 				| undefined,
 			isLoading: ! store.hasFinishedResolution( 'getEntityRecord', [
@@ -460,16 +473,19 @@ function AISettingsPage() {
 		};
 	}, [] );
 
-	const { editEntityRecord, saveEditedEntityRecord } =
-		useDispatch( coreStore );
+	const { editEntityRecord } = useDispatch( coreStore );
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- __experimentalSaveSpecifiedEntityEdits is not in the public types.
+	const { __experimentalSaveSpecifiedEntityEdits: saveSpecifiedEdits } =
+		useDispatch( coreStore ) as any;
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
+	const registry = useRegistry();
 
 	const featureDefinitions = useMemo< FeatureData[] >( () => {
 		const sourceFeatures =
 			PAGE_DATA.features.length > 0
 				? PAGE_DATA.features
-				: Object.keys( siteSettings ?? {} )
+				: Object.keys( editedRecord ?? {} )
 						.filter( ( key ) =>
 							FEATURE_SETTING_PATTERN.test( key )
 						)
@@ -499,7 +515,7 @@ function AISettingsPage() {
 		}
 
 		return uniqueFeatures;
-	}, [ siteSettings ] );
+	}, [ editedRecord ] );
 
 	const featureGroups = useMemo< FeatureGroupData[] >(
 		() =>
@@ -522,35 +538,12 @@ function AISettingsPage() {
 	const data: AISettings = useMemo( () => {
 		const aiSettings: AISettings = {};
 		for ( const key of aiSettingKeys ) {
-			aiSettings[ key ] = Boolean( siteSettings?.[ key ] ?? false );
+			aiSettings[ key ] = Boolean( editedRecord?.[ key ] ?? false );
 		}
 		return aiSettings;
-	}, [ aiSettingKeys, siteSettings ] );
+	}, [ aiSettingKeys, editedRecord ] );
 
 	const globalEnabled = data[ GLOBAL_FIELD.id ];
-
-	// Keep a ref to the latest data so handleChange can read previous values
-	// without adding `data` to its dependency array (which would recreate the
-	// callback on every settings change).
-	const dataRef = useRef( data );
-	dataRef.current = data;
-
-	// Guard against concurrent auto-save requests from rapid toggle clicks.
-	const savingRef = useRef( false );
-
-	// Stable references for feature edit components to prevent React remounts
-	// when siteSettings changes (which would reset InlineFeatureSettings state).
-	// Stores the feature reference alongside the component so the cache is
-	// invalidated when the feature definition changes.
-	const editComponentsRef = useRef(
-		new Map<
-			string,
-			{
-				component: ReturnType< typeof createFeatureToggleWithSettings >;
-				feature: FeatureData;
-			}
-		>()
-	);
 
 	const fields = useMemo< Field< AISettings >[] >(
 		() => [
@@ -566,17 +559,7 @@ function AISettingsPage() {
 				if ( ! globalEnabled ) {
 					baseField.Edit = DisabledToggle;
 				} else if ( feature.settingsFields.length > 0 ) {
-					let cached =
-						editComponentsRef.current.get( feature.id );
-					if ( ! cached || cached.feature !== feature ) {
-						cached = {
-							component:
-								createFeatureToggleWithSettings( feature ),
-							feature,
-						};
-						editComponentsRef.current.set( feature.id, cached );
-					}
-					baseField.Edit = cached.component;
+					baseField.Edit = getFeatureEditComponent( feature );
 				} else {
 					baseField.Edit = 'toggle' as const;
 				}
@@ -663,63 +646,45 @@ function AISettingsPage() {
 
 	const handleChange = useCallback(
 		async ( edits: Record< string, unknown > ) => {
-			if ( savingRef.current ) {
-				return;
-			}
-			savingRef.current = true;
+			const keys = Object.keys( edits );
 
-			// Capture previous values for rollback on failure.
-			const previousValues: Record< string, unknown > = {};
-			for ( const key of Object.keys( edits ) ) {
-				previousValues[ key ] = dataRef.current[ key ];
-			}
-
+			// Optimistic update — the UI reflects the new value immediately.
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
 			editEntityRecord( 'root', 'site', undefined, edits );
 
-			const entry = Object.entries( edits )[ 0 ];
-			let message: string;
-			if ( ! entry ) {
-				message = __( 'Settings saved.', 'ai' );
-			} else if ( entry[ 0 ] === GLOBAL_FIELD_ID ) {
-				message = entry[ 1 ]
-					? __( 'AI enabled.', 'ai' )
-					: __( 'AI disabled.', 'ai' );
-			} else {
-				const feature = featureDefinitions.find(
-					( f ) => f.settingName === entry[ 0 ]
-				);
-				const label = feature?.label ?? entry[ 0 ];
-				if ( entry[ 1 ] ) {
-					// translators: %s: Feature label.
-					message = sprintf( __( '%s enabled.', 'ai' ), label );
-				} else {
-					// translators: %s: Feature label.
-					message = sprintf( __( '%s disabled.', 'ai' ), label );
-				}
-			}
+			const message = buildToggleMessage( edits, featureDefinitions );
 
 			try {
-				// @ts-expect-error -- core-data types don't expose saveEditedEntityRecord for 'root'/'site' args.
-				await saveEditedEntityRecord( 'root', 'site' );
+				await saveSpecifiedEdits( 'root', 'site', undefined, keys, {
+					throwOnError: true,
+				} );
 				createSuccessNotice( message, { type: 'snackbar' } );
 			} catch {
-				// Revert the optimistic edit on failure.
+				// Revert only the toggled keys to their server-side values.
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any -- DataRegistry typing doesn't expose .select(); core-data selectors aren't fully typed for 'root'/'site' entity args.
+				const serverRecord = ( registry as any )
+					.select( coreStore )
+					.getEntityRecord( 'root', 'site' ) as
+					| Record< string, unknown >
+					| undefined;
+				const revert: Record< string, unknown > = {};
+				for ( const key of keys ) {
+					revert[ key ] = serverRecord?.[ key ];
+				}
 				// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
-				editEntityRecord( 'root', 'site', undefined, previousValues );
+				editEntityRecord( 'root', 'site', undefined, revert );
 				createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
 					type: 'snackbar',
 				} );
-			} finally {
-				savingRef.current = false;
 			}
 		},
 		[
 			editEntityRecord,
-			saveEditedEntityRecord,
+			saveSpecifiedEdits,
 			createSuccessNotice,
 			createErrorNotice,
 			featureDefinitions,
+			registry,
 		]
 	);
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -518,10 +518,15 @@ function AISettingsPage() {
 
 	// Stable references for feature edit components to prevent React remounts
 	// when siteSettings changes (which would reset InlineFeatureSettings state).
+	// Stores the feature reference alongside the component so the cache is
+	// invalidated when the feature definition changes.
 	const editComponentsRef = useRef(
 		new Map<
 			string,
-			ReturnType< typeof createFeatureToggleWithSettings >
+			{
+				component: ReturnType< typeof createFeatureToggleWithSettings >;
+				feature: FeatureData;
+			}
 		>()
 	);
 
@@ -539,16 +544,18 @@ function AISettingsPage() {
 				if ( ! globalEnabled ) {
 					baseField.Edit = DisabledToggle;
 				} else if ( feature.settingsFields.length > 0 ) {
-					if (
-						! editComponentsRef.current.has( feature.id )
-					) {
-						editComponentsRef.current.set(
-							feature.id,
-							createFeatureToggleWithSettings( feature )
-						);
+					const cached =
+						editComponentsRef.current.get( feature.id );
+					if ( ! cached || cached.feature !== feature ) {
+						editComponentsRef.current.set( feature.id, {
+							component:
+								createFeatureToggleWithSettings( feature ),
+							feature,
+						} );
 					}
 					baseField.Edit =
-						editComponentsRef.current.get( feature.id )!;
+						editComponentsRef.current.get( feature.id )!
+							.component;
 				} else {
 					baseField.Edit = 'toggle' as const;
 				}

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -516,6 +516,12 @@ function AISettingsPage() {
 
 	const globalEnabled = data[ GLOBAL_FIELD.id ];
 
+	// Keep a ref to the latest data so handleChange can read previous values
+	// without adding `data` to its dependency array (which would recreate the
+	// callback on every settings change).
+	const dataRef = useRef( data );
+	dataRef.current = data;
+
 	// Guard against concurrent auto-save requests from rapid toggle clicks.
 	const savingRef = useRef( false );
 
@@ -652,7 +658,7 @@ function AISettingsPage() {
 			// Capture previous values for rollback on failure.
 			const previousValues: Record< string, unknown > = {};
 			for ( const key of Object.keys( edits ) ) {
-				previousValues[ key ] = data[ key ];
+				previousValues[ key ] = dataRef.current[ key ];
 			}
 
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
@@ -701,7 +707,6 @@ function AISettingsPage() {
 			createSuccessNotice,
 			createErrorNotice,
 			featureDefinitions,
-			data,
 		]
 	);
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -53,6 +53,7 @@ interface PageData {
 
 const FEATURE_SETTING_PATTERN = /^wpai_feature_(.+)_enabled$/;
 const GLOBAL_FIELD_ID = 'wpai_features_enabled';
+const noop = () => {};
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
@@ -241,7 +242,7 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 			help={ field.description }
 			checked={ !! field.getValue( { item: data } ) }
 			// No-op handler required to satisfy React's controlled-component warning; the toggle is disabled.
-			onChange={ () => {} }
+			onChange={ noop }
 			disabled
 		/>
 	);

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -6,7 +6,7 @@ import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
@@ -25,12 +25,26 @@ interface FeatureGroupData {
 	description: string;
 }
 
+interface SettingsFieldElement {
+	value: string;
+	label: string;
+}
+
+interface SettingsFieldData {
+	id: string;
+	label: string;
+	type: string;
+	default: unknown;
+	elements: SettingsFieldElement[];
+}
+
 interface FeatureData {
 	id: string;
 	settingName: string;
 	label: string;
 	description: string;
 	category: string;
+	settingsFields: SettingsFieldData[];
 }
 
 interface PageData {
@@ -54,6 +68,39 @@ function toStringValue( value: unknown ): string {
 
 function isDefined< T >( value: T | null | undefined ): value is T {
 	return value !== null && value !== undefined;
+}
+
+function parseSettingsField( value: unknown ): SettingsFieldData | null {
+	if ( ! isRecord( value ) ) {
+		return null;
+	}
+
+	const field = value as Partial< SettingsFieldData >;
+	const id = toStringValue( field.id );
+	if ( ! id ) {
+		return null;
+	}
+
+	const rawElements = field.elements;
+
+	return {
+		id,
+		label: toStringValue( field.label ),
+		type: toStringValue( field.type ) || 'string',
+		default: field.default ?? '',
+		elements: Array.isArray( rawElements )
+			? ( rawElements as unknown[] )
+					.filter( isRecord )
+					.map( ( el ) => {
+						const element = el as Partial< SettingsFieldElement >;
+						return {
+							value: toStringValue( element.value ),
+							label: toStringValue( element.label ),
+						};
+					} )
+					.filter( ( el ) => el.value !== '' )
+			: [],
+	};
 }
 
 function parseFeatureGroup( value: unknown ): FeatureGroupData | null {
@@ -89,12 +136,17 @@ function parseFeature( value: unknown ): FeatureData | null {
 		toStringValue( feature.id ) ||
 		getFeatureIdFromSettingName( settingName );
 
+	const rawFields = Array.isArray( feature.settingsFields )
+		? feature.settingsFields
+		: [];
+
 	return {
 		id,
 		settingName,
 		label: toStringValue( feature.label ) || getDefaultLabel( id ),
 		description: toStringValue( feature.description ),
 		category: toStringValue( feature.category ) || 'other',
+		settingsFields: rawFields.map( parseSettingsField ).filter( isDefined ),
 	};
 }
 
@@ -200,6 +252,163 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	);
 }
 
+/**
+ * Inline sub-settings form for an experiment's custom fields.
+ * Rendered below the toggle inside the same card, with its own Save button.
+ */
+function InlineFeatureSettings( {
+	feature,
+	siteSettings,
+}: {
+	feature: FeatureData;
+	siteSettings: Record< string, unknown > | undefined;
+} ) {
+	const [ localEdits, setLocalEdits ] = useState< Record< string, unknown > >(
+		{}
+	);
+	const isDirty = Object.keys( localEdits ).length > 0;
+	const [ isSaving, setIsSaving ] = useState( false );
+
+	const { editEntityRecord, saveEditedEntityRecord } =
+		useDispatch( coreStore );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const data = useMemo( () => {
+		const base: Record< string, unknown > = {};
+		for ( const field of feature.settingsFields ) {
+			base[ field.id ] = siteSettings?.[ field.id ] ?? field.default;
+		}
+		return { ...base, ...localEdits };
+	}, [ feature.settingsFields, siteSettings, localEdits ] );
+
+	const fields = useMemo< Field< Record< string, unknown > >[] >(
+		() =>
+			feature.settingsFields.map( ( settingsField ) => {
+				const fieldDef: Field< Record< string, unknown > > = {
+					id: settingsField.id,
+					label: settingsField.label,
+				};
+
+				if ( settingsField.type === 'integer' ) {
+					fieldDef.type = 'integer';
+				} else if ( settingsField.elements.length > 0 ) {
+					fieldDef.type = 'text';
+					fieldDef.elements = settingsField.elements;
+				} else {
+					fieldDef.type = 'text';
+				}
+
+				return fieldDef;
+			} ),
+		[ feature.settingsFields ]
+	);
+
+	const form = useMemo< Form >(
+		() => ( {
+			fields: feature.settingsFields.map( ( f ) => f.id ),
+		} ),
+		[ feature.settingsFields ]
+	);
+
+	const handleChange = useCallback( ( edits: Record< string, unknown > ) => {
+		setLocalEdits( ( prev ) => ( { ...prev, ...edits } ) );
+	}, [] );
+
+	const handleSave = useCallback( async () => {
+		setIsSaving( true );
+		try {
+			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
+			editEntityRecord( 'root', 'site', undefined, localEdits );
+			// @ts-expect-error -- core-data types don't expose saveEditedEntityRecord for 'root'/'site' args.
+			await saveEditedEntityRecord( 'root', 'site' );
+			setLocalEdits( {} );
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: Feature label.
+					__( '%s settings saved.', 'ai' ),
+					feature.label
+				),
+				{ type: 'snackbar' }
+			);
+		} catch {
+			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
+				type: 'snackbar',
+			} );
+		} finally {
+			setIsSaving( false );
+		}
+	}, [
+		localEdits,
+		editEntityRecord,
+		saveEditedEntityRecord,
+		createSuccessNotice,
+		createErrorNotice,
+		feature.label,
+	] );
+
+	return (
+		<div className="ai-feature-settings-form">
+			<DataForm< Record< string, unknown > >
+				data={ data }
+				fields={ fields }
+				form={ form }
+				onChange={ handleChange }
+			/>
+			{ ( isDirty || isSaving ) && (
+				<div className="ai-feature-settings-form__actions">
+					<Button
+						variant="primary"
+						onClick={ handleSave }
+						isBusy={ isSaving }
+						disabled={ isSaving }
+						size="compact"
+					>
+						{ __( 'Save', 'ai' ) }
+					</Button>
+				</div>
+			) }
+		</div>
+	);
+}
+
+/**
+ * Creates a custom Edit component for a feature toggle that also renders
+ * inline sub-settings when the feature is enabled.
+ */
+function createFeatureToggleWithSettings(
+	feature: FeatureData,
+	siteSettings: Record< string, unknown > | undefined
+) {
+	return function FeatureToggleWithSettings( {
+		field,
+		data,
+		onChange,
+	}: DataFormControlProps< AISettings > ) {
+		const checked = !! field.getValue( { item: data } );
+
+		return (
+			<div className="ai-feature-toggle-with-settings">
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ field.label }
+					help={ field.description }
+					checked={ checked }
+					onChange={ ( value ) => {
+						onChange( { [ field.id ]: value } );
+					} }
+				/>
+				{ checked && (
+					<InlineFeatureSettings
+						feature={ feature }
+						siteSettings={ siteSettings }
+					/>
+				) }
+			</div>
+		);
+	};
+}
+
 function AISettingsPage() {
 	const { siteSettings, isLoading } = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
@@ -238,6 +447,7 @@ function AISettingsPage() {
 								label: getDefaultLabel( id ),
 								description: '',
 								category: 'other',
+								settingsFields: [],
 							};
 						} );
 
@@ -286,15 +496,29 @@ function AISettingsPage() {
 	const fields = useMemo< Field< AISettings >[] >(
 		() => [
 			GLOBAL_FIELD,
-			...featureDefinitions.map( ( feature ) => ( {
-				id: feature.settingName,
-				label: feature.label,
-				description: feature.description,
-				type: 'boolean' as const,
-				Edit: globalEnabled ? ( 'toggle' as const ) : DisabledToggle,
-			} ) ),
+			...featureDefinitions.map( ( feature ) => {
+				const baseField: Field< AISettings > = {
+					id: feature.settingName,
+					label: feature.label,
+					description: feature.description,
+					type: 'boolean' as const,
+				};
+
+				if ( ! globalEnabled ) {
+					baseField.Edit = DisabledToggle;
+				} else if ( feature.settingsFields.length > 0 ) {
+					baseField.Edit = createFeatureToggleWithSettings(
+						feature,
+						siteSettings
+					);
+				} else {
+					baseField.Edit = 'toggle' as const;
+				}
+
+				return baseField;
+			} ),
 		],
-		[ featureDefinitions, globalEnabled ]
+		[ featureDefinitions, globalEnabled, siteSettings ]
 	);
 
 	const form = useMemo< Form >( () => {

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -6,7 +6,7 @@ import { Button, Notice, Spinner, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
@@ -258,17 +258,23 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
  * Inline sub-settings form for an experiment's custom fields.
  * Rendered below the toggle inside the same card, with its own Save button.
  *
- * @param {Object}                              root0              Component props.
- * @param {FeatureData}                         root0.feature      The feature with custom settings fields.
- * @param {Record< string, unknown >|undefined} root0.siteSettings Current site settings from core-data.
+ * @param {Object}      root0         Component props.
+ * @param {FeatureData} root0.feature The feature with custom settings fields.
  */
 function InlineFeatureSettings( {
 	feature,
-	siteSettings,
 }: {
 	feature: FeatureData;
-	siteSettings: Record< string, unknown > | undefined;
 } ) {
+	// Read siteSettings directly from the store so this component can
+	// re-render independently without forcing its parent to recreate.
+	const siteSettings = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
+		const store: any = select( coreStore );
+		return store.getEditedEntityRecord( 'root', 'site' ) as
+			| Record< string, unknown >
+			| undefined;
+	}, [] );
 	const [ localEdits, setLocalEdits ] = useState< Record< string, unknown > >(
 		{}
 	);
@@ -382,13 +388,9 @@ function InlineFeatureSettings( {
  * Creates a custom Edit component for a feature toggle that also renders
  * inline sub-settings when the feature is enabled.
  *
- * @param {FeatureData}                         feature      The feature with custom settings fields.
- * @param {Record< string, unknown >|undefined} siteSettings Current site settings from core-data.
+ * @param {FeatureData} feature The feature with custom settings fields.
  */
-function createFeatureToggleWithSettings(
-	feature: FeatureData,
-	siteSettings: Record< string, unknown > | undefined
-) {
+function createFeatureToggleWithSettings( feature: FeatureData ) {
 	return function FeatureToggleWithSettings( {
 		field,
 		data,
@@ -408,10 +410,7 @@ function createFeatureToggleWithSettings(
 					} }
 				/>
 				{ checked && (
-					<InlineFeatureSettings
-						feature={ feature }
-						siteSettings={ siteSettings }
-					/>
+					<InlineFeatureSettings feature={ feature } />
 				) }
 			</div>
 		);
@@ -502,6 +501,15 @@ function AISettingsPage() {
 
 	const globalEnabled = data[ GLOBAL_FIELD.id ];
 
+	// Stable references for feature edit components to prevent React remounts
+	// when siteSettings changes (which would reset InlineFeatureSettings state).
+	const editComponentsRef = useRef(
+		new Map<
+			string,
+			ReturnType< typeof createFeatureToggleWithSettings >
+		>()
+	);
+
 	const fields = useMemo< Field< AISettings >[] >(
 		() => [
 			GLOBAL_FIELD,
@@ -516,10 +524,16 @@ function AISettingsPage() {
 				if ( ! globalEnabled ) {
 					baseField.Edit = DisabledToggle;
 				} else if ( feature.settingsFields.length > 0 ) {
-					baseField.Edit = createFeatureToggleWithSettings(
-						feature,
-						siteSettings
-					);
+					if (
+						! editComponentsRef.current.has( feature.id )
+					) {
+						editComponentsRef.current.set(
+							feature.id,
+							createFeatureToggleWithSettings( feature )
+						);
+					}
+					baseField.Edit =
+						editComponentsRef.current.get( feature.id )!;
 				} else {
 					baseField.Edit = 'toggle' as const;
 				}
@@ -527,7 +541,7 @@ function AISettingsPage() {
 				return baseField;
 			} ),
 		],
-		[ featureDefinitions, globalEnabled, siteSettings ]
+		[ featureDefinitions, globalEnabled ]
 	);
 
 	const form = useMemo< Form >( () => {

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -68,11 +68,7 @@ function isDefined< T >( value: T | null | undefined ): value is T {
 }
 
 function isSettingsField( value: unknown ): value is SettingsFieldData {
-	return (
-		isRecord( value ) &&
-		typeof value[ 'id' ] === 'string' &&
-		value[ 'id' ] !== ''
-	);
+	return isRecord( value ) && typeof value.id === 'string' && value.id !== '';
 }
 
 function parseFeatureGroup( value: unknown ): FeatureGroupData | null {
@@ -254,22 +250,19 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 		[ feature.settingsFields ]
 	);
 
-	const { editedRecord, nonTransientEdits } = useSelect(
-		( select ) => {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
-			const store: any = select( coreStore );
-			return {
-				editedRecord: store.getEditedEntityRecord( 'root', 'site' ) as
-					| Record< string, unknown >
-					| undefined,
-				nonTransientEdits: ( store.getEntityRecordNonTransientEdits(
-					'root',
-					'site'
-				) ?? {} ) as Record< string, unknown >,
-			};
-		},
-		[]
-	);
+	const { editedRecord, nonTransientEdits } = useSelect( ( select ) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
+		const store: any = select( coreStore );
+		return {
+			editedRecord: store.getEditedEntityRecord( 'root', 'site' ) as
+				| Record< string, unknown >
+				| undefined,
+			nonTransientEdits: ( store.getEntityRecordNonTransientEdits(
+				'root',
+				'site'
+			) ?? {} ) as Record< string, unknown >,
+		};
+	}, [] );
 
 	const [ isSaving, setIsSaving ] = useState( false );
 

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -83,11 +83,13 @@ function parseSettingsField( value: unknown ): SettingsFieldData | null {
 
 	const rawElements = field.elements;
 
+	const type = toStringValue( field.type ) || 'string';
+
 	return {
 		id,
 		label: toStringValue( field.label ),
-		type: toStringValue( field.type ) || 'string',
-		default: field.default ?? '',
+		type,
+		default: field.default ?? ( type === 'integer' ? 0 : '' ),
 		elements: Array.isArray( rawElements )
 			? ( rawElements as unknown[] )
 					.filter( isRecord )

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -68,7 +68,11 @@ function isDefined< T >( value: T | null | undefined ): value is T {
 }
 
 function isSettingsField( value: unknown ): value is SettingsFieldData {
-	return isRecord( value ) && typeof value.id === 'string' && value.id !== '';
+	if ( ! isRecord( value ) ) {
+		return false;
+	}
+	const id = value.id;
+	return typeof id === 'string' && id !== '';
 }
 
 function parseFeatureGroup( value: unknown ): FeatureGroupData | null {

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -17,7 +17,7 @@
 .ai-feature-settings-form {
 	margin-top: 12px;
 	padding-top: 12px;
-	border-top: 1px solid rgba(0, 0, 0, 0.1);
+	border-top: 1px solid var(--wp-components-color-gray-300, rgba(0, 0, 0, 0.1));
 }
 
 .ai-feature-settings-form__actions {

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -17,7 +17,7 @@
 .ai-feature-settings-form {
 	margin-top: 12px;
 	padding-top: 12px;
-	border-top: 1px solid #e0e0e0;
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .ai-feature-settings-form__actions {

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -13,9 +13,3 @@
 .ai-settings-page .components-notice {
 	margin: 0 0 24px;
 }
-
-.ai-settings-page__save {
-	display: flex;
-	justify-content: flex-end;
-	padding-top: 16px;
-}

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -13,3 +13,15 @@
 .ai-settings-page .components-notice {
 	margin: 0 0 24px;
 }
+
+.ai-feature-settings-form {
+	margin-top: 12px;
+	padding-top: 12px;
+	border-top: 1px solid #e0e0e0;
+}
+
+.ai-feature-settings-form__actions {
+	display: flex;
+	justify-content: flex-end;
+	margin-top: 12px;
+}

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -15,9 +15,15 @@
 }
 
 .ai-feature-settings-form {
-	margin-top: 12px;
-	padding-top: 12px;
-	border-top: 1px solid var(--wp-components-color-gray-300, rgba(0, 0, 0, 0.1));
+	margin-top: 4px;
+	padding-left: 52px;
+	max-width: 480px;
+
+	.components-base-control__label,
+	.components-input-control__label,
+	.dataforms-layouts-regular__field-label {
+		text-transform: none !important;
+	}
 }
 
 .ai-feature-settings-form__actions {

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -16,7 +16,7 @@
 
 .ai-feature-settings-form {
 	margin-top: 4px;
-	padding-left: 52px;
+	padding-left: 40px;
 	max-width: 480px;
 
 	.components-base-control__label,

--- a/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
@@ -175,7 +175,7 @@ class Test_Feature_With_Settings extends Abstract_Feature {
 			array(
 				'id'       => 'color',
 				'label'    => 'Color',
-				'type'     => 'string',
+				'type'     => 'text',
 				'default'  => 'blue',
 				'elements' => array(
 					array(
@@ -362,7 +362,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $fields, 'Should return two settings fields' );
 		$this->assertSame( 'color', $fields[0]['id'], 'First field should have short id "color"' );
 		$this->assertSame( 'count', $fields[1]['id'], 'Second field should have short id "count"' );
-		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'text', $fields[0]['type'] );
 		$this->assertSame( 'integer', $fields[1]['type'] );
 	}
 
@@ -398,7 +398,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 		$fields  = $feature->get_settings_fields_metadata();
 
 		$this->assertSame( 'Color', $fields[0]['label'] );
-		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'text', $fields[0]['type'] );
 		$this->assertSame( 'blue', $fields[0]['default'] );
 		$this->assertCount( 2, $fields[0]['elements'] );
 		$this->assertSame( 'blue', $fields[0]['elements'][0]['value'] );

--- a/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
@@ -139,6 +139,66 @@ class Test_Empty_Category_Experiment extends Abstract_Feature {
 }
 
 /**
+ * Test feature with custom settings fields.
+ *
+ * @since x.x.x
+ */
+class Test_Feature_With_Settings extends Abstract_Feature {
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_id(): string {
+		return 'test-with-settings';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function load_metadata(): array {
+		return array(
+			'label'       => 'Test With Settings',
+			'description' => 'Test feature with custom settings fields',
+			'category'    => Experiment_Category::EDITOR,
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): void {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_settings_fields(): array {
+		return array(
+			array(
+				'id'       => 'color',
+				'label'    => 'Color',
+				'type'     => 'string',
+				'default'  => 'blue',
+				'elements' => array(
+					array(
+						'value' => 'blue',
+						'label' => 'Blue',
+					),
+					array(
+						'value' => 'red',
+						'label' => 'Red',
+					),
+				),
+			),
+			array(
+				'id'      => 'count',
+				'label'   => 'Count',
+				'type'    => 'integer',
+				'default' => 3,
+			),
+		);
+	}
+}
+
+/**
  * Abstract_Feature test case.
  *
  * @since 0.4.0
@@ -258,5 +318,94 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 	public function test_get_stability_custom() {
 		$experiment = new Mock_Custom_Stability_Experiment();
 		$this->assertEquals( 'stable', $experiment->get_stability(), 'Custom stability should be returned from metadata' );
+	}
+
+	/**
+	 * Tests that get_settings_fields() returns an empty array by default.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_returns_empty_by_default(): void {
+		$experiment = new Test_Uncategorized_Experiment();
+
+		$this->assertSame(
+			array(),
+			$experiment->get_settings_fields(),
+			'get_settings_fields() should return an empty array by default'
+		);
+	}
+
+	/**
+	 * Tests that get_settings_fields_metadata() returns an empty array when no fields are defined.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_metadata_returns_empty_when_no_fields(): void {
+		$experiment = new Test_Uncategorized_Experiment();
+
+		$this->assertSame(
+			array(),
+			$experiment->get_settings_fields_metadata(),
+			'get_settings_fields_metadata() should return an empty array when no fields are defined'
+		);
+	}
+
+	/**
+	 * Tests that get_settings_fields() returns declared fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_returns_declared_fields(): void {
+		$feature = new Test_Feature_With_Settings();
+		$fields  = $feature->get_settings_fields();
+
+		$this->assertCount( 2, $fields, 'Should return two settings fields' );
+		$this->assertSame( 'color', $fields[0]['id'], 'First field should have short id "color"' );
+		$this->assertSame( 'count', $fields[1]['id'], 'Second field should have short id "count"' );
+		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'integer', $fields[1]['type'] );
+	}
+
+	/**
+	 * Tests that get_settings_fields_metadata() resolves short IDs to full option names.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_metadata_resolves_option_names(): void {
+		$feature = new Test_Feature_With_Settings();
+		$fields  = $feature->get_settings_fields_metadata();
+
+		$this->assertCount( 2, $fields, 'Should return two settings fields' );
+		$this->assertSame(
+			'wpai_feature_test-with-settings_field_color',
+			$fields[0]['id'],
+			'First field id should be resolved to full option name'
+		);
+		$this->assertSame(
+			'wpai_feature_test-with-settings_field_count',
+			$fields[1]['id'],
+			'Second field id should be resolved to full option name'
+		);
+	}
+
+	/**
+	 * Tests that get_settings_fields_metadata() preserves other field properties.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_metadata_preserves_field_properties(): void {
+		$feature = new Test_Feature_With_Settings();
+		$fields  = $feature->get_settings_fields_metadata();
+
+		$this->assertSame( 'Color', $fields[0]['label'] );
+		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'blue', $fields[0]['default'] );
+		$this->assertCount( 2, $fields[0]['elements'] );
+		$this->assertSame( 'blue', $fields[0]['elements'][0]['value'] );
+		$this->assertSame( 'red', $fields[0]['elements'][1]['value'] );
+
+		$this->assertSame( 'Count', $fields[1]['label'] );
+		$this->assertSame( 'integer', $fields[1]['type'] );
+		$this->assertSame( 3, $fields[1]['default'] );
 	}
 }

--- a/tests/Integration/Includes/BootstrapTest.php
+++ b/tests/Integration/Includes/BootstrapTest.php
@@ -159,7 +159,7 @@ class Stub_Feature_With_Settings extends Abstract_Feature {
 			array(
 				'id'       => 'mode',
 				'label'    => 'Mode',
-				'type'     => 'string',
+				'type'     => 'text',
 				'default'  => 'auto',
 				'elements' => array(
 					array(
@@ -464,7 +464,7 @@ class BootstrapTest extends WP_UnitTestCase {
 
 		// Other properties should be preserved.
 		$this->assertSame( 'Mode', $feature['settingsFields'][0]['label'] );
-		$this->assertSame( 'string', $feature['settingsFields'][0]['type'] );
+		$this->assertSame( 'text', $feature['settingsFields'][0]['type'] );
 		$this->assertCount( 2, $feature['settingsFields'][0]['elements'] );
 		$this->assertSame( 'integer', $feature['settingsFields'][1]['type'] );
 	}

--- a/tests/Integration/Includes/BootstrapTest.php
+++ b/tests/Integration/Includes/BootstrapTest.php
@@ -125,6 +125,64 @@ class Stub_No_Category_Feature extends Abstract_Feature {
 }
 
 /**
+ * Stub feature with custom settings fields.
+ */
+class Stub_Feature_With_Settings extends Abstract_Feature {
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_id(): string {
+		return 'stub-with-settings';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function load_metadata(): array {
+		return array(
+			'label'       => 'Stub With Settings',
+			'description' => 'A feature with custom settings.',
+			'category'    => Experiment_Category::EDITOR,
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): void {}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_settings_fields(): array {
+		return array(
+			array(
+				'id'       => 'mode',
+				'label'    => 'Mode',
+				'type'     => 'string',
+				'default'  => 'auto',
+				'elements' => array(
+					array(
+						'value' => 'auto',
+						'label' => 'Auto',
+					),
+					array(
+						'value' => 'manual',
+						'label' => 'Manual',
+					),
+				),
+			),
+			array(
+				'id'      => 'limit',
+				'label'   => 'Limit',
+				'type'    => 'integer',
+				'default' => 10,
+			),
+		);
+	}
+}
+
+/**
  * Stub feature with HTML in its description.
  */
 class Stub_HTML_Description_Feature extends Abstract_Feature {
@@ -376,5 +434,51 @@ class BootstrapTest extends WP_UnitTestCase {
 		// Should still produce valid output using default groups.
 		$this->assertCount( 1, $result['groups'] );
 		$this->assertSame( 'Editor Experiments', $result['groups'][0]['label'] );
+	}
+
+	/**
+	 * Test that settingsFields are included in feature metadata.
+	 */
+	public function test_feature_with_settings_includes_settings_fields() {
+		$this->registry->register_feature( new Stub_Feature_With_Settings() );
+
+		$result = \WordPress\AI\get_settings_feature_metadata( $this->registry );
+
+		$this->assertCount( 1, $result['features'] );
+		$feature = $result['features'][0];
+
+		$this->assertArrayHasKey( 'settingsFields', $feature, 'Feature metadata should include settingsFields' );
+		$this->assertCount( 2, $feature['settingsFields'], 'Should include two settings fields' );
+
+		// IDs should be resolved to full option names.
+		$this->assertSame(
+			'wpai_feature_stub-with-settings_field_mode',
+			$feature['settingsFields'][0]['id'],
+			'Settings field id should be resolved to full option name'
+		);
+		$this->assertSame(
+			'wpai_feature_stub-with-settings_field_limit',
+			$feature['settingsFields'][1]['id'],
+			'Settings field id should be resolved to full option name'
+		);
+
+		// Other properties should be preserved.
+		$this->assertSame( 'Mode', $feature['settingsFields'][0]['label'] );
+		$this->assertSame( 'string', $feature['settingsFields'][0]['type'] );
+		$this->assertCount( 2, $feature['settingsFields'][0]['elements'] );
+		$this->assertSame( 'integer', $feature['settingsFields'][1]['type'] );
+	}
+
+	/**
+	 * Test that features without settings have empty settingsFields array.
+	 */
+	public function test_feature_without_settings_has_empty_settings_fields() {
+		$this->registry->register_feature( new Stub_Editor_Feature() );
+
+		$result = \WordPress\AI\get_settings_feature_metadata( $this->registry );
+
+		$feature = $result['features'][0];
+		$this->assertArrayHasKey( 'settingsFields', $feature );
+		$this->assertSame( array(), $feature['settingsFields'], 'Feature without custom settings should have empty settingsFields' );
 	}
 }

--- a/tests/Integration/Includes/Experiments/Content_Classification/Content_ClassificationTest.php
+++ b/tests/Integration/Includes/Experiments/Content_Classification/Content_ClassificationTest.php
@@ -272,7 +272,7 @@ class Content_ClassificationTest extends WP_UnitTestCase {
 
 		// Verify strategy field.
 		$this->assertSame( 'strategy', $fields[0]['id'] );
-		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'text', $fields[0]['type'] );
 		$this->assertSame( 'existing_only', $fields[0]['default'] );
 		$this->assertCount( 2, $fields[0]['elements'], 'Strategy field should have two element options' );
 		$this->assertSame( 'existing_only', $fields[0]['elements'][0]['value'] );

--- a/tests/Integration/Includes/Experiments/Content_Classification/Content_ClassificationTest.php
+++ b/tests/Integration/Includes/Experiments/Content_Classification/Content_ClassificationTest.php
@@ -258,4 +258,71 @@ class Content_ClassificationTest extends WP_UnitTestCase {
 
 		$this->assertEquals( 1, $experiment->get_max_suggestions(), 'Filtered value of 0 should be clamped to 1' );
 	}
+
+	/**
+	 * Test that get_settings_fields() returns strategy and max_suggestions.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_returns_expected_fields() {
+		$experiment = new Content_Classification();
+		$fields     = $experiment->get_settings_fields();
+
+		$this->assertCount( 2, $fields, 'Should declare two custom settings fields' );
+
+		// Verify strategy field.
+		$this->assertSame( 'strategy', $fields[0]['id'] );
+		$this->assertSame( 'string', $fields[0]['type'] );
+		$this->assertSame( 'existing_only', $fields[0]['default'] );
+		$this->assertCount( 2, $fields[0]['elements'], 'Strategy field should have two element options' );
+		$this->assertSame( 'existing_only', $fields[0]['elements'][0]['value'] );
+		$this->assertSame( 'allow_new', $fields[0]['elements'][1]['value'] );
+
+		// Verify max_suggestions field.
+		$this->assertSame( 'max_suggestions', $fields[1]['id'] );
+		$this->assertSame( 'integer', $fields[1]['type'] );
+		$this->assertSame( 5, $fields[1]['default'] );
+	}
+
+	/**
+	 * Test that get_settings_fields_metadata() resolves IDs to full option names.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_settings_fields_metadata_resolves_ids() {
+		$experiment = new Content_Classification();
+		$fields     = $experiment->get_settings_fields_metadata();
+
+		$this->assertSame(
+			'wpai_feature_content-classification_field_strategy',
+			$fields[0]['id'],
+			'Strategy field id should be resolved to full option name'
+		);
+		$this->assertSame(
+			'wpai_feature_content-classification_field_max_suggestions',
+			$fields[1]['id'],
+			'Max suggestions field id should be resolved to full option name'
+		);
+	}
+
+	/**
+	 * Test that register_settings() registers options with show_in_rest.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_register_settings_has_show_in_rest() {
+		$experiment = new Content_Classification();
+		$experiment->register_settings();
+
+		$registered = get_registered_settings();
+
+		$strategy_key        = 'wpai_feature_content-classification_field_strategy';
+		$max_suggestions_key = 'wpai_feature_content-classification_field_max_suggestions';
+
+		$this->assertArrayHasKey( $strategy_key, $registered, 'Strategy setting should be registered' );
+		$this->assertArrayHasKey( $max_suggestions_key, $registered, 'Max suggestions setting should be registered' );
+
+		$this->assertNotEmpty( $registered[ $strategy_key ]['show_in_rest'], 'Strategy should have show_in_rest' );
+		$this->assertNotEmpty( $registered[ $max_suggestions_key ]['show_in_rest'], 'Max suggestions should have show_in_rest' );
+	}
 }

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -90,7 +90,7 @@ test.describe( 'Plugin settings', () => {
 		// Ensure feature toggles are disabled when AI is disabled.
 		await expect(
 			page
-				.locator( '#ai-wp-admin-app input[type="checkbox"]:disabled' )
+				.locator( '#ai-wp-admin-app [role="checkbox"][aria-disabled="true"]' )
 				.first()
 		).toBeVisible();
 

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -85,7 +85,7 @@ test.describe( 'Plugin settings', () => {
 
 		// Ensure global AI setting is disabled.
 		await expect(
-			page.getByRole( 'checkbox', { name: 'Enable AI' } )
+			page.getByLabel( 'Enable AI' )
 		).not.toBeChecked();
 
 		// Ensure feature checkboxes are disabled when AI is disabled.
@@ -100,7 +100,7 @@ test.describe( 'Plugin settings', () => {
 
 		// Ensure global AI setting is enabled.
 		await expect(
-			page.getByRole( 'checkbox', { name: 'Enable AI' } )
+			page.getByLabel( 'Enable AI' )
 		).toBeChecked();
 
 		// Ensure we see the editor experiments section.

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -141,7 +141,9 @@ test.describe( 'Plugin settings', () => {
 		await otherToggle.click();
 
 		// Wait for the auto-save snackbar to confirm siteSettings changed.
-		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+		await expect(
+			page.getByText( 'Title Generation enabled.' )
+		).toBeVisible();
 
 		// Assert: inline settings must still show the pending edit (not reset).
 		await expect( strategySelect ).toHaveValue( newValue );

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Plugin settings', () => {
 		// Ensure global AI setting is disabled.
 		await expect( page.getByLabel( 'Enable AI' ) ).not.toBeChecked();
 
-		// Ensure feature checkboxes are disabled when AI is disabled.
+		// Ensure feature toggles are disabled when AI is disabled.
 		await expect(
 			page
 				.locator( '#ai-wp-admin-app input[type="checkbox"]:disabled' )

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -84,9 +84,7 @@ test.describe( 'Plugin settings', () => {
 		await disableExperiments( admin, page );
 
 		// Ensure global AI setting is disabled.
-		await expect(
-			page.getByLabel( 'Enable AI' )
-		).not.toBeChecked();
+		await expect( page.getByLabel( 'Enable AI' ) ).not.toBeChecked();
 
 		// Ensure feature checkboxes are disabled when AI is disabled.
 		await expect(
@@ -99,9 +97,7 @@ test.describe( 'Plugin settings', () => {
 		await enableExperiments( admin, page );
 
 		// Ensure global AI setting is enabled.
-		await expect(
-			page.getByLabel( 'Enable AI' )
-		).toBeChecked();
+		await expect( page.getByLabel( 'Enable AI' ) ).toBeChecked();
 
 		// Ensure we see the editor experiments section.
 		await expect( page.getByText( 'Editor Experiments' ) ).toBeVisible();

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -90,7 +90,9 @@ test.describe( 'Plugin settings', () => {
 		// Ensure feature toggles are disabled when AI is disabled.
 		await expect(
 			page
-				.locator( '#ai-wp-admin-app [role="checkbox"][aria-disabled="true"]' )
+				.locator(
+					'#ai-wp-admin-app [role="checkbox"][aria-disabled="true"]'
+				)
 				.first()
 		).toBeVisible();
 
@@ -125,9 +127,7 @@ test.describe( 'Plugin settings', () => {
 		// Change the strategy to create a pending local edit.
 		const originalValue = await strategySelect.inputValue();
 		const newValue =
-			originalValue === 'existing_only'
-				? 'allow_new'
-				: 'existing_only';
+			originalValue === 'existing_only' ? 'allow_new' : 'existing_only';
 		await strategySelect.selectOption( newValue );
 
 		// Verify the Save button appears (confirms pending edits exist).

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -91,7 +91,7 @@ test.describe( 'Plugin settings', () => {
 		await expect(
 			page
 				.locator(
-					'#ai-wp-admin-app [role="checkbox"][aria-disabled="true"]'
+					'#ai-wp-admin-app .components-form-toggle.is-disabled'
 				)
 				.first()
 		).toBeVisible();
@@ -142,7 +142,9 @@ test.describe( 'Plugin settings', () => {
 
 		// Wait for the auto-save snackbar to confirm siteSettings changed.
 		await expect(
-			page.getByText( 'Title Generation enabled.' )
+			page.locator( '.components-snackbar__content', {
+				hasText: 'Title Generation enabled.',
+			} )
 		).toBeVisible();
 
 		// Assert: inline settings must still show the pending edit (not reset).

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -9,6 +9,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const {
 	clearConnectors,
 	disableExperiments,
+	enableExperiment,
 	enableExperiments,
 	visitConnectorsPage,
 	visitSettingsPage,
@@ -104,5 +105,46 @@ test.describe( 'Plugin settings', () => {
 
 		// Ensure we see the admin experiments section.
 		await expect( page.getByText( 'Admin Experiments' ) ).toBeVisible();
+	} );
+
+	test( 'Inline settings retain pending edits when another toggle auto-saves', async ( {
+		admin,
+		page,
+	} ) => {
+		// Setup: Enable AI and Content Classification.
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'Content Classification' );
+
+		// Visit settings page fresh to ensure no stale snackbars.
+		await visitSettingsPage( admin );
+
+		// Wait for Content Classification inline settings to render.
+		const strategySelect = page.getByLabel( 'Taxonomy strategy' );
+		await expect( strategySelect ).toBeVisible( { timeout: 10000 } );
+
+		// Change the strategy to create a pending local edit.
+		const originalValue = await strategySelect.inputValue();
+		const newValue =
+			originalValue === 'existing_only'
+				? 'allow_new'
+				: 'existing_only';
+		await strategySelect.selectOption( newValue );
+
+		// Verify the Save button appears (confirms pending edits exist).
+		const saveButton = page
+			.locator( '.ai-feature-settings-form' )
+			.getByRole( 'button', { name: 'Save' } );
+		await expect( saveButton ).toBeVisible();
+
+		// Toggle another experiment to trigger auto-save (changes siteSettings).
+		const otherToggle = page.getByLabel( 'Title Generation' );
+		await otherToggle.click();
+
+		// Wait for the auto-save snackbar to confirm siteSettings changed.
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+
+		// Assert: inline settings must still show the pending edit (not reset).
+		await expect( strategySelect ).toHaveValue( newValue );
+		await expect( saveButton ).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -84,7 +84,9 @@ async function setStrategy( admin, page, strategy ) {
 	await saveButton.click();
 
 	await expect(
-		page.getByText( 'Content Classification settings saved.' )
+		page.locator( '.components-snackbar__content', {
+			hasText: 'Content Classification settings saved.',
+		} )
 	).toBeVisible();
 }
 

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -83,7 +83,9 @@ async function setStrategy( admin, page, strategy ) {
 		.getByRole( 'button', { name: 'Save' } );
 	await saveButton.click();
 
-	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+	await expect(
+		page.getByText( 'Content Classification settings saved.' )
+	).toBeVisible();
 }
 
 test.describe( 'Content Classification Experiment', () => {

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -76,6 +76,12 @@ async function setStrategy( admin, page, strategy ) {
 
 	const strategySelect = page.getByLabel( 'Taxonomy strategy' );
 	await expect( strategySelect ).toBeVisible( { timeout: 10000 } );
+
+	// Nothing to do if the strategy is already set.
+	if ( ( await strategySelect.inputValue() ) === strategy ) {
+		return;
+	}
+
 	await strategySelect.selectOption( strategy );
 
 	const saveButton = page

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -13,7 +13,7 @@ import {
 	enableExperiment,
 } from '../../utils/helpers';
 
-const EXPERIMENT_ID = 'content-classification';
+const EXPERIMENT_LABEL = 'Content Classification';
 
 // Content Classification has a 150 word minimum requirement.
 const LONG_CONTENT =
@@ -92,7 +92,7 @@ test.describe( 'Content Classification Experiment', () => {
 		await enableExperiments( admin, page );
 
 		// Enable the Content Classification Experiment.
-		await enableExperiment( admin, page, EXPERIMENT_ID );
+		await enableExperiment( admin, page, EXPERIMENT_LABEL );
 	} );
 
 	test( 'Shows the "Suggest Tags" button in the Tags panel', async ( {
@@ -330,7 +330,7 @@ test.describe( 'Content Classification Experiment', () => {
 		page,
 	} ) => {
 		// Disable the Content Classification Experiment.
-		await disableExperiment( admin, page, EXPERIMENT_ID );
+		await disableExperiment( admin, page, EXPERIMENT_LABEL );
 
 		// Create a new post with content.
 		await admin.createNewPost( {

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -72,16 +72,18 @@ async function openTaxonomyPanel( editor, page, panelLabel ) {
  * @param {string} strategy The strategy value ('existing_only' or 'allow_new').
  */
 async function setStrategy( admin, page, strategy ) {
-	await admin.visitAdminPage( 'options-general.php?page=ai' );
-	await page
-		.locator( '#wpai_feature_content-classification_field_strategy' )
-		.selectOption( strategy );
-	await page.locator( '#submit' ).click();
-	await expect(
-		page.locator( '.wrap .notice-success', {
-			hasText: 'Settings saved',
-		} )
-	).toHaveCount( 1 );
+	await admin.visitAdminPage( 'options-general.php?page=ai-wp-admin' );
+
+	const strategySelect = page.getByLabel( 'Taxonomy strategy' );
+	await expect( strategySelect ).toBeVisible( { timeout: 10000 } );
+	await strategySelect.selectOption( strategy );
+
+	const saveButton = page
+		.locator( '.ai-feature-settings-form' )
+		.getByRole( 'button', { name: 'Save' } );
+	await saveButton.click();
+
+	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
 }
 
 test.describe( 'Content Classification Experiment', () => {

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -141,7 +141,7 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.uncheck();
-	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+	await expect( page.getByText( 'AI disabled.' ) ).toBeVisible();
 };
 
 /**
@@ -162,7 +162,7 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.check();
-	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+	await expect( page.getByText( 'AI enabled.' ) ).toBeVisible();
 };
 
 /**
@@ -189,7 +189,9 @@ export const enableExperiment = async (
 	await toggle.check();
 
 	// Ensure the save was successful.
-	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+	await expect(
+		page.getByText( `${ experimentLabel } enabled.` )
+	).toBeVisible();
 };
 
 /**
@@ -216,5 +218,7 @@ export const disableExperiment = async (
 	await toggle.uncheck();
 
 	// Ensure the save was successful.
-	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+	await expect(
+		page.getByText( `${ experimentLabel } disabled.` )
+	).toBeVisible();
 };

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -133,9 +133,7 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 	await visitSettingsPage( admin );
 
 	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByRole( 'checkbox', {
-		name: 'Enable AI',
-	} );
+	const globalToggle = page.getByLabel( 'Enable AI' );
 	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
 
 	// Nothing to do if experiments are already disabled.
@@ -156,9 +154,7 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 	await visitSettingsPage( admin );
 
 	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByRole( 'checkbox', {
-		name: 'Enable AI',
-	} );
+	const globalToggle = page.getByLabel( 'Enable AI' );
 	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
 
 	// Nothing to do if experiments are already enabled.
@@ -182,17 +178,15 @@ export const enableExperiment = async (
 	experimentLabel: string
 ) => {
 	await visitSettingsPage( admin );
-	const checkbox = page.getByRole( 'checkbox', {
-		name: experimentLabel,
-	} );
-	await expect( checkbox ).toBeVisible( { timeout: 10000 } );
+	const toggle = page.getByLabel( experimentLabel );
+	await expect( toggle ).toBeVisible( { timeout: 10000 } );
 
 	// Nothing to do if this experiment is already enabled.
-	if ( await checkbox.isChecked() ) {
+	if ( await toggle.isChecked() ) {
 		return;
 	}
 
-	await checkbox.check();
+	await toggle.check();
 
 	// Ensure the save was successful.
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
@@ -211,17 +205,15 @@ export const disableExperiment = async (
 	experimentLabel: string
 ) => {
 	await visitSettingsPage( admin );
-	const checkbox = page.getByRole( 'checkbox', {
-		name: experimentLabel,
-	} );
-	await expect( checkbox ).toBeVisible( { timeout: 10000 } );
+	const toggle = page.getByLabel( experimentLabel );
+	await expect( toggle ).toBeVisible( { timeout: 10000 } );
 
 	// Nothing to do if this experiment is already disabled.
-	if ( ! ( await checkbox.isChecked() ) ) {
+	if ( ! ( await toggle.isChecked() ) ) {
 		return;
 	}
 
-	await checkbox.uncheck();
+	await toggle.uncheck();
 
 	// Ensure the save was successful.
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -141,7 +141,9 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.uncheck();
-	await expect( page.getByText( 'AI disabled.' ) ).toBeVisible();
+	await expect(
+		page.locator( '.components-snackbar__content', { hasText: 'AI disabled.' } )
+	).toBeVisible();
 };
 
 /**
@@ -162,7 +164,9 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.check();
-	await expect( page.getByText( 'AI enabled.' ) ).toBeVisible();
+	await expect(
+		page.locator( '.components-snackbar__content', { hasText: 'AI enabled.' } )
+	).toBeVisible();
 };
 
 /**
@@ -190,7 +194,9 @@ export const enableExperiment = async (
 
 	// Ensure the save was successful.
 	await expect(
-		page.getByText( `${ experimentLabel } enabled.` )
+		page.locator( '.components-snackbar__content', {
+			hasText: `${ experimentLabel } enabled.`,
+		} )
 	).toBeVisible();
 };
 
@@ -219,6 +225,8 @@ export const disableExperiment = async (
 
 	// Ensure the save was successful.
 	await expect(
-		page.getByText( `${ experimentLabel } disabled.` )
+		page.locator( '.components-snackbar__content', {
+			hasText: `${ experimentLabel } disabled.`,
+		} )
 	).toBeVisible();
 };

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -143,7 +143,6 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.uncheck();
-	await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
 };
 
@@ -167,7 +166,6 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 		return;
 	}
 	await globalToggle.check();
-	await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
 };
 
@@ -195,7 +193,6 @@ export const enableExperiment = async (
 	}
 
 	await checkbox.check();
-	await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
 	// Ensure the save was successful.
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
@@ -225,7 +222,6 @@ export const disableExperiment = async (
 	}
 
 	await checkbox.uncheck();
-	await page.getByRole( 'button', { name: 'Save Changes' } ).click();
 
 	// Ensure the save was successful.
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -142,7 +142,9 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 	}
 	await globalToggle.uncheck();
 	await expect(
-		page.locator( '.components-snackbar__content', { hasText: 'AI disabled.' } )
+		page.locator( '.components-snackbar__content', {
+			hasText: 'AI disabled.',
+		} )
 	).toBeVisible();
 };
 
@@ -165,7 +167,9 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 	}
 	await globalToggle.check();
 	await expect(
-		page.locator( '.components-snackbar__content', { hasText: 'AI enabled.' } )
+		page.locator( '.components-snackbar__content', {
+			hasText: 'AI enabled.',
+		} )
 	).toBeVisible();
 };
 


### PR DESCRIPTION
## Summary
- Replace checkbox controls with toggle switches on the AI settings page
- Auto-save settings on each toggle change instead of requiring a manual "Save Changes" button click
- Show contextual snackbar notices (e.g. "AI enabled.", "Content Classification disabled.")
- Allow experiments to declare custom settings fields via `get_settings_fields()` on `Abstract_Feature`, rendered as inline DataForms below the experiment toggle when enabled
- Migrate Content Classification's custom settings (taxonomy strategy, max suggestions) from server-rendered HTML to DataForm fields with `show_in_rest` support
- Custom experiment settings use a separate Save button that only appears when changes are pending

## Test plan
- [ ] Visit the AI settings page and verify toggles render instead of checkboxes
- [ ] Toggle a setting and verify it auto-saves with a contextual snackbar message
- [ ] Disable the global AI toggle and verify feature toggles become disabled
- [ ] Enable Content Classification and verify the strategy and max suggestions fields appear inline below the toggle
- [ ] Disable Content Classification and verify the sub-settings disappear
- [ ] Change the taxonomy strategy, verify the Save button appears, click it, and confirm the snackbar and value persistence on reload
- [ ] Verify `/wp/v2/settings/` REST API returns `wpai_feature_content-classification_field_strategy` and `wpai_feature_content-classification_field_max_suggestions`
- [ ] Run E2E tests: `npm run test:e2e -- --grep "Plugin settings"` and `npm run test:e2e -- --grep "Content Classification"`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-376-e0bddc272f4101c04a2f3b49366f5c84034bd8be.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->