### PR TITLE
Fix: System prompts for Guardrailing Excerpt & Title

### DIFF
--- a/includes/Abilities/Excerpt_Generation/system-instruction.php
+++ b/includes/Abilities/Excerpt_Generation/system-instruction.php
@@ -21,4 +21,5 @@ The excerpt suggestion should follow these requirements:
 - Must reflect the actual content and context accurately, not generic summaries or clickbait
 - Should be self-contained and readable on its own, providing enough context for readers to understand the topic without reading the full article
 - Ensure the excerpt you return matches the language of the content you are given. For example, if the content is in English, the excerpt should be in English. If the content is in Spanish, the excerpt should be in Spanish
+- Output only the excerpt text. Respond directly without preamble, without phrases like "Here is...", "Here's...", "Sure,", or "Of course,". Do not wrap the output in quotes, code fences, or tags. Do not add closing remarks, follow-up questions, or meta-commentary
 INSTRUCTION;

--- a/includes/Abilities/Title_Generation/system-instruction.php
+++ b/includes/Abilities/Title_Generation/system-instruction.php
@@ -23,4 +23,5 @@ The title suggestion should follow these requirements:
 - Should be distinct in tone and focus
 - Must reflect the actual content and context, not generic clickbait
 - Ensure the title you return matches the language of the content you are given. For example, if the content is in English, the title should be in English. If the content is in Spanish, the title should be in Spanish
+- Output only the title text. Respond directly without preamble, without phrases like "Here is...", "Here's...", "Sure,", or "Of course,". Do not wrap the output in quotes, code fences, or tags. Do not add closing remarks, follow-up questions, or meta-commentary
 INSTRUCTION;


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/395
Closes https://github.com/WordPress/ai/issues/399

It adds an output-format guardrail to the Excerpt Generation and Title Generation system instructions so the model returns only the excerpt or title and no conversational preamble, wrapper quotes, code fences, markdown, or trailing meta-commentary.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Both issues report the same class of bug: generated excerpts and titles arrive with extra wrapper text that gets saved verbatim into the post's excerpt / title / slug.

The root cause in both cases is that the existing system instructions do not explicitly constrain the model to return only the excerpt/title text. Frontier models mostly infer this; smaller instruction-tuned models do not, and add conversational scaffolding by default.

As discussed on #395, the agreed approach is a minimal prompt-level fix rather than output post-processing, and without bloating the instruction.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds one requirement bullet at the end of each affected system instruction. The wording follows "eliminating preambles" recipes from major AI providers along with a positive output contract plus a short specific negative list which is the pattern empirically most robust across both frontier and smaller models.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.6
Used for: Researching cross-model prompt techniques for suppressing preambles (Anthropic prompt-engineering docs, OpenAI GPT-4.1 guide, Meta Llama guide). Final wording, file edits, and testing were implemented by me.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Check out this branch.
2. Configure a small/light model likely to exhibit the bug. Example: HuggingFace free-tier via the HuggingFace connector as described by the reported with `Meta-Llama-3-8B-Instruct` is what I tested with.
3. Create or open a post with ~500 words.
4. For Excerpt: in the sidebar, click `Generate excerpt`. Repeat 5–10 times. Expected: each generated excerpt is plain text with no `Here's...` / `Sure,` preface, no surrounding quotes, no markdown.
5. For Title: click `Re-generate`. Repeat 5–10 times. Expected: a plain, single-line title; no `Based on the content...`, no `**` / `###`, no `(N characters)` suffix, no `Why this works:` explanation.
6. Sanity check with a frontier model (OpenAI / Anthropic / Google) behavior should be unchanged from before this PR (the new bullet is not supposed to regress well-behaved models).

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1512" height="713" alt="image" src="https://github.com/user-attachments/assets/a204ce0d-2c1a-412f-aca9-61a7a18692a4" /> | <img width="1512" height="718" alt="image" src="https://github.com/user-attachments/assets/f1a7d300-7136-4a83-a79b-330f3fabad0a" /> |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Excerpt and Title generation no longer include conversational preambles, wrapper quotes, markdown, or meta-commentary when using smaller language models.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-440-4a222ad58a702f9bc704350e8b7c8e7e56253481.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->