### PR TITLE
Add E2E coverage for dashboard widgets

### DIFF
--- a/tests/e2e/specs/admin/dashboard.spec.js
+++ b/tests/e2e/specs/admin/dashboard.spec.js
@@ -1,0 +1,125 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	clearConnectors,
+	disableExperiments,
+	visitAdminPage,
+} = require( '../../utils/helpers' );
+
+async function loginAsUser( page, username, password ) {
+	await page.goto( '/wp-login.php' );
+	await page.getByLabel( 'Username or Email Address' ).fill( username );
+	await page.getByLabel( 'Password', { exact: true } ).fill( password );
+	await page.getByRole( 'button', { name: 'Log In' } ).click();
+}
+
+test.describe( 'Dashboard widgets', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.deactivatePlugin( 'e2e-test-request-mocking' );
+	} );
+
+	test( 'Admin can see AI dashboard widgets', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
+
+		await visitAdminPage( admin, 'index.php' );
+
+		await expect(
+			page.getByRole( 'heading', { name: 'AI Status' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'AI Capabilities' } )
+		).toBeVisible();
+	} );
+
+	test( 'AI Capabilities shows the expected summary metrics', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
+
+		await visitAdminPage( admin, 'index.php' );
+
+		const capabilitiesWidget = page.locator( '#wpai_capabilities' );
+		const statCards = capabilitiesWidget.locator(
+			'.ai-dashboard-capabilities__stat-card'
+		);
+
+		await expect( capabilitiesWidget ).toBeVisible();
+		await expect(
+			page.getByRole( 'heading', { name: 'AI Capabilities' } )
+		).toBeVisible();
+		await expect( statCards ).toHaveCount( 4 );
+		await expect( capabilitiesWidget ).toContainText( 'Total Abilities' );
+		await expect( capabilitiesWidget ).toContainText( 'Core' );
+		await expect( capabilitiesWidget ).toContainText( 'Plugins' );
+		await expect( capabilitiesWidget ).toContainText( 'Theme' );
+		await expect( capabilitiesWidget ).toContainText(
+			'Provider Capabilities'
+		);
+	} );
+
+	test( 'AI Status shows getting started checklist when setup is incomplete', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
+
+		await clearConnectors( admin, page );
+		await disableExperiments( admin, page );
+
+		await visitAdminPage( admin, 'index.php' );
+
+		await expect(
+			page.getByText(
+				'Complete these steps to get started with the AI plugin:'
+			)
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'link', { name: 'Configure an AI provider' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Globally enable AI Features' } )
+		).toBeVisible();
+		await expect(
+			page.getByRole( 'link', { name: 'Enable a feature or experiment' } )
+		).toBeVisible();
+	} );
+
+	test( 'Non-admin users do not see AI dashboard widgets', async ( {
+		page,
+		requestUtils,
+	} ) => {
+		const username = `ai-editor-${ Date.now() }`;
+		const password = 'password';
+
+		await requestUtils.createUser( {
+			username,
+			email: `${ username }@example.com`,
+			password,
+			roles: [ 'editor' ],
+		} );
+
+		await loginAsUser( page, username, password );
+		await page.goto( '/wp-admin/index.php' );
+
+		await expect(
+			page.getByRole( 'heading', { name: 'AI Status' } )
+		).toHaveCount( 0 );
+		await expect(
+			page.getByRole( 'heading', { name: 'AI Capabilities' } )
+		).toHaveCount( 0 );
+	} );
+} );

