### PR TITLE
Refactor string checks to use str_starts_with and str_contains functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
     "phpcompatibility/phpcompatibility-wp": "^3.0.0-alpha",
     "phpstan/extension-installer": "^1.3",
+    "phpstan/php-8-stubs": "^0.4.0",
     "phpstan/phpstan-deprecation-rules": "^2.0.4",
     "phpstan/phpstan-phpunit": "^2.0.16",
     "phpstan/phpstan": "^2.1.40",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec801b927825beacdfb555819da72964",
+    "content-hash": "7642fa9733001c87e1df6111c0581a7e",
     "packages": [],
     "packages-dev": [
         {
@@ -965,6 +965,38 @@
                 "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
             },
             "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/php-8-stubs",
+            "version": "0.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/php-8-stubs.git",
+                "reference": "2da4cdab8ac153926628877fbacebc80ba175b7c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/php-8-stubs/zipball/2da4cdab8ac153926628877fbacebc80ba175b7c",
+                "reference": "2da4cdab8ac153926628877fbacebc80ba175b7c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Php8StubsMap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT",
+                "PHP-3.01"
+            ],
+            "description": "PHP stubs extracted from php-src",
+            "support": {
+                "issues": "https://github.com/phpstan/php-8-stubs/issues",
+                "source": "https://github.com/phpstan/php-8-stubs/tree/0.4.34"
+            },
+            "time": "2025-12-02T00:23:47+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -161,7 +161,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 		// If an image URL is provided, get the image from the URL.
 		if ( ! empty( $args['image_url'] ) ) {
 			// Preserve data URIs as-is so the AI client can read the inline bytes.
-			if ( 0 === strpos( $args['image_url'], 'data:' ) ) {
+			if ( str_starts_with( $args['image_url'], 'data:' ) ) {
 				return $this->prepare_reference_result( $args['image_url'] );
 			}
 
@@ -323,7 +323,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 		$normalized_url     = $this->normalize_upload_url( $url );
 		$normalized_baseurl = $this->normalize_upload_url( $uploads['baseurl'] );
 
-		if ( false === strpos( $normalized_url, $normalized_baseurl ) ) {
+		if ( ! str_contains( $normalized_url, $normalized_baseurl ) ) {
 			return null;
 		}
 
@@ -339,8 +339,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 		// Reject path traversal attempts in the relative path.
 		if (
 			'..' === $relative_path ||
-			0 === strpos( $relative_path, '../' ) ||
-			false !== strpos( $relative_path, '/..' )
+			str_starts_with( $relative_path, '../' ) ||
+			str_contains( $relative_path, '/..' )
 		) {
 			return null;
 		}
@@ -358,7 +358,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 		$real_full_path = wp_normalize_path( $real_full_path );
 
 		// Ensure the resolved path is strictly within the uploads base directory.
-		if ( 0 !== strpos( $real_full_path, $base_dir ) ) {
+		if ( ! str_starts_with( $real_full_path, $base_dir ) ) {
 			return null;
 		}
 
@@ -457,7 +457,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 			return '';
 		}
 
-		if ( 0 === strpos( $value, 'data:' ) ) {
+		if ( str_starts_with( $value, 'data:' ) ) {
 			return $value;
 		}
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,6 +22,11 @@ parameters:
 		paths:
 				- ai.php
 				- includes/
+		scanFiles:
+			# These are needed due config.platform.php being 7.4 in composer.json and wordpress-stubs not including polyfills.
+			# See <https://github.com/php-stubs/wordpress-stubs/issues/100>.
+			- vendor/phpstan/php-8-stubs/stubs/ext/standard/str_contains.php
+			- vendor/phpstan/php-8-stubs/stubs/ext/standard/str_starts_with.php
 		# Temporary while WP 7.0 beta AI Client migration is in progress.
 		ignoreErrors:
 			- '#Function wp_ai_client_prompt not found\.#'


### PR DESCRIPTION
## What?
This pull request updates several string handling operations to use more modern and readable PHP string functions. The changes improve code clarity and maintainability by replacing older `strpos` patterns with `str_starts_with` and `str_contains`.

## Changelog Entry
> Changed - Refactor `strpos` to `str_starts_with` and `str_contains`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-438-5789bf7157e1067225e1954bf1262968f3ecbcfb.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->