### PR TITLE
Add a default cooldown of 7 days for GitHub Action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     groups:
       github-actions-updates:
         patterns: ['*']
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: composer
     directory: '/'


### PR DESCRIPTION
## What?

Adds a default cooldown of 7 days for GitHub Action updates via Dependabot.

## Why?

Ensure Dependabot doesn't prompt us to update a package that was updated recently, leading to a higher risk for exploits.

See https://github.com/WordPress/performance/pull/2277 for more details.

## How?

Adds a cooldown config option for GitHub Action updates. Note we already have a cooldown option set for composer and npm updates

### Use of AI Tools

None

## Testing Instructions

n/a

## Changelog Entry

> Developer - Add a 7 day cooldown period for GitHub Action updates triggered by Dependabot.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-553-819f9d41ef2012dc17bbb053a01ee228806f0339.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->