### PR TITLE
Add custom experiment reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The AI plugin is meant to be studied, forked, and extended.  If you’re a host 
 If you’re a plugin developer, you’ll be able to:
 
 * Read the [Contributing Guide](CONTRIBUTING.md) for detailed development information.
+* Study the [Custom Experiment Reference](docs/experiments/custom-experiment-reference.md) for an end-to-end extension example.
 * Register new AI abilities.
 * Override default behavior with custom filters.
 * Reuse the same building blocks in your own plugins.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -6,6 +6,7 @@ Welcome to the AI plugin development guide. This document provides everything yo
 
 - [Architecture Overview](ARCHITECTURE_OVERVIEW.md)
 - [Creating a New Experiment](#creating-a-new-experiment)
+- [Custom Experiment Reference](experiments/custom-experiment-reference.md)
 - [Plugin API](#plugin-api)
 - [Development Workflow](#development-workflow)
 - [Additional Resources](#additional-resources)
@@ -124,6 +125,8 @@ class My_Experiment extends Abstract_Feature {
   }
 }
 ```
+
+If you want a complete end-to-end reference instead of a starter snippet, see the [Custom Experiment Reference](experiments/custom-experiment-reference.md). It points to the in-repo `Example_Experiment` implementation and shows a minimal third-party plugin example using the same extension points.
 
 ### Step 3: Register the Experiment
 
@@ -345,7 +348,8 @@ Push your branch and create a pull request. Follow the contribution guidelines i
 - [Contributing Guidelines](../CONTRIBUTING.md) - Code standards and contribution process
 - [Testing Strategy](TESTING.md) – Testing philosophy and guidelines
 - [Testing REST API Strategy](TESTING_REST_API.md) – Guidelines specific to testing REST API integrations
-- [Example Experiment](../includes/Experiments/Example_Experiment/README.md) - Reference implementation
+- [Custom Experiment Reference](experiments/custom-experiment-reference.md) - Documented example for extending the plugin
+- [Example Experiment](../includes/Experiments/Example_Experiment/README.md) - In-repo reference implementation
 - [WordPress Plugin Handbook](https://developer.wordpress.org/plugins/)
 - [Experiment Lifecycle](EXPERIMENT_LIFECYCLE.md) - Defines how new Experiments land in the plugin and how they could graduate towards WordPress core
 - [WordPress AI Team](https://make.wordpress.org/ai/)

--- a/docs/experiments/custom-experiment-reference.md
+++ b/docs/experiments/custom-experiment-reference.md
@@ -1,6 +1,6 @@
 # Custom Experiment Reference
 
-This page is a reference example for developers extending the WordPress AI plugin with a custom experiment.
+This serves as a reference example for developers extending the WordPress AI plugin with a custom experiment.
 
 The example is intentionally small and uses the same APIs and patterns as the plugin itself. It is demo code, not production-ready plugin scaffolding.
 

--- a/docs/experiments/custom-experiment-reference.md
+++ b/docs/experiments/custom-experiment-reference.md
@@ -1,0 +1,123 @@
+# Custom Experiment Reference
+
+This page is a reference example for developers extending the WordPress AI plugin with a custom experiment.
+
+The example is intentionally small and uses the same APIs and patterns as the plugin itself. It is demo code, not production-ready plugin scaffolding.
+
+## What This Example Shows
+
+- Creating a feature class by extending `Abstract_Feature`
+- Registering the experiment with the AI plugin
+- Adding metadata such as the label, description, and category
+- Hooking into WordPress actions and filters in `register()`
+- Disabling the experiment with the standard feature filters
+
+## Reference Class
+
+The plugin ships with a complete reference implementation at:
+
+- `includes/Experiments/Example_Experiment/Example_Experiment.php`
+- `includes/Experiments/Example_Experiment/README.md`
+
+That example is not enabled as a default built-in experiment. It exists to show the expected structure for third-party extensions.
+
+## Minimal Plugin Example
+
+The following example shows the smallest practical custom experiment plugin:
+
+```php
+<?php
+/**
+ * Plugin Name: My AI Experiment
+ */
+
+declare( strict_types=1 );
+
+namespace MyPlugin\AI;
+
+use WordPress\AI\Abstracts\Abstract_Feature;
+use WordPress\AI\Experiments\Experiment_Category;
+
+class My_Experiment extends Abstract_Feature {
+	public static function get_id(): string {
+		return 'my-experiment';
+	}
+
+	protected function load_metadata(): array {
+		return array(
+			'label'       => __( 'My Experiment', 'my-plugin' ),
+			'description' => __( 'Example custom experiment built on the AI plugin.', 'my-plugin' ),
+			'category'    => Experiment_Category::ADMIN,
+		);
+	}
+
+	public function register(): void {
+		add_action( 'admin_notices', array( $this, 'render_notice' ) );
+	}
+
+	public function render_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		echo '<div class="notice notice-info"><p>';
+		echo esc_html__( 'My Experiment is active.', 'my-plugin' );
+		echo '</p></div>';
+	}
+}
+
+add_action(
+	'wpai_register_features',
+	static function( $registry ): void {
+		$registry->register_feature( new My_Experiment() );
+	}
+);
+```
+
+## Why This Follows Recommended Patterns
+
+- `Abstract_Feature` provides the shared experiment lifecycle used throughout the plugin.
+- `load_metadata()` keeps labels and descriptions in one place, matching built-in experiments.
+- `register()` is where the experiment attaches behavior through WordPress hooks.
+- `wpai_register_features` is the safest entry point for third-party plugins because it registers your feature after the plugin sets up its registry.
+
+## Alternative Registration Method
+
+If you want your class added to the default feature class list before instantiation, use the `wpai_default_feature_classes` filter:
+
+```php
+add_filter(
+	'wpai_default_feature_classes',
+	static function( array $feature_classes ): array {
+		$feature_classes[ My_Experiment::get_id() ] = My_Experiment::class;
+		return $feature_classes;
+	}
+);
+```
+
+This is useful when your integration closely mirrors the plugin's built-in feature loading flow.
+
+## Disable the Experiment
+
+Disable only this experiment:
+
+```php
+add_filter( 'wpai_feature_my-experiment_enabled', '__return_false' );
+```
+
+Disable all AI plugin features:
+
+```php
+add_filter( 'wpai_features_enabled', '__return_false' );
+```
+
+## Next Steps
+
+After the experiment class is working, most production integrations will also want to:
+
+- add tests under `tests/Integration/`
+- add any editor or admin assets through `Asset_Loader`
+- document settings, abilities, and REST endpoints
+- note any provider or environment requirements
+
+For a deeper walkthrough, see the [Developer Guide](../DEVELOPER_GUIDE.md) and the in-repo Example Experiment reference implementation.


### PR DESCRIPTION
## What?
Closes #184

Adds a documented custom experiment reference for developers extending the AI plugin.

## Why?
The repository already includes example experiment code, but it is not surfaced as an easy-to-follow reference for plugin developers. This makes the extension path harder to discover than it needs to be.

## How?
- add a new `docs/experiments/custom-experiment-reference.md` page
- link that reference from the developer guide table of contents and resources section
- add a short pointer from the main README developer experience section
- clearly mark the example as reference/demo code and point readers to the in-repo `Example_Experiment` implementation

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: drafting the initial documentation update and PR text; final file changes were reviewed and committed by me.

## Testing Instructions
1. Open `docs/experiments/custom-experiment-reference.md` and confirm the example explains how to register a custom experiment.
2. Open `docs/DEVELOPER_GUIDE.md` and confirm the new reference is linked from the table of contents, experiment creation section, and resources section.
3. Open `README.md` and confirm the developer experience section links to the new reference page.

## Screenshots or screencast
Not applicable.

## Changelog Entry
> Development Update - Add custom experiment reference documentation for developers extending the plugin.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-499-32ca14282f4217efffaf56af56ed37c0abb8193a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->