### PR TITLE
Force LTR for ability schema JSON viewer

### DIFF
--- a/src/experiments/abilities-explorer/index.scss
+++ b/src/experiments/abilities-explorer/index.scss
@@ -160,6 +160,9 @@
 	max-height: 500px;
 	overflow-y: auto;
 	position: relative;
+	/* JSON output is always LTR regardless of language. */
+	/*rtl:ignore*/
+	direction: ltr;
 }
 
 .ability-schema-wrapper {


### PR DESCRIPTION
Part of #483

## What?
Force LTR direction on the ability schema JSON viewer in the Abilities Explorer.

## Why?
JSON output is structurally LTR and should not be flipped when the admin language is RTL.

## How?
Add `direction: ltr;` to `.ability-schema-display` with an `/*rtl:ignore*/` directive so RTLCSS preserves it in the generated `-rtl.css`.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Diagnosing the malformed `rtl:ignore` comment and applying the fix.

## Testing Instructions
1. Switch the WP admin to an RTL language (e.g. Arabic).
2. Open Abilities Explorer and view an ability's schema.
3. Confirm the JSON renders left-to-right.

| Before | After |
|--------|--------|
| <img width="1038" height="646" alt="image" src="https://github.com/user-attachments/assets/eece20a2-5659-46c9-a777-9fb154611b6e" /> | <img width="1051" height="647" alt="image" src="https://github.com/user-attachments/assets/0aeb160f-195a-4825-a217-832a96a2afc7" /> | 

## Changelog Entry
> Fixed - Ability schema JSON viewer now stays LTR under RTL admin languages.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-485-554db2db8a49f4dfac37cc36a14813a3bd781675.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->