### PR TITLE
Ignore .wp-env.test.override.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ CLAUDE.md
 
 # WP ENV
 /.wp-env.override.json
+/.wp-env.test.override.json
 
 # Tests & Coverage
 /coverage/


### PR DESCRIPTION
Follow-up to #447

## What?
Adds `/.wp-env.test.override.json` to `.gitignore` so a local test-only `wp-env` override file is never tracked.

## Why?

Sometimes, we might want to change the settings of our test environment, not just our development environment, locally.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Drafting the commit message and PR description; the change itself is a one-line `.gitignore` addition reviewed and verified by me.

## Changelog Entry
> Development Update - Ignore `/.wp-env.test.override.json` so local test-only `wp-env` overrides stay untracked.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-484-a17722e17b05fa5b852907192fb4699b2102f64f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->