### PR TITLE
Fixed - Filter Guidelines service queries by wp_guideline_type=content

### DIFF
--- a/includes/Services/Guidelines.php
+++ b/includes/Services/Guidelines.php
@@ -33,6 +33,24 @@ class Guidelines {
 	public const POST_TYPE = 'wp_guideline';
 
 	/**
+	 * Taxonomy used by Gutenberg 23.1+ to distinguish guideline types.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @var string
+	 */
+	public const GUIDELINE_TYPE_TAXONOMY = 'wp_guideline_type';
+
+	/**
+	 * Term slug that identifies content guidelines within the type taxonomy.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @var string
+	 */
+	private const GUIDELINE_TYPE_CONTENT = 'content';
+
+	/**
 	 * Singleton instance.
 	 *
 	 * @since 0.8.0
@@ -304,16 +322,28 @@ class Guidelines {
 		}
 
 		// Gutenberg saves guidelines as 'draft' by default; both statuses are valid.
-		$query = new WP_Query(
-			array(
-				'post_type'      => self::POST_TYPE,
-				'posts_per_page' => 1,
-				'post_status'    => array( 'publish', 'draft' ),
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-				'no_found_rows'  => true,
-			)
+		$query_args = array(
+			'post_type'      => self::POST_TYPE,
+			'posts_per_page' => 1,
+			'post_status'    => array( 'publish', 'draft' ),
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
 		);
+
+		// Gutenberg 23.1+ registers a type taxonomy; restrict to content guidelines
+		// so artifact guidelines cannot shadow them during prompt assembly.
+		if ( taxonomy_exists( self::GUIDELINE_TYPE_TAXONOMY ) ) {
+			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => self::GUIDELINE_TYPE_TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => self::GUIDELINE_TYPE_CONTENT,
+				),
+			);
+		}
+
+		$query = new WP_Query( $query_args );
 
 		$post = $query->posts[0] ?? null;
 

--- a/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
+++ b/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
@@ -56,15 +56,35 @@ trait Guidelines_CPT_Helpers {
 	}
 
 	/**
+	 * Registers the guideline type taxonomy (Gutenberg 23.1+) for testing.
+	 *
+	 * @since 0.9.1
+	 *
+	 * @return void
+	 */
+	private function register_guideline_type_taxonomy(): void {
+		if ( taxonomy_exists( Guidelines::GUIDELINE_TYPE_TAXONOMY ) ) {
+			return;
+		}
+
+		register_taxonomy(
+			Guidelines::GUIDELINE_TYPE_TAXONOMY,
+			Guidelines::POST_TYPE,
+			array( 'public' => false )
+		);
+	}
+
+	/**
 	 * Creates a guidelines post with the given category meta values.
 	 *
 	 * @since 0.8.0
 	 *
-	 * @param array<string, string> $categories  Keyed array of category => guideline text.
-	 * @param string                $post_status Optional. The post status. Defaults to 'publish'.
+	 * @param array<string, string> $categories    Keyed array of category => guideline text.
+	 * @param string                $post_status   Optional. The post status. Defaults to 'publish'.
+	 * @param string|null           $guideline_type Optional. Term slug to assign via the type taxonomy (e.g. 'content', 'artifact').
 	 * @return int The created post ID.
 	 */
-	private function create_guidelines_post( array $categories, string $post_status = 'publish' ): int {
+	private function create_guidelines_post( array $categories, string $post_status = 'publish', ?string $guideline_type = null ): int {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Guidelines::POST_TYPE,
@@ -79,6 +99,10 @@ trait Guidelines_CPT_Helpers {
 			}
 
 			update_post_meta( $post_id, self::$guideline_category_meta_keys[ $category ], $value );
+		}
+
+		if ( null !== $guideline_type && taxonomy_exists( Guidelines::GUIDELINE_TYPE_TAXONOMY ) ) {
+			wp_set_object_terms( $post_id, $guideline_type, Guidelines::GUIDELINE_TYPE_TAXONOMY );
 		}
 
 		// Reset cache so the service picks up the new post.

--- a/tests/Integration/Includes/Services/Guidelines_Test.php
+++ b/tests/Integration/Includes/Services/Guidelines_Test.php
@@ -383,6 +383,59 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that a newer artifact guideline does not shadow a content guideline
+	 * when the wp_guideline_type taxonomy is registered (Gutenberg 23.1+).
+	 *
+	 * @since 0.9.1
+	 */
+	public function test_get_guidelines_ignores_artifact_type_when_taxonomy_exists(): void {
+		$this->register_guidelines_cpt();
+		$this->register_guideline_type_taxonomy();
+
+		// Create the content guideline first (older).
+		$content_post_id = $this->create_guidelines_post(
+			array( 'site' => 'Content guideline text.' ),
+			'publish',
+			'content'
+		);
+
+		// Create a newer artifact guideline — without the fix this would be picked up instead.
+		$this->create_guidelines_post(
+			array( 'site' => 'Artifact guideline text.' ),
+			'publish',
+			'artifact'
+		);
+
+		$guidelines = $this->service->get_guidelines( 'site' );
+
+		$this->assertIsArray( $guidelines );
+		$this->assertSame(
+			'Content guideline text.',
+			$guidelines['site'],
+			'Should return the content-type guideline, not the newer artifact-type one'
+		);
+	}
+
+	/**
+	 * Tests that guidelines are still returned when the type taxonomy exists
+	 * but the post has no type term assigned (untyped posts are excluded).
+	 *
+	 * @since 0.9.1
+	 */
+	public function test_get_guidelines_returns_null_for_untyped_post_when_taxonomy_exists(): void {
+		$this->register_guidelines_cpt();
+		$this->register_guideline_type_taxonomy();
+
+		// Post exists but has no wp_guideline_type term.
+		$this->create_guidelines_post( array( 'site' => 'Untyped guideline.' ) );
+
+		$this->assertNull(
+			$this->service->get_guidelines(),
+			'Should return null when no content-typed guideline post exists'
+		);
+	}
+
+	/**
 	 * Tests that format_for_prompt() skips empty categories.
 	 *
 	 * @since 0.8.0


### PR DESCRIPTION
## Summary

- Adds a `GUIDELINE_TYPE_TAXONOMY` constant (`wp_guideline_type`) and a private `GUIDELINE_TYPE_CONTENT` constant (`content`) to the `Guidelines` service.
- When the `wp_guideline_type` taxonomy is registered (Gutenberg 23.1+), `fetch_guidelines()` now appends a `tax_query` to restrict the query to posts assigned the `content` term, preventing a newer `artifact` guideline from shadowing the intended content guideline during prompt assembly.
- Falls back to the previous unfiltered query on sites running Gutenberg < 23.1 where the taxonomy does not exist.

Fixes #529.

## Changes

- `includes/Services/Guidelines.php` — add constants, conditionally add `tax_query` in `fetch_guidelines()`.
- `tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php` — add `register_guideline_type_taxonomy()` helper; extend `create_guidelines_post()` with an optional `$guideline_type` parameter.
- `tests/Integration/Includes/Services/Guidelines_Test.php` — add two new tests covering the mixed artifact/content scenario and the untyped-post edge case.

## Test plan

- [ ] Existing `Guidelines_Test` suite still passes.
- [ ] `test_get_guidelines_ignores_artifact_type_when_taxonomy_exists` confirms the content guideline is returned when a newer artifact guideline also exists.
- [ ] `test_get_guidelines_returns_null_for_untyped_post_when_taxonomy_exists` confirms untyped posts are excluded when the taxonomy is present.
- [ ] Manual: install Gutenberg 23.1.x, reproduce steps from #529, verify the correct content guideline is used in prompt assembly.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-531-225ab0007f92b86aaba966a29eec463f05453dc1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->