### PR TITLE
Fix bulk alt text no-provider notice

### DIFF
--- a/src/experiments/alt-text-generation/bulk.ts
+++ b/src/experiments/alt-text-generation/bulk.ts
@@ -30,11 +30,15 @@ declare global {
  * @since 0.7.0
  *
  * @param message The initial message to display in the notice.
+ * @param type    The admin notice type.
  * @return The paragraph element used to update the notice message.
  */
-function createNotice( message: string ): HTMLParagraphElement {
+function createNotice(
+	message: string,
+	type: 'info' | 'error' = 'info'
+): HTMLParagraphElement {
 	const notice = document.createElement( 'div' );
-	notice.className = 'notice notice-info is-dismissible';
+	notice.className = `notice notice-${ type } is-dismissible`;
 
 	const paragraph = document.createElement( 'p' );
 	paragraph.textContent = message;
@@ -77,7 +81,7 @@ async function processBulkAltText(): Promise< void > {
 	);
 
 	if ( ! isProviderAvailable() ) {
-		createNotice( noProviderMessage );
+		createNotice( noProviderMessage, 'error' );
 		return;
 	}
 

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -12,10 +12,12 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
  * Internal dependencies
  */
 const {
+	clearCredentials,
 	disableExperiment,
 	disableExperiments,
 	enableExperiment,
 	enableExperiments,
+	seedCredentials,
 } = require( '../../utils/helpers' );
 
 // Path to a test image (1x1 PNG) used for media upload in E2E tests.
@@ -447,6 +449,52 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		// Verify query args have been stripped from the URL.
 		expect( page.url() ).not.toContain( 'wpai_bulk_alt_text' );
 		expect( page.url() ).not.toContain( 'wpai_attachment_ids' );
+	} );
+
+	test( 'Bulk action shows an error notice when no provider is configured', async ( {
+		admin,
+		requestUtils,
+		page,
+	} ) => {
+		await clearCredentials( requestUtils );
+
+		try {
+			// Globally turn on Experiments.
+			await enableExperiments( admin, page );
+
+			// Enable the Alt Text Generation Experiment.
+			await enableExperiment( admin, page, 'Alt Text Generation' );
+
+			// Upload a test image.
+			await requestUtils.uploadMedia( TEST_IMAGE_PATH );
+
+			// Navigate to Media Library in list mode.
+			await admin.visitAdminPage( 'upload.php', 'mode=list' );
+
+			// Select all items via the header checkbox.
+			await page.locator( '#cb-select-all-1' ).check();
+
+			// Choose the bulk action.
+			await page
+				.locator( '#bulk-action-selector-top' )
+				.selectOption( 'wpai_generate_alt_text' );
+
+			// Click Apply.
+			await page.locator( '#doaction' ).click();
+
+			await expect(
+				page.locator( '.notice-error p', {
+					hasText:
+						'This feature requires a valid AI Connector to function properly.',
+				} )
+			).toBeVisible( { timeout: 30000 } );
+
+			// Verify query args have been stripped from the URL.
+			expect( page.url() ).not.toContain( 'wpai_bulk_alt_text' );
+			expect( page.url() ).not.toContain( 'wpai_attachment_ids' );
+		} finally {
+			await seedCredentials( requestUtils );
+		}
 	} );
 
 	test( 'Query args are stripped from URL after generation completes', async ( {


### PR DESCRIPTION
## What?

Updates the bulk Alt Text Generation no-provider message to use an error admin notice.

## Why?

When running the Media Library bulk **Generate Alt Text** action without a configured AI Connector, generation cannot proceed.

The existing message explained the problem, but it used a neutral info notice even though the action failed. Using an error notice makes the state clearer and better matches the severity of the issue.

## How?

- Allows the bulk alt text notice helper to render either info or error notices.
- Uses an error notice when no AI provider is configured.
- Adds E2E coverage for the no-provider bulk action path.

### Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

## Testing Instructions

1. Use WordPress 7.0 RC4.
2. Ensure no AI Connector API key is configured.
3. Enable AI features and the Alt Text Generation experiment.
4. Open Media Library in list view.
5. Select one or more images.
6. Choose **Generate Alt Text** from the bulk actions dropdown.
7. Click **Apply**.
8. Confirm an error notice appears explaining that an AI Connector is required.

Automated checks run locally:

- `npm run lint:js -- src/experiments/alt-text-generation/bulk.ts tests/e2e/specs/experiments/alt-text-generation.spec.js`
- `npm run typecheck`
- `npm run build`
- `npm run test:e2e -- tests/e2e/specs/experiments/alt-text-generation.spec.js --project=chromium --grep "Bulk action shows an error notice when no provider is configured"`

## Screenshots or screencast

### Before

No provider is configured. The bulk action cannot generate alt text, but the message appears as an info notice.

<img width="2472" height="1292" alt="before" src="https://github.com/user-attachments/assets/fc7a584a-9f59-4183-ac13-28dd99fd7740" />

### After

No provider is configured. The same message appears as an error notice.

<img width="2464" height="1446" alt="after" src="https://github.com/user-attachments/assets/eaaf57db-b631-4ac8-960c-258555328a68" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-561-8d67c57389bab262b8807fa4ed209e6d3dbc1ac7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->