### PR TITLE
Fix meta description no-provider modal

### DIFF
--- a/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
@@ -28,6 +28,7 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 		isGenerating,
 		suggestion,
 		currentDescription,
+		ensureProviderAvailable,
 		generateDescription,
 		applyDescription,
 	} = useMetaDescription();
@@ -40,12 +41,18 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 
 	const handleOpenModal = async () => {
 		setEditableText( currentDescription );
-		setIsModalOpen( true );
 
 		// Auto-generate on first open if no existing description.
 		if ( ! hasDescription ) {
+			if ( ! ensureProviderAvailable() ) {
+				return;
+			}
+			setIsModalOpen( true );
 			await generateDescription();
+			return;
 		}
+
+		setIsModalOpen( true );
 	};
 
 	const handleOpenEditModal = () => {
@@ -55,6 +62,9 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 
 	const handleRegenerate = async () => {
 		setEditableText( currentDescription );
+		if ( ! ensureProviderAvailable() ) {
+			return;
+		}
 		setIsModalOpen( true );
 		await generateDescription();
 	};

--- a/src/experiments/meta-description/components/useMetaDescription.ts
+++ b/src/experiments/meta-description/components/useMetaDescription.ts
@@ -33,6 +33,7 @@ interface UseMetaDescriptionReturn {
 	currentDescription: string;
 	metaKey: string;
 	hasSeoPlugin: boolean;
+	ensureProviderAvailable: () => boolean;
 	generateDescription: () => Promise< void >;
 	applyDescription: ( text: string ) => void;
 }
@@ -53,6 +54,11 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 	const [ isGenerating, setIsGenerating ] = useState( false );
 	const [ suggestion, setSuggestion ] =
 		useState< MetaDescriptionSuggestion | null >( null );
+
+	const ensureProviderAvailable = useCallback(
+		() => ensureProvider( NOTICE_ID ),
+		[]
+	);
 
 	const { postId, content, title, meta } = useSelect( ( select ) => {
 		const editor = select( editorStore );
@@ -133,6 +139,7 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 		currentDescription: meta?.[ metaKey ] ?? '',
 		metaKey,
 		hasSeoPlugin,
+		ensureProviderAvailable,
 		generateDescription,
 		applyDescription,
 	};

--- a/tests/e2e/specs/experiments/no-provider-degradation.spec.js
+++ b/tests/e2e/specs/experiments/no-provider-degradation.spec.js
@@ -140,7 +140,7 @@ test.describe( 'Graceful degradation when no AI provider is configured', () => {
 		await expectProviderNotice( page );
 	} );
 
-	test( 'Meta Description shows notice when clicking Generate without a provider', async ( {
+	test( 'Meta Description shows notice without opening the modal when no provider exists', async ( {
 		admin,
 		editor,
 		page,
@@ -166,11 +166,9 @@ test.describe( 'Graceful degradation when no AI provider is configured', () => {
 		await expect( generateButton ).toBeVisible( { timeout: 5000 } );
 		await generateButton.click();
 
-		// The modal opens and generateDescription() fires — close it first.
-		const cancelButton = page.getByRole( 'button', { name: 'Cancel' } );
-		if ( ( await cancelButton.count() ) > 0 ) {
-			await cancelButton.click();
-		}
+		await expect(
+			page.locator( '.ai-meta-description-modal' )
+		).not.toBeVisible();
 
 		await expectProviderNotice( page );
 	} );


### PR DESCRIPTION
## What?

Prevents the Meta Description modal from opening when no AI provider is configured.

## Why?

When clicking **Generate Meta Description** without a configured AI Connector, the plugin correctly shows the provider warning. However, the Meta Description modal also opened even though generation could not proceed.

This made the UI feel inconsistent with the other no-provider flows, where the user only sees the provider notice and is directed to configure a connector.

## How?

- Checks provider availability before opening the Meta Description modal for generation.
- Keeps the existing provider warning and `Manage Connectors` action.
- Keeps manual editing unchanged when a meta description already exists.
- Updates the existing no-provider E2E test to confirm the modal does not open.

### Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

## Testing Instructions

1. Ensure no AI Connector API key is configured.
2. Enable AI features and the Meta Description Generation experiment.
3. Open a new post in the block editor.
4. Expand the Meta Description panel.
5. Click **Generate Meta Description**.
6. Confirm the provider warning appears with a **Manage Connectors** link.
7. Confirm the Meta Description modal does not open.

Automated checks run locally:

- `npm run lint:js -- src/experiments/meta-description/components/useMetaDescription.ts src/experiments/meta-description/components/MetaDescriptionPanel.tsx tests/e2e/specs/experiments/no-provider-degradation.spec.js`
- `npm run typecheck`
- `npm run test:e2e -- tests/e2e/specs/experiments/no-provider-degradation.spec.js`

## Screenshots or screencast

### Before

No provider is configured. The warning appears, but the Meta Description modal also opens even though generation cannot proceed.

<img width="1235" height="998" alt="wp-ai-meta-description-before" src="https://github.com/user-attachments/assets/7e317cfd-0d56-4969-bf86-b4263d95171b" />

### After

No provider is configured. The same warning appears, but the Meta Description modal stays closed.

<img width="1235" height="998" alt="wp-ai-meta-description-after" src="https://github.com/user-attachments/assets/a3ecfc36-1921-4e40-9b11-f7a804f2101c" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-558-9a3aa0ca97244805c2f429ec990ee75beddba9d0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->