### PR TITLE
Add descriptive filenames for AI-generated featured images

### DIFF
--- a/includes/Abilities/Image/Import_Base64_Image.php
+++ b/includes/Abilities/Image/Import_Base64_Image.php
@@ -40,6 +40,11 @@ class Import_Base64_Image extends Abstract_Ability {
 					'sanitize_callback' => 'sanitize_text_field',
 					'description'       => esc_html__( 'The filename of the image.', 'ai' ),
 				),
+				'filename_context' => array(
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+					'description'       => esc_html__( 'Context used to generate a default filename for the image.', 'ai' ),
+				),
 				'title'       => array(
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
@@ -139,14 +144,19 @@ class Import_Base64_Image extends Abstract_Ability {
 		$args = wp_parse_args(
 			$input,
 			array(
-				'filename'    => 'ai-generated-image-' . time(),
-				'title'       => '',
-				'description' => '',
-				'alt_text'    => '',
-				'mime_type'   => null,
-				'meta'        => array(),
+				'filename'         => '',
+				'filename_context' => '',
+				'title'            => '',
+				'description'      => '',
+				'alt_text'         => '',
+				'mime_type'        => null,
+				'meta'             => array(),
 			),
 		);
+
+		if ( empty( $args['filename'] ) ) {
+			$args['filename'] = $this->generate_default_filename( $args['filename_context'] );
+		}
 
 		// Verify the data is a base64 encoded string.
 		try {
@@ -332,6 +342,46 @@ class Import_Base64_Image extends Abstract_Ability {
 			'title'       => $attachment->post_title,
 			'description' => $attachment->post_content,
 			'alt_text'    => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+		);
+	}
+
+	/**
+	 * Generates a default filename for an imported image.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $context Context to include in the filename.
+	 * @return string The generated filename without a file extension.
+	 */
+	protected function generate_default_filename( string $context = '' ): string {
+		$timestamp = (string) time();
+		$context   = trim( sanitize_text_field( $context ) );
+		$filename  = 'ai-generated-image-' . $timestamp;
+
+		if ( '' !== $context ) {
+			$slug = sanitize_title( wp_trim_words( $context, 8, '' ) );
+
+			if ( '' !== $slug ) {
+				$filename = sprintf(
+					'ai-generated-image-%1$s-%2$s',
+					$slug,
+					$timestamp
+				);
+			}
+		}
+
+		/**
+		 * Filters the default filename used for imported AI-generated images.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $filename The generated filename without a file extension.
+		 * @param string $context  The context used to derive the filename.
+		 */
+		return (string) apply_filters(
+			'ai_image_import_filename',
+			$filename,
+			$context
 		);
 	}
 }

--- a/src/features/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/features/image-generation/components/GenerateFeaturedImage.tsx
@@ -15,6 +15,31 @@ import { generateImage } from '../functions/generate-image';
 import { uploadImage } from '../functions/upload-image';
 
 /**
+ * Gets filename context for generated featured images.
+ *
+ * @param {string} title   The current post title.
+ * @param {string} content The current post content.
+ * @return {string|undefined} The preferred filename context.
+ */
+function getFilenameContext(
+	title: string,
+	content: string
+): string | undefined {
+	const trimmedTitle = title.trim();
+
+	if ( trimmedTitle ) {
+		return trimmedTitle;
+	}
+
+	const plainContent = content
+		.replace( /<[^>]+>/g, ' ' )
+		.replace( /\s+/g, ' ' )
+		.trim();
+
+	return plainContent || undefined;
+}
+
+/**
  * GenerateFeaturedImage component.
  *
  * Provides a button to generate a featured image.
@@ -25,6 +50,7 @@ export default function GenerateFeaturedImage(): React.JSX.Element {
 	const { editPost } = useDispatch( editorStore );
 
 	const content = select( editorStore ).getEditedPostContent();
+	const title = select( editorStore ).getEditedPostAttribute( 'title' );
 	const featuredImage =
 		select( editorStore ).getEditedPostAttribute( 'featured_media' );
 
@@ -51,8 +77,10 @@ export default function GenerateFeaturedImage(): React.JSX.Element {
 			const generatedImageData = await generateImage( content, {
 				onProgress: setProgressMessage,
 			} );
+			const filenameContext = getFilenameContext( title, content );
 			const importedImage = await uploadImage( generatedImageData, {
 				onProgress: setProgressMessage,
+				...( filenameContext ? { filenameContext } : {} ),
 			} );
 			editPost( {
 				featured_media: importedImage.id,

--- a/src/features/image-generation/functions/upload-image.ts
+++ b/src/features/image-generation/functions/upload-image.ts
@@ -21,15 +21,20 @@ const { aiImageGenerationData } = window as any;
 /**
  * Uploads an image to the media library.
  *
- * @param {GeneratedImageData} imageData              The generated image data (from generateImage).
- * @param {Object}             options                Optional settings.
- * @param {Function}           options.onProgress     Callback invoked with progress messages.
- * @param                      options.altTextEnabled
+ * @param {GeneratedImageData} imageData               The generated image data (from generateImage).
+ * @param {Object}             options                 Optional settings.
+ * @param {Function}           options.onProgress      Callback invoked with progress messages.
+ * @param {boolean}            options.altTextEnabled  Whether to generate alt text before upload.
+ * @param {string}             options.filenameContext Context used to build a default filename.
  * @return {Promise<UploadedImage>} A promise that resolves to the uploaded image data.
  */
 export async function uploadImage(
 	{ image, prompt, prompts }: GeneratedImageData,
-	options?: { onProgress?: ImageProgressCallback; altTextEnabled?: boolean }
+	options?: {
+		onProgress?: ImageProgressCallback;
+		altTextEnabled?: boolean;
+		filenameContext?: string;
+	}
 ): Promise< UploadedImage > {
 	const onProgress = options?.onProgress;
 	const promptHistory = prompts?.length ? prompts : [ prompt ];
@@ -74,6 +79,10 @@ export async function uploadImage(
 
 	// Set our image title to be a trimmed version of the alt text.
 	params.title = trimText( params.alt_text ?? '' );
+
+	if ( options?.filenameContext?.trim() ) {
+		params.filename_context = options.filenameContext.trim();
+	}
 
 	onProgress?.( __( 'Importing image…', 'ai' ) );
 

--- a/src/features/image-generation/types.ts
+++ b/src/features/image-generation/types.ts
@@ -74,6 +74,7 @@ export interface AILabelProps {
 export interface ImageImportAbilityInput {
 	data: string;
 	filename?: string;
+	filename_context?: string;
 	title?: string;
 	description?: string;
 	alt_text?: string;

--- a/tests/Integration/Includes/Abilities/Image_ImportTest.php
+++ b/tests/Integration/Includes/Abilities/Image_ImportTest.php
@@ -133,6 +133,7 @@ class Image_ImportTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'properties', $schema, 'Schema should have properties' );
 		$this->assertArrayHasKey( 'data', $schema['properties'], 'Schema should have data property' );
 		$this->assertArrayHasKey( 'filename', $schema['properties'], 'Schema should have filename property' );
+		$this->assertArrayHasKey( 'filename_context', $schema['properties'], 'Schema should have filename_context property' );
 		$this->assertArrayHasKey( 'title', $schema['properties'], 'Schema should have title property' );
 		$this->assertArrayHasKey( 'description', $schema['properties'], 'Schema should have description property' );
 		$this->assertArrayHasKey( 'alt_text', $schema['properties'], 'Schema should have alt_text property' );
@@ -147,6 +148,7 @@ class Image_ImportTest extends WP_UnitTestCase {
 
 		// Verify optional properties.
 		$this->assertEquals( 'string', $schema['properties']['filename']['type'], 'Filename should be string type' );
+		$this->assertEquals( 'string', $schema['properties']['filename_context']['type'], 'Filename context should be string type' );
 		$this->assertEquals( 'string', $schema['properties']['title']['type'], 'Title should be string type' );
 		$this->assertEquals( 'string', $schema['properties']['description']['type'], 'Description should be string type' );
 		$this->assertEquals( 'string', $schema['properties']['alt_text']['type'], 'Alt text should be string type' );
@@ -272,6 +274,63 @@ class Image_ImportTest extends WP_UnitTestCase {
 
 		// Verify the meta data was saved.
 		$this->assertEquals( 'custom_meta_value', get_post_meta( $result['image']['id'], 'custom_meta_key', true ), 'Meta data should be saved' );
+	}
+
+	/**
+	 * Test that execute_callback() uses filename context when no filename is provided.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_with_filename_context() {
+		$reflection = new \ReflectionClass( $this->ability );
+		$method     = $reflection->getMethod( 'execute_callback' );
+		$method->setAccessible( true );
+
+		// Create a user with upload_files capability.
+		$user_id = $this->factory->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $user_id );
+
+		$input = array(
+			'data'             => $this->valid_base64_image,
+			'filename_context' => 'WordPress SEO Guide',
+			'mime_type'        => 'image/png',
+		);
+
+		$result = $method->invoke( $this->ability, $input );
+
+		$this->assertMatchesRegularExpression(
+			'/^ai-generated-image-wordpress-seo-guide-\d+\.png$/',
+			$result['image']['filename'],
+			'Image filename should include the provided filename context.'
+		);
+	}
+
+	/**
+	 * Test that generated filenames can be customized with a filter.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_generate_default_filename_is_filterable() {
+		$reflection = new \ReflectionClass( $this->ability );
+		$method     = $reflection->getMethod( 'generate_default_filename' );
+		$method->setAccessible( true );
+
+		add_filter(
+			'ai_image_import_filename',
+			static function (): string {
+				return 'custom-ai-image-name';
+			}
+		);
+
+		$result = $method->invoke( $this->ability, 'WordPress SEO Guide' );
+
+		remove_all_filters( 'ai_image_import_filename' );
+
+		$this->assertSame(
+			'custom-ai-image-name',
+			$result,
+			'Filtered filename should be returned.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
## What?
Closes #402

Improves default filenames for AI-generated featured images by including post context before the timestamp, while preserving the existing fallback when no context is available.

## Why?
Featured images generated through the AI flow currently land in the Media Library with generic timestamp-only filenames like `ai-generated-image-<timestamp>`. That makes generated uploads harder to identify and does not reflect the post they belong to, which is the issue reported in #402.

## How?
The featured-image UI now passes filename context from the post title first, then stripped post content if the title is empty. The image import ability uses that context to generate filenames in the format `ai-generated-image-<context>-<timestamp>`. If no usable context exists, it still falls back to the original timestamp-only filename. A new `ai_image_import_filename` filter was also added so developers can override the generated default, and integration tests were added for both context-based filenames and the filter.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: Drafting the implementation and test updates; final changes were reviewed and edited before submission.

## Testing Instructions
1. Enable the Image Generation and Editing feature.
2. Create a new post with a title such as `WordPress SEO Guide` and body content.
3. Generate a featured image from the post editor.
4. Open the Media Library and confirm the uploaded file uses a descriptive filename like `ai-generated-image-wordpress-seo-guide-<timestamp>.png`.
5. Repeat with an empty title and confirm the filename falls back to content-derived context.
6. Repeat with no usable title or content and confirm the filename falls back to `ai-generated-image-<timestamp>.png`.

Ran locally:
- `npm run typecheck`
- `npm run lint:js -- src/features/image-generation/components/GenerateFeaturedImage.tsx src/features/image-generation/functions/upload-image.ts src/features/image-generation/types.ts`
- `php -l includes/Abilities/Image/Import_Base64_Image.php`
- `php -l tests/Integration/Includes/Abilities/Image_ImportTest.php`

Not run locally:
- `vendor/bin/phpunit` was unavailable in this workspace.
- `vendor/bin/phpcs` was unavailable in this workspace.

## Changelog Entry
> Fixed - Add descriptive default filenames for AI-generated featured images using post context when available.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-480-2fa3126e0717aca496664aeabb13cf3faebd3135.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->