### PR TITLE
fix: update references of Re-generate to Regenerate

### DIFF
--- a/docs/experiments/excerpt-generation.md
+++ b/docs/experiments/excerpt-generation.md
@@ -327,7 +327,7 @@ You can extend the React components to add custom UI elements:
    - Scroll to the excerpt panel (or enable it in Screen Options)
    - Click the "Generate excerpt" button
    - Verify the excerpt is generated and populated in the field
-   - Click "Re-generate excerpt" to test regeneration
+   - Click "Regenerate excerpt" to test regeneration
 
 3. **Test with different post types:**
    - The experiment only loads for post types that support excerpts

--- a/docs/experiments/summarization.md
+++ b/docs/experiments/summarization.md
@@ -406,7 +406,7 @@ GET /wp-json/wp/v2/posts/123?context=edit
    - Click the "Generate AI Summary" button
    - Verify a paragraph block is created at the top with the summary
    - Verify the summary is saved to post meta
-   - Click "Re-generate AI Summary" to test regeneration
+   - Click "Regenerate AI Summary" to test regeneration
    - Select the summary block and use the toolbar button to regenerate
 
 3. **Test with different post types:**

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,7 @@ You can view the active plugin roadmap in a filtered view in the WordPress AI [G
 2. Activate the plugin through the 'Plugins' screen in WordPress.
 3. Go to `Settings -> Connectors` and setup at least one AI connector.
 4. Go to `Settings -> AI` and globally enable functionality and then enable the individual features or experiments you want to test.
-5. Start experimenting with AI features! For the Title Generation experiment, edit a post and click into the title field. You should see a `Generate/Re-generate` button above the field. Click that button and after the request is complete, title suggestions will be displayed in a modal. Choose the title you like and click the `Select` button to insert it into the title field.
+5. Start experimenting with AI features! For the Title Generation experiment, edit a post and click into the title field. You should see a `Generate/Regenerate` button above the field. Click that button and after the request is complete, title suggestions will be displayed in a modal. Choose the title you like and click the `Select` button to insert it into the title field.
 
 == For Developers ==
 

--- a/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
@@ -36,7 +36,7 @@ export default function ExcerptGeneration(): JSX.Element | null {
 	if ( isGenerating ) {
 		buttonLabel = __( 'Generating…', 'ai' );
 	} else if ( hasExcerpt ) {
-		buttonLabel = __( 'Re-generate excerpt', 'ai' );
+		buttonLabel = __( 'Regenerate excerpt', 'ai' );
 	}
 
 	return (

--- a/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
@@ -34,7 +34,7 @@ export default function ExcerptInlineButton(): JSX.Element | null {
 	if ( isGenerating ) {
 		buttonLabel = __( 'Generating…', 'ai' );
 	} else if ( hasExcerpt ) {
-		buttonLabel = __( 'Re-generate excerpt', 'ai' );
+		buttonLabel = __( 'Regenerate excerpt', 'ai' );
 	}
 
 	return (

--- a/src/experiments/summarization/components/SummarizationBlockControls.tsx
+++ b/src/experiments/summarization/components/SummarizationBlockControls.tsx
@@ -30,7 +30,7 @@ const Controls = () => {
 	if ( isSummarizing ) {
 		buttonLabel = __( 'Generating…', 'ai' );
 	} else if ( hasSummary ) {
-		buttonLabel = __( 'Re-generate Summary', 'ai' );
+		buttonLabel = __( 'Regenerate Summary', 'ai' );
 	}
 
 	// Don't render if disabled.

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -29,7 +29,7 @@ export default function SummarizationPlugin() {
 	if ( isSummarizing ) {
 		buttonLabel = __( 'Generating…', 'ai' );
 	} else if ( hasSummary ) {
-		buttonLabel = __( 'Re-generate Summary', 'ai' );
+		buttonLabel = __( 'Regenerate Summary', 'ai' );
 	}
 	const buttonDescription = hasSummary
 		? __(

--- a/tests/e2e/specs/experiments/content-summarization.spec.js
+++ b/tests/e2e/specs/experiments/content-summarization.spec.js
@@ -76,7 +76,7 @@ test.describe( 'Content Summarization Experiment', () => {
 
 		// Ensure the Generate Summary button text is updated.
 		await expect( generateButton ).toBeVisible();
-		await expect( generateButton ).toHaveText( 'Re-generate Summary' );
+		await expect( generateButton ).toHaveText( 'Regenerate Summary' );
 
 		// Save the post.
 		await editor.saveDraft();

--- a/tests/e2e/specs/experiments/excerpt-generation.spec.js
+++ b/tests/e2e/specs/experiments/excerpt-generation.spec.js
@@ -83,7 +83,7 @@ test.describe( 'Excerpt Generation Experiment', () => {
 		// Ensure the excerpt button text is updated.
 		await expect(
 			page.locator( '.ai-excerpt-generation button' )
-		).toHaveText( 'Re-generate excerpt' );
+		).toHaveText( 'Regenerate excerpt' );
 
 		// Delete the excerpt.
 		await page


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/439

Updates all instances of the hyphenated "Re-generate" to "Regenerate".

## Why?
This ensures consistent spelling and terminology across the plugin's user interface, documentation, and test suites.

## How?
Performed a global search and replace across the repository to update "Re-generate" to "Regenerate". This includes updates to UI copy, Markdown documentation, and End-to-End test assertions so the testing suite continues to pass.

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Updated UI copy and tests to use "Regenerate" consistently instead of "Re-generate".

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-449-8ce7522048a36a4a51a564d4f1ec55d4d106d73c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->