### PR TITLE
Fix failed comment moderation badge rendering

### DIFF
--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -631,6 +631,8 @@ class Comment_Moderation extends Abstract_Feature {
 			$this->render_pending_badge( $comment_id );
 		} elseif ( self::STATUS_PROCESSING === $status ) {
 			$this->render_processing_badge( $comment_id );
+		} elseif ( self::STATUS_FAILED === $status ) {
+			$this->render_failed_badge();
 		} else {
 			// Empty or not analyzed - show dash.
 			echo '<span class="ai-badge ai-badge--empty">—</span>';
@@ -653,6 +655,8 @@ class Comment_Moderation extends Abstract_Feature {
 			$this->render_pending_badge( $comment_id );
 		} elseif ( self::STATUS_PROCESSING === $status ) {
 			$this->render_processing_badge( $comment_id );
+		} elseif ( self::STATUS_FAILED === $status ) {
+			$this->render_failed_badge();
 		} else {
 			// Empty or not analyzed - show dash.
 			echo '<span class="ai-badge ai-badge--empty">—</span>';
@@ -739,6 +743,18 @@ class Comment_Moderation extends Abstract_Feature {
 			'<span class="ai-badge ai-badge--processing" data-comment-id="%d" data-ai-status="processing">%s</span>',
 			absint( $comment_id ),
 			esc_html__( 'Analyzing…', 'ai' )
+		);
+	}
+
+	/**
+	 * Renders a failed analysis badge.
+	 *
+	 * @since x.x.x
+	 */
+	private function render_failed_badge(): void {
+		printf(
+			'<span class="ai-badge ai-badge--failed">%s</span>',
+			esc_html__( 'Failed', 'ai' )
 		);
 	}
 

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -36,6 +36,7 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	private function create_comment_without_hooks(): int {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Direct insert avoids comment hooks for moderation tests.
 		$wpdb->insert(
 			$wpdb->comments,
 			array(
@@ -445,6 +446,32 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 
 		$this->assertStringContainsString( 'data-ai-status="pending"', $output );
 		$this->assertStringContainsString( 'data-comment-id="' . $comment_id . '"', $output );
+	}
+
+	/**
+	 * Test render_column() outputs failed badge markup for failed status.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_render_column_outputs_failed_badge_for_failed_status() {
+		wp_set_current_user( $this->admin_user_id );
+		$comment_id = $this->create_comment_without_hooks();
+		update_comment_meta( $comment_id, Comment_Moderation::META_ANALYSIS_STATUS, Comment_Moderation::STATUS_FAILED );
+
+		$experiment = new Comment_Moderation();
+
+		ob_start();
+		$experiment->render_column( 'wpai_sentiment', $comment_id );
+		$sentiment_output = ob_get_clean();
+
+		ob_start();
+		$experiment->render_column( 'wpai_toxicity', $comment_id );
+		$toxicity_output = ob_get_clean();
+
+		$this->assertStringContainsString( 'ai-badge--failed', $sentiment_output );
+		$this->assertStringContainsString( 'Failed', $sentiment_output );
+		$this->assertStringContainsString( 'ai-badge--failed', $toxicity_output );
+		$this->assertStringContainsString( 'Failed', $toxicity_output );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Keeps failed Comment Moderation analysis visible after the comments page is reloaded.

## Why?

When comment analysis fails during lazy analysis, the comments table briefly shows the expected red **Failed** badge. However, after reloading the page, the same saved `failed` analysis status is rendered as `—`.

This makes a failed analysis look the same as a comment that has not been analyzed.

## How?

- Renders the existing `failed` analysis status in the Sentiment and Toxicity columns.
- Reuses the existing `ai-badge--failed` styling.
- Adds integration test coverage for failed status rendering in both columns.

### Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

## Testing Instructions

1. Enable AI features and the Comment Moderation experiment.
2. Create or use a comment with `_wpai_analysis_status` set to `failed`.
3. Open **Comments** in wp-admin.
4. Confirm the Sentiment and Toxicity columns show **Failed**.
5. Reload the page.
6. Confirm the Sentiment and Toxicity columns still show **Failed** instead of `—`.

Automated checks run locally:

```bash
npm run test:php -- --filter Comment_ModerationTest
npm run lint:php -- includes/Experiments/Comment_Moderation/Comment_Moderation.php tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
```

## Screenshots or screencast

### Before

Failed analysis is shown immediately after lazy analysis fails, but reloading the comments page changes the same failed status back to `—`.

<img width="800" height="515" alt="Before" src="https://github.com/user-attachments/assets/ed071791-c775-4dde-9fbd-a11eae4b906d" />

### After

Failed analysis remains visible as **Failed** after the comments page is reloaded.

<img width="800" height="515" alt="After" src="https://github.com/user-attachments/assets/a1b381d8-ffb6-48ab-a870-37111d4856c6" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-568-918aa93dbefee2b633df20cac8c8a3d028b5444c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->