### PR TITLE
Add a new public method to the `Comment_Analysis` class that is used to analyze a comment

### DIFF
--- a/includes/Abilities/Comment_Moderation/Comment_Analysis.php
+++ b/includes/Abilities/Comment_Moderation/Comment_Analysis.php
@@ -79,7 +79,22 @@ class Comment_Analysis extends Abstract_Ability {
 	 * @return array{comment_id: int, toxicity_score: float, sentiment: string}|\WP_Error The result of the ability execution.
 	 */
 	protected function execute_callback( $input ) {
-		$comment_id = absint( $input['comment_id'] ?? 0 );
+		return $this->analyze_comment_by_id( absint( $input['comment_id'] ?? 0 ) );
+	}
+
+	/**
+	 * Analyzes a comment by ID from trusted internal plugin flows.
+	 *
+	 * This method intentionally does not perform user capability checks. User-invoked
+	 * ability execution must go through execute(), which runs permission_callback().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $comment_id Comment ID.
+	 * @return array{comment_id: int, toxicity_score: float, sentiment: string}|\WP_Error The result of the analysis.
+	 */
+	public function analyze_comment_by_id( int $comment_id ) {
+		$comment_id = absint( $comment_id );
 
 		if ( ! $comment_id ) {
 			return new WP_Error(
@@ -201,6 +216,24 @@ class Comment_Analysis extends Abstract_Ability {
 	 * @return array{toxicity_score: float, sentiment: string}|\WP_Error The analysis result.
 	 */
 	private function analyze_comment( string $content, string $author ) {
+		/**
+		 * Filters the comment analysis result before calling the AI provider.
+		 *
+		 * Returning an array short-circuits the provider call. This is primarily useful for tests
+		 * and integrations that provide their own comment analysis implementation.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param array{toxicity_score: float, sentiment: string}|null $result  Precomputed analysis result.
+		 * @param string                                              $content Comment content.
+		 * @param string                                              $author  Comment author name.
+		 */
+		$pre_result = apply_filters( 'wpai_comment_analysis_result', null, $content, $author );
+
+		if ( is_array( $pre_result ) ) {
+			return $this->sanitize_analysis_result( $pre_result );
+		}
+
 		$prompt = sprintf(
 			"Comment by %s:\n\"\"\"%s\"\"\"",
 			$author,
@@ -229,20 +262,7 @@ class Comment_Analysis extends Abstract_Ability {
 			);
 		}
 
-		// Validate and sanitize the response.
-		$toxicity_score = isset( $parsed['toxicity_score'] )
-			? max( 0, min( 1, (float) $parsed['toxicity_score'] ) )
-			: 0;
-
-		$valid_sentiments = array( 'positive', 'negative', 'neutral' );
-		$sentiment        = isset( $parsed['sentiment'] ) && in_array( $parsed['sentiment'], $valid_sentiments, true )
-			? $parsed['sentiment']
-			: 'neutral';
-
-		return array(
-			'toxicity_score' => $toxicity_score,
-			'sentiment'      => $sentiment,
-		);
+		return $this->sanitize_analysis_result( $parsed );
 	}
 
 	/**
@@ -262,6 +282,30 @@ class Comment_Analysis extends Abstract_Ability {
 		return $this->ensure_text_generation_supported(
 			$prompt_builder,
 			esc_html__( 'Comment analysis failed. Please ensure you have a connected provider that supports text generation.', 'ai' )
+		);
+	}
+
+	/**
+	 * Sanitizes an analysis result.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $result Raw analysis result.
+	 * @return array{toxicity_score: float, sentiment: string} Sanitized analysis result.
+	 */
+	private function sanitize_analysis_result( array $result ): array {
+		$toxicity_score = isset( $result['toxicity_score'] )
+			? max( 0, min( 1, (float) $result['toxicity_score'] ) )
+			: 0;
+
+		$valid_sentiments = array( 'positive', 'negative', 'neutral' );
+		$sentiment        = isset( $result['sentiment'] ) && in_array( $result['sentiment'], $valid_sentiments, true )
+			? $result['sentiment']
+			: 'neutral';
+
+		return array(
+			'toxicity_score' => $toxicity_score,
+			'sentiment'      => $sentiment,
 		);
 	}
 }

--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -84,6 +84,15 @@ class Comment_Moderation extends Abstract_Feature {
 	public const STATUS_FAILED = 'failed';
 
 	/**
+	 * Comment analysis ability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var \WordPress\AI\Abilities\Comment_Moderation\Comment_Analysis|null
+	 */
+	private $comment_analysis_ability = null;
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @since x.x.x
@@ -166,13 +175,7 @@ class Comment_Moderation extends Abstract_Feature {
 			return;
 		}
 
-		// Analyze the comment using the comment-analysis ability.
-		$ability = wp_get_ability( 'ai/comment-analysis' );
-		if ( ! $ability ) {
-			return;
-		}
-
-		$analysis = $ability->execute( array( 'comment_id' => $comment_id ) );
+		$analysis = $this->get_comment_analysis_ability()->analyze_comment_by_id( (int) $comment_id );
 		if ( is_wp_error( $analysis ) ) {
 			return;
 		}
@@ -201,6 +204,26 @@ class Comment_Moderation extends Abstract_Feature {
 				'comment_approved' => '0',
 			)
 		);
+	}
+
+	/**
+	 * Gets the comment analysis ability for trusted internal use.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WordPress\AI\Abilities\Comment_Moderation\Comment_Analysis Comment analysis ability.
+	 */
+	private function get_comment_analysis_ability(): Comment_Analysis_Ability {
+		if ( ! $this->comment_analysis_ability ) {
+			$this->comment_analysis_ability = new Comment_Analysis_Ability( 'ai/comment-analysis',
+				array(
+					'label'       => __( 'Comment Analysis', 'ai' ),
+					'description' => __( 'Analyzes a comment for toxicity and sentiment.', 'ai' ),
+				)
+			);
+		}
+
+		return $this->comment_analysis_ability;
 	}
 
 	/**
@@ -461,8 +484,8 @@ class Comment_Moderation extends Abstract_Feature {
 				sprintf(
 					/* translators: %d: Number of comments queued for analysis. */
 					_n(
-						'%d comment queued for AI analysis.',
-						'%d comments queued for AI analysis.',
+						'%d comment queued for analysis.',
+						'%d comments queued for analysis.',
 						$count,
 						'ai'
 					),

--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -215,7 +215,8 @@ class Comment_Moderation extends Abstract_Feature {
 	 */
 	private function get_comment_analysis_ability(): Comment_Analysis_Ability {
 		if ( ! $this->comment_analysis_ability ) {
-			$this->comment_analysis_ability = new Comment_Analysis_Ability( 'ai/comment-analysis',
+			$this->comment_analysis_ability = new Comment_Analysis_Ability(
+				'ai/comment-analysis',
 				array(
 					'label'       => __( 'Comment Analysis', 'ai' ),
 					'description' => __( 'Analyzes a comment for toxicity and sentiment.', 'ai' ),

--- a/tests/Integration/Includes/Abilities/Comment_AnalysisTest.php
+++ b/tests/Integration/Includes/Abilities/Comment_AnalysisTest.php
@@ -9,8 +9,8 @@ namespace WordPress\AI\Tests\Integration\Includes\Abilities;
 
 use WP_Error;
 use WP_UnitTestCase;
-use WordPress\AI\Abstracts\Abstract_Feature;
 use WordPress\AI\Abilities\Comment_Moderation\Comment_Analysis;
+use WordPress\AI\Abstracts\Abstract_Feature;
 use WordPress\AI\Experiments\Comment_Moderation\Comment_Moderation;
 
 /**

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -239,12 +239,52 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test moderate_comment() analyzes comments when the current user cannot moderate comments.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_moderate_comment_analyzes_comment_for_user_without_moderate_comments_capability() {
+		$user_id    = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		$comment_id = $this->create_comment_without_hooks();
+		$experiment = new Comment_Moderation();
+
+		wp_set_current_user( $user_id );
+		add_filter( 'wpai_comment_analysis_result', array( $this, 'filter_comment_analysis_result' ) );
+
+		$experiment->moderate_comment( $comment_id );
+
+		remove_filter( 'wpai_comment_analysis_result', array( $this, 'filter_comment_analysis_result' ) );
+
+		$this->assertSame(
+			Comment_Moderation::STATUS_COMPLETE,
+			get_comment_meta( $comment_id, Comment_Moderation::META_ANALYSIS_STATUS, true )
+		);
+		$this->assertSame( 'negative', get_comment_meta( $comment_id, Comment_Moderation::META_SENTIMENT, true ) );
+		$this->assertSame( '0.8', get_comment_meta( $comment_id, Comment_Moderation::META_TOXICITY_SCORE, true ) );
+		$this->assertSame( '0', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * Filters the analysis result for tests.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array{toxicity_score: float, sentiment: string} Analysis result.
+	 */
+	public function filter_comment_analysis_result(): array {
+		return array(
+			'toxicity_score' => 0.8,
+			'sentiment'      => 'negative',
+		);
+	}
+
+	/**
 	 * Test show_bulk_action_notice() renders notice when queued count is valid.
 	 *
 	 * @since x.x.x
 	 */
 	public function test_show_bulk_action_notice_renders_notice() {
-		$experiment                    = new Comment_Moderation();
+		$experiment                   = new Comment_Moderation();
 		$_GET['wpai_analysis_queued'] = '2';
 
 		ob_start();
@@ -261,7 +301,7 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	 * @since x.x.x
 	 */
 	public function test_show_bulk_action_notice_does_nothing_for_invalid_count() {
-		$experiment                    = new Comment_Moderation();
+		$experiment                   = new Comment_Moderation();
 		$_GET['wpai_analysis_queued'] = '0';
 
 		ob_start();

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -292,7 +292,7 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'notice-success', $output );
-		$this->assertStringContainsString( '2 comments queued for AI analysis.', $output );
+		$this->assertStringContainsString( '2 comments queued for analysis.', $output );
 	}
 
 	/**

--- a/tests/e2e/specs/experiments/comment-moderation.spec.js
+++ b/tests/e2e/specs/experiments/comment-moderation.spec.js
@@ -69,7 +69,7 @@ test.describe( 'Comment Moderation Experiment', () => {
 		// Ensure the admin notice shows and has the right text.
 		await expect(
 			page.locator( '.notice-success', {
-				hasText: /1 comment queued for AI analysis/,
+				hasText: /1 comment queued for analysis/,
 			} )
 		).toBeVisible();
 


### PR DESCRIPTION
## What?

Closes #515 

Add a new `analyze_comment_by_id` method to the `Comment_Analysis` class and use that whenever we want to analyze a comment.

## Why?

If we directly use the `Comment_Analysis` Ability to analyze a comment, it will require the `permission_callback` to pass which requires a user to be logged in and have the `moderate_comments` capability. While this is great and we want that in place, this means we can't use this class to analyze a newly added comment from a non-logged in user or a non-admin/editor user.

## How?

- Adds a new `analyze_comment_by_id` method to the `Comment_Analysis` class
- When the `Comment_Analysis` Ability is called, the execution callback will now use this method (after passing the permission check)
- When we analyze a newly added comment, instead of directly calling the Ability (which will trigger the permission check) instead call this new `analyze_comment_by_id` method. Since we hook this to `wp_insert_comment`, WordPress has already run it's own checks so no need for us to have a permission check here

### Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): GPT-5.5
Used for: Analyzing the problem and suggesting some approaches. I considered the approaches and settled on what I felt was right and AI executed on that plan. Final review and testing by me

## Testing Instructions

1. Pull down this PR
2. Turn on the Comment Moderation experiment
3. Ensure you have an AI Connector in place
4. Ensure comments are allowed on your site
5. As a logged-in user, go to the front-end and leave a comment. Ensure this comment is saved
6. Go to the `Comments` screen in the admin and ensure you see this comment and you see Sentiment and Toxicity values
7. Log out
8. Go to a post and leave a comment
9. Ensure that comment goes through
10. Log back in and find that comment on the `Comments` screen and ensure you see this comment and you see Sentiment and Toxicity values
11. From that screen, manually analyze one or more comments and ensure that still works

## Changelog Entry

> Fixed - Ensure comment moderation works properly for comments left by non-logged in users and users without the `comment_moderation` capability

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-516-b62cf7f0b9816f9af48d9fdc7edb7af8147716da.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->