### PR TITLE
fix: remove additionalProperties from suggestions schema

### DIFF
--- a/includes/Abilities/Review_Notes/Review_Notes.php
+++ b/includes/Abilities/Review_Notes/Review_Notes.php
@@ -259,24 +259,22 @@ class Review_Notes extends Abstract_Ability {
 	 */
 	protected function suggestions_schema(): array {
 		return array(
-			'type'                 => 'object',
-			'properties'           => array(
+			'type'       => 'object',
+			'properties' => array(
 				'suggestions' => array(
 					'type'  => 'array',
 					'items' => array(
-						'type'                 => 'object',
-						'properties'           => array(
+						'type'       => 'object',
+						'properties' => array(
 							'review_type' => array( 'type' => 'string' ),
 							'text'        => array( 'type' => 'string' ),
 							'priority'    => array( 'type' => 'integer' ),
 						),
-						'required'             => array( 'review_type', 'text', 'priority' ),
-						'additionalProperties' => false,
+						'required' => array( 'review_type', 'text', 'priority' ),
 					),
 				),
 			),
-			'required'             => array( 'suggestions' ),
-			'additionalProperties' => false,
+			'required' => array( 'suggestions' ),
 		);
 	}
 

--- a/includes/Abilities/Review_Notes/Review_Notes.php
+++ b/includes/Abilities/Review_Notes/Review_Notes.php
@@ -270,11 +270,11 @@ class Review_Notes extends Abstract_Ability {
 							'text'        => array( 'type' => 'string' ),
 							'priority'    => array( 'type' => 'integer' ),
 						),
-						'required' => array( 'review_type', 'text', 'priority' ),
+						'required'   => array( 'review_type', 'text', 'priority' ),
 					),
 				),
 			),
-			'required' => array( 'suggestions' ),
+			'required'   => array( 'suggestions' ),
 		);
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #544 

<!-- In a few words, what is the PR actually doing? -->
Generate Review Notes experiment was not working with an error shown on screen that read: 
`Bad Request (400) - Invalid JSON payload received. Unknown name "additionalProperties" at 'generation_config.response_schema.properties[0].value.items': Cannot find field. Invalid JSON payload received. Unknown name "additionalProperties" at 'generation_config.response_schema': Cannot find field.
`
This PR fixed that, allowing the feature to work again.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As mentioned above, it fixes the Review Notes feature.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR just removes the `'additionalProperties' => false` pair from the items and the root schema of Review Note Suggestions.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: No

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Just try generating the Review Notes normally. They should generate the suggestions instead of throwing an error.

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Bug preventing review note suggestions from getting generated

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginZipFile%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-543-c8090512f6ac7dc7181f3dd03785a32952fd698f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->