### PR TITLE
Fix JS translation loading and make all text translatable

### DIFF
--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -78,8 +78,8 @@ final class Asset_Loader {
 	 * @param string $file_name The script file name without the .js extension.
 	 */
 	public static function enqueue_script( string $handle, string $file_name ): void {
-		$script_url    = self::ASSET_URL . $file_name . '.js';
-		$asset_data    = self::get_asset_file_data( $file_name );
+		$script_url = self::ASSET_URL . $file_name . '.js';
+		$asset_data = self::get_asset_file_data( $file_name );
 
 		// Bail if there's nothing to enqueue.
 		if ( ! $asset_data ) {

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -78,8 +78,9 @@ final class Asset_Loader {
 	 * @param string $file_name The script file name without the .js extension.
 	 */
 	public static function enqueue_script( string $handle, string $file_name ): void {
-		$script_url = self::ASSET_URL . $file_name . '.js';
-		$asset_data = self::get_asset_file_data( $file_name );
+		$script_url    = self::ASSET_URL . $file_name . '.js';
+		$asset_data    = self::get_asset_file_data( $file_name );
+		$script_handle = self::HANDLE_PREFIX . $handle;
 
 		// Bail if there's nothing to enqueue.
 		if ( ! $asset_data ) {
@@ -87,7 +88,7 @@ final class Asset_Loader {
 		}
 
 		wp_enqueue_script(
-			self::HANDLE_PREFIX . $handle,
+			$script_handle,
 			$script_url,
 			$asset_data['dependencies'],
 			$asset_data['version'],
@@ -97,12 +98,17 @@ final class Asset_Loader {
 		// Localize global data.
 		foreach ( self::$global_data as $object_name => $data ) {
 			wp_add_inline_script(
-				self::HANDLE_PREFIX . $handle,
+				$script_handle,
 				sprintf( 'window.ai%s=%s;', $object_name, wp_json_encode( $data ) ),
 				'before'
 			);
 		}
 		self::$global_data = array();
+
+		// Load translations for strings wrapped with @wordpress/i18n functions.
+		// No path is passed because translations are auto-distributed by
+		// WordPress.org to wp-content/languages/plugins/.
+		wp_set_script_translations( $script_handle, 'ai' );
 	}
 
 	/**

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -80,7 +80,6 @@ final class Asset_Loader {
 	public static function enqueue_script( string $handle, string $file_name ): void {
 		$script_url    = self::ASSET_URL . $file_name . '.js';
 		$asset_data    = self::get_asset_file_data( $file_name );
-		$script_handle = self::HANDLE_PREFIX . $handle;
 
 		// Bail if there's nothing to enqueue.
 		if ( ! $asset_data ) {
@@ -88,7 +87,7 @@ final class Asset_Loader {
 		}
 
 		wp_enqueue_script(
-			$script_handle,
+			self::HANDLE_PREFIX . $handle,
 			$script_url,
 			$asset_data['dependencies'],
 			$asset_data['version'],
@@ -98,17 +97,13 @@ final class Asset_Loader {
 		// Localize global data.
 		foreach ( self::$global_data as $object_name => $data ) {
 			wp_add_inline_script(
-				$script_handle,
+				self::HANDLE_PREFIX . $handle,
 				sprintf( 'window.ai%s=%s;', $object_name, wp_json_encode( $data ) ),
 				'before'
 			);
 		}
 		self::$global_data = array();
-
-		// Load translations for strings wrapped with @wordpress/i18n functions.
-		// No path is passed because translations are auto-distributed by
-		// WordPress.org to wp-content/languages/plugins/.
-		wp_set_script_translations( $script_handle, 'ai' );
+		wp_set_script_translations( self::HANDLE_PREFIX . $handle, 'ai' );
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -504,6 +504,8 @@ class Admin_Page {
 			)
 		);
 
+		$provider_tags = array( 'strong' => array() );
+
 		$screen->add_help_tab(
 			array(
 				'id'      => 'abilities-providers',
@@ -511,9 +513,9 @@ class Admin_Page {
 				'content' =>
 					'<p>' . esc_html__( 'Every ability is associated with a provider that indicates where it comes from:', 'ai' ) . '</p>' .
 					'<ul>' .
-						'<li><strong>' . esc_html__( 'Core', 'ai' ) . '</strong>: ' . esc_html__( 'Built into WordPress itself.', 'ai' ) . '</li>' .
-						'<li><strong>' . esc_html__( 'Plugin', 'ai' ) . '</strong>: ' . esc_html__( 'Registered by an active plugin.', 'ai' ) . '</li>' .
-						'<li><strong>' . esc_html__( 'Theme', 'ai' ) . '</strong>: ' . esc_html__( 'Registered by the active theme.', 'ai' ) . '</li>' .
+						'<li>' . wp_kses( __( '<strong>Core</strong>: Built into WordPress itself.', 'ai' ), $provider_tags ) . '</li>' .
+						'<li>' . wp_kses( __( '<strong>Plugin</strong>: Registered by an active plugin.', 'ai' ), $provider_tags ) . '</li>' .
+						'<li>' . wp_kses( __( '<strong>Theme</strong>: Registered by the active theme.', 'ai' ), $provider_tags ) . '</li>' .
 					'</ul>',
 			)
 		);

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -369,7 +369,9 @@ import './index.scss';
 			}
 
 			const iconHtml = isValid ? '✓' : '✗';
-			const titleText = isValid ? 'Valid' : 'Validation Errors';
+			const titleText = isValid
+				? __( 'Valid', 'ai' )
+				: __( 'Validation Errors', 'ai' );
 			const className = isValid
 				? 'validation-success'
 				: 'validation-error';

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -3,6 +3,11 @@
  */
 
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Global dependencies
  */
 const { aiAbilityExplorer, navigator } = window;
@@ -241,7 +246,9 @@ import './index.scss';
 				'ability-input-schema'
 			);
 			if ( ! schemaElement ) {
-				this.showValidation( true, [ 'JSON syntax is valid' ] );
+				this.showValidation( true, [
+					__( 'JSON syntax is valid', 'ai' ),
+				] );
 				return;
 			}
 
@@ -251,7 +258,7 @@ import './index.scss';
 				schema = JSON.parse( schemaElement.textContent );
 			} catch {
 				this.showValidation( false, [
-					'Failed to parse input schema',
+					__( 'Failed to parse input schema', 'ai' ),
 				] );
 				return;
 			}
@@ -261,7 +268,7 @@ import './index.scss';
 
 			if ( errors.length === 0 ) {
 				this.showValidation( true, [
-					'Input is valid according to the schema',
+					__( 'Input is valid according to the schema', 'ai' ),
 				] );
 			} else {
 				this.showValidation( false, errors );

--- a/src/experiments/comment-moderation/components/LazyAnalysisController.tsx
+++ b/src/experiments/comment-moderation/components/LazyAnalysisController.tsx
@@ -13,6 +13,7 @@ import type React from 'react';
  * WordPress dependencies
  */
 import { useEffect, useCallback, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -127,7 +128,7 @@ function updateBadges( comment: PendingComment, result: AnalysisResult ): void {
  */
 function markBadgeFailed( badge: HTMLElement ): void {
 	badge.className = 'ai-badge ai-badge--failed';
-	badge.textContent = 'Failed';
+	badge.textContent = __( 'Failed', 'ai' );
 	badge.setAttribute( 'data-ai-status', 'failed' );
 }
 
@@ -136,7 +137,7 @@ function markBadgeFailed( badge: HTMLElement ): void {
  */
 function markBadgeProcessing( badge: HTMLElement ): void {
 	badge.className = 'ai-badge ai-badge--processing';
-	badge.textContent = 'Analyzing…';
+	badge.textContent = __( 'Analyzing…', 'ai' );
 	badge.setAttribute( 'data-ai-status', 'processing' );
 }
 

--- a/src/experiments/meta-description/components/useMetaDescription.ts
+++ b/src/experiments/meta-description/components/useMetaDescription.ts
@@ -103,10 +103,7 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 				setSuggestion( response.description );
 			} else {
 				createErrorNotice(
-					__(
-						'No meta description suggestion was generated.',
-						'ai'
-					),
+					__( 'No meta description suggestion was generated.', 'ai' ),
 					{ id: NOTICE_ID, isDismissible: true }
 				);
 			}

--- a/src/experiments/meta-description/components/useMetaDescription.ts
+++ b/src/experiments/meta-description/components/useMetaDescription.ts
@@ -8,6 +8,7 @@
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
 /**
@@ -102,7 +103,10 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 				setSuggestion( response.description );
 			} else {
 				createErrorNotice(
-					'No meta description suggestion was generated.',
+					__(
+						'No meta description suggestion was generated.',
+						'ai'
+					),
 					{ id: NOTICE_ID, isDismissible: true }
 				);
 			}
@@ -110,7 +114,8 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 			const message =
 				typeof error === 'string'
 					? error
-					: error?.message ?? 'Failed to generate meta description.';
+					: error?.message ??
+					  __( 'Failed to generate meta description.', 'ai' );
 
 			createErrorNotice( message, {
 				id: NOTICE_ID,

--- a/tests/Integration/Includes/Asset_LoaderTest.php
+++ b/tests/Integration/Includes/Asset_LoaderTest.php
@@ -134,7 +134,7 @@ class Asset_LoaderTest extends WP_UnitTestCase {
 	/**
 	 * @since 0.8.0
 	 */
-	public function test_enqueue_script_falls_back_to_empty_deps_when_missing(): void {
+	public function test_enqueue_script_succeeds_when_asset_file_omits_dependencies(): void {
 		$this->create_asset_file(
 			'no-deps',
 			array( 'version' => '1.0.0' )
@@ -143,7 +143,8 @@ class Asset_LoaderTest extends WP_UnitTestCase {
 		Asset_Loader::enqueue_script( 'no-deps', 'no-deps' );
 
 		$this->assertTrue( wp_script_is( 'ai_no-deps', 'enqueued' ) );
-		$this->assertSame( array(), wp_scripts()->registered['ai_no-deps']->deps );
+		// wp_set_script_translations() appends wp-i18n to the otherwise empty deps.
+		$this->assertSame( array( 'wp-i18n' ), wp_scripts()->registered['ai_no-deps']->deps );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Fixes internationalization (i18n) gaps across several experiments so that user-facing text is fully translatable.

## Why?

Three problems were found:

1. **JS translations were not working at all.** Strings in JS/TS were wrapped with `@wordpress/i18n` functions, but `wp_set_script_translations()` was never called for any enqueued script. As a result every JS-side string rendered in English regardless of the site locale.
2. **Translatable strings were built by hard concatenation.** In the Abilities Explorer help tab, each provider description was split into two translatable strings joined by a literal `<strong>` tag and `": "`. Translators could not see the full sentence and could not reorder the markup for their language.
3. **Some user-visible text was never wrapped in a translation function.** Toxicity/sentiment badge labels, badge states, an error notice, and JSON validation messages were hardcoded, so they could never be localized and were invisible to the i18n string scanner.

## How?

1. Call `wp_set_script_translations()` for every script enqueued through `Asset_Loader::enqueue_script()`. No path is passed because the plugin is distributed on WordPress.org, which auto-delivers translation JSON to `wp-content/languages/plugins/`.
2. Make each Abilities Explorer provider description a single translatable string with the `<strong>` tag inside, escaped with `wp_kses()` instead of `esc_html__()`.
3. Wrap the remaining hardcoded user-facing strings (badge states, error notice, JSON validation messages and status titles) with `__()`.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Auditing the codebase for i18n issues and drafting the fixes. All changes were reviewed and verified by me.

## Testing Instructions

1. Switch the site to the Japanese (`ja`) locale and make sure the plugin's Japanese translations are installed.
2. Access http://localhost:8890/wp-admin/update-core.php and download any available translations.
3. Confirm JS-side strings now translate.

## Screenshots

### Before

<img width="1248" height="721" alt="image" src="https://github.com/user-attachments/assets/b705c618-e28e-4b2d-b3be-3778f88b8e2d" />

### After
<img width="1248" height="725" alt="image" src="https://github.com/user-attachments/assets/171d6f39-8408-4380-a831-ecb6656fbaf0" />

## Changelog Entry

> Fixed - User-facing text in several experiments is now fully translatable, and JS-side translations are loaded at runtime.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-582-34ed4e6791c2787986564caa316f74686f5dbbe6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->