### PR TITLE
Fix Alt-Text generation on decorative images resulting in false error message in Media Lib

### DIFF
--- a/src/experiments/alt-text-generation/bulk.ts
+++ b/src/experiments/alt-text-generation/bulk.ts
@@ -11,12 +11,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { runAbility } from '../../utils/run-ability';
+import { generateAltText } from '../../utils/generate-alt-text';
 import { isProviderAvailable } from '../../utils/provider-status';
-
-type AbilityResponse = {
-	alt_text?: string;
-};
 
 type BulkData = {
 	attachmentIds: number[];
@@ -27,8 +23,6 @@ declare global {
 		aiAltTextGenerationBulkData?: BulkData;
 	}
 }
-
-const ABILITY_NAME = 'ai/alt-text-generation';
 
 /**
  * Creates and injects a dismissible admin notice into the page.
@@ -102,18 +96,8 @@ async function processBulkAltText(): Promise< void > {
 
 	for ( const id of attachmentIds ) {
 		try {
-			const response = await runAbility< AbilityResponse >(
-				ABILITY_NAME,
-				{
-					attachment_id: id,
-				}
-			);
-
-			const altText = response?.alt_text;
-
-			if ( ! altText ) {
-				throw new Error( __( 'Empty response received.', 'ai' ) );
-			}
+			const result = await generateAltText( id );
+			const altText = result.alt_text;
 
 			await apiFetch( {
 				path: `/wp/v2/media/${ id }`,

--- a/src/experiments/alt-text-generation/media.ts
+++ b/src/experiments/alt-text-generation/media.ts
@@ -10,13 +10,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import type { AltTextGenerationAbilityInput } from './types';
-import { runAbility } from '../../utils/run-ability';
+import {
+	generateAltText,
+	type AltTextGenerationResult,
+} from '../../utils/generate-alt-text';
 import { isProviderAvailable } from '../../utils/provider-status';
-
-type AbilityResponse = {
-	alt_text?: string;
-};
 
 type FieldContext = {
 	getAttachmentId: () => number | null;
@@ -50,8 +48,6 @@ declare global {
 		};
 	}
 }
-
-const ABILITY_NAME = 'ai/alt-text-generation';
 
 class AltTextMediaControls {
 	private context: FieldContext;
@@ -136,8 +132,6 @@ class AltTextMediaControls {
 	 * Handles the generate button click.
 	 *
 	 * @since 0.3.0
-	 *
-	 * @return The generated alt text.
 	 */
 	private async handleGenerate(): Promise< void > {
 		if (
@@ -166,15 +160,23 @@ class AltTextMediaControls {
 		this.setStatus( __( 'Generating alt text…', 'ai' ) );
 
 		try {
-			const generated = await requestAltText( this.context );
-			this.textarea.value = generated;
+			const result = await requestAltText( this.context );
+			this.textarea.value = result.alt_text;
 			this.textarea.dispatchEvent(
 				new Event( 'input', { bubbles: true } )
 			);
 			this.textarea.dispatchEvent(
 				new Event( 'change', { bubbles: true } )
 			);
-			this.setStatus( __( 'Alt text generated and applied.', 'ai' ) );
+
+			const message = result.is_decorative
+				? __(
+						'Image identified as decorative. Alt text cleared.',
+						'ai'
+				  )
+				: __( 'Alt text generated and applied.', 'ai' );
+
+			this.setStatus( message );
 		} catch ( error ) {
 			const message = getErrorMessage( error );
 			this.setStatus( message, true );
@@ -210,37 +212,18 @@ class AltTextMediaControls {
  * @since 0.3.0
  *
  * @param context The field context.
- * @return The generated alt text.
+ * @return The generated alt text result.
  */
-async function requestAltText( context: FieldContext ): Promise< string > {
-	const params: AltTextGenerationAbilityInput = {};
+async function requestAltText(
+	context: FieldContext
+): Promise< AltTextGenerationResult > {
 	const attachmentId = context.getAttachmentId();
+	const imageUrl = context.getImageUrl();
 
-	if ( attachmentId ) {
-		params.attachment_id = attachmentId;
-	} else {
-		const imageUrl = context.getImageUrl();
-		if ( imageUrl ) {
-			params.image_url = imageUrl;
-		}
-	}
-
-	if ( Object.keys( params ).length === 0 ) {
-		throw new Error(
-			__( 'Unable to determine which image to describe.', 'ai' )
-		);
-	}
-
-	const response = await runAbility< AbilityResponse >(
-		ABILITY_NAME,
-		params
+	return await generateAltText(
+		attachmentId ?? undefined,
+		imageUrl ?? undefined
 	);
-
-	if ( response?.alt_text ) {
-		return response.alt_text;
-	}
-
-	throw new Error( __( 'Failed to generate alt text.', 'ai' ) );
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/557

<!-- In a few words, what is the PR actually doing? -->
This PR resolves the false image alt-text generation error observed when an image is decorative.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It improves the UX flow and ensures the ambiguous error is fixed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Utilises `generateAltText()` method in `media.ts` and `bulk.ts` of alt-text-generation experiment.
- Adds 'Image identified as decorative. Alt text cleared.' text in media library to enhance UX and properly resolve the earlier ambiguous error.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3 Flash
Used for: Refactoring the code; final implementation was reviewed by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Configure an AI Connector and enable the Alt Text Generation experiment.
2. Upload an image the model is likely to mark decorative (e.g. a thin divider line, a solid color block, a purely ornamental flourish).
3. Single image: open the attachment in the Media Library, click Generate in the alt text panel.
- Observe: "Image identified as decorative. Alt text cleared" success result.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

<img width="2476" height="1388" alt="image" src="https://github.com/user-attachments/assets/4d4155dd-8511-4c63-b2c0-16a62a285ffc" />


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - False error for Alt-Text generation on decorative images in media library

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-559-6fcb2284d973518855384239633017b7e8b76a1c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->