### PR TITLE
Fix featured image no-provider notice

### DIFF
--- a/src/features/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/features/image-generation/components/GenerateFeaturedImage.tsx
@@ -13,6 +13,9 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { generateImage } from '../functions/generate-image';
 import { uploadImage } from '../functions/upload-image';
+import { ensureProvider } from '../../../utils/provider-status';
+
+const NOTICE_ID = 'ai_image_generation_error';
 
 /**
  * GenerateFeaturedImage component.
@@ -35,11 +38,13 @@ export default function GenerateFeaturedImage(): React.JSX.Element | null {
 	 * Handles the generate button click.
 	 */
 	const handleGenerate = async () => {
+		if ( ! ensureProvider( NOTICE_ID ) ) {
+			return;
+		}
+
 		setIsGenerating( true );
 		setProgress( '' );
-		( dispatch( noticesStore ) as any ).removeNotice(
-			'ai_image_generation_error'
-		);
+		( dispatch( noticesStore ) as any ).removeNotice( NOTICE_ID );
 
 		try {
 			const generatedImageData = await generateImage( content, {
@@ -57,7 +62,7 @@ export default function GenerateFeaturedImage(): React.JSX.Element | null {
 					? error.message
 					: __( 'An error occurred during image generation.', 'ai' );
 			( dispatch( noticesStore ) as any ).createErrorNotice( message, {
-				id: 'ai_image_generation_error',
+				id: NOTICE_ID,
 				isDismissible: true,
 			} );
 		} finally {

--- a/tests/e2e/specs/experiments/no-provider-degradation.spec.js
+++ b/tests/e2e/specs/experiments/no-provider-degradation.spec.js
@@ -140,6 +140,31 @@ test.describe( 'Graceful degradation when no AI provider is configured', () => {
 		await expectProviderNotice( page );
 	} );
 
+	test( 'Featured Image Generation shows notice when clicking Generate without a provider', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await enableExperiment( admin, page, 'Image Generation and Editing' );
+
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'Test Featured Image No Provider',
+			content:
+				'Test content for featured image generation without a provider.',
+		} );
+		await editor.saveDraft();
+		await editor.openDocumentSettingsSidebar();
+
+		const generateButton = page.locator( '.ai-featured-image button', {
+			hasText: 'Generate featured image',
+		} );
+		await expect( generateButton ).toBeVisible( { timeout: 5000 } );
+		await generateButton.click();
+
+		await expectProviderNotice( page );
+	} );
+
 	test( 'Meta Description shows notice without opening the modal when no provider exists', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What?

Fix the Featured Image Generation no-provider behavior.

When no AI connector is configured, clicking **Generate featured image** now shows the shared connector-required notice with the **Manage Connectors** link.

## Why?

Before this change, the featured image flow skipped the shared provider guard and continued into prompt generation. That caused a lower-level error such as:

```text
Failed to generate prompt: Image prompt generation failed. Please ensure you have a connected provider that supports text generation.
```

This was inconsistent with other AI features.

## How?

Use the existing `ensureProvider()` helper before starting featured image generation.

## Testing Instructions

Automated checks run locally:

```bash
npm run lint:js -- src/features/image-generation/components/GenerateFeaturedImage.tsx tests/e2e/specs/experiments/no-provider-degradation.spec.js
npm run build
npm run typecheck
PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 WP_BASE_URL=http://localhost:8889 npm run test:e2e -- tests/e2e/specs/experiments/no-provider-degradation.spec.js --grep "Featured Image Generation"
```

Manual verification:

1. Disable/remove AI connector credentials.
2. Enable **Image Generation and Editing**.
3. Open the post editor.
4. In the Featured Image panel, click **Generate featured image**.
5. Confirm the notice says: “This feature requires an AI Connector to function properly.”
6. Confirm the notice includes the **Manage Connectors** link.

## Screenshots/Screencast

Before:

Shows the lower-level prompt generation error.
<img width="1000" height="260" alt="before" src="https://github.com/user-attachments/assets/5e676bd3-f4a5-4ae1-b295-141900445ea5" />


After:

Shows the shared connector-required notice with the Manage Connectors link.
<img width="1212" height="998" alt="after" src="https://github.com/user-attachments/assets/c2b8ad69-884b-486c-a240-f3eae97e6762" />

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-576-8a2c01c29c005b0ac36c663f0a0a35a6e7cade4d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->