### PR TITLE
Add support for the new `gpt-image-2` model

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -237,11 +237,11 @@ function get_preferred_image_models(): array {
 		),
 		array(
 			'openai',
-			'gpt-image-1.5',
+			'gpt-image-2',
 		),
 		array(
 			'openai',
-			'gpt-image-1-mini',
+			'gpt-image-1.5',
 		),
 	);
 

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -527,13 +527,13 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[4], 'Fifth model should be an array' );
 		$this->assertCount( 2, $result[4], 'Fifth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[4][0], 'Fifth model provider should be openai' );
-		$this->assertEquals( 'gpt-image-1.5', $result[4][1], 'Fifth model name should be gpt-image-1.5' );
+		$this->assertEquals( 'gpt-image-2', $result[4][1], 'Fifth model name should be gpt-image-2' );
 
 		// Check sixth model (openai).
 		$this->assertIsArray( $result[5], 'Sixth model should be an array' );
 		$this->assertCount( 2, $result[5], 'Sixth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[5][0], 'Sixth model provider should be openai' );
-		$this->assertEquals( 'gpt-image-1-mini', $result[5][1], 'Sixth model name should be gpt-image-1' );
+		$this->assertEquals( 'gpt-image-1.5', $result[5][1], 'Sixth model name should be gpt-image-1.5' );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Adds the new `gpt-image-2` model to our preferred model list

## Why?

OpenAI [recently announced](https://openai.com/index/introducing-chatgpt-images-2-0/) the new `gpt-image-2` model and it supposedly is significantly better than the previous model and it's also cheaper to use.

## How?

- Add `gpt-image-2` to our preferred model list
- Remove `gpt-image-1-mini` from that list

### Use of AI Tools

None

## Testing Instructions

1. Checkout this PR
2. Setup the OpenAI provider
3. Turn on image generation
4. Generate an image and ensure it works

## Changelog Entry

> Added - `gpt-image-2` to our preferred model list.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-456-e0b1ac7e00901ddfb3111204575159eab3ea3ca5.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->