### PR TITLE
Fix untranslated error strings

### DIFF
--- a/src/experiments/summarization/functions/generate-summary.ts
+++ b/src/experiments/summarization/functions/generate-summary.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { runAbility } from '../../../utils/run-ability';
@@ -26,7 +31,7 @@ export async function generateSummary(
 				return response as string;
 			}
 
-			throw new Error( 'Invalid response from API' );
+			throw new Error( __( 'Invalid response from API.', 'ai' ) );
 		} )
 		.catch( ( error ) => {
 			throw new Error( error.message );

--- a/src/features/image-generation/functions/generate-image.ts
+++ b/src/features/image-generation/functions/generate-image.ts
@@ -3,7 +3,7 @@
  */
 import { select } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies

--- a/src/features/image-generation/functions/generate-image.ts
+++ b/src/features/image-generation/functions/generate-image.ts
@@ -44,7 +44,11 @@ export async function generateImage(
 		prompt = await generatePrompt( content, formatContext( context ) );
 	} catch ( error: any ) {
 		throw new Error(
-			`Failed to generate prompt: ${ error.message || error }`
+			sprintf(
+				/* translators: %s: Error message returned while generating an image prompt. */
+				__( 'Failed to generate prompt: %s', 'ai' ),
+				error?.message || error
+			)
 		);
 	}
 
@@ -66,7 +70,9 @@ export async function generateImage(
 				return result as GeneratedImageData;
 			}
 
-			throw new Error( 'Invalid response from generate image' );
+			throw new Error(
+				__( 'Invalid response from generate image.', 'ai' )
+			);
 		} )
 		.catch( ( error ) => {
 			throw new Error( error.message );

--- a/src/features/image-generation/functions/get-context.ts
+++ b/src/features/image-generation/functions/get-context.ts
@@ -27,9 +27,7 @@ export async function getContext( postId: number ): Promise< PostContext > {
 				return response as PostContext;
 			}
 
-			throw new Error(
-				__( 'Invalid response from get context.', 'ai' )
-			);
+			throw new Error( __( 'Invalid response from get context.', 'ai' ) );
 		} )
 		.catch( ( error ) => {
 			throw new Error( error.message );

--- a/src/features/image-generation/functions/get-context.ts
+++ b/src/features/image-generation/functions/get-context.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import { runAbility } from '../../../utils/run-ability';
@@ -22,7 +27,9 @@ export async function getContext( postId: number ): Promise< PostContext > {
 				return response as PostContext;
 			}
 
-			throw new Error( 'Invalid response from get context' );
+			throw new Error(
+				__( 'Invalid response from get context.', 'ai' )
+			);
 		} )
 		.catch( ( error ) => {
 			throw new Error( error.message );

--- a/src/features/image-generation/functions/upload-image.ts
+++ b/src/features/image-generation/functions/upload-image.ts
@@ -87,7 +87,9 @@ export async function uploadImage(
 				return response.image as UploadedImage;
 			}
 
-			throw new Error( 'Invalid response from image import' );
+			throw new Error(
+				__( 'Invalid response from image import.', 'ai' )
+			);
 		} )
 		.catch( ( error ) => {
 			throw new Error( error.message );


### PR DESCRIPTION
## What?
Closes #181

Fixes several untranslated user-facing error strings in image-generation and summarization flows.

## Why?
Issue #181 calls for an internationalization audit across user-facing surfaces. These helper functions still contained hard-coded English error messages that can surface in the UI, which makes the plugin less ready for translation.

## How?
- wrap hard-coded image-generation error strings in `__()`
- localize the invalid-response fallback in summarization
- replace the string-interpolated prompt-generation failure with a translated `sprintf()` message
- keep the patch focused on concrete user-facing error paths

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: identifying likely untranslated strings and drafting the initial patch/PR text; final file changes were reviewed and committed by me.

## Testing Instructions
1. Review the changed files and confirm the new fallback error strings use the `ai` text domain.
2. Verify the image-generation helpers now use translated fallback messages for invalid responses.
3. Verify summarization now uses a translated invalid-response fallback.

## Screenshots or screencast
Not applicable.

## Changelog Entry
> Fixed - Localize several user-facing fallback error strings in image-generation and summarization flows.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-500-f538b80111f7d3273aba9e182498c0e973b299d6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->