### PR TITLE
Fix: Bug: Empty space shown for Model field when saved provider no longer exists

### DIFF
--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, Spinner } from '@wordpress/components';
+import { Button, Notice, Spinner } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
@@ -105,6 +105,9 @@ export function DeveloperSettings( {
 	);
 
 	const hasSavedSelection = settings.provider !== '' || settings.model !== '';
+	const hasStaleProvider =
+		!! settings.provider &&
+		! providers.find( ( p ) => p.id === settings.provider );
 
 	if ( capability === 'none' ) {
 		return (
@@ -134,6 +137,18 @@ export function DeveloperSettings( {
 			) }
 			{ ! isLoading && ! fetchError && (
 				<>
+					{ hasStaleProvider && (
+						<Notice
+							className="ai-developer-mode-fields__notice"
+							status="warning"
+							isDismissible={ false }
+						>
+							{ __(
+								'The previously selected provider is no longer available. This feature will not function as expected until a valid provider is selected or the selection is reset to default.',
+								'ai'
+							) }
+						</Notice>
+					) }
 					<div ref={ formWrapperRef }>
 						<DataForm< DeveloperSelection >
 							data={ settings }

--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -1,11 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { Button, Notice, Spinner } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { DataForm } from '@wordpress/dataviews';
 import type { Field, Form } from '@wordpress/dataviews';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Notice } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -138,16 +139,14 @@ export function DeveloperSettings( {
 			{ ! isLoading && ! fetchError && (
 				<>
 					{ hasStaleProvider && (
-						<Notice
-							className="ai-developer-mode-fields__notice"
-							status="warning"
-							isDismissible={ false }
-						>
-							{ __(
-								'The previously selected provider is no longer available. This feature will not function as expected until a valid provider is selected or the selection is reset to default.',
-								'ai'
-							) }
-						</Notice>
+						<Notice.Root className="ai-developer-mode-fields__notice" intent="warning">
+							<Notice.Description>
+								{ __(
+									'The previously selected provider is no longer available. This feature will not function as expected until a valid provider is selected or the selection is reset to default.',
+									'ai'
+								) }
+							</Notice.Description>
+						</Notice.Root>
 					) }
 					<div ref={ formWrapperRef }>
 						<DataForm< DeveloperSelection >

--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -78,7 +78,9 @@ export function DeveloperSettings( {
 				id: 'model',
 				type: 'text' as const,
 				label: __( 'Model', 'ai' ),
-				isVisible: ( data: DeveloperSelection ) => !! data.provider,
+				isVisible: ( data: DeveloperSelection ) =>
+					!! data.provider &&
+					!! providers.find( ( p ) => p.id === data.provider ),
 				getElements: getModelElements,
 				Edit: 'select',
 			},

--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -139,7 +139,10 @@ export function DeveloperSettings( {
 			{ ! isLoading && ! fetchError && (
 				<>
 					{ hasStaleProvider && (
-						<Notice.Root className="ai-developer-mode-fields__notice" intent="warning">
+						<Notice.Root
+							className="ai-developer-mode-fields__notice"
+							intent="warning"
+						>
 							<Notice.Description>
 								{ __(
 									'The previously selected provider is no longer available. This feature will not function as expected until a valid provider is selected or the selection is reset to default.',

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -70,6 +70,10 @@
 		line-height: 1.4;
 	}
 
+	.ai-developer-mode-fields__notice {
+		margin-bottom: var(--wpds-dimension-gap-lg, 12px);
+	}
+
 	.ai-developer-mode-fields__reset-button {
 		margin-top: var(--wpds-dimension-gap-lg, 12px);
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/551

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR removes the extra empty space, when provider and model are selected, and then provider is removed, it shows blank space in model selection area in settings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR checks for current providers fetched and what is stored in settings. If current providers does not have that data, the field would not render.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): GitHub Copilot, Claude
Model(s): Claude Opus 4.6
Used for: Used for issue creation and PR description, plus review the approach.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open Developer Settings for any feature.
2. Select a provider from the Provider dropdown.
3. Select a model from the Model dropdown.
4. Remove the selected provider (e.g., deactivate/delete the provider integration).
5. Return to Developer Settings for the same feature.
6. You would see there is no extra spacing.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ------ |
| <img width="1440" height="713" alt="Image" src="https://github.com/user-attachments/assets/d51d48c7-a974-4bce-b125-eedfd2630a21" /> | <img width="1440" height="752" alt="Screenshot 2026-05-14 at 12 43 19 PM" src="https://github.com/user-attachments/assets/7447c4dc-0263-4fb5-b32c-17b2e0e0cb13" /> |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Fixed - Empty space shown for Model field when saved provider no longer exists in developer settings.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-552-8b3d41a2b2c9fd70b3581213c2ede39521acb1ec.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->