--- a/tests/e2e/specs/admin/dashboard.spec.js
+++ b/tests/e2e/specs/admin/dashboard.spec.js
@@ -17,6 +17,10 @@ const {
 } = require( '../../utils/helpers' );
 
 test.describe( 'Dashboard widgets', () => {
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.deleteAllUsers();
+	} );
+
 	test( 'Admin can see AI dashboard widgets', async ( { admin, page } ) => {
 		await visitAdminPage( admin, 'index.php' );
 

--- a/tests/e2e/specs/admin/dashboard.spec.js
+++ b/tests/e2e/specs/admin/dashboard.spec.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+const {
+	RequestUtils,
+	test,
+	expect,
+} = require( '@wordpress/e2e-test-utils-playwright' );
 
 /**
  * Internal dependencies
@@ -12,25 +16,8 @@ const {
 	visitAdminPage,
 } = require( '../../utils/helpers' );
 
-async function loginAsUser( page, username, password ) {
-	await page.goto( '/wp-login.php' );
-	await page.getByLabel( 'Username or Email Address' ).fill( username );
-	await page.getByLabel( 'Password', { exact: true } ).fill( password );
-	await page.getByRole( 'button', { name: 'Log In' } ).click();
-}
-
 test.describe( 'Dashboard widgets', () => {
-	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.deactivatePlugin( 'e2e-test-request-mocking' );
-	} );
-
-	test( 'Admin can see AI dashboard widgets', async ( {
-		admin,
-		page,
-		requestUtils,
-	} ) => {
-		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
-
+	test( 'Admin can see AI dashboard widgets', async ( { admin, page } ) => {
 		await visitAdminPage( admin, 'index.php' );
 
 		await expect(
@@ -44,10 +31,7 @@ test.describe( 'Dashboard widgets', () => {
 	test( 'AI Capabilities shows the expected summary metrics', async ( {
 		admin,
 		page,
-		requestUtils,
 	} ) => {
-		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
-
 		await visitAdminPage( admin, 'index.php' );
 
 		const capabilitiesWidget = page.locator( '#wpai_capabilities' );
@@ -72,10 +56,7 @@ test.describe( 'Dashboard widgets', () => {
 	test( 'AI Status shows getting started checklist when setup is incomplete', async ( {
 		admin,
 		page,
-		requestUtils,
 	} ) => {
-		await requestUtils.activatePlugin( 'e2e-test-request-mocking' );
-
 		await clearConnectors( admin, page );
 		await disableExperiments( admin, page );
 
@@ -112,7 +93,17 @@ test.describe( 'Dashboard widgets', () => {
 			roles: [ 'editor' ],
 		} );
 
-		await loginAsUser( page, username, password );
+		const editorRequestUtils = await RequestUtils.setup( {
+			user: { username, password },
+		} );
+
+		await editorRequestUtils.login();
+		await page
+			.context()
+			.addCookies(
+				( await editorRequestUtils.request.storageState() ).cookies
+			);
+		await editorRequestUtils.request.dispose();
 		await page.goto( '/wp-admin/index.php' );
 
 		await expect(


### PR DESCRIPTION
## What?
Adds end-to-end test coverage for the AI dashboard widgets in wp-admin.

## Why?
The dashboard widgets are a user-facing feature, but there was no browser-level test coverage for them. Adding E2E coverage helps catch regressions in widget visibility, onboarding state, and permissions.

## How?
- Added a new E2E spec for the dashboard widgets.
- Verified that admins can see the `AI Status` and `AI Capabilities` widgets.
- Verified that the `AI Capabilities` widget shows the expected summary metrics and the provider capabilities section.
- Verified that the `AI Status` widget shows the getting started checklist when setup is incomplete.
- Verified that non-admin users do not see the widgets.

### Use of AI Tools
I used AI assistance to help review the repository, draft the E2E test file, and iterate on the test assertions. I manually reviewed the implementation, validated the behavior locally, and verified the final test runs before submitting.

## Testing Instructions
1. Start the test environment.
2. Run:
   `npm run test:e2e -- tests/e2e/specs/admin/dashboard.spec.js`
3. Confirm all 4 dashboard widget E2E tests pass.
4. Optionally verify manually in wp-admin that:
   - admins can see the `AI Status` and `AI Capabilities` widgets
   - the `AI Status` widget shows the onboarding checklist when setup is incomplete
   - non-admin users do not see the widgets

### Testing Instructions for Keyboard
1. Open the WordPress admin dashboard.
2. Use keyboard navigation to move through the dashboard widgets.
3. Confirm the `AI Status` and `AI Capabilities` widgets are reachable and visible for admin users.

## Screenshots or screencast
Not applicable.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-498-411e5961fd8e544fcf45fb0a44943269555f8f93.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->