### PR TITLE
fix: respect global AI toggle for post utility abilities

### DIFF
--- a/includes/Main.php
+++ b/includes/Main.php
@@ -127,8 +127,22 @@ final class Main {
 				( new Dashboard_Widgets( $registry ) )->init();
 			}
 
-			// Register our post-related WordPress Abilities.
-			( new Posts() )->register();
+			/**
+			 * Filters whether to enable AI features.
+			 *
+			 * @since 0.6.0
+			 *
+			 * @param bool $enabled Whether to enable AI features.
+			 */
+			$features_enabled = (bool) apply_filters( 'wpai_features_enabled', true );
+
+			// Read the admin UI database option (the 'Enable AI' setting).
+			$global_enabled = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
+
+			// Register post-related Abilities only when AI is globally enabled and not disabled via filter.
+			if ( $features_enabled && $global_enabled ) {
+				( new Posts() )->register();
+			}
 		} catch ( \Throwable $e ) {
 			_doing_it_wrong(
 				__METHOD__,


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/563

<!-- In a few words, what is the PR actually doing? -->
This PR ensures that post utility abilities (`ai/get-post-details` and `ai/get-post-terms`) are only registered when the global "Enable AI" setting is turned on.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`Posts::register()` was being called unconditionally inside `Main::initialize_features()`, bypassing the global AI setting entirely. This meant that turning "Enable AI" off in the admin settings had no effect on these two abilities, they remained registered.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Wrapped `Posts::register()` in a similar check as used by `Features\Loader::initialize_features()`:

1. `$features_enabled = apply_filters( 'wpai_features_enabled', true );`: Respects developer-level programmatic overrides.
2. `$global_enabled = get_option( Settings_Registration::GLOBAL_OPTION, false );`: Respects the admin "Enable AI" UI setting.

`Posts::register()` now only runs when both conditions are true, bringing the utility abilities in line with how all other plugin features handle the global AI toggle.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): Antigravity
Model(s): Claude
Used for: Tracing the root cause through the codebase, validating the fix approach, and reviewing documentation/comments. Final implementation, code review, and all decisions were made by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable "Enable AI" in **Settings → AI**.
2. Make a `GET` request to `/wp-json/wp-abilities/v1/abilities` (authenticated via Application Password).
3. Confirm `ai/get-post-details` is present in the response.
4. Go to **Settings → AI** and disable "Enable AI". Save.
5. Repeat the `GET` request.
6. Confirm `ai/get-post-details` and `ai/get-post-terms` are **no longer present** in the response.

Alternatively, you can verify the raw registration state via WP-CLI:
**When AI is enabled:**
```bash
wp eval 'echo wp_get_ability("ai/get-post-terms") ? "registered\n" : "missing\n";'
```
Expected output: `registered`

**When AI is disabled:**
```bash
wp eval 'echo wp_get_ability("ai/get-post-terms") ? "registered\n" : "missing\n";'
```
Expected output: `missing`

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/cca916db-879b-4d51-ab1f-9e2bf40a995d

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Post utility abilities (ai/get-post-details, ai/get-post-terms) are now correctly hidden when the global "Enable AI" setting is disabled.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-566-0ca6830d048a3ff38b2c27d962ba5c12332f0963.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->