### PR TITLE
Hide title generation until content exists

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -14,7 +14,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { dispatch, select, useDispatch } from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { update } from '@wordpress/icons';
@@ -78,8 +78,15 @@ interface TitleToolbarProps {
 export default function TitleToolbar( {
 	isStandalone = false,
 }: TitleToolbarProps ): React.JSX.Element | null {
-	const postId = select( editorStore ).getCurrentPostId();
-	const title = select( editorStore ).getEditedPostAttribute( 'title' );
+	const { postId, content, title } = useSelect( ( select ) => {
+		const editor = select( editorStore );
+
+		return {
+			postId: editor.getCurrentPostId(),
+			content: editor.getEditedPostContent() || '',
+			title: editor.getEditedPostAttribute( 'title' ) || '',
+		};
+	}, [] );
 
 	const { editPost } = useDispatch( editorStore );
 
@@ -94,6 +101,7 @@ export default function TitleToolbar( {
 		setGeneratedTitle( '' );
 	};
 
+	const hasContent = content.trim().length > 0;
 	const hasTitle = title.trim().length > 0;
 
 	let buttonLabel: string = __( 'Generate', 'ai' );
@@ -112,7 +120,6 @@ export default function TitleToolbar( {
 			return;
 		}
 
-		const content = select( editorStore ).getEditedPostContent();
 		setIsGenerating( true );
 		( dispatch( noticesStore ) as any ).removeNotice(
 			'ai_title_generation_error'
@@ -141,7 +148,6 @@ export default function TitleToolbar( {
 	 * Fetches a new suggestion without closing the modal.
 	 */
 	const handleRegenerate = async () => {
-		const content = select( editorStore ).getEditedPostContent();
 		setIsRegenerating( true );
 		( dispatch( noticesStore ) as any ).removeNotice(
 			'ai_title_generation_error'
@@ -172,8 +178,8 @@ export default function TitleToolbar( {
 		closeModal();
 	};
 
-	// Don't render if disabled.
-	if ( ! aiTitleGenerationData?.enabled ) {
+	// Don't render if disabled or there is no post content to generate from.
+	if ( ! aiTitleGenerationData?.enabled || ! hasContent ) {
 		return null;
 	}
 

--- a/tests/e2e/specs/experiments/title-generation.spec.js
+++ b/tests/e2e/specs/experiments/title-generation.spec.js
@@ -95,6 +95,52 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 	} );
 
+	test( 'Only shows Title Generation after content exists', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Title Generation Experiment.
+		await enableExperiment( admin, page, 'Title Generation' );
+
+		// Create a new empty post.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: '',
+			content: '',
+		} );
+
+		// Click into the title field.
+		await editor.canvas.locator( '.editor-post-title__input' ).click();
+
+		// Ensure the title toolbar is not visible before content exists.
+		await expect(
+			editor.canvas.locator( '.ai-title-toolbar-container button' )
+		).toHaveCount( 0 );
+
+		// Add content to the post body.
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'This is some test content for the Title Generation Experiment.',
+			},
+		} );
+
+		// Refocus the title field.
+		await editor.canvas.locator( '.editor-post-title__input' ).click();
+
+		// Ensure the title toolbar is visible with "Generate" label.
+		await expect(
+			editor.canvas.locator( '.ai-title-toolbar-container', {
+				hasText: 'Generate',
+			} )
+		).toBeVisible();
+	} );
+
 	test( 'Can use the Title Generation Experiment with a post with a title', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What?
Closes #391

Hides the Title Generation control until the post has body content, and adds an e2e regression test for that empty-state behavior.

## Why?
The current UI shows the title generation toolbar even when there is no content to generate from. That creates a confusing empty-state flow and matches the behavior reported in #391.

## How?
The title toolbar now reads live editor state with `useSelect` and returns `null` when the edited post content is empty. The existing Generate/Regenerate labeling stays the same once content exists. An e2e test was added to verify the toolbar stays hidden for a blank post and appears after content is added.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: Drafting the implementation and regression test; final changes were reviewed and edited before submission.

## Testing Instructions
1. Enable the Title Generation experiment.
2. Create a new post with no title and no body content.
3. Focus the title field and confirm the Title Generation control is not shown.
4. Add body content to the post.
5. Focus the title field again and confirm the control appears with the `Generate` label.
6. For a post that already has a title and body content, confirm the control still appears with the `Regenerate` label.

Ran locally:
- `npm run typecheck`
- `npm run lint:js -- src/experiments/title-generation/components/TitleToolbar.tsx tests/e2e/specs/experiments/title-generation.spec.js`

## Changelog Entry
> Fixed - Hide the Title Generation control until a post has content to generate from.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-479-ab80b8f446e7e3e7e1fa0ab9e58ddce5b705110e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->