### PR TITLE
Add an admin redirect from the old `ai` page to the new `ai-wp-admin` page

### DIFF
--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -30,6 +30,7 @@ class Settings_Page {
 
 	/**
 	 * Legacy settings page slug.
+	 * TODO: either once [0.6.0 is less than 10% of installs](https://wordpress.org/plugins/ai/advanced/) or we're in October 2026 let's remove this section in case other plugin(s) are attempting to use the `ai` page.
 	 *
 	 * @since x.x.x
 	 *

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -14,6 +14,7 @@ namespace WordPress\AI\Settings;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\Features\Feature_Category;
 use WordPress\AI\Features\Registry;
+
 use function WordPress\AI\has_ai_credentials;
 use function WordPress\AI\has_valid_ai_credentials;
 
@@ -26,6 +27,15 @@ defined( 'ABSPATH' ) || exit;
  * @since 0.1.0
  */
 class Settings_Page {
+
+	/**
+	 * Legacy settings page slug.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const LEGACY_PAGE_SLUG = 'ai';
 
 	/**
 	 * The settings page slug.
@@ -45,6 +55,9 @@ class Settings_Page {
 	 * @return void
 	 */
 	public static function init( Registry $registry ): void {
+		add_action( 'admin_init', array( self::class, 'maybe_redirect_legacy_page' ), 1 );
+		add_action( 'admin_page_access_denied', array( self::class, 'maybe_redirect_legacy_page' ) );
+
 		if ( function_exists( 'ai_ai_wp_admin_render_page' ) ) {
 			add_action(
 				'admin_menu',
@@ -89,6 +102,34 @@ class Settings_Page {
 					);
 				}
 			);
+		}
+	}
+
+	/**
+	 * Redirects legacy settings page slug to the current settings route.
+	 *
+	 * @since x.x.x
+	 */
+	public static function maybe_redirect_legacy_page(): void {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading query param for admin page detection only, no data processing.
+		if ( ! isset( $_GET['page'] ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Reading query param for admin page detection only, no data processing.
+		$page = sanitize_key( wp_unslash( (string) $_GET['page'] ) );
+		if ( self::LEGACY_PAGE_SLUG !== $page ) {
+			return;
+		}
+
+		$redirect_url = add_query_arg(
+			'page',
+			self::PAGE_SLUG,
+			admin_url( 'options-general.php' )
+		);
+
+		if ( wp_safe_redirect( $redirect_url, 301, 'WordPress AI plugin' ) ) {
+			exit;
 		}
 	}
 

--- a/tests/Integration/Includes/Settings/Settings_PageTest.php
+++ b/tests/Integration/Includes/Settings/Settings_PageTest.php
@@ -238,6 +238,8 @@ class Settings_PageTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_all_filters( 'wpai_settings_feature_groups' );
 		remove_all_filters( 'wpai_settings_feature_metadata' );
+		remove_all_filters( 'wp_redirect' );
+		$_GET = array();
 		parent::tearDown();
 	}
 
@@ -485,5 +487,44 @@ class Settings_PageTest extends WP_UnitTestCase {
 		$feature = $result['features'][0];
 		$this->assertArrayHasKey( 'settingsFields', $feature );
 		$this->assertSame( array(), $feature['settingsFields'], 'Feature without custom settings should have empty settingsFields' );
+	}
+
+	/**
+	 * Test that init registers an admin redirect hook for the legacy settings slug.
+	 */
+	public function test_init_registers_legacy_settings_redirect_hook() {
+		Settings_Page::init( $this->registry );
+
+		$this->assertTrue(
+			has_action( 'admin_init', array( Settings_Page::class, 'maybe_redirect_legacy_page' ) ) !== false
+		);
+		$this->assertTrue(
+			has_action( 'admin_page_access_denied', array( Settings_Page::class, 'maybe_redirect_legacy_page' ) ) !== false
+		);
+	}
+
+	/**
+	 * Test that the legacy settings slug redirects to the new slug.
+	 */
+	public function test_legacy_settings_slug_redirects_to_new_slug() {
+		$captured_location = null;
+		$captured_status   = null;
+
+		add_filter(
+			'wp_redirect',
+			static function ( $location, $status ) use ( &$captured_location, &$captured_status ) {
+				$captured_location = $location;
+				$captured_status   = $status;
+				return false;
+			},
+			10,
+			2
+		);
+
+		$_GET['page'] = 'ai';
+		Settings_Page::maybe_redirect_legacy_page();
+
+		$this->assertSame( admin_url( 'options-general.php?page=ai-wp-admin' ), $captured_location );
+		$this->assertSame( 301, $captured_status );
 	}
 }


### PR DESCRIPTION
## What?

Redirect from the old settings page to the new one:
`options-general.php?page=ai` -> `options-general.php?page=ai-wp-admin`

## Why?

In #340 we switched to a new approach to building our settings page. This required a new page slug, `ai-wp-admin`. For anyone still trying to access the old slug of `ai`, you'll get an access denied error. We probably should have introduced a redirect for that in #340 but better late then never.

## How?

- Listen for admin requests going to `ai` and redirect to `ai-wp-admin`
- Ensure we listen both on `admin_init` and `admin_page_access_denied`, as it seems the latter fires most consistently
- Update our unit tests to account for this change

### Use of AI Tools

Used Cursor running GPT-5.3 Codex to investigate and execute the approach. Tested and refined slightly myself

## Testing Instructions

1. Checkout this PR
2. Ensure you can go to the current settings page, either by going to `Settings > AI`, going to the plugin list screen and clicking Settings under the AI plugin, or manually typing in `wp-admin/options-general.php?page=ai-wp-admin`
3. Manually type in the old URL and ensure you are redirected: `wp-admin/options-general.php?page=ai`
4. Ensure other variations of that URL properly deny access, like `wp-admin/options-general.php?page=ai-wp` or `wp-admin/options-general.php?page=ai-experiments`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-424-8346415bb1b77baff953935ac6089363f7a98805.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->