### PR TITLE
Fix: Hide "Generate Editorial Note" option in Revisions mode

### DIFF
--- a/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
+++ b/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
@@ -12,8 +12,11 @@ import {
 	MenuItem,
 	Spinner,
 } from '@wordpress/components';
-import { BlockSettingsMenuControls } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
+import {
+	BlockSettingsMenuControls,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editPostStore } from '@wordpress/edit-post';
 import { PluginPostStatusInfo } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
@@ -43,6 +46,11 @@ export default function EditorialNotesPlugin() {
 	const { openGeneralSidebar } = useDispatch( editPostStore );
 	const openNotesPanel = () =>
 		openGeneralSidebar?.( 'edit-post/collab-sidebar' );
+
+	const isPreviewMode = useSelect( ( select ) => {
+		return ( select( blockEditorStore ) as any ).getSettings()
+			.isPreviewMode;
+	}, [] );
 
 	if ( ! ( window as any ).aiEditorialNotesData?.enabled ) {
 		return null;
@@ -127,7 +135,8 @@ export default function EditorialNotesPlugin() {
 					if (
 						! selectedBlocks.every( ( name ) =>
 							REVIEWABLE_BLOCK_TYPES.includes( name )
-						)
+						) ||
+						isPreviewMode
 					) {
 						return null;
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #590

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, when a user opens the Revisions in the block editor, the Generate Editorial Note button is still visible when user clicks any block settings dropdown.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check the current state of the editor via `isPreviewMode` of `@wordpress/block-editor` settings and render the menu item only if its not in preview mode.

Note: We are not able to use `isRevisionsMode` or `showDiff` (via isShowingRevisionDiff),. They are registered as private selectors within the @wordpress/editor data store.

### Use of AI Tools

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini 3.1 Pro
Used for: Identify the core hooks/stores details with implementation of BlockSettingsMenuControls and Create testing instructions in PR.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Navigate to Settings → AI and ensure AI Editorial Notes is enabled.
2. Create or edit a post and add some paragraph blocks.
3. Save the post, make a change, and save it again to generate a revision history.
4. Open the post settings sidebar and click to view Revisions.
5. Inside the Revisions diff viewer, click on any block to open its block settings menu (the 3 dots).
6. Verify that "Generate Editorial Note" does not appear in the menu (only Copy and Copy Styles should be visible).
7. Exit the Revisions view and return to the normal editor.
8. Click on a block to open its block settings menu, and verify that "Generate Editorial Note" does appear normally.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1470" height="836" alt="Screenshot 2026-05-20 at 12 29 00 PM" src="https://github.com/user-attachments/assets/6e206dea-4060-4c6a-bdbf-e8c11d6458fa" />|<img width="1470" height="833" alt="Screenshot 2026-05-20 at 12 28 31 PM" src="https://github.com/user-attachments/assets/7c25d312-2faf-4f0b-8423-a57bbe453814" />|

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - "Generate Editorial Note" button appearing in the block settings menu during post revisions.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-591-d13953d7cd7075d1a8780521b8434837c2273be8.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->