### PR TITLE
Remove references to DALL·E image models

### DIFF
--- a/docs/experiments/image-generation.md
+++ b/docs/experiments/image-generation.md
@@ -695,7 +695,6 @@ You can filter which AI image models are used for image generation using the `wp
 add_filter( 'wpai_preferred_image_models', function( $models ) {
     // Prefer specific image models
     return array(
-        array( 'openai', 'dall-e-3' ),
         array( 'openai', 'gpt-image-1' ),
         array( 'google', 'imagen-4.0-generate-001' ),
     );
@@ -853,7 +852,7 @@ npm run test:php
 
 - The ability uses `get_preferred_image_models()` to determine which AI image models to use
 - Models are tried in order until one succeeds
-- Default models include Google's Gemini (e.g. gemini-3-pro-image-preview, gemini-2.5-flash-image), Imagen, and OpenAI's DALL-E 3 and GPT-image models
+- Default models include Google's Gemini (e.g. gemini-3.1-flash-image-preview, gemini-2.5-flash-image), Imagen, and OpenAI's GPT-image models
 - All default models support image generation; the Google models also support image editing (when a reference image is provided)
 - Request timeout is set to 90 seconds to accommodate longer image generation times
 

--- a/tests/e2e-request-mocking/responses/OpenAI/models.json
+++ b/tests/e2e-request-mocking/responses/OpenAI/models.json
@@ -74,18 +74,6 @@
             "owned_by": "system"
         },
         {
-            "id": "dall-e-3",
-            "object": "model",
-            "created": 1698785189,
-            "owned_by": "system"
-        },
-        {
-            "id": "dall-e-2",
-            "object": "model",
-            "created": 1698798177,
-            "owned_by": "system"
-        },
-        {
             "id": "gpt-4-1106-preview",
             "object": "model",
             "created": 1698957206,


### PR DESCRIPTION
## What?

Removes any references to OpenAI's DALL·E image models

## Why?

OpenAI announced that the DALL·E image models (both 2 and 3) are being deprecated on May 12. I had thought we were still referencing DALL·E 3 in our preferred image model list but apparently I had already removed that in #361. We still had a few references in documentation and tests so this PR removes those.

## How?

- Removes any references to DALL·E image models in our documentation
- Removes the DALL·E image models from our mock test response

### Use of AI Tools

None

## Testing Instructions

None needed. Ensure tests pass

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-414-23ec8a0260d9add6d33ddd13ef30c1f3f67eef14.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->