### PR TITLE
Keep focus on Provider select after Reset to default 

### DIFF
--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -5,7 +5,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { Button, Spinner } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -52,6 +58,8 @@ export function DeveloperSettings( {
 	const [ providers, setProviders ] = useState< ProviderData[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ fetchError, setFetchError ] = useState< string | null >( null );
+
+	const formWrapperRef = useRef< HTMLDivElement >( null );
 
 	const { settings, update, clear, isSaving } =
 		useDeveloperFeatureSettings( featureId );
@@ -170,20 +178,28 @@ export function DeveloperSettings( {
 			) }
 			{ ! isLoading && ! fetchError && (
 				<>
-					<DataForm< DeveloperSelection >
-						data={ settings }
-						fields={ fields }
-						form={ form }
-						onChange={ handleChange }
-					/>
+					<div ref={ formWrapperRef }>
+						<DataForm< DeveloperSelection >
+							data={ settings }
+							fields={ fields }
+							form={ form }
+							onChange={ handleChange }
+						/>
+					</div>
 					{ hasSavedSelection && (
 						<Button
 							variant="link"
 							className="ai-developer-mode-fields__reset-button"
 							onClick={ () => {
+								formWrapperRef.current
+									?.querySelector< HTMLSelectElement >(
+										'select'
+									)
+									?.focus();
 								void clear();
 							} }
 							disabled={ isSaving }
+							accessibleWhenDisabled
 						>
 							{ __( 'Reset to default', 'ai' ) }
 						</Button>


### PR DESCRIPTION
See https://github.com/WordPress/ai/issues/180#issuecomment-4412792914

## What?

1. Move keyboard focus to the Provider select when the developer settings "Reset to default" button is clicked, so focus is not lost when the button unmounts. 
2. Make the disabled button focusable.

## Why?

1. The "Reset to default" button is rendered only while a saved provider/model selection exists. Clicking it clears the selection, which immediately removes the button from the DOM.
2. The button becomes disabled the moment the provider is changed until the network communication is completed. Therefore, if the Tab key is pressed repeatedly immediately after changing the provider, users might miss the button without noticing it.

## How?

1.  Wrap the `DataForm` in a ref-bearing `<div>` so we can locate the rendered Provider `<select>`. Unfortunately, the DataForm component itself does not support refs.
2. Add `accessibleWhenDisabled` to the button so the focus target stays interactive while the save is in flight.

`DataForm` itself is a plain function component (not `forwardRef`), and the `Field` API has no ref hook for the underlying control, so wrapping with a ref + `querySelector` is the least invasive option.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Drafting the focus-management change and this PR description; reviewed and edited by me.

## Testing Instructions

1. Enable the "Mode selection" setting.
2. Pick a non-default Provider (and optionally a Model) so the "Reset to default" button appears.
3. Immediately press the Tab key twice before the network communication finishes.
4. The disabled button should then be focused.
5. Click the button.
6. Verify focus immediately moves to the Provider `<select>`.

## Screenshots or screencast

https://github.com/user-attachments/assets/6864b90a-2e83-48fe-aab8-8678bde7bc2c

## Changelog Entry

> Fixed - Keep keyboard focus on the Provider select when resetting per-feature developer settings to default.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-532-92e13d79d3cc450f87e3698564cb72cbfac89925.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->