### PR TITLE
Fix global AI enabled option migration

### DIFF
--- a/includes/Admin/Upgrades.php
+++ b/includes/Admin/Upgrades.php
@@ -72,8 +72,6 @@ final class Upgrades {
 	 * @since 0.6.0
 	 */
 	public static function do_upgrades(): void {
-		self::repair_global_enabled_option();
-
 		$db_version = get_option( self::VERSION_OPTION_KEY, '' );
 
 		foreach ( self::UPGRADE_CLASSES as $upgrade_class ) {
@@ -106,49 +104,6 @@ final class Upgrades {
 		// If all upgrades completed successfully, the plugin was successfully upgraded to the latest version.
 		delete_option( self::FAILED_UPGRADE_OPTION_KEY );
 		update_option( self::VERSION_OPTION_KEY, WPAI_VERSION );
-	}
-
-	/**
-	 * Repairs legacy and incorrect global enabled option names.
-	 *
-	 * @since 0.6.0
-	 */
-	private static function repair_global_enabled_option(): void {
-		$new_option = 'wpai_features_enabled';
-
-		foreach ( array( 'ai_experiments_enabled', 'ai_experiment_enabled', 'wpai_feature_enabled' ) as $old_option ) {
-			if ( ! self::option_exists( $old_option ) || self::option_exists( $new_option ) ) {
-				continue;
-			}
-
-			$old_value = get_option( $old_option, '' );
-			if ( '' === $old_value ) {
-				continue;
-			}
-
-			update_option( $new_option, $old_value );
-			delete_option( $old_option );
-		}
-	}
-
-	/**
-	 * Checks whether an option exists, regardless of its stored value.
-	 *
-	 * @since 0.6.0
-	 *
-	 * @param string $option_name The option name to look up.
-	 * @return bool Whether the option exists.
-	 */
-	private static function option_exists( string $option_name ): bool {
-		global $wpdb;
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-		return null !== $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT option_id FROM {$wpdb->options} WHERE option_name = %s",
-				$option_name
-			)
-		);
 	}
 
 	/**

--- a/includes/Admin/Upgrades.php
+++ b/includes/Admin/Upgrades.php
@@ -72,6 +72,8 @@ final class Upgrades {
 	 * @since 0.6.0
 	 */
 	public static function do_upgrades(): void {
+		self::repair_global_enabled_option();
+
 		$db_version = get_option( self::VERSION_OPTION_KEY, '' );
 
 		foreach ( self::UPGRADE_CLASSES as $upgrade_class ) {
@@ -104,6 +106,49 @@ final class Upgrades {
 		// If all upgrades completed successfully, the plugin was successfully upgraded to the latest version.
 		delete_option( self::FAILED_UPGRADE_OPTION_KEY );
 		update_option( self::VERSION_OPTION_KEY, WPAI_VERSION );
+	}
+
+	/**
+	 * Repairs legacy and incorrect global enabled option names.
+	 *
+	 * @since 0.6.0
+	 */
+	private static function repair_global_enabled_option(): void {
+		$new_option = 'wpai_features_enabled';
+
+		foreach ( array( 'ai_experiments_enabled', 'ai_experiment_enabled', 'wpai_feature_enabled' ) as $old_option ) {
+			if ( ! self::option_exists( $old_option ) || self::option_exists( $new_option ) ) {
+				continue;
+			}
+
+			$old_value = get_option( $old_option, '' );
+			if ( '' === $old_value ) {
+				continue;
+			}
+
+			update_option( $new_option, $old_value );
+			delete_option( $old_option );
+		}
+	}
+
+	/**
+	 * Checks whether an option exists, regardless of its stored value.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param string $option_name The option name to look up.
+	 * @return bool Whether the option exists.
+	 */
+	private static function option_exists( string $option_name ): bool {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		return null !== $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT option_id FROM {$wpdb->options} WHERE option_name = %s",
+				$option_name
+			)
+		);
 	}
 
 	/**

--- a/includes/Admin/Upgrades/V0_6_0.php
+++ b/includes/Admin/Upgrades/V0_6_0.php
@@ -39,7 +39,8 @@ class V0_6_0 extends Abstract_Upgrade {
 	 */
 	protected function upgrade(): void {
 		// Update the global options first.
-		$this->migrate_option( 'ai_experiment_enabled', 'wpai_feature_enabled' );
+		$this->migrate_option( 'ai_experiments_enabled', 'wpai_features_enabled' );
+		$this->migrate_option( 'ai_experiment_enabled', 'wpai_features_enabled' );
 
 		// Loop through the features and migrate them.
 		// We don't use the classes to protect for future compatibility.

--- a/includes/Admin/Upgrades/V1_0_0.php
+++ b/includes/Admin/Upgrades/V1_0_0.php
@@ -36,8 +36,20 @@ class V1_0_0 extends Abstract_Upgrade {
 	 * @since 1.0.0
 	 */
 	protected function upgrade(): void {
+		$this->migrate_global_enabled_option();
 		$this->migrate_option( 'wpai_feature_review-notes_enabled', 'wpai_feature_editorial-notes_enabled' );
 		$this->migrate_option( 'wpai_feature_refine-notes_enabled', 'wpai_feature_editorial-updates_enabled' );
+	}
+
+	/**
+	 * Repairs legacy and incorrect global enabled option names.
+	 *
+	 * @since 1.0.0
+	 */
+	private function migrate_global_enabled_option(): void {
+		foreach ( array( 'ai_experiments_enabled', 'ai_experiment_enabled', 'wpai_feature_enabled' ) as $old_option ) {
+			$this->migrate_option( $old_option, 'wpai_features_enabled' );
+		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Admin/Upgrades/V0_6_0Test.php
+++ b/tests/Integration/Includes/Admin/Upgrades/V0_6_0Test.php
@@ -27,7 +27,9 @@ class V0_6_0Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		delete_option( 'wpai_version' );
+		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'wpai_features_enabled' );
 		delete_option( 'wpai_feature_enabled' );
 		delete_option( 'ai_experiment_excerpt-generation_enabled' );
 		delete_option( 'wpai_feature_excerpt-generation_enabled' );
@@ -40,7 +42,9 @@ class V0_6_0Test extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( 'wpai_version' );
+		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'wpai_features_enabled' );
 		delete_option( 'wpai_feature_enabled' );
 		delete_option( 'ai_experiment_excerpt-generation_enabled' );
 		delete_option( 'wpai_feature_excerpt-generation_enabled' );
@@ -54,13 +58,13 @@ class V0_6_0Test extends WP_UnitTestCase {
 	 * @since 0.6.0
 	 */
 	public function test_run_migrates_global_enabled_option() {
-		update_option( 'ai_experiment_enabled', '1' );
+		update_option( 'ai_experiments_enabled', '1' );
 
 		( new V0_6_0( '' ) )->run();
 
-		$this->assertEquals( '1', get_option( 'wpai_feature_enabled' ) );
+		$this->assertEquals( '1', get_option( 'wpai_features_enabled' ) );
 		$this->assertNull(
-			$this->get_option_from_db( 'ai_experiment_enabled' ),
+			$this->get_option_from_db( 'ai_experiments_enabled' ),
 			'Old option should be deleted'
 		);
 	}
@@ -82,17 +86,17 @@ class V0_6_0Test extends WP_UnitTestCase {
 	 * @since 0.6.0
 	 */
 	public function test_run_skips_when_version_already_current() {
-		update_option( 'ai_experiment_enabled', '1' );
+		update_option( 'ai_experiments_enabled', '1' );
 
 		( new V0_6_0( '0.6.0' ) )->run();
 
 		$this->assertNull(
-			$this->get_option_from_db( 'wpai_feature_enabled' ),
+			$this->get_option_from_db( 'wpai_features_enabled' ),
 			'Should not write new option when version is current'
 		);
 		$this->assertEquals(
 			'1',
-			get_option( 'ai_experiment_enabled' ),
+			get_option( 'ai_experiments_enabled' ),
 			'Old option should remain when skipped'
 		);
 	}
@@ -106,8 +110,8 @@ class V0_6_0Test extends WP_UnitTestCase {
 		( new V0_6_0( '' ) )->run();
 
 		$this->assertNull(
-			$this->get_option_from_db( 'wpai_feature_enabled' ),
-			'wpai_feature_enabled should not be written on fresh install'
+			$this->get_option_from_db( 'wpai_features_enabled' ),
+			'wpai_features_enabled should not be written on fresh install'
 		);
 	}
 
@@ -117,15 +121,15 @@ class V0_6_0Test extends WP_UnitTestCase {
 	 * @since 0.6.0
 	 */
 	public function test_run_migrates_only_options_missing_new_value() {
-		update_option( 'wpai_feature_enabled', 'already-set' );
-		update_option( 'ai_experiment_enabled', '1' );
+		update_option( 'wpai_features_enabled', 'already-set' );
+		update_option( 'ai_experiments_enabled', '1' );
 		update_option( 'ai_experiment_excerpt-generation_enabled', '1' );
 
 		( new V0_6_0( '' ) )->run();
 
 		$this->assertEquals(
 			'already-set',
-			get_option( 'wpai_feature_enabled' ),
+			get_option( 'wpai_features_enabled' ),
 			'Global feature flag should not be overwritten'
 		);
 		$this->assertEquals(
@@ -139,7 +143,7 @@ class V0_6_0Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals(
 			'1',
-			get_option( 'ai_experiment_enabled' ),
+			get_option( 'ai_experiments_enabled' ),
 			'Non-migrated old option should remain'
 		);
 	}
@@ -150,13 +154,30 @@ class V0_6_0Test extends WP_UnitTestCase {
 	 * @since 0.6.0
 	 */
 	public function test_run_skips_empty_old_values() {
-		update_option( 'ai_experiment_enabled', '' );
+		update_option( 'ai_experiments_enabled', '' );
 
 		( new V0_6_0( '' ) )->run();
 
 		$this->assertNull(
-			$this->get_option_from_db( 'wpai_feature_enabled' ),
+			$this->get_option_from_db( 'wpai_features_enabled' ),
 			'New option should not be set when old is empty string'
+		);
+	}
+
+	/**
+	 * Tests that run() migrates the singular global option typo when present.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_run_migrates_singular_global_enabled_option_typo() {
+		update_option( 'ai_experiment_enabled', '1' );
+
+		( new V0_6_0( '' ) )->run();
+
+		$this->assertEquals( '1', get_option( 'wpai_features_enabled' ) );
+		$this->assertNull(
+			$this->get_option_from_db( 'ai_experiment_enabled' ),
+			'Old option should be deleted'
 		);
 	}
 

--- a/tests/Integration/Includes/Admin/Upgrades/V1_0_0Test.php
+++ b/tests/Integration/Includes/Admin/Upgrades/V1_0_0Test.php
@@ -27,6 +27,10 @@ class V1_0_0Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		delete_option( 'wpai_version' );
+		delete_option( 'ai_experiments_enabled' );
+		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'wpai_features_enabled' );
+		delete_option( 'wpai_feature_enabled' );
 		delete_option( 'wpai_feature_review-notes_enabled' );
 		delete_option( 'wpai_feature_editorial-notes_enabled' );
 		delete_option( 'wpai_feature_refine-notes_enabled' );
@@ -40,6 +44,10 @@ class V1_0_0Test extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( 'wpai_version' );
+		delete_option( 'ai_experiments_enabled' );
+		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'wpai_features_enabled' );
+		delete_option( 'wpai_feature_enabled' );
 		delete_option( 'wpai_feature_review-notes_enabled' );
 		delete_option( 'wpai_feature_editorial-notes_enabled' );
 		delete_option( 'wpai_feature_refine-notes_enabled' );
@@ -97,6 +105,91 @@ class V1_0_0Test extends WP_UnitTestCase {
 		$this->assertEquals( '1', get_option( 'wpai_feature_editorial-updates_enabled' ) );
 		$this->assertNull( $this->get_option_from_db( 'wpai_feature_review-notes_enabled' ) );
 		$this->assertNull( $this->get_option_from_db( 'wpai_feature_refine-notes_enabled' ) );
+	}
+
+	/**
+	 * Tests that run() repairs the legacy global experiments option.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_run_repairs_legacy_global_experiments_option() {
+		update_option( 'ai_experiments_enabled', '1' );
+
+		( new V1_0_0( '0.9.0' ) )->run();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Legacy global experiments option should migrate to the current global features option'
+		);
+		$this->assertNull(
+			$this->get_option_from_db( 'ai_experiments_enabled' ),
+			'Legacy global experiments option should be deleted after migration'
+		);
+	}
+
+	/**
+	 * Tests that run() repairs the singular global feature option.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_run_repairs_singular_global_feature_option() {
+		update_option( 'wpai_feature_enabled', '1' );
+
+		( new V1_0_0( '0.9.0' ) )->run();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Singular global feature option should migrate to the current global features option'
+		);
+		$this->assertNull(
+			$this->get_option_from_db( 'wpai_feature_enabled' ),
+			'Singular global feature option should be deleted after migration'
+		);
+	}
+
+	/**
+	 * Tests that run() does not overwrite the current global enabled option.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_run_does_not_overwrite_current_global_enabled_option() {
+		update_option( 'ai_experiments_enabled', '1' );
+		add_option( 'wpai_features_enabled', false );
+
+		( new V1_0_0( '0.9.0' ) )->run();
+
+		$this->assertFalse(
+			get_option( 'wpai_features_enabled' ),
+			'Current global features option should not be overwritten by stale legacy values'
+		);
+		$this->assertEquals(
+			'1',
+			get_option( 'ai_experiments_enabled' ),
+			'Legacy option should remain when migration is skipped'
+		);
+	}
+
+	/**
+	 * Tests that run() does not repair empty legacy global enabled options.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_run_does_not_repair_empty_legacy_global_enabled_option() {
+		update_option( 'ai_experiments_enabled', '' );
+
+		( new V1_0_0( '0.9.0' ) )->run();
+
+		$this->assertNull(
+			$this->get_option_from_db( 'wpai_features_enabled' ),
+			'Current global features option should not be written for empty legacy values'
+		);
+		$this->assertEquals(
+			'',
+			get_option( 'ai_experiments_enabled' ),
+			'Empty legacy option should remain when migration is skipped'
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/Admin/UpgradesTest.php
+++ b/tests/Integration/Includes/Admin/UpgradesTest.php
@@ -138,6 +138,28 @@ class UpgradesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that do_upgrades() does not repair empty legacy global enabled options.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_do_upgrades_does_not_repair_empty_legacy_global_enabled_option() {
+		update_option( 'wpai_version', '99.0.0' );
+		update_option( 'ai_experiments_enabled', '' );
+
+		Upgrades::do_upgrades();
+
+		$this->assertNull(
+			get_option( 'wpai_features_enabled', null ),
+			'Current global features option should not be written for empty legacy values'
+		);
+		$this->assertEquals(
+			'',
+			get_option( 'ai_experiments_enabled' ),
+			'Empty legacy option should remain when repair is skipped'
+		);
+	}
+
+	/**
 	 * Tests that do_upgrades() migrates the legacy global experiments option.
 	 *
 	 * @since 0.6.0

--- a/tests/Integration/Includes/Admin/UpgradesTest.php
+++ b/tests/Integration/Includes/Admin/UpgradesTest.php
@@ -28,8 +28,12 @@ class UpgradesTest extends WP_UnitTestCase {
 
 		delete_option( 'wpai_version' );
 		delete_option( 'wpai_failed_upgrade_message' );
+		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'ai_experiment_excerpt-generation_enabled' );
+		delete_option( 'wpai_features_enabled' );
 		delete_option( 'wpai_feature_enabled' );
+		delete_option( 'wpai_feature_excerpt-generation_enabled' );
 	}
 
 	/**
@@ -40,8 +44,12 @@ class UpgradesTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		delete_option( 'wpai_version' );
 		delete_option( 'wpai_failed_upgrade_message' );
+		delete_option( 'ai_experiments_enabled' );
 		delete_option( 'ai_experiment_enabled' );
+		delete_option( 'ai_experiment_excerpt-generation_enabled' );
+		delete_option( 'wpai_features_enabled' );
 		delete_option( 'wpai_feature_enabled' );
+		delete_option( 'wpai_feature_excerpt-generation_enabled' );
 
 		parent::tearDown();
 	}
@@ -64,19 +72,111 @@ class UpgradesTest extends WP_UnitTestCase {
 	 */
 	public function test_do_upgrades_skips_when_version_is_current() {
 		update_option( 'wpai_version', '99.0.0' );
-		// This option is from v0.5.0. If that gets removed we should use a different dummy op
-		update_option( 'ai_experiment_enabled', '1' );
+		update_option( 'ai_experiment_excerpt-generation_enabled', '1' );
 
 		Upgrades::do_upgrades();
 
 		$this->assertEquals(
 			'1',
-			get_option( 'ai_experiment_enabled' ),
+			get_option( 'ai_experiment_excerpt-generation_enabled' ),
 			'Old option should remain when skipped'
 		);
 		$this->assertNull(
-			get_option( 'ai_features_enabled', null ),
+			get_option( 'wpai_feature_excerpt-generation_enabled', null ),
 			'New option should not be set when skipped'
+		);
+	}
+
+	/**
+	 * Tests that do_upgrades() repairs legacy global enabled options before version checks.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_do_upgrades_repairs_legacy_global_enabled_option_when_version_is_current() {
+		update_option( 'wpai_version', '99.0.0' );
+		update_option( 'ai_experiments_enabled', '1' );
+
+		Upgrades::do_upgrades();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Legacy global experiments option should be repaired even when no versioned upgrades run'
+		);
+		$this->assertNull(
+			get_option( 'ai_experiments_enabled', null ),
+			'Legacy global experiments option should be deleted after repair'
+		);
+		$this->assertEquals(
+			WPAI_VERSION,
+			get_option( 'wpai_version' ),
+			'Plugin version should be stored after upgrades complete'
+		);
+	}
+
+	/**
+	 * Tests that do_upgrades() does not overwrite the current global enabled option.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_do_upgrades_does_not_overwrite_current_global_enabled_option() {
+		update_option( 'wpai_version', '99.0.0' );
+		update_option( 'ai_experiments_enabled', '1' );
+		add_option( 'wpai_features_enabled', false );
+
+		Upgrades::do_upgrades();
+
+		$this->assertFalse(
+			get_option( 'wpai_features_enabled' ),
+			'Current global features option should not be overwritten by stale legacy values'
+		);
+		$this->assertEquals(
+			'1',
+			get_option( 'ai_experiments_enabled' ),
+			'Legacy option should remain when repair is skipped'
+		);
+	}
+
+	/**
+	 * Tests that do_upgrades() migrates the legacy global experiments option.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_do_upgrades_migrates_legacy_global_experiments_option() {
+		update_option( 'ai_experiments_enabled', '1' );
+
+		Upgrades::do_upgrades();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Legacy global experiments option should migrate to the current global features option'
+		);
+		$this->assertNull(
+			get_option( 'ai_experiments_enabled', null ),
+			'Legacy global experiments option should be deleted after migration'
+		);
+	}
+
+	/**
+	 * Tests that do_upgrades() repairs the singular global feature option.
+	 *
+	 * @since 0.6.0
+	 */
+	public function test_do_upgrades_repairs_singular_global_feature_option() {
+		update_option( 'wpai_version', '0.9.0' );
+		update_option( 'wpai_feature_enabled', '1' );
+
+		Upgrades::do_upgrades();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Singular global feature option should migrate to the current global features option'
+		);
+		$this->assertNull(
+			get_option( 'wpai_feature_enabled', null ),
+			'Singular global feature option should be deleted after migration'
 		);
 	}
 

--- a/tests/Integration/Includes/Admin/UpgradesTest.php
+++ b/tests/Integration/Includes/Admin/UpgradesTest.php
@@ -88,78 +88,6 @@ class UpgradesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that do_upgrades() repairs legacy global enabled options before version checks.
-	 *
-	 * @since 0.6.0
-	 */
-	public function test_do_upgrades_repairs_legacy_global_enabled_option_when_version_is_current() {
-		update_option( 'wpai_version', '99.0.0' );
-		update_option( 'ai_experiments_enabled', '1' );
-
-		Upgrades::do_upgrades();
-
-		$this->assertEquals(
-			'1',
-			get_option( 'wpai_features_enabled' ),
-			'Legacy global experiments option should be repaired even when no versioned upgrades run'
-		);
-		$this->assertNull(
-			get_option( 'ai_experiments_enabled', null ),
-			'Legacy global experiments option should be deleted after repair'
-		);
-		$this->assertEquals(
-			WPAI_VERSION,
-			get_option( 'wpai_version' ),
-			'Plugin version should be stored after upgrades complete'
-		);
-	}
-
-	/**
-	 * Tests that do_upgrades() does not overwrite the current global enabled option.
-	 *
-	 * @since 0.6.0
-	 */
-	public function test_do_upgrades_does_not_overwrite_current_global_enabled_option() {
-		update_option( 'wpai_version', '99.0.0' );
-		update_option( 'ai_experiments_enabled', '1' );
-		add_option( 'wpai_features_enabled', false );
-
-		Upgrades::do_upgrades();
-
-		$this->assertFalse(
-			get_option( 'wpai_features_enabled' ),
-			'Current global features option should not be overwritten by stale legacy values'
-		);
-		$this->assertEquals(
-			'1',
-			get_option( 'ai_experiments_enabled' ),
-			'Legacy option should remain when repair is skipped'
-		);
-	}
-
-	/**
-	 * Tests that do_upgrades() does not repair empty legacy global enabled options.
-	 *
-	 * @since 0.6.0
-	 */
-	public function test_do_upgrades_does_not_repair_empty_legacy_global_enabled_option() {
-		update_option( 'wpai_version', '99.0.0' );
-		update_option( 'ai_experiments_enabled', '' );
-
-		Upgrades::do_upgrades();
-
-		$this->assertNull(
-			get_option( 'wpai_features_enabled', null ),
-			'Current global features option should not be written for empty legacy values'
-		);
-		$this->assertEquals(
-			'',
-			get_option( 'ai_experiments_enabled' ),
-			'Empty legacy option should remain when repair is skipped'
-		);
-	}
-
-	/**
 	 * Tests that do_upgrades() migrates the legacy global experiments option.
 	 *
 	 * @since 0.6.0
@@ -181,7 +109,29 @@ class UpgradesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that do_upgrades() repairs the singular global feature option.
+	 * Tests that do_upgrades() repairs the legacy global experiments option when upgrading to 1.0.0.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_do_upgrades_repairs_legacy_global_experiments_option_from_0_9_0() {
+		update_option( 'wpai_version', '0.9.0' );
+		update_option( 'ai_experiments_enabled', '1' );
+
+		Upgrades::do_upgrades();
+
+		$this->assertEquals(
+			'1',
+			get_option( 'wpai_features_enabled' ),
+			'Legacy global experiments option should migrate to the current global features option'
+		);
+		$this->assertNull(
+			get_option( 'ai_experiments_enabled', null ),
+			'Legacy global experiments option should be deleted after migration'
+		);
+	}
+
+	/**
+	 * Tests that do_upgrades() migrates the singular global feature option.
 	 *
 	 * @since 0.6.0
 	 */


### PR DESCRIPTION
## What?

Fixes migration of the global AI enabled setting from older AI Experiments installs.

## Why?

Older versions saved the global toggle as `ai_experiments_enabled`.

The existing upgrade routine intended to migrate old experiment settings, but the global option used the wrong names. As a result, after upgrading from AI Experiments 0.5.0 to the current AI plugin, the global **Enable AI** setting could appear disabled even though it had been enabled before the upgrade.

## How?

- Migrates `ai_experiments_enabled` to the current `wpai_features_enabled` option.
- Keeps support for the singular typo option names created by earlier upgrade logic.
- Repairs the global enabled option before version checks, so already-upgraded sites can recover too.
- Avoids overwriting `wpai_features_enabled` if the current option already exists.
- Updates upgrade tests for both fresh legacy upgrades and already-upgraded repair cases.

## Testing Instructions

Automated checks run locally:

```bash
npm run test:php
npm run lint:php
npm run lint:php:stan
```

Manual verification:

1. Install AI Experiments 0.5.0.
2. Go to `Settings > AI Experiments`.
3. Enable experiments.
4. Upgrade to this branch.
5. Go to `Settings > AI`.
6. Confirm **Enable AI** remains enabled.

## Screenshots/Screencast

Before: AI Experiments 0.5.0 has experiments enabled.
<img width="800" height="502" alt="Migration Issue before" src="https://github.com/user-attachments/assets/5f21b8d4-5821-44bb-bf99-12f035232c7a" />


After: Current AI settings preserve the global enabled state after upgrade.
<img width="800" height="459" alt="Migration Issue after" src="https://github.com/user-attachments/assets/0ac18349-0aaf-4f03-ae5b-e462827dfa5e" />

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-586-169dea71f52d6ff7f8528327d45b2ffdcabfe73e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->