### PR TITLE
Fix automatic comment moderation without provider

### DIFF
--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -292,6 +292,10 @@ class Comment_Moderation extends Abstract_Feature {
 	 * @param int $comment_id Comment ID.
 	 */
 	public function moderate_comment( $comment_id ): void {
+		if ( ! has_ai_credentials() ) {
+			return;
+		}
+
 		$comment = get_comment( (int) $comment_id );
 		if ( ! $comment || ! is_a( $comment, '\WP_Comment' ) ) {
 			return;

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -267,6 +267,28 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test moderate_comment() skips automatic analysis when credentials are missing.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_moderate_comment_skips_analysis_when_credentials_are_missing() {
+		remove_filter( 'wpai_has_ai_credentials', '__return_true' );
+
+		$comment_id = $this->create_comment_without_hooks();
+		$experiment = new Comment_Moderation();
+
+		$experiment->moderate_comment( $comment_id );
+
+		$this->assertSame(
+			'',
+			get_comment_meta( $comment_id, Comment_Moderation::META_ANALYSIS_STATUS, true ),
+			'Automatic analysis should not mark comments as failed when no provider credentials are configured.'
+		);
+		$this->assertSame( '', get_comment_meta( $comment_id, Comment_Moderation::META_SENTIMENT, true ) );
+		$this->assertSame( '', get_comment_meta( $comment_id, Comment_Moderation::META_TOXICITY_SCORE, true ) );
+	}
+
+	/**
 	 * Filters the analysis result for tests.
 	 *
 	 * @since 0.9.0


### PR DESCRIPTION
## What?

Prevents automatic Comment Moderation from attempting to analyze newly inserted comments when no AI provider credentials are configured.

## Why?

Manual Comment Moderation actions already avoid running analysis without provider credentials. The automatic `wp_insert_comment` path did not, which could silently mark new comments with `_wpai_analysis_status=failed` even though no provider was configured.

## How?

- Added an early credentials check before automatic comment analysis runs.
- Added a regression test to confirm no moderation meta is written when credentials are missing.

## Testing Instructions

1. Enable the AI plugin and Comment Moderation experiment.
2. Ensure no AI provider credentials are configured.
3. Add a new comment.
4. Confirm the comment is not marked with `_wpai_analysis_status=failed`.

Tested locally with:

```bash
vendor/bin/phpunit -c phpunit.xml.dist tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
composer run-script lint

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-554-00550cbd0065897bd318ea59eb6f7db5e5178058.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->