### PR TITLE
Fix Abilities Explorer page heading

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -72,7 +72,7 @@ class Admin_Page {
 		$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : 'list'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		echo '<div class="wrap ability-explorer-wrap">';
-		echo '<h1>' . esc_html__( 'Ability Explorer', 'ai' ) . '</h1>';
+		echo '<h1>' . esc_html__( 'Abilities Explorer', 'ai' ) . '</h1>';
 
 		// Render appropriate view based on action.
 		switch ( $action ) {

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Admin_PageTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Admin_PageTest.php
@@ -201,6 +201,6 @@ class Admin_PageTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertStringContainsString( 'ability-explorer-wrap', $output );
-		$this->assertStringContainsString( 'Ability Explorer', $output );
+		$this->assertStringContainsString( 'Abilities Explorer', $output );
 	}
 }

--- a/tests/e2e/specs/experiments/abilities-explorer.spec.js
+++ b/tests/e2e/specs/experiments/abilities-explorer.spec.js
@@ -46,6 +46,14 @@ test.describe( 'Abilities Explorer Experiment', () => {
 		// Visit the Abilities Explorer page.
 		await admin.visitAdminPage( 'tools.php?page=ai-abilities-explorer' );
 
+		// Ensure the page heading matches the Abilities Explorer label.
+		await expect(
+			page.getByRole( 'heading', {
+				name: 'Abilities Explorer',
+				level: 1,
+			} )
+		).toBeVisible();
+
 		// Ensure the abilities stats section is visible.
 		await expect(
 			page.locator( '.ability-explorer-wrap .ability-explorer-stats' )


### PR DESCRIPTION
## What?

Fixes the Abilities Explorer admin page heading so it matches the feature name used everywhere else in the UI.

The page title and Tools menu already use “Abilities Explorer”, but the page heading showed “Ability Explorer”.

## Why?

The mismatch is visible in the WordPress admin and makes the experiment name inconsistent across the same screen.

## How?

- Updates the Abilities Explorer page `<h1>` from “Ability Explorer” to “Abilities Explorer”.
- Updates the existing PHP integration assertion.
- Adds E2E coverage for the visible page heading.

## Testing Instructions

Automated checks run locally:

```bash
npm run build
npm run lint:js
npm run typecheck
npm run test:php
npm run lint:php
npm run lint:php:stan
npm run test:e2e -- tests/e2e/specs/experiments/abilities-explorer.spec.js
```

Focused Abilities Explorer E2E passed:

```bash
npm run test:e2e -- tests/e2e/specs/experiments/abilities-explorer.spec.js
```

Full E2E was also run:

```bash
npm run test:e2e
```

The Abilities Explorer tests passed in the full run. The full suite had unrelated failures outside this patch area.

## Screenshots/Screencast

### Before

The page heading showed “Ability Explorer”, while the menu and browser title showed “Abilities Explorer”.

<img width="1536" height="863" alt="abilities-explorer-heading-mismatch-before" src="https://github.com/user-attachments/assets/ed5f9209-2ace-408d-ba18-6a223d6fcdb6" />

### After

The page heading now matches the menu and browser title.

<img width="1536" height="863" alt="abilities-explorer-heading-mismatch-after" src="https://github.com/user-attachments/assets/5371ed0a-cd24-492a-adbe-8c9b13bf6698" />

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-585-aa65f59c6cd092234e08d19de42682ed4a23a1d0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->