### PR TITLE
Fix: Redundant API requests for providers on settings page when multiple features share the same capability

### DIFF
--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -1,34 +1,17 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { Button, Spinner } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
-import {
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from '@wordpress/element';
+import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { useDeveloperFeatureSettings } from '../hooks/use-developer-feature-settings';
-
-interface ModelData {
-	id: string;
-	name: string;
-}
-
-interface ProviderData {
-	id: string;
-	name: string;
-	models: ModelData[];
-}
+import { useProviders } from '../hooks/use-providers';
 
 interface DeveloperSettingsProps {
 	featureId: string;
@@ -55,41 +38,12 @@ export function DeveloperSettings( {
 	featureId,
 	capability,
 }: DeveloperSettingsProps ): React.JSX.Element {
-	const [ providers, setProviders ] = useState< ProviderData[] >( [] );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ fetchError, setFetchError ] = useState< string | null >( null );
+	const { providers, isLoading, fetchError } = useProviders( capability );
 
 	const formWrapperRef = useRef< HTMLDivElement >( null );
 
 	const { settings, update, clear, isSaving } =
 		useDeveloperFeatureSettings( featureId );
-
-	useEffect( () => {
-		if ( capability === 'none' ) {
-			setProviders( [] );
-			setFetchError( null );
-			setIsLoading( false );
-			return;
-		}
-
-		setIsLoading( true );
-		setFetchError( null );
-
-		apiFetch< ProviderData[] >( {
-			path: `/ai/v1/providers?capability=${ encodeURIComponent(
-				capability
-			) }`,
-		} )
-			.then( ( data ) => {
-				setProviders( data );
-			} )
-			.catch( () => {
-				setFetchError( __( 'Failed to load providers.', 'ai' ) );
-			} )
-			.finally( () => {
-				setIsLoading( false );
-			} );
-	}, [ capability ] );
 
 	const getModelElements = useCallback( () => {
 		const provider = providers.find( ( p ) => p.id === settings.provider );

--- a/routes/ai-home/hooks/use-providers.ts
+++ b/routes/ai-home/hooks/use-providers.ts
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+interface ModelData {
+	id: string;
+	name: string;
+}
+
+interface ProviderData {
+	id: string;
+	name: string;
+	models: ModelData[];
+}
+
+interface UseProvidersReturn {
+	providers: ProviderData[];
+	isLoading: boolean;
+	fetchError: string | null;
+}
+
+const providersCache = new Map< string, Promise< ProviderData[] > >();
+
+/**
+ * Fetches providers for a given capability, deduplicating concurrent requests.
+ *
+ * Uses a module-level cache so that multiple callers with the same capability
+ * share a single in-flight request. Failed requests are evicted from the cache
+ * to allow retries.
+ *
+ * @param {string} capability The AI capability to filter providers by.
+ * @return {Promise<ProviderData[]>} The providers matching the capability.
+ */
+function fetchProviders( capability: string ): Promise< ProviderData[] > {
+	const existing = providersCache.get( capability );
+	if ( existing ) {
+		return existing;
+	}
+
+	const promise = apiFetch< ProviderData[] >( {
+		path: `/ai/v1/providers?capability=${ encodeURIComponent(
+			capability
+		) }`,
+	} ).catch( ( error ) => {
+		// Remove failed entries so a retry is possible on next mount.
+		providersCache.delete( capability );
+		throw error;
+	} );
+
+	providersCache.set( capability, promise );
+	return promise;
+}
+
+/**
+ * Hook that fetches and caches AI providers by capability.
+ *
+ * Multiple components requesting the same capability will share a single network
+ * request. Results are cached for the lifetime of the page.
+ *
+ * @param {string} capability The AI capability type (e.g. 'text_generation', 'vision').
+ * @return {UseProvidersReturn} The providers list, loading state, and any error.
+ */
+export function useProviders( capability: string ): UseProvidersReturn {
+	const [ providers, setProviders ] = useState< ProviderData[] >( [] );
+	const [ isLoading, setIsLoading ] = useState( capability !== 'none' );
+	const [ fetchError, setFetchError ] = useState< string | null >( null );
+
+	useEffect( () => {
+		if ( capability === 'none' ) {
+			setProviders( [] );
+			setFetchError( null );
+			setIsLoading( false );
+			return;
+		}
+
+		setIsLoading( true );
+		setFetchError( null );
+
+		fetchProviders( capability )
+			.then( ( data ) => {
+				setProviders( data );
+				setFetchError( null );
+			} )
+			.catch( () => {
+				setProviders( [] );
+				setFetchError( __( 'Failed to load providers.', 'ai' ) );
+			} )
+			.finally( () => {
+				setIsLoading( false );
+			} );
+	}, [ capability ] );
+
+	return { providers, isLoading, fetchError };
+}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/541

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR fixes the issue related to AI Settings page where same requests were being fired multiple times.
- For detail info - See https://github.com/WordPress/ai/issues/541

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Use the approach to remove providers fetch logic to a custom hook and implement a module level cache for requests results based on capability.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): GitHub Copilot, Claude
Model(s): Opus 4.6
Used for: Providing suggestion on improvement based on issue. Reviwed the code generated manually and then raised the PR.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open Page - `options-general.php?page=ai-wp-admin`, Enable model selection.
2. Enable all features.
3. Check the network request, it should only be 3 for now, `text_generation, vision, image_generation`, instead of individual request for each features. 

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/21b80a2a-bfbe-4f11-adbf-bab79d5679a9


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Changed - Deduplicate provider API requests on the settings page by caching fetches per capability, reducing redundant network calls.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-542-b7972a2a3ba5c67a4b98ccf8e664af5ca92ae8a5.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->