### PR TITLE
fix: make title and term suggestion UI reactive

### DIFF
--- a/src/experiments/content-classification/components/SuggestionPanel.tsx
+++ b/src/experiments/content-classification/components/SuggestionPanel.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { Button, Flex, FlexItem } from '@wordpress/components';
-import { select } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf } from '@wordpress/i18n';
 import { close as closeIcon, update } from '@wordpress/icons';
@@ -44,7 +44,10 @@ export default function SuggestionPanel( {
 		handleDismissAll,
 	} = useContentClassification( taxonomy );
 
-	const taxonomyObject: any = select( coreStore ).getTaxonomy( taxonomy );
+	const taxonomyObject: any = useSelect(
+		( selectFn ) => selectFn( coreStore ).getTaxonomy( taxonomy ),
+		[ taxonomy ]
+	);
 	const taxonomyLabel: string = taxonomyObject?.name ?? taxonomy;
 
 	const hasSuggestions = suggestions.length > 0;

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { dispatch, select } from '@wordpress/data';
+import { dispatch, select, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 import { useState, useCallback } from '@wordpress/element';
@@ -118,8 +118,14 @@ export function useContentClassification( taxonomy: string ): {
 	handleDismiss: ( suggestion: TagSuggestion ) => void;
 	handleDismissAll: () => void;
 } {
-	const postId = select( editorStore ).getCurrentPostId() as number;
-	const content = select( editorStore ).getEditedPostContent();
+	const { postId, content } = useSelect( ( selectFn ) => {
+		const editor = selectFn( editorStore );
+
+		return {
+			postId: editor.getCurrentPostId() as number,
+			content: editor.getEditedPostContent(),
+		};
+	}, [] );
 	const [ isGenerating, setIsGenerating ] = useState< boolean >( false );
 	const [ suggestions, setSuggestions ] = useState< TagSuggestion[] >( [] );
 	const { removeNotice, createErrorNotice } = dispatch( noticesStore ) as any;
@@ -141,10 +147,12 @@ export function useContentClassification( taxonomy: string ): {
 		removeNotice( NOTICE_ID );
 
 		try {
+			const latestContent = select( editorStore ).getEditedPostContent();
+
 			// Generate suggestions.
 			const result = await generateSuggestions(
 				postId,
-				content,
+				latestContent,
 				taxonomy,
 				settings.strategy,
 				settings.maxSuggestions
@@ -167,7 +175,7 @@ export function useContentClassification( taxonomy: string ): {
 		} finally {
 			setIsGenerating( false );
 		}
-	}, [ postId, content, taxonomy, removeNotice, createErrorNotice ] );
+	}, [ postId, taxonomy, removeNotice, createErrorNotice ] );
 
 	// Remove a suggestion from the list.
 	const removeSuggestionFromList = ( suggestion: TagSuggestion ) => {

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -14,7 +14,7 @@ import {
 	ToolbarGroup,
 	ToolbarButton,
 } from '@wordpress/components';
-import { dispatch, select, useDispatch } from '@wordpress/data';
+import { dispatch, select, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { update } from '@wordpress/icons';
@@ -80,8 +80,14 @@ interface TitleToolbarProps {
 export default function TitleToolbar( {
 	isStandalone = false,
 }: TitleToolbarProps ): React.JSX.Element | null {
-	const postId = select( editorStore ).getCurrentPostId();
-	const title = select( editorStore ).getEditedPostAttribute( 'title' );
+	const { postId, title } = useSelect( ( selectFn ) => {
+		const editor = selectFn( editorStore );
+
+		return {
+			postId: editor.getCurrentPostId(),
+			title: editor.getEditedPostAttribute( 'title' ) as string,
+		};
+	}, [] );
 
 	const { editPost } = useDispatch( editorStore );
 


### PR DESCRIPTION
## What?

Closes #579

Fixes two stale editor state issues in the AI experiment UI:

- the title generation toolbar label was not reactive to title changes
- the content classification suggestion button state was not reactive to content changes
- content classification requests could send stale editor content when generating term suggestions

## Why?

Both issues came from reading editor state with `select()` directly in component render paths instead of subscribing reactively with `useSelect()`.

In title generation, the toolbar could keep showing `Generate` or `Regenerate` based on the title value from the initial render, even after the title changed.

In content classification, the suggest button could remain disabled or enabled based on stale content, and the generate action could submit older content instead of the latest editor state.

## How?

This PR updates the affected components and hook to use reactive editor store reads where UI state depends on live editor data.

- `src/experiments/title-generation/components/TitleToolbar.tsx`
  - Replaced render-time `select()` reads for `postId` and `title` with `useSelect()`
- `src/experiments/content-classification/components/useContentClassification.ts`
  - Replaced render-time `select()` reads for `postId` and `content` with `useSelect()`
  - Updated the generate handler to read the latest editor content at click time before sending the request
- `src/experiments/content-classification/components/SuggestionPanel.tsx`
  - Replaced render-time taxonomy lookup with `useSelect()` for reactive store usage consistency

### Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Implementing the component fixes

## Testing Instructions

1. Enable the `Title Generation` experiment.
2. Open the post editor.
3. Focus the title field so the toolbar appears.
4. Start with an empty title and confirm the button shows `Generate`.
5. Without reloading, add a title and confirm the button updates to `Regenerate`.
6. Clear the title again and confirm the button updates back to `Generate`.
7. Enable the `Content Classification` experiment.
8. Open the `Tags` or `Categories` panel in the post editor.
9. Start with content under roughly 150 words and confirm the suggest button is disabled.
10. Without reloading or closing the panel, add enough content to cross the threshold and confirm the suggest button becomes enabled immediately.
11. Remove enough content to go back below the threshold and confirm the button disables again.
12. Add a distinctive final sentence to the content, trigger `Suggest Tags` or `Suggest Categories`, and verify the generated request uses the latest editor content.

## Screenshots or screencast

### Title generation

| Before | After |
| ------ | ----- |
| [Title before](https://github.com/user-attachments/assets/cb9cb8cf-6d99-4b7e-a49d-fbe6aba89bae) | [Title after](https://github.com/user-attachments/assets/6493a3e1-cf48-41a2-8b35-70348b2bc4ef) |

### Content classification suggestions

| Before | After |
| ------ | ----- |
| [Suggestion before](https://github.com/user-attachments/assets/738c2618-28aa-4bd3-b813-d7590879dc72) | [Suggestion after](https://github.com/user-attachments/assets/f5f1d80c-950b-4cfa-ab05-883a390f5556) |

## Changelog Entry

> Fixed - Make title generation and content classification UI react to current editor state.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-583-43387d2003bdf36de3b34982e9f1157b4dca460b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->