### PR TITLE
For image gen, move guidelines from being system instructions to being part of the prompt

### DIFF
--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -248,18 +248,18 @@ class Generate_Image extends Abstract_Ability {
 		$request_options = new RequestOptions();
 		$request_options->setTimeout( 90 );
 
+		// Inject guidelines into the prompt. Unlike the other features, we don't
+		// use system instructions here because most image gen models don't support them.
+		$guidelines = $this->get_guidelines_for_prompt();
+		if ( $guidelines ) {
+			$prompt .= "\n\n" . 'The following guidelines represent the site&#039;s editorial standards. Apply them where relevant. If guidelines conflict with the above input, prioritize accuracy.';
+			$prompt .= "\n\n" . $guidelines;
+		}
+
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_request_options( $request_options )
 			->as_output_file_type( FileTypeEnum::inline() )
 			->using_model_preference( ...get_preferred_image_models() );
-
-		// Inject guidelines as a system instruction to match other abilities.
-		$guidelines = $this->get_guidelines_for_prompt();
-		if ( $guidelines ) {
-			$instruction  = 'The following guidelines represent the site&#039;s editorial standards. Apply them where relevant. Do not fabricate content to satisfy guidelines. If guidelines conflict with the input, prioritize accuracy.';
-			$instruction .= "\n\n" . $guidelines;
-			$prompt_builder->using_system_instruction( $instruction );
-		}
 
 		if ( null !== $reference_image ) {
 			try {


### PR DESCRIPTION
## What?

Closes #496

For image generation, add matching guidelines as part of the prompt instead of system instructions

## Why?

Turns out some image generation models (like OpenAI) don't support system instructions. This was wrong advice by me on the PR that implemented guideline support (I must have been testing with Google only).

This means that trying to generate images using OpenAI when you have guidelines in place won't work if those are set as system instructions.

## How?

Instead of setting the guidelines as a system prompt, append those to the prompt

### Use of AI Tools

None

## Testing Instructions

1. Pull this PR down
2. Ensure you have Image Generation turned on
3. Configure OpenAI as your AI Connector
4. Install the Gutenberg plugin and turn on the guidelines experiment
5. Add Site and Images guidelines
6. Generate an image and ensure it works

## Changelog Entry

> Changed - For image generation, set guidelines as part of the prompt instead of system instructions.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-497-8e782c556239a910064e4a419afa55b2fdddc977.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->