### PR TITLE
New filter in the status dashboard widget to set configured status

### DIFF
--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -216,6 +216,23 @@ class AI_Status_Widget {
 				&& ! empty( $auth['setting_name'] )
 				&& '' !== get_option( $auth['setting_name'], '' ) );
 
+			/**
+			 * Filters whether an AI connector is configured.
+			 *
+			 * Allows third-party plugins to declare credential availability for
+			 * connectors that do not rely on API key settings.
+			 *
+			 * The dynamic portion of the hook name, `$slug`, refers to the connector slug.
+			 * For example, if the connector slug is 'openai', the hook name
+			 * will be 'wpai_is_openai_connector_configured'.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool $configured Whether the connector is configured.
+			 * @param array<string, mixed> $connector_data The connector data.
+			 */
+			$configured = (bool) apply_filters( "wpai_is_{$slug}_connector_configured", $configured, $connector_data );
+
 			$connectors[] = array(
 				'name'       => $connector_data['name'] ?? $slug,
 				'configured' => $configured,


### PR DESCRIPTION
## What?

See https://github.com/Fueled/ai-provider-for-ollama/issues/54

Adds a new filter to the connector configured status in our dashboard widget

## Why?

We assume a connector is configured if it has valid API key in place. But some connectors may not rely on API keys (like Ollama) or may have some other validation handling. This filter allows those providers to set the proper configuration status, similar to what we added in #337 

## How?

Adds a new filter, `wpai_is_{$slug}_connector_configured`, that allows others to determine if a connector is configured properly or not

### Use of AI Tools

None

## Testing Instructions

Hard to test until a connector plugin (like Ollama) is updated to take advantage of this new filter. For now, test need to ensure the dashboard status widget works as expected

## Changelog Entry

> Development Update - New filter, `wpai_is_{$slug}_connector_configured`, that allows others to filter the configuration status of an individual connector in our status widget.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-473-8bfd0bbe333b16ce98b0985b4e581241f76c8b64.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->