### PR TITLE
Fix comment moderation sorting with missing meta

### DIFF
--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -548,20 +548,46 @@ class Comment_Moderation extends Abstract_Feature {
 			);
 		}
 
-		if ( ! empty( $meta_query ) ) {
-			$query->query_vars['meta_query'] = $meta_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		}
-
 		// Handle sorting.
 		$orderby = $query->query_vars['orderby'] ?? '';
 
+		// Use named meta queries so comments without analysis metadata remain visible when sorted.
 		if ( 'wpai_sentiment' === $orderby ) {
-			$query->query_vars['meta_key'] = self::META_SENTIMENT;
-			$query->query_vars['orderby']  = 'meta_value';
+			$meta_query[] = array(
+				'relation'             => 'OR',
+				'wpai_sentiment_sort'  => array(
+					'key'     => self::META_SENTIMENT,
+					'compare' => 'EXISTS',
+				),
+				'wpai_sentiment_empty' => array(
+					'key'     => self::META_SENTIMENT,
+					'compare' => 'NOT EXISTS',
+				),
+			);
+
+			$query->query_vars['orderby'] = 'wpai_sentiment_sort';
 		} elseif ( 'wpai_toxicity' === $orderby ) {
-			$query->query_vars['meta_key'] = self::META_TOXICITY_SCORE;
-			$query->query_vars['orderby']  = 'meta_value_num';
+			$meta_query[] = array(
+				'relation'            => 'OR',
+				'wpai_toxicity_sort'  => array(
+					'key'     => self::META_TOXICITY_SCORE,
+					'compare' => 'EXISTS',
+					'type'    => 'DECIMAL(10, 5)',
+				),
+				'wpai_toxicity_empty' => array(
+					'key'     => self::META_TOXICITY_SCORE,
+					'compare' => 'NOT EXISTS',
+				),
+			);
+
+			$query->query_vars['orderby'] = 'wpai_toxicity_sort';
 		}
+
+		if ( empty( $meta_query ) ) {
+			return;
+		}
+
+		$query->query_vars['meta_query'] = $meta_query; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -387,6 +387,72 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that sorting keeps comments without moderation metadata visible.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_comment_sorting_includes_comments_without_analysis_meta() {
+		set_current_screen( 'edit-comments' );
+		$experiment = new Comment_Moderation();
+		add_action( 'pre_get_comments', array( $experiment, 'handle_sorting_and_filtering' ) );
+
+		try {
+			$comment_without_meta = $this->create_comment_without_hooks();
+
+			$comment_neg = $this->create_comment_without_hooks();
+			update_comment_meta( $comment_neg, Comment_Moderation::META_SENTIMENT, 'negative' );
+			update_comment_meta( $comment_neg, Comment_Moderation::META_TOXICITY_SCORE, 0.8 );
+
+			$comment_pos = $this->create_comment_without_hooks();
+			update_comment_meta( $comment_pos, Comment_Moderation::META_SENTIMENT, 'positive' );
+			update_comment_meta( $comment_pos, Comment_Moderation::META_TOXICITY_SCORE, 0.2 );
+
+			$comments = get_comments(
+				array(
+					'fields'  => 'ids',
+					'orderby' => 'wpai_sentiment',
+					'order'   => 'ASC',
+				)
+			);
+
+			$this->assertSame( array( $comment_without_meta, $comment_neg, $comment_pos ), $comments );
+
+			$comments = get_comments(
+				array(
+					'fields'  => 'ids',
+					'orderby' => 'wpai_sentiment',
+					'order'   => 'DESC',
+				)
+			);
+
+			$this->assertSame( array( $comment_pos, $comment_neg, $comment_without_meta ), $comments );
+
+			$comments = get_comments(
+				array(
+					'fields'  => 'ids',
+					'orderby' => 'wpai_toxicity',
+					'order'   => 'ASC',
+				)
+			);
+
+			$this->assertSame( array( $comment_without_meta, $comment_pos, $comment_neg ), $comments );
+
+			$comments = get_comments(
+				array(
+					'fields'  => 'ids',
+					'orderby' => 'wpai_toxicity',
+					'order'   => 'DESC',
+				)
+			);
+
+			$this->assertSame( array( $comment_neg, $comment_pos, $comment_without_meta ), $comments );
+		} finally {
+			remove_action( 'pre_get_comments', array( $experiment, 'handle_sorting_and_filtering' ) );
+			set_current_screen( 'front' );
+		}
+	}
+
+	/**
 	 * Test that add_dashboard_pills appends HTML only on the dashboard screen.
 	 *
 	 * @since x.x.x


### PR DESCRIPTION
## What?

Follow up to #518.

Fixes Comment Moderation sorting so comments without AI moderation metadata stay visible when sorting by Sentiment or Toxicity.

## Why?

The comments list can include both analyzed and unanalyzed comments. Before this change, sorting by Sentiment or Toxicity used `meta_key` sorting, which only returns comments that have that meta key. As a result, unanalyzed comments disappeared from the list even though the total item count still included them.

## How?

- Updates the Comment Moderation sort query to use named `meta_query` clauses for comments with and without moderation metadata.
- Keeps existing Sentiment and Toxicity filtering behavior unchanged.
- Adds integration test coverage for Sentiment and Toxicity sorting in both ascending and descending order.
- Confirms comments without moderation metadata remain included in sorted results.

### Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT / Codex
Used for: Helping inspect the repository, draft and iterate on the patch, run local verification commands, and review the PR description. I manually reviewed the implementation, validated the behavior locally, and verified the final test results before submitting.

## Testing Instructions

1. Enable the Comment Moderation experiment.
2. Create or use comments where some have AI moderation metadata and some do not.
3. Go to `wp-admin/edit-comments.php`.
4. Sort by the Sentiment column.
5. Confirm comments without Sentiment metadata remain visible.
6. Sort by the Toxicity column.
7. Confirm comments without Toxicity metadata remain visible.
8. Run:

```bash
composer run-script test
composer run-script lint
composer run-script phpstan
```

## Screenshots or screencast

Not applicable. This fixes list table sorting behavior and is covered by integration tests.

## Changelog Entry

> Fixed - Keep comments without AI moderation metadata visible when sorting Comment Moderation columns.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-538-34efc7aff61b098aa10789505a33c4897c95e777.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->