### PR TITLE
fix: defer failed Requirement messages until translation functions are available

### DIFF
--- a/includes/Requirements.php
+++ b/includes/Requirements.php
@@ -55,7 +55,7 @@ final class Requirements {
 
 			$success = $check_callback['check']();
 
-			// The callback is stored, but only trigged inside the admin notice so strings can be translated.
+			// The callback is stored, but only triggered inside the admin notice callback so strings can be translated.
 			$this->requirements[ $slug ] = $success ? true : $check_callback['error_message'];
 		}
 

--- a/includes/Requirements.php
+++ b/includes/Requirements.php
@@ -55,6 +55,7 @@ final class Requirements {
 
 			$success = $check_callback['check']();
 
+			// The callback is stored, but only trigged inside the admin notice so strings can be translated.
 			$this->requirements[ $slug ] = $success ? true : $check_callback['error_message'];
 		}
 
@@ -130,12 +131,16 @@ final class Requirements {
 			'network_admin_notices',
 		);
 
-		foreach ( $hooks as $hook ) {
-			$error_message = $this->get_admin_notice_message_html();
+		// Store a local copy to pass to the static callback.
+		$requirements = $this->requirements;
 
+		foreach ( $hooks as $hook ) {
 			add_action(
 				$hook,
-				static function () use ( $error_message ) {
+				static function () use ( $requirements ) {
+					// Messages are generated inside the hook to ensure the translation functions are available.
+					$error_message = self::get_admin_notice_message_html( $requirements );
+
 					wp_admin_notice(
 						wp_kses(
 							$error_message,
@@ -167,6 +172,7 @@ final class Requirements {
 				return false;
 			}
 		}
+
 		return true;
 	}
 
@@ -177,9 +183,11 @@ final class Requirements {
 	 *
 	 * @since x.x.x
 	 *
+	 * @param array<string,(true|callable():string)> $requirements The requirements check results, keyed by requirement slug.
+	 *
 	 * @return string The admin notice message.
 	 */
-	private function get_admin_notice_message_html(): string {
+	private static function get_admin_notice_message_html( array $requirements ): string {
 		$error_messages = array_map(
 			static function ( $result ) {
 				if ( is_callable( $result ) ) {
@@ -187,7 +195,7 @@ final class Requirements {
 				}
 				return null;
 			},
-			$this->requirements
+			$requirements
 		);
 		$error_messages = array_filter( $error_messages );
 

--- a/tests/Integration/Includes/RequirementsTest.php
+++ b/tests/Integration/Includes/RequirementsTest.php
@@ -120,7 +120,7 @@ class RequirementsTest extends WP_UnitTestCase {
 
 	/**
 	 * Used to mimic translation functions being called before the plugin's text domain is loaded.
-	 * This is needed since we're manually invoking admin_notices. and not actually loading the plugin.
+	 * This is needed since we're manually invoking admin_notices, rather than actually loading the plugin.
 	 *
 	 * @since x.x.x
 	 */

--- a/tests/Integration/Includes/RequirementsTest.php
+++ b/tests/Integration/Includes/RequirementsTest.php
@@ -34,12 +34,16 @@ class RequirementsTest extends WP_UnitTestCase {
 		$checks = $reflection->getMethod( 'get_requirements' );
 		$checks->setAccessible( true );
 
+		// Test a failing requirement check.
 		$property = $reflection->getProperty( 'requirements' );
 		$property->setAccessible( true );
 		$property->setValue(
 			$requirements,
-			array(
-				'php' => static fn() => 'PHP version check failed.',
+			array_merge(
+				$property->getValue( $requirements ),
+				array(
+					'testfail' => static fn() => esc_html__( 'Test check failed.', 'ai' ),
+				)
 			)
 		);
 
@@ -49,35 +53,21 @@ class RequirementsTest extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'admin_notices' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
 		$message = ob_get_clean();
-		$this->assertStringContainsString( 'PHP version check failed.', $message );
+		$this->assertStringContainsString( 'Test check failed.', $message );
+		$this->assertStringNotContainsString( '<ul>', $message, 'Single failure should not produce a list.' );
+
+		// Check it is also output in network admin notices.
+		ob_start();
+		do_action( 'network_admin_notices' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+		$message = ob_get_clean();
+		$this->assertStringContainsString( 'Test check failed.', $message );
+		$this->assertStringNotContainsString( '<ul>', $message, 'Single failure should not produce a list.' );
 	}
 
 	/**
 	 * @since x.x.x
 	 */
-	public function test_are_requirements_met_registers_admin_notice_hooks_on_failure() {
-		$requirements = new Requirements();
-
-		$reflection = new \ReflectionClass( Requirements::class );
-		$property   = $reflection->getProperty( 'requirements' );
-		$property->setAccessible( true );
-		$property->setValue(
-			$requirements,
-			array(
-				'php' => static fn() => 'PHP version check failed.',
-			)
-		);
-
-		$requirements->are_requirements_met();
-
-		$this->assertNotFalse( has_action( 'admin_notices' ) );
-		$this->assertNotFalse( has_action( 'network_admin_notices' ) );
-	}
-
-	/**
-	 * @since x.x.x
-	 */
-	public function test_individual_requirement_checks_pass_in_test_environment() {
+	public function test_individual_requirements_are_valid() {
 		$requirements = new Requirements();
 		$reflection   = new \ReflectionClass( Requirements::class );
 		$method       = $reflection->getMethod( 'get_requirements' );
@@ -85,27 +75,12 @@ class RequirementsTest extends WP_UnitTestCase {
 
 		$checks = $method->invoke( $requirements );
 
-		$this->assertArrayHasKey( 'php', $checks );
-		$this->assertArrayHasKey( 'wp', $checks );
-		$this->assertArrayHasKey( 'assets', $checks );
+		$this->assertNotEmpty( $checks, 'There should be at least one requirement check defined.' );
 
 		foreach ( $checks as $slug => $check ) {
 			$this->assertTrue( $check['check'](), "Requirement '{$slug}' should pass in the test environment." );
-		}
-	}
 
-	/**
-	 * @since x.x.x
-	 */
-	public function test_error_messages_return_non_empty_strings() {
-		$requirements = new Requirements();
-		$reflection   = new \ReflectionClass( Requirements::class );
-		$method       = $reflection->getMethod( 'get_requirements' );
-		$method->setAccessible( true );
-
-		$checks = $method->invoke( $requirements );
-
-		foreach ( $checks as $slug => $check ) {
+			// Manually invoke the error message to test it.
 			$message = $check['error_message']();
 			$this->assertIsString( $message );
 			$this->assertNotEmpty( $message, "Requirement '{$slug}' should have a non-empty error message." );
@@ -113,9 +88,11 @@ class RequirementsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that multiple failed requirements render as a list via the admin_notices hook.
+	 *
 	 * @since x.x.x
 	 */
-	public function test_get_admin_notice_message_html_with_single_failure() {
+	public function test_admin_notice_outputs_multiple_failure_messages() {
 		$requirements = new Requirements();
 		$reflection   = new \ReflectionClass( Requirements::class );
 
@@ -124,22 +101,37 @@ class RequirementsTest extends WP_UnitTestCase {
 		$property->setValue(
 			$requirements,
 			array(
-				'php' => static fn() => 'PHP check failed.',
+				'php'       => static fn() => esc_html__( 'PHP check failed.', 'ai' ),
+				'wordpress' => static fn() => esc_html__( 'WordPress check failed.', 'ai' ),
 			)
 		);
 
-		$method = $reflection->getMethod( 'get_admin_notice_message_html' );
-		$method->setAccessible( true );
-		$message = $method->invoke( $requirements );
+		$requirements->are_requirements_met();
 
-		$this->assertStringContainsString( 'PHP check failed.', $message );
-		$this->assertStringNotContainsString( '<ul>', $message, 'Single failure should not produce a list.' );
+		ob_start();
+		do_action( 'admin_notices' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<ul>', $output );
+		$this->assertEquals( 2, substr_count( $output, '<li>' ), 'There should be exactly two list items for the two failed checks.' );
+		$this->assertStringContainsString( 'PHP check failed.', $output );
+		$this->assertStringContainsString( 'WordPress check failed.', $output );
 	}
 
 	/**
+	 * Used to mimic translation functions being called before the plugin's text domain is loaded.
+	 * This is needed since we're manually invoking admin_notices. and not actually loading the plugin.
+	 *
 	 * @since x.x.x
 	 */
-	public function test_get_admin_notice_message_html_with_multiple_failures() {
+	public function test_error_message_callbacks_are_deferred_until_admin_notice_render() {
+		$callback_invoked = false;
+
+		$callback = static function () use ( &$callback_invoked ) {
+			$callback_invoked = true;
+			return esc_html__( 'Deferred callback was invoked.', 'ai' );
+		};
+
 		$requirements = new Requirements();
 		$reflection   = new \ReflectionClass( Requirements::class );
 
@@ -148,17 +140,18 @@ class RequirementsTest extends WP_UnitTestCase {
 		$property->setValue(
 			$requirements,
 			array(
-				'php'       => static fn() => 'PHP check failed.',
-				'wordpress' => static fn() => 'WordPress check failed.',
+				'test' => $callback,
 			)
 		);
 
-		$method = $reflection->getMethod( 'get_admin_notice_message_html' );
-		$method->setAccessible( true );
-		$message = $method->invoke( $requirements );
+		$this->assertFalse( $requirements->are_requirements_met() );
+		$this->assertFalse( $callback_invoked, 'Callback should not be invoked during are_requirements_met().' );
 
-		$this->assertStringContainsString( '<ul>', $message );
-		$this->assertStringContainsString( 'PHP check failed.', $message );
-		$this->assertStringContainsString( 'WordPress check failed.', $message );
+		ob_start();
+		do_action( 'admin_notices' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals
+		$output = ob_get_clean();
+
+		$this->assertTrue( $callback_invoked, 'Callback should be invoked when admin notice is rendered.' );
+		$this->assertStringContainsString( 'Deferred callback was invoked.', $output );
 	}
 }

--- a/tests/Integration/Includes/RequirementsTest.php
+++ b/tests/Integration/Includes/RequirementsTest.php
@@ -31,9 +31,6 @@ class RequirementsTest extends WP_UnitTestCase {
 		$requirements = new Requirements();
 		$reflection   = new \ReflectionClass( Requirements::class );
 
-		$checks = $reflection->getMethod( 'get_requirements' );
-		$checks->setAccessible( true );
-
 		// Test a failing requirement check.
 		$property = $reflection->getProperty( 'requirements' );
 		$property->setAccessible( true );


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
- Follows up https://github.com/WordPress/ai/pull/268#discussion_r3119500578

<!-- In a few words, what is the PR actually doing? -->

This PR moves the failed requirement message generation so they're triggered inside `{network_}admin_notices`.

RequirementsTest has been cleaned up to cover the full public API (mocking the `::$requirements) instead of testing individual methods), and to cover this particular edge case.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While we need to resolve the checks as early as possible, messages can only be generated after translation functions are loaded.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`::get_admin_notice_message_html()` is now a static method that takes the array of `::$requirements` passed inside the  `{network_}admin_notices` callback.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

GitHub Copilot autocomplete

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->



## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="1529" height="1350" alt="image" src="https://github.com/user-attachments/assets/d328c18f-efa0-4be0-a908-bd4ef63a0b79" />

(This screenshot is with #268 applied 
<img width="2050" height="567" alt="image" src="https://github.com/user-attachments/assets/2f0817d6-48c0-49e7-a9c1-b08e6316d9b0" />
)

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
> Development Update - Development related updates.

Fixed - Defer failed `Requirements` messages until translation functions are available.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-453-9aa91110bb3850d35fc03bbaf76c161f187bdc09.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->