### PR TITLE
Review Notes and Refine Notes: Add post type support check

### DIFF
--- a/src/experiments/refine-notes/index.tsx
+++ b/src/experiments/refine-notes/index.tsx
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { PostTypeSupportCheck } from '@wordpress/editor';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -14,6 +15,10 @@ import RefineNotesPlugin from './components/RefineNotesPlugin';
 
 if ( ( window as any ).aiRefineNotesData?.enabled ) {
 	registerPlugin( 'ai-refine-notes', {
-		render: RefineNotesPlugin,
+		render: () => (
+			<PostTypeSupportCheck supportKeys="editor.notes">
+				<RefineNotesPlugin />
+			</PostTypeSupportCheck>
+		),
 	} );
 }

--- a/src/experiments/review-notes/index.tsx
+++ b/src/experiments/review-notes/index.tsx
@@ -5,6 +5,7 @@
 /**
  * WordPress dependencies
  */
+import { PostTypeSupportCheck } from '@wordpress/editor';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -13,5 +14,9 @@ import { registerPlugin } from '@wordpress/plugins';
 import ReviewNotesPlugin from './components/ReviewNotesPlugin';
 
 registerPlugin( 'ai-review-notes', {
-	render: ReviewNotesPlugin,
+	render: () => (
+		<PostTypeSupportCheck supportKeys="editor.notes">
+			<ReviewNotesPlugin />
+		</PostTypeSupportCheck>
+	),
 } );


### PR DESCRIPTION
## What?

Guards the Review Notes and the Refine Notes editor plugins behind a `PostTypeSupportCheck` so it only renders on post types that declare support for `editor.notes`.

## Why?

These UIs were registered globally and rendered in the editor regardless of whether the current post type supports Notes.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: PR description drafting. The code change was authored and reviewed by me.

## Testing Instructions

1. On a post type that supports `editor.notes` (e.g. `post`), confirm these UIs load as before.
2. On a post type that does not declare `editor.notes` support, confirm these UI no longer render in the editor.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="893" height="491" alt="before" src="https://github.com/user-attachments/assets/55b6a99d-74be-4a67-bce5-862940522192" /> | <img width="889" height="481" alt="after" src="https://github.com/user-attachments/assets/a600ac81-56fc-472b-87d0-cb30655464e1" /> |

## Changelog Entry

> Changed - Render the Review Notes editor plugin only on post types that support `editor.notes`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-444-5271b21302c5a020ab2bc72512e37036380b151a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->