### PR TITLE
fix(a11y): improve focus visibility on suggested terms

### DIFF
--- a/src/experiments/content-classification/index.scss
+++ b/src/experiments/content-classification/index.scss
@@ -49,6 +49,11 @@
 		&:hover {
 			color: var(--wp-admin-theme-color, #007cba);
 		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color, #3858e9) !important;
+			outline: 2px solid transparent;
+		}
 	}
 
 	&__pill-parent {
@@ -78,6 +83,11 @@
 
 		&:hover {
 			color: #cc1818;
+		}
+
+		&:focus {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, 1.5px) var(--wp-admin-theme-color, #3858e9) !important;
+			outline: 2px solid transparent;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/570

<!-- In a few words, what is the PR actually doing? -->
This PR improves the focus visibility of the suggested term and dismiss buttons inside the Suggested Terms taxonomy pills for keyboard users.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously, keyboard users could not discern which button within a suggested taxonomy pill had focus. This improves accessibility and focus clarity.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added explicit focus styles to the suggested-term action buttons so the focused state is clearly visible, using existing WordPress admin theme variables for consistency.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.1 Pro, Gemini 3 Flash
Used for: Suggesting and implementing the fix. Final implementation was reviewed and edited by me.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open a post with content (about 150+ words).
2. Click “Suggest Categories” to show suggested terms.
3. Use the keyboard (Tab/Shift+Tab) to focus the buttons.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->
Add button is focused:
<img width="280" height="130" alt="Add_Button_Focused" src="https://github.com/user-attachments/assets/261246d6-a581-4241-8525-a4a890bb9649" />

Dismiss button is focused:
<img width="284" height="131" alt="Dismiss_Button_Focused" src="https://github.com/user-attachments/assets/98e0968c-758d-4ed0-bd57-855db4c05e3b" />

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Improve keyboard focus visibility for suggested term actions in content classification.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-580-a17075c8b9b8c1f91bc02cc8f1965c0007f294df.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->