### PR TITLE
Fix: Content Classification: Make character count locale-aware

### DIFF
--- a/src/experiments/content-classification/components/SuggestionPanel.tsx
+++ b/src/experiments/content-classification/components/SuggestionPanel.tsx
@@ -42,6 +42,7 @@ export default function SuggestionPanel( {
 		handleAccept,
 		handleDismiss,
 		handleDismissAll,
+		wordCountType,
 	} = useContentClassification( taxonomy );
 
 	const taxonomyObject: any = select( coreStore ).getTaxonomy( taxonomy );
@@ -73,10 +74,15 @@ export default function SuggestionPanel( {
 
 			{ ! hasEnoughContent && ! hasSuggestions && (
 				<p className="ai-content-classification__hint components-base-control__help">
-					{ __(
-						'Add more content to enable AI suggestions (approximately 150 words).',
-						'ai'
-					) }
+					{ wordCountType === 'words'
+						? __(
+								'Add more content to enable AI suggestions (approximately 150 words).',
+								'ai'
+						  )
+						: __(
+								'Add more content to enable AI suggestions (approximately 150 characters).',
+								'ai'
+						  ) }
 				</p>
 			) }
 

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -130,6 +130,11 @@ export function useContentClassification( taxonomy: string ): {
 	 * translators: If your word count is based on single characters (e.g. East Asian characters),
 	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 	 * Do not translate into your own language.
+	 *
+	 * Uses the default (core) text domain so the word count type stays consistent
+	 * with WordPress core's behavior.
+	 *
+	 * See - https://github.com/WordPress/ai/pull/577#discussion_r3265155502
 	 */
 	// eslint-disable-next-line @wordpress/i18n-text-domain
 	const wordCountType = _x(

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -131,10 +131,10 @@ export function useContentClassification( taxonomy: string ): {
 	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
 	 * Do not translate into your own language.
 	 */
+	// eslint-disable-next-line @wordpress/i18n-text-domain
 	const wordCountType = _x(
 		'words',
-		'Word count type. Do not translate!',
-		'ai'
+		'Word count type. Do not translate!'
 	) as Strategy;
 
 	// Check if content has enough words or characters.

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -5,12 +5,13 @@
 /**
  * WordPress dependencies
  */
+import { _x } from '@wordpress/i18n';
 import { dispatch, select } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
-import { count as wordCount } from '@wordpress/wordcount';
+import { count as wordCount, type Strategy } from '@wordpress/wordcount';
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -26,7 +27,7 @@ import type {
 	ContentClassificationData,
 } from '../types';
 
-const MINIMUM_WORD_COUNT = 150;
+const MINIMUM_WORD_CHARACTER_COUNT = 150;
 const NOTICE_ID = 'ai_content_classification_error';
 
 const getSettings = (): ContentClassificationData =>
@@ -117,6 +118,7 @@ export function useContentClassification( taxonomy: string ): {
 	handleAccept: ( suggestion: TagSuggestion ) => void;
 	handleDismiss: ( suggestion: TagSuggestion ) => void;
 	handleDismissAll: () => void;
+	wordCountType: Strategy;
 } {
 	const postId = select( editorStore ).getCurrentPostId() as number;
 	const content = select( editorStore ).getEditedPostContent();
@@ -124,9 +126,21 @@ export function useContentClassification( taxonomy: string ): {
 	const [ suggestions, setSuggestions ] = useState< TagSuggestion[] >( [] );
 	const { removeNotice, createErrorNotice } = dispatch( noticesStore ) as any;
 
-	// Check if content has enough words.
+	/**
+	 * translators: If your word count is based on single characters (e.g. East Asian characters),
+	 * enter 'characters_excluding_spaces' or 'characters_including_spaces'. Otherwise, enter 'words'.
+	 * Do not translate into your own language.
+	 */
+	const wordCountType = _x(
+		'words',
+		'Word count type. Do not translate!',
+		'ai'
+	) as Strategy;
+
+	// Check if content has enough words or characters.
 	const hasEnoughContent =
-		wordCount( content || '', 'words' ) >= MINIMUM_WORD_COUNT;
+		wordCount( content || '', wordCountType ) >=
+		MINIMUM_WORD_CHARACTER_COUNT;
 
 	const handleGenerate = useCallback( async () => {
 		if ( ! ensureProvider( NOTICE_ID ) ) {
@@ -203,6 +217,7 @@ export function useContentClassification( taxonomy: string ): {
 		handleAccept,
 		handleDismiss,
 		handleDismissAll,
+		wordCountType,
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/571

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR updates the content clasification experiment for suggestion to use dynamic wordCount based on user's locale.
- It uses `words, characters_excluding_spaces, or characters_including_spaces` for wordCount.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Updates the `useContentClassification` to use `wordCountType` as suggested here and most of places, https://github.com/WordPress/gutenberg/blob/1ecc3d2fe9c819af35ef312563805bc16a103036/packages/block-library/src/post-time-to-read/edit.js#L51-L61

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- None

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- Change the site language to Japanese.
- Open a post.
- Copy the following Japanese text multiple times to create content: `こんにちは。`
- Confirm that the Suggest Categories button should enable now.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1440" height="718" alt="Screenshot 2026-05-19 at 2 33 21 PM" src="https://private-user-images.githubusercontent.com/54422211/594536786-944d15d8-8530-4355-892c-a7923310e016.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzkxODE2NTgsIm5iZiI6MTc3OTE4MTM1OCwicGF0aCI6Ii81NDQyMjIxMS81OTQ1MzY3ODYtOTQ0ZDE1ZDgtODUzMC00MzU1LTg5MmMtYTc5MjMzMTBlMDE2LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjA1MTklMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwNTE5VDA5MDIzOFomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTdjODQzYTZmMWYzZmEwNmI5NTY5M2E3MGI1MTNmMmMzZDA2ZDE3MjAwNjJiYTBhNDg0MjBmNTVmZjJhZWJjMDUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JnJlc3BvbnNlLWNvbnRlbnQtdHlwZT1pbWFnZSUyRnBuZyJ9.vRTcCw0bKclxcoZcGAftRflWXMSg5ykPYyMZwk_dvEw" /> | <img width="1440" height="718" alt="Screenshot 2026-05-19 at 2 33 21 PM" src="https://github.com/user-attachments/assets/be8f19d3-2002-49f4-b0b3-3365bd9a4fbe" /> |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Added - Determine wordCountType for content classification experiment to use words or characters based on users locale.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-577-e0c4bb41034c64677d275db6634afc5b98a7b2dc.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->