### PR TITLE
UX: Update AI Connector notice to warning style

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -1025,7 +1025,7 @@ function AISettingsPage() {
 			>
 				<Stack className="ai-settings-page" direction="column" gap="md">
 					{ ! PAGE_DATA.hasValidCredentials && (
-						<Notice.Root intent="error">
+						<Notice.Root intent="warning">
 							<Notice.Description>
 								{ ! PAGE_DATA.hasCredentials
 									? __(

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -37,7 +37,7 @@ test.describe( 'Plugin settings', () => {
 		await seedCredentials( requestUtils );
 	} );
 
-	test( 'Can visit the settings page and see error message', async ( {
+	test( 'Can visit the settings page and see warning message', async ( {
 		admin,
 		page,
 		requestUtils,
@@ -58,7 +58,7 @@ test.describe( 'Plugin settings', () => {
 			)
 		).toBeVisible();
 
-		// Ensure the no AI Connectors error message is displayed.
+		// Ensure the no AI Connectors warning message is displayed.
 		await expect(
 			page
 				.locator( '#ai-wp-admin-app' )


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #564

This PR updates the AI Connector notice on the settings page from a destructive/red `error` styling to a yellow `warning` styling.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, the notice indicating that no AI Connectors are configured is displayed using a red error banner.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
* Changed the `intent` prop on `<Notice.Root>` from `"error"` to `"warning"` in stage.tsx

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Clear or deactivate all configured AI Connectors in your WordPress administration dashboard.
2. Navigate to the AI plugin settings page.
3. Verify that the notice at the top is displayed with a **warning/yellow** styling and a caution icon instead of a destructive/red alert.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1470" height="837" alt="Screenshot 2026-05-18 at 1 14 38 PM" src="https://github.com/user-attachments/assets/b832cc30-eb48-4a7a-be43-36510e265f2c" />|<img width="1468" height="837" alt="Screenshot 2026-05-18 at 1 14 20 PM" src="https://github.com/user-attachments/assets/827df878-aec4-46c6-9380-37d811088af7" />|

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - Update AI Connector setup notice styling from error to warning.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-565-49c931fc5b498768af518442c747b89dfdc6da1d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->