### PR TITLE
Allow bulk enabling/disabling experiments in groups

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -41,8 +41,15 @@ interface PageData {
 	features: FeatureData[];
 }
 
+interface SelectAllToggleProps extends DataFormControlProps< AISettings > {
+	featureSettingNames: string[];
+	groupLabel: string;
+	globalEnabled: boolean;
+}
+
 const FEATURE_SETTING_PATTERN = /^wpai_feature_(.+)_enabled$/;
 const GLOBAL_FIELD_ID = 'wpai_features_enabled';
+const SELECT_ALL_FIELD_PREFIX = 'wpai_select_all_';
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
@@ -113,6 +120,30 @@ function getDefaultLabel( key: string ): string {
 
 function getSectionId( groupId: string ): string {
 	return `feature-group-${ groupId.replace( /[^a-zA-Z0-9_-]/g, '-' ) }`;
+}
+
+function getSelectAllFieldId( groupId: string ): string {
+	return `${ SELECT_ALL_FIELD_PREFIX }${ groupId.replace(
+		/[^a-zA-Z0-9_-]/g,
+		'_'
+	) }`;
+}
+
+function createSelectAllEditComponent(
+	featureSettingNames: string[],
+	groupLabel: string,
+	globalEnabled: boolean
+): React.ComponentType< DataFormControlProps< AISettings > > {
+	return function SelectAllEdit( props ) {
+		return (
+			<SelectAllToggle
+				{ ...props }
+				featureSettingNames={ featureSettingNames }
+				groupLabel={ groupLabel }
+				globalEnabled={ globalEnabled }
+			/>
+		);
+	};
 }
 
 function buildFallbackFeatureGroups(
@@ -200,6 +231,58 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	);
 }
 
