### PR TITLE
Filter Guidelines service queries by content guideline type

### DIFF
--- a/includes/Services/Guidelines.php
+++ b/includes/Services/Guidelines.php
@@ -33,6 +33,24 @@ class Guidelines {
 	public const POST_TYPE = 'wp_guideline';
 
 	/**
+	 * Taxonomy slug used by Gutenberg 23.1+ to split guideline posts by purpose.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @var string
+	 */
+	public const TAXONOMY = 'wp_guideline_type';
+
+	/**
+	 * Term slug for the site-wide content guideline singleton.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @var string
+	 */
+	public const TERM_CONTENT = 'content';
+
+	/**
 	 * Singleton instance.
 	 *
 	 * @since 0.8.0
@@ -304,16 +322,30 @@ class Guidelines {
 		}
 
 		// Gutenberg saves guidelines as 'draft' by default; both statuses are valid.
-		$query = new WP_Query(
-			array(
-				'post_type'      => self::POST_TYPE,
-				'posts_per_page' => 1,
-				'post_status'    => array( 'publish', 'draft' ),
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-				'no_found_rows'  => true,
-			)
+		$query_args = array(
+			'post_type'      => self::POST_TYPE,
+			'posts_per_page' => 1,
+			'post_status'    => array( 'publish', 'draft' ),
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			'no_found_rows'  => true,
 		);
+
+		// Gutenberg 23.1+ splits guidelines into types via the wp_guideline_type
+		// taxonomy. Without this filter the newest artifact guideline would shadow
+		// the content singleton in prompt assembly. On older Gutenberg the
+		// taxonomy isn't registered and we fall back to the legacy "newest wins".
+		if ( taxonomy_exists( self::TAXONOMY ) ) {
+			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => self::TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => self::TERM_CONTENT,
+				),
+			);
+		}
+
+		$query = new WP_Query( $query_args );
 
 		$post = $query->posts[0] ?? null;
 

--- a/includes/Services/Guidelines.php
+++ b/includes/Services/Guidelines.php
@@ -35,7 +35,7 @@ class Guidelines {
 	/**
 	 * Taxonomy slug used by Gutenberg 23.1+ to split guideline posts by purpose.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 *
 	 * @var string
 	 */
@@ -44,7 +44,7 @@ class Guidelines {
 	/**
 	 * Term slug for the site-wide content guideline singleton.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 *
 	 * @var string
 	 */

--- a/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
+++ b/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
@@ -61,7 +61,7 @@ trait Guidelines_CPT_Helpers {
 	 * Mirrors Gutenberg 23.1+'s taxonomy registration so the service can
 	 * filter by the `content` term.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 *
 	 * @return void
 	 */

--- a/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
+++ b/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
@@ -56,15 +56,43 @@ trait Guidelines_CPT_Helpers {
 	}
 
 	/**
+	 * Registers the wp_guideline_type taxonomy for testing.
+	 *
+	 * Mirrors Gutenberg 23.1+'s taxonomy registration so the service can
+	 * filter by the `content` term.
+	 *
+	 * @since 1.0.1
+	 *
+	 * @return void
+	 */
+	private function register_guidelines_taxonomy(): void {
+		$this->register_guidelines_cpt();
+
+		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
+			return;
+		}
+
+		register_taxonomy(
+			Guidelines::TAXONOMY,
+			Guidelines::POST_TYPE,
+			array(
+				'public'       => false,
+				'hierarchical' => true,
+			)
+		);
+	}
+
+	/**
 	 * Creates a guidelines post with the given category meta values.
 	 *
 	 * @since 0.8.0
 	 *
 	 * @param array<string, string> $categories  Keyed array of category => guideline text.
 	 * @param string                $post_status Optional. The post status. Defaults to 'publish'.
+	 * @param string|null           $type        Optional. wp_guideline_type term slug to assign. Defaults to null (no assignment).
 	 * @return int The created post ID.
 	 */
-	private function create_guidelines_post( array $categories, string $post_status = 'publish' ): int {
+	private function create_guidelines_post( array $categories, string $post_status = 'publish', ?string $type = null ): int {
 		$post_id = self::factory()->post->create(
 			array(
 				'post_type'   => Guidelines::POST_TYPE,
@@ -79,6 +107,10 @@ trait Guidelines_CPT_Helpers {
 			}
 
 			update_post_meta( $post_id, self::$guideline_category_meta_keys[ $category ], $value );
+		}
+
+		if ( null !== $type && taxonomy_exists( Guidelines::TAXONOMY ) ) {
+			wp_set_object_terms( $post_id, $type, Guidelines::TAXONOMY );
 		}
 
 		// Reset cache so the service picks up the new post.

--- a/tests/Integration/Includes/Services/Guidelines_Test.php
+++ b/tests/Integration/Includes/Services/Guidelines_Test.php
@@ -46,6 +46,11 @@ class Guidelines_Test extends WP_UnitTestCase {
 		Guidelines::reset_cache();
 		remove_all_filters( 'wpai_use_guidelines' );
 		remove_all_filters( 'wpai_max_guideline_length' );
+
+		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
+			unregister_taxonomy( Guidelines::TAXONOMY );
+		}
+
 		parent::tearDown();
 	}
 
@@ -380,6 +385,89 @@ class Guidelines_Test extends WP_UnitTestCase {
 			$this->service->get_block_guidelines( 'core/paragraph' ),
 			'Should return null when filter disables guidelines'
 		);
+	}
+
+	/**
+	 * Tests that get_guidelines() returns the content-typed post even when
+	 * a newer artifact-typed post exists.
+	 *
+	 * Regression test for the issue where Gutenberg 23.1's wp_guideline_type
+	 * taxonomy allows artifact guidelines to coexist with the content singleton,
+	 * and the service used to pick whichever was most recent.
+	 *
+	 * @since 1.0.1
+	 */
+	public function test_get_guidelines_prefers_content_type_over_newer_artifact(): void {
+		$this->register_guidelines_taxonomy();
+
+		$content_post_id = $this->create_guidelines_post(
+			array( 'site' => 'Content guideline.' ),
+			'publish',
+			Guidelines::TERM_CONTENT
+		);
+
+		// Bump the content post's date into the past so the artifact is strictly newer.
+		wp_update_post(
+			array(
+				'ID'            => $content_post_id,
+				'post_date'     => '2026-01-01 00:00:00',
+				'post_date_gmt' => '2026-01-01 00:00:00',
+			)
+		);
+
+		$this->create_guidelines_post(
+			array( 'site' => 'Artifact guideline.' ),
+			'publish',
+			'artifact'
+		);
+
+		Guidelines::reset_cache();
+
+		$result = $this->service->get_guidelines( 'site' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Content guideline.', $result['site'] );
+	}
+
+	/**
+	 * Tests that get_guidelines() returns null when only artifact-typed
+	 * guidelines exist, since artifacts are not site-wide content guidelines.
+	 *
+	 * @since 1.0.1
+	 */
+	public function test_get_guidelines_returns_null_when_only_artifact_exists(): void {
+		$this->register_guidelines_taxonomy();
+		$this->create_guidelines_post(
+			array( 'site' => 'Artifact guideline.' ),
+			'publish',
+			'artifact'
+		);
+
+		$this->assertNull(
+			$this->service->get_guidelines(),
+			'Should ignore artifact-typed guidelines when looking up the content singleton'
+		);
+	}
+
+	/**
+	 * Tests that on older Gutenberg builds where the taxonomy is not registered,
+	 * the service still returns the most recent guideline post.
+	 *
+	 * @since 1.0.1
+	 */
+	public function test_get_guidelines_falls_back_to_latest_when_taxonomy_unavailable(): void {
+		$this->register_guidelines_cpt();
+		$this->create_guidelines_post( array( 'site' => 'Legacy guideline.' ) );
+
+		$this->assertFalse(
+			taxonomy_exists( Guidelines::TAXONOMY ),
+			'Taxonomy must not be registered for this scenario'
+		);
+
+		$result = $this->service->get_guidelines( 'site' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Legacy guideline.', $result['site'] );
 	}
 
 	/**

--- a/tests/Integration/Includes/Services/Guidelines_Test.php
+++ b/tests/Integration/Includes/Services/Guidelines_Test.php
@@ -395,7 +395,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 * taxonomy allows artifact guidelines to coexist with the content singleton,
 	 * and the service used to pick whichever was most recent.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 */
 	public function test_get_guidelines_prefers_content_type_over_newer_artifact(): void {
 		$this->register_guidelines_taxonomy();
@@ -433,7 +433,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 * Tests that get_guidelines() returns null when only artifact-typed
 	 * guidelines exist, since artifacts are not site-wide content guidelines.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 */
 	public function test_get_guidelines_returns_null_when_only_artifact_exists(): void {
 		$this->register_guidelines_taxonomy();
@@ -453,7 +453,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 * Tests that on older Gutenberg builds where the taxonomy is not registered,
 	 * the service still returns the most recent guideline post.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 */
 	public function test_get_guidelines_falls_back_to_latest_when_taxonomy_unavailable(): void {
 		$this->register_guidelines_cpt();


### PR DESCRIPTION
## Summary
- Restrict `Guidelines::fetch_guidelines()` to the `content` term of the new `wp_guideline_type` taxonomy so a newer `artifact` guideline can't shadow the content singleton in prompt assembly.
- Fall back to the existing "newest wins" query when the taxonomy isn't registered (Gutenberg < 23.1), preserving backwards compatibility.
- Add `Guidelines::TAXONOMY` / `Guidelines::TERM_CONTENT` constants and three regression tests covering the content-vs-artifact preference, artifact-only sites, and the pre-taxonomy fallback path.

Fixes #529.

## Test plan
- [x] `composer run-script format` — clean
- [x] `composer run-script lint` — clean
- [x] `composer run-script phpstan` — clean for changed files (pre-existing unrelated `Requirements.php` warning)
- [x] `npm run test:php -- --filter Guidelines_Test` — 31/31 pass
- [x] `npm run test:php -- --filter Abstract_Ability_Guidelines_Test` — 9/9 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-593-c54174830aaf3e1b0e95c85fc9f9f26103e453e9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->