### PR TITLE
Remove unneeded `function_exists` checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,18 @@ jobs:
             - name: Make Composer packages available globally
               run: echo "${PWD}/vendor/bin" >> "$GITHUB_PATH"
 
+            - name: Setup Node.js
+              uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+              with:
+                  cache: 'npm'
+                  node-version-file: '.nvmrc'
+
+            - name: Install NPM dependencies
+              run: npm ci
+
+            - name: Build assets
+              run: npm run build
+
             - name: Run PHP static analysis tests
               id: phpstan
               run: phpstan analyse -vvv --error-format=checkstyle | cs2pr

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -35,13 +35,7 @@ class Ability_Handler {
 	 * @return array<array<string,mixed>> Array of abilities.
 	 */
 	public static function get_all_abilities(): array {
-		if ( ! function_exists( 'wp_get_abilities' ) ) {
-			return array();
-		}
-
-		$all_abilities = wp_get_abilities();
-
-		return self::format_abilities( $all_abilities );
+		return self::format_abilities( wp_get_abilities() );
 	}
 
 	/**
@@ -53,10 +47,6 @@ class Ability_Handler {
 	 * @return array<string,mixed>|null Ability data or null if not found.
 	 */
 	public static function get_ability( string $slug ): ?array {
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return null;
-		}
-
 		$ability = wp_get_ability( $slug );
 
 		if ( ! $ability ) {
@@ -132,7 +122,7 @@ class Ability_Handler {
 		$category_slug = $ability->get_category();
 
 		$category_label = esc_html__( 'Other', 'ai' );
-		if ( ! empty( $category_slug ) && function_exists( 'wp_get_ability_category' ) ) {
+		if ( ! empty( $category_slug ) ) {
 			$category_obj = wp_get_ability_category( $category_slug );
 			if ( $category_obj ) {
 				$category_label = $category_obj->get_label();
@@ -240,13 +230,6 @@ class Ability_Handler {
 	 * }
 	 */
 	public static function invoke_ability( string $slug, array $input = array() ): array {
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return array(
-				'success' => false,
-				'error'   => 'Abilities API not available',
-			);
-		}
-
 		$ability = wp_get_ability( $slug );
 
 		if ( ! $ability ) {

--- a/includes/bootstrap.php
+++ b/includes/bootstrap.php
@@ -316,7 +316,7 @@ function load(): void {
 
 	// Load auto-generated wp-build registration if present.
 	if ( file_exists( WPAI_PLUGIN_DIR . 'build/build.php' ) ) {
-		require_once WPAI_PLUGIN_DIR . 'build/build.php'; // @phpstan-ignore requireOnce.fileNotFound
+		require_once WPAI_PLUGIN_DIR . 'build/build.php';
 	}
 
 	// Handle any pending upgrades.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -306,12 +306,7 @@ function get_preferred_vision_models(): array {
  * @return bool True if we have AI credentials, false otherwise.
  */
 function has_ai_credentials(): bool {
-	if ( ! function_exists( 'wp_get_connectors' ) ) {
-		return false;
-	}
-
-	$connectors = wp_get_connectors();
-
+	$connectors      = wp_get_connectors();
 	$has_credentials = false;
 
 	foreach ( $connectors as $connector_data ) {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,6 +27,7 @@ parameters:
 			- '#Function wp_ai_client_prompt not found\.#'
 			- '#WP_AI_Client_[A-Za-z0-9_]+#'
 			- '#WordPress\\AiClient\\#'
+			- '#Function wp_get_connectors not found\.#'
 		excludePaths:
 			analyse:
 				- tests/

--- a/tests/Integration/Includes/Experiments/Image_Generation/Image_GenerationTest.php
+++ b/tests/Integration/Includes/Experiments/Image_Generation/Image_GenerationTest.php
@@ -80,11 +80,6 @@ class Image_GenerationTest extends WP_UnitTestCase {
 	 * @since 0.3.0
 	 */
 	public function test_experiment_registers_abilities() {
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			$this->markTestSkipped( 'WP_Ability class not available' );
-			return;
-		}
-
 		// Expect warnings about already registered abilities from other tests.
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::register' );
 

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -157,11 +157,6 @@ class HelpersTest extends WP_UnitTestCase {
 		// Expect the incorrect usage notice when abilities are called with non-existent posts.
 		$this->setExpectedIncorrectUsage( 'WP_Ability::execute' );
 
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			$this->markTestSkipped( 'WP_Ability class not available' );
-			return;
-		}
-
 		$context = \WordPress\AI\get_post_context( 99999 );
 
 		$this->assertIsArray( $context, 'Should return an array' );
@@ -180,11 +175,6 @@ class HelpersTest extends WP_UnitTestCase {
 				'post_title'   => 'Test Post',
 			)
 		);
-
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			$this->markTestSkipped( 'WP_Ability class not available' );
-			return;
-		}
 
 		$context = \WordPress\AI\get_post_context( $post_id );
 
@@ -209,11 +199,6 @@ class HelpersTest extends WP_UnitTestCase {
 				'post_excerpt' => 'Test excerpt',
 			)
 		);
-
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			$this->markTestSkipped( 'WP_Ability class not available' );
-			return;
-		}
 
 		$context = \WordPress\AI\get_post_context( $post_id );
 
@@ -242,11 +227,6 @@ class HelpersTest extends WP_UnitTestCase {
 				'post_content' => 'Test content',
 			)
 		);
-
-		if ( ! function_exists( 'wp_get_ability' ) ) {
-			$this->markTestSkipped( 'WP_Ability class not available' );
-			return;
-		}
 
 		wp_set_post_categories( $post_id, array( $category_id ) );
 		wp_set_post_tags( $post_id, array( 'Test Tag' ) );


### PR DESCRIPTION
## What?

Remove unneeded `function_exists` checks

## Why?

As mentioned [here](https://github.com/WordPress/ai/pull/304#pullrequestreview-4073945290), we have some `function_exists` checks that aren't technically needed since the functions we check for are in versions of WordPress that match or exceed our minimum (6.9 and 7.0).

## How?

For any core WordPress functions that we know are always available in WordPress 7.0 (our minimum) remove `function_exists` checks

### Use of AI Tools

None

## Testing Instructions

Not a lot needed here other than ensuring tests pass. Could also test the Abilities Explorer experiment to ensure it still works as expected

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-378-b63f9d781564e8f63692217d61905754bfc3eae3.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->