+function SelectAllToggle( {
+	data,
+	onChange,
+	featureSettingNames,
+	groupLabel,
+	globalEnabled,
+}: SelectAllToggleProps ) {
+	const enabledCount = featureSettingNames.filter(
+		( settingName ) => !! data[ settingName ]
+	).length;
+
+	const isAllEnabled = enabledCount === featureSettingNames.length;
+
+	// Dynamic label based on current state
+	const label = isAllEnabled
+		? sprintf(
+				// translators: %s: Group label (e.g., "Editor Experiments")
+				__( 'Disable all %s', 'ai' ),
+				groupLabel
+		  )
+		: sprintf(
+				// translators: %s: Group label (e.g., "Editor Experiments")
+				__( 'Enable all %s', 'ai' ),
+				groupLabel
+		  );
+
+	const handleToggle = useCallback(
+		( checked: boolean ) => {
+			const updates: Record< string, boolean > = {};
+
+			for ( const settingName of featureSettingNames ) {
+				updates[ settingName ] = checked;
+			}
+
+			onChange( updates );
+		},
+		[ featureSettingNames, onChange ]
+	);
+
+	return (
+		<div className="ai-select-all-toggle">
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ label }
+				checked={ isAllEnabled }
+				onChange={ handleToggle }
+				disabled={ ! globalEnabled }
+			/>
+		</div>
+	);
+}
+
 function AISettingsPage() {
 	const { siteSettings, isLoading } = useSelect( ( select ) => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- core-data store selectors aren't fully typed for 'root'/'site' entity args.
@@ -270,8 +353,13 @@ function AISettingsPage() {
 			settingKeys.add( feature.settingName );
 		}
 
+		// Add select-all field IDs (they're virtual, not saved to DB)
+		for ( const group of featureGroups ) {
+			settingKeys.add( getSelectAllFieldId( group.id ) );
+		}
+
 		return Array.from( settingKeys );
-	}, [ featureDefinitions ] );
+	}, [ featureDefinitions, featureGroups ] );
 
 	const data: AISettings = useMemo( () => {
 		const aiSettings: AISettings = {};
@@ -281,21 +369,53 @@ function AISettingsPage() {
 		return aiSettings;
 	}, [ aiSettingKeys, siteSettings ] );
 
-	const globalEnabled = data[ GLOBAL_FIELD.id ];
+	const globalEnabled = Boolean( data[ GLOBAL_FIELD.id ] );
 
-	const fields = useMemo< Field< AISettings >[] >(
-		() => [
-			GLOBAL_FIELD,
-			...featureDefinitions.map( ( feature ) => ( {
-				id: feature.settingName,
-				label: feature.label,
-				description: feature.description,
-				type: 'boolean' as const,
-				Edit: globalEnabled ? ( 'toggle' as const ) : DisabledToggle,
-			} ) ),
-		],
-		[ featureDefinitions, globalEnabled ]
-	);
+	const fields = useMemo< Field< AISettings >[] >( () => {
+		// Group features by category to create select-all fields
+		const groupedFeatures = new Map< string, FeatureData[] >();
+		for ( const feature of featureDefinitions ) {
+			const category = feature.category || 'other';
+			const categoryFeatures = groupedFeatures.get( category ) ?? [];
+			categoryFeatures.push( feature );
+			groupedFeatures.set( category, categoryFeatures );
+		}
+
+		// Create select-all fields for each group
+		const selectAllFields: Field< AISettings >[] = [];
+		for ( const group of featureGroups ) {
+			const groupFeatures = groupedFeatures.get( group.id ) ?? [];
+			if ( groupFeatures.length === 0 ) {
+				continue;
+			}
+
+			const featureSettingNames = groupFeatures.map(
+				( f ) => f.settingName
+			);
+
+			selectAllFields.push( {
+				id: getSelectAllFieldId( group.id ),
+				label: '', // Dynamic label set by SelectAllToggle component
+				type: 'boolean',
+				Edit: createSelectAllEditComponent(
+					featureSettingNames,
+					group.label,
+					globalEnabled
+				),
+			} );
+		}
+
+		// Create individual feature fields
+		const featureFields = featureDefinitions.map( ( feature ) => ( {
+			id: feature.settingName,
+			label: feature.label,
+			description: feature.description,
+			type: 'boolean' as const,
+			Edit: globalEnabled ? ( 'toggle' as const ) : DisabledToggle,
+		} ) );
+
+		return [ GLOBAL_FIELD, ...selectAllFields, ...featureFields ];
+	}, [ featureDefinitions, featureGroups, globalEnabled ] );
 
 	const form = useMemo< Form >( () => {
 		const groupedFields = new Map< string, string[] >();
@@ -317,6 +437,11 @@ function AISettingsPage() {
 			}
 
 			seenCategories.add( group.id );
+
+			// Add select-all field as first child
+			const selectAllFieldId = getSelectAllFieldId( group.id );
+			const sectionChildren = [ selectAllFieldId, ...children ];
+
 			sectionFields.push( {
 				id: getSectionId( group.id ),
 				label: group.label,
@@ -327,7 +452,7 @@ function AISettingsPage() {
 					isOpened: true,
 					isCollapsible: true,
 				},
-				children,
+				children: sectionChildren,
 			} );
 		}
 
@@ -335,6 +460,10 @@ function AISettingsPage() {
 			if ( children.length === 0 || seenCategories.has( category ) ) {
 				continue;
 			}
+
+			// Add select-all field as first child
+			const selectAllFieldId = getSelectAllFieldId( category );
+			const sectionChildren = [ selectAllFieldId, ...children ];
 
 			sectionFields.push( {
 				id: getSectionId( category ),
@@ -346,7 +475,7 @@ function AISettingsPage() {
 					isOpened: true,
 					isCollapsible: true,
 				},
-				children,
+				children: sectionChildren,
 			} );
 		}
 
@@ -373,28 +502,70 @@ function AISettingsPage() {
 
 	const handleChange = useCallback(
 		async ( edits: Record< string, unknown > ) => {
-			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
-			editEntityRecord( 'root', 'site', undefined, edits );
+			// Filter out virtual select-all fields - they shouldn't be saved
+			const actualEdits: Record< string, unknown > = {};
+			for ( const [ key, value ] of Object.entries( edits ) ) {
+				if ( ! key.startsWith( SELECT_ALL_FIELD_PREFIX ) ) {
+					actualEdits[ key ] = value;
+				}
+			}
 
-			const entry = Object.entries( edits )[ 0 ];
+			// If no actual edits after filtering, skip
+			if ( Object.keys( actualEdits ).length === 0 ) {
+				return;
+			}
+
+			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
+			editEntityRecord( 'root', 'site', undefined, actualEdits );
+
+			// Determine success message
 			let message: string;
-			if ( ! entry ) {
-				message = __( 'Settings saved.', 'ai' );
-			} else if ( entry[ 0 ] === GLOBAL_FIELD_ID ) {
-				message = entry[ 1 ]
-					? __( 'AI enabled.', 'ai' )
-					: __( 'AI disabled.', 'ai' );
-			} else {
-				const feature = featureDefinitions.find(
-					( f ) => f.settingName === entry[ 0 ]
-				);
-				const label = feature?.label ?? entry[ 0 ];
-				if ( entry[ 1 ] ) {
-					// translators: %s: Feature label.
-					message = sprintf( __( '%s enabled.', 'ai' ), label );
+			const editCount = Object.keys( actualEdits ).length;
+
+			if ( editCount > 1 ) {
+				// Bulk edit message
+				const enabledCount =
+					Object.values( actualEdits ).filter( Boolean ).length;
+				if ( enabledCount === editCount ) {
+					message = sprintf(
+						// translators: %d: number of experiments.
+						__( '%d experiments enabled.', 'ai' ),
+						editCount
+					);
+				} else if ( enabledCount === 0 ) {
+					message = sprintf(
+						// translators: %d: number of experiments.
+						__( '%d experiments disabled.', 'ai' ),
+						editCount
+					);
 				} else {
-					// translators: %s: Feature label.
-					message = sprintf( __( '%s disabled.', 'ai' ), label );
+					message = sprintf(
+						// translators: %d: number of experiments.
+						__( '%d experiments updated.', 'ai' ),
+						editCount
+					);
+				}
+			} else {
+				// Single edit message
+				const entry = Object.entries( actualEdits )[ 0 ];
+				if ( ! entry ) {
+					message = __( 'Settings saved.', 'ai' );
+				} else if ( entry[ 0 ] === GLOBAL_FIELD_ID ) {
+					message = entry[ 1 ]
+						? __( 'AI enabled.', 'ai' )
+						: __( 'AI disabled.', 'ai' );
+				} else {
+					const feature = featureDefinitions.find(
+						( f ) => f.settingName === entry[ 0 ]
+					);
+					const label = feature?.label ?? entry[ 0 ];
+					if ( entry[ 1 ] ) {
+						// translators: %s: Feature label.
+						message = sprintf( __( '%s enabled.', 'ai' ), label );
+					} else {
+						// translators: %s: Feature label.
+						message = sprintf( __( '%s disabled.', 'ai' ), label );
+					}
 				}
 			}
 

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -13,3 +13,19 @@
 .ai-settings-page .components-notice {
 	margin: 0 0 24px;
 }
+
+.ai-select-all-toggle {
+	padding: 12px;
+	margin-bottom: 16px;
+	background-color: #f0f0f0;
+	border-radius: 4px;
+	border: 1px solid #dcdcde;
+
+	.components-base-control {
+		margin-bottom: 0;
+	}
+
+	.components-toggle-control__label {
+		font-weight: 600;
+	}
+}

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -104,9 +104,9 @@ test.describe( 'Plugin settings', () => {
 		).toBeChecked();
 
 		// Ensure we see the editor experiments section.
-		await expect( page.getByText( 'Editor Experiments' ) ).toBeVisible();
+		await expect( page.getByText( 'Editor Experiments', { exact: true } ) ).toBeVisible();
 
 		// Ensure we see the admin experiments section.
-		await expect( page.getByText( 'Admin Experiments' ) ).toBeVisible();
+		await expect( page.getByText( 'Admin Experiments', { exact: true } ) ).toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -12,7 +12,16 @@ const {
 	enableExperiments,
 	visitConnectorsPage,
 	visitSettingsPage,
+	getSelectAllToggle,
+	enableAllExperimentsInGroup,
+	disableAllExperimentsInGroup,
+	getExperimentTogglesInGroup,
 } = require( '../../utils/helpers' );
+
+const EXPERIMENT_GROUPS = {
+	editor: 'Editor Experiments',
+	admin: 'Admin Experiments',
+};
 
 test.describe( 'Plugin settings', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
@@ -104,9 +113,221 @@ test.describe( 'Plugin settings', () => {
 		).toBeChecked();
 
 		// Ensure we see the editor experiments section.
-		await expect( page.getByText( 'Editor Experiments', { exact: true } ) ).toBeVisible();
+		await expect(
+			page.getByText( 'Editor Experiments', { exact: true } )
+		).toBeVisible();
 
 		// Ensure we see the admin experiments section.
-		await expect( page.getByText( 'Admin Experiments', { exact: true } ) ).toBeVisible();
+		await expect(
+			page.getByText( 'Admin Experiments', { exact: true } )
+		).toBeVisible();
+	} );
+
+	test( 'Can turn on all experiments in a group', async ( {
+		admin,
+		page,
+	} ) => {
+		// Ensure AI is enabled first.
+		await enableExperiments( admin, page );
+
+		// Ensure all experiments are disabled to start.
+		await disableAllExperimentsInGroup(
+			admin,
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		// Find the "Enable all Editor Experiments" toggle.
+		const selectAllToggle = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		await expect( selectAllToggle ).toBeVisible( { timeout: 10000 } );
+
+		// Ensure setting is disabled.
+		await expect( selectAllToggle ).not.toBeChecked();
+
+		// Click the select-all toggle to enable all experiments.
+		await selectAllToggle.check();
+
+		// Verify the success message appears.
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+
+		// Verify the toggle label changed to "Disable all".
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: new RegExp(
+					`Disable all ${ EXPERIMENT_GROUPS.editor }`,
+					'i'
+				),
+			} )
+		).toBeVisible();
+
+		// Verify all experiments in the group are now enabled.
+		const experimentToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		for ( const toggle of experimentToggles ) {
+			await expect( toggle ).toBeChecked();
+		}
+	} );
+
+	test( 'Can turn off all experiments in a group', async ( {
+		admin,
+		page,
+	} ) => {
+		// Ensure AI is enabled first.
+		await enableExperiments( admin, page );
+
+		// First enable all experiments.
+		await enableAllExperimentsInGroup(
+			admin,
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		// Find the "Disable all" toggle.
+		const selectAllToggle = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		await expect( selectAllToggle ).toBeVisible();
+
+		// Ensure setting is disabled.
+		await expect( selectAllToggle ).toBeChecked();
+
+		// Click the select-all toggle to disable all experiments.
+		await selectAllToggle.uncheck();
+
+		// Verify the success message appears.
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+
+		// Verify the toggle label changed to "Enable all".
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: new RegExp(
+					`Enable all ${ EXPERIMENT_GROUPS.editor }`,
+					'i'
+				),
+			} )
+		).toBeVisible();
+
+		// Verify all experiments in the group are now disabled.
+		const experimentToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		for ( const toggle of experimentToggles ) {
+			await expect( toggle ).not.toBeChecked();
+		}
+	} );
+
+	test( 'Can turn on all experiments in a group when experiments are in mixed state', async ( {
+		admin,
+		page,
+	} ) => {
+		// Ensure AI is enabled.
+		await enableExperiments( admin, page );
+
+		// First disable all experiments in the group.
+		await disableAllExperimentsInGroup(
+			admin,
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		// Get all experiment toggles in the group.
+		const experimentToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		// Enable just the first experiment to create a mixed state.
+		if ( experimentToggles.length > 0 ) {
+			await experimentToggles[ 0 ].check();
+			await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+		}
+
+		// Verify the select-all toggle shows "Enable all" (because not all are enabled).
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: new RegExp(
+					`Enable all ${ EXPERIMENT_GROUPS.editor }`,
+					'i'
+				),
+			} )
+		).toBeVisible();
+
+		// Clicking it should enable all experiments.
+		const selectAllToggle = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		await selectAllToggle.check();
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+
+		// Verify all are now enabled.
+		for ( const toggle of experimentToggles ) {
+			await expect( toggle ).toBeChecked();
+		}
+	} );
+
+	test( 'Cannot bulk manage experiments when global AI is disabled', async ( {
+		admin,
+		page,
+	} ) => {
+		// Disable global AI.
+		await disableExperiments( admin, page );
+
+		// Verify the select-all toggle is disabled.
+		const selectAllToggle = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		await expect( selectAllToggle ).toBeDisabled();
+
+		// Enable AI again.
+		await enableExperiments( admin, page );
+
+		// Verify the select-all toggle is now enabled.
+		await expect( selectAllToggle ).toBeEnabled();
+	} );
+
+	test( 'Each experiment group has its own select all toggle', async ( {
+		admin,
+		page,
+	} ) => {
+		// Ensure AI is enabled.
+		await enableExperiments( admin, page );
+
+		// Verify all groups have select-all toggles.
+		const editorSelectAll = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		const adminSelectAll = getSelectAllToggle(
+			page,
+			EXPERIMENT_GROUPS.admin
+		);
+
+		await expect( editorSelectAll ).toBeVisible();
+		await expect( adminSelectAll ).toBeVisible();
+
+		// Enable all Editor Experiments.
+		await editorSelectAll.click();
+		await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+
+		// Verify Editor Experiments are enabled but Admin Experiments are not affected.
+		const editorToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+		for ( const toggle of editorToggles ) {
+			await expect( toggle ).toBeChecked();
+		}
+
+		// Admin Experiments should remain unchanged.
+		await expect( adminSelectAll ).not.toBeChecked();
 	} );
 } );

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -13,7 +13,7 @@ import {
 	enableExperiment,
 } from '../../utils/helpers';
 
-const EXPERIMENT_ID = 'content-classification';
+const EXPERIMENT_LABEL = 'Content Classification';
 
 // Content Classification has a 150 word minimum requirement.
 const LONG_CONTENT =
@@ -90,7 +90,7 @@ test.describe( 'Content Classification Experiment', () => {
 		await enableExperiments( admin, page );
 
 		// Enable the Content Classification Experiment.
-		await enableExperiment( admin, page, EXPERIMENT_ID );
+		await enableExperiment( admin, page, EXPERIMENT_LABEL );
 	} );
 
 	test( 'Shows the "Suggest Tags" button in the Tags panel', async ( {
@@ -328,7 +328,7 @@ test.describe( 'Content Classification Experiment', () => {
 		page,
 	} ) => {
 		// Disable the Content Classification Experiment.
-		await disableExperiment( admin, page, EXPERIMENT_ID );
+		await disableExperiment( admin, page, EXPERIMENT_LABEL );
 
 		// Create a new post with content.
 		await admin.createNewPost( {

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -226,3 +226,101 @@ export const disableExperiment = async (
 	// Ensure the save was successful.
 	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
 };
+
+/**
+ * Gets the "Enable all" / "Disable all" toggle for a specific experiment group.
+ *
+ * @param page      The page object.
+ * @param groupName The name of the experiment group (e.g., 'Editor Experiments').
+ * @return The select-all toggle locator.
+ */
+export const getSelectAllToggle = ( page: Page, groupName: string ) => {
+	return page.getByRole( 'checkbox', {
+		name: new RegExp( `(Enable|Disable) all ${ groupName }`, 'i' ),
+	} );
+};
+
+/**
+ * Enables all experiments in a specific group using the select-all toggle.
+ *
+ * @param admin     The admin fixture from the test context.
+ * @param page      The page object.
+ * @param groupName The name of the experiment group (e.g., 'Editor Experiments').
+ */
+export const enableAllExperimentsInGroup = async (
+	admin: Admin,
+	page: Page,
+	groupName: string
+) => {
+	await visitSettingsPage( admin );
+
+	const selectAllToggle = getSelectAllToggle( page, groupName );
+	await expect( selectAllToggle ).toBeVisible( { timeout: 10000 } );
+
+	// Nothing to do if this is already enabled.
+	if ( await selectAllToggle.isChecked() ) {
+		return;
+	}
+
+	await selectAllToggle.check();
+	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+};
+
+/**
+ * Disables all experiments in a specific group using the select-all toggle.
+ *
+ * @param admin     The admin fixture from the test context.
+ * @param page      The page object.
+ * @param groupName The name of the experiment group (e.g., 'Editor Experiments').
+ */
+export const disableAllExperimentsInGroup = async (
+	admin: Admin,
+	page: Page,
+	groupName: string
+) => {
+	await visitSettingsPage( admin );
+
+	const selectAllToggle = getSelectAllToggle( page, groupName );
+	await expect( selectAllToggle ).toBeVisible( { timeout: 10000 } );
+
+	// Nothing to do if this is already disabled.
+	if ( ! ( await selectAllToggle.isChecked() ) ) {
+		return;
+	}
+
+	await selectAllToggle.uncheck();
+	await expect( page.getByTestId( 'snackbar' ) ).toBeVisible();
+};
+
+/**
+ * Gets all experiment toggles within a specific group section.
+ *
+ * @param page      The page object.
+ * @param groupName The name of the experiment group (e.g., 'Editor Experiments').
+ * @return Array of toggle locators.
+ */
+export const getExperimentTogglesInGroup = async (
+	page: Page,
+	groupName: string
+) => {
+	// Find the section by its heading.
+	const section = page
+		.locator( '[class*="dataviews-card"]' )
+		.filter( { has: page.getByText( groupName, { exact: true } ) } );
+
+	// Get all checkboxes in that section, excluding the select-all toggle.
+	const allToggles = section.getByRole( 'checkbox' );
+	const count = await allToggles.count();
+	const experimentToggles = [];
+
+	for ( let i = 0; i < count; i++ ) {
+		const toggle = allToggles.nth( i );
+		const label = await toggle.textContent();
+		// Exclude the select-all toggle.
+		if ( ! label?.match( /^(Enable|Disable) all/ ) ) {
+			experimentToggles.push( toggle );
+		}
+	}
+
+	return experimentToggles;
+};


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #334 

<!-- In a few words, what is the PR actually doing? -->
Add controls to bulk enable / disable all features in an experiment group.

Branched off #376 which contains the work of swapping checkboxes with toggles. The issue mentioned using a checkbox but since we've moved away and using toggles now I thought a `ToggleControl` would be more appropriate.

## Testing Instructions
- Visit the AI settings page and verify a new section is shown on the group headings and should contain a toggle to bulk manage all features in that group
- The toggle should allow enabling / disabling all features at once. If the group has a mixed state (i.e. some features enabled, some features disabled) then the toggle should act as "Enable All".
- Settings should be auto-saved with a contextual snackbar message showing
- If the global AI toggle is disable, the bulk manage toggle should become disabled
- Run E2E tests: `npm run test:e2e -- --grep "Plugin settings"`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-379-c3cdb8211a00790c7c3e0f1870a75c7bd8797c4b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->