### PR TITLE
Better connector approval matching

### DIFF
--- a/includes/Connector_Approval/Caller_Identifier.php
+++ b/includes/Connector_Approval/Caller_Identifier.php
@@ -98,7 +98,6 @@ final class Caller_Identifier {
 			'/wp-includes/class-requests.php',
 			'/wp-includes/ai-client/',
 			'/wp-includes/php-ai-client/',
-			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Admin' . DIRECTORY_SEPARATOR,
 			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Connector_Approval' . DIRECTORY_SEPARATOR,
 			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Logging' . DIRECTORY_SEPARATOR,
 			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Settings' . DIRECTORY_SEPARATOR,

--- a/includes/Connector_Approval/Caller_Identifier.php
+++ b/includes/Connector_Approval/Caller_Identifier.php
@@ -84,8 +84,13 @@ final class Caller_Identifier {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		$core   = wp_normalize_path( ABSPATH . WPINC ) . '/';
-		$plugin = wp_normalize_path( WPAI_PLUGIN_DIR ) . 'includes/';
+		$wp_includes = defined( 'WPINC' ) ? constant( 'WPINC' ) : 'wp-includes';
+		if ( ! is_string( $wp_includes ) ) {
+			$wp_includes = 'wp-includes';
+		}
+
+		$core   = wp_normalize_path( ABSPATH . $wp_includes ) . '/';
+		$plugin = wp_normalize_path( dirname( __DIR__ ) ) . '/';
 
 		$this->skip_prefixes = array(
 			$core . 'option.php',
@@ -105,7 +110,6 @@ final class Caller_Identifier {
 			$plugin . 'Logging/',
 			$plugin . 'Settings/',
 			$plugin . 'helpers.php',
-			$plugin . 'Main.php',
 		);
 	}
 

--- a/includes/Connector_Approval/Caller_Identifier.php
+++ b/includes/Connector_Approval/Caller_Identifier.php
@@ -70,13 +70,13 @@ final class Caller_Identifier {
 	private array $cache = array();
 
 	/**
-	 * Substrings that indicate a stack frame is infrastructure rather than a request origin.
+	 * Path prefixes that indicate a stack frame is infrastructure rather than a request origin.
 	 *
 	 * @since 1.0.0
 	 *
 	 * @var list<string>
 	 */
-	private array $skip_substrings;
+	private array $skip_prefixes;
 
 	/**
 	 * Constructor.
@@ -84,24 +84,28 @@ final class Caller_Identifier {
 	 * @since 1.0.0
 	 */
 	public function __construct() {
-		$this->skip_substrings = array(
-			'/wp-includes/option.php',
-			'/wp-includes/class-wp-hook.php',
-			'/wp-includes/plugin.php',
-			'/wp-includes/connectors.php',
-			'/wp-includes/class-wp-connector-registry.php',
-			'/wp-includes/http.php',
-			'/wp-includes/class-wp-http.php',
-			'/wp-includes/class-http.php',
-			'/wp-includes/class-wp-http-requests-hooks.php',
-			'/wp-includes/Requests/',
-			'/wp-includes/class-requests.php',
-			'/wp-includes/ai-client/',
-			'/wp-includes/php-ai-client/',
-			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Connector_Approval' . DIRECTORY_SEPARATOR,
-			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Logging' . DIRECTORY_SEPARATOR,
-			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Settings' . DIRECTORY_SEPARATOR,
-			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'helpers.php',
+		$core   = wp_normalize_path( ABSPATH . WPINC ) . '/';
+		$plugin = wp_normalize_path( WPAI_PLUGIN_DIR ) . 'includes/';
+
+		$this->skip_prefixes = array(
+			$core . 'option.php',
+			$core . 'class-wp-hook.php',
+			$core . 'plugin.php',
+			$core . 'connectors.php',
+			$core . 'class-wp-connector-registry.php',
+			$core . 'http.php',
+			$core . 'class-wp-http.php',
+			$core . 'class-http.php',
+			$core . 'class-wp-http-requests-hooks.php',
+			$core . 'Requests/',
+			$core . 'class-requests.php',
+			$core . 'ai-client/',
+			$core . 'php-ai-client/',
+			$plugin . 'Connector_Approval/',
+			$plugin . 'Logging/',
+			$plugin . 'Settings/',
+			$plugin . 'helpers.php',
+			$plugin . 'Main.php',
 		);
 	}
 
@@ -189,8 +193,8 @@ final class Caller_Identifier {
 	 */
 	private function should_skip( string $file ): bool {
 		$normalized = wp_normalize_path( $file );
-		foreach ( $this->skip_substrings as $needle ) {
-			if ( str_contains( $normalized, wp_normalize_path( $needle ) ) ) {
+		foreach ( $this->skip_prefixes as $prefix ) {
+			if ( str_starts_with( $normalized, wp_normalize_path( $prefix ) ) ) {
 				return true;
 			}
 		}

--- a/includes/Connector_Approval/Caller_Identifier.php
+++ b/includes/Connector_Approval/Caller_Identifier.php
@@ -70,7 +70,7 @@ final class Caller_Identifier {
 	private array $cache = array();
 
 	/**
-	 * Substrings that indicate a stack frame is part of the enforcement plumbing itself.
+	 * Substrings that indicate a stack frame is infrastructure rather than a request origin.
 	 *
 	 * @since 1.0.0
 	 *
@@ -98,7 +98,11 @@ final class Caller_Identifier {
 			'/wp-includes/class-requests.php',
 			'/wp-includes/ai-client/',
 			'/wp-includes/php-ai-client/',
+			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Admin' . DIRECTORY_SEPARATOR,
 			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Connector_Approval' . DIRECTORY_SEPARATOR,
+			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Logging' . DIRECTORY_SEPARATOR,
+			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'Settings' . DIRECTORY_SEPARATOR,
+			DIRECTORY_SEPARATOR . 'includes' . DIRECTORY_SEPARATOR . 'helpers.php',
 		);
 	}
 
@@ -145,7 +149,7 @@ final class Caller_Identifier {
 	}
 
 	/**
-	 * Finds the first stack frame that belongs to an extension and describes it.
+	 * Finds the deepest stack frame that belongs to an extension and describes it.
 	 *
 	 * @since 1.0.0
 	 *
@@ -153,6 +157,8 @@ final class Caller_Identifier {
 	 * @return array{type: string, basename: string, name: string}|null
 	 */
 	private function resolve( array $frames ): ?array {
+		$origin = null;
+
 		foreach ( $frames as $frame ) {
 			$file = isset( $frame['file'] ) && is_string( $frame['file'] ) ? $frame['file'] : '';
 			if ( '' === $file ) {
@@ -164,12 +170,14 @@ final class Caller_Identifier {
 			}
 
 			$extension = $this->classify_file( $file );
-			if ( null !== $extension ) {
-				return $extension;
+			if ( null === $extension ) {
+				continue;
 			}
+
+			$origin = $extension;
 		}
 
-		return null;
+		return $origin;
 	}
 
 	/**

--- a/tests/Integration/Includes/Connector_Approval/Caller_IdentifierTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Caller_IdentifierTest.php
@@ -92,4 +92,24 @@ class Caller_IdentifierTest extends WP_UnitTestCase {
 		$this->assertSame( Caller_Identifier::TYPE_PLUGIN, $result['type'] );
 		$this->assertSame( 'consumer-plugin', $result['basename'] );
 	}
+
+	/**
+	 * Test that another plugin's matching internal directory is not skipped.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_does_not_skip_matching_directory_names_in_other_plugins(): void {
+		$result = $this->resolve_frames(
+			array(
+				array(
+					'file' => WP_PLUGIN_DIR . '/another-plugin/includes/Settings/Options.php',
+					'line' => 21,
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( Caller_Identifier::TYPE_PLUGIN, $result['type'] );
+		$this->assertSame( 'another-plugin', $result['basename'] );
+	}
 }

--- a/tests/Integration/Includes/Connector_Approval/Caller_IdentifierTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Caller_IdentifierTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Integration tests for the Caller_Identifier class.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Connector_Approval
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Connector_Approval;
+
+use ReflectionMethod;
+use WP_UnitTestCase;
+use WordPress\AI\Connector_Approval\Caller_Identifier;
+
+/**
+ * Caller_Identifier test case.
+ *
+ * @since x.x.x
+ */
+class Caller_IdentifierTest extends WP_UnitTestCase {
+	/**
+	 * Resolves a synthetic stack with the private Caller_Identifier resolver.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<int, array<string, mixed>> $frames Synthetic stack frames.
+	 * @return array{type: string, basename: string, name: string}|null
+	 */
+	private function resolve_frames( array $frames ): ?array {
+		$identifier = new Caller_Identifier();
+		$resolve    = new ReflectionMethod( Caller_Identifier::class, 'resolve' );
+		$resolve->setAccessible( true );
+
+		$result = $resolve->invoke( $identifier, $frames );
+
+		return is_array( $result ) ? $result : null;
+	}
+
+	/**
+	 * Test that request logging frames are treated as infrastructure.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_skips_request_logging_frames_when_identifying_origin(): void {
+		$result = $this->resolve_frames(
+			array(
+				array(
+					'file' => WP_PLUGIN_DIR . '/ai/includes/Logging/Logging_Http_Transporter.php',
+					'line' => 85,
+				),
+				array(
+					'file' => ABSPATH . 'wp-includes/http.php',
+					'line' => 612,
+				),
+				array(
+					'file' => ABSPATH . 'wp-admin/options-connectors.php',
+					'line' => 42,
+				),
+			)
+		);
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test that the deepest extension frame is treated as the origin.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_identifies_deepest_extension_frame_as_origin(): void {
+		$result = $this->resolve_frames(
+			array(
+				array(
+					'file' => WP_PLUGIN_DIR . '/ai/includes/Logging/Logging_Http_Transporter.php',
+					'line' => 85,
+				),
+				array(
+					'file' => WP_PLUGIN_DIR . '/ai/includes/Experiments/Title_Generation/Title_Generation.php',
+					'line' => 262,
+				),
+				array(
+					'file' => ABSPATH . 'wp-includes/class-wp-hook.php',
+					'line' => 324,
+				),
+				array(
+					'file' => WP_PLUGIN_DIR . '/consumer-plugin/includes/request-ai.php',
+					'line' => 38,
+				),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( Caller_Identifier::TYPE_PLUGIN, $result['type'] );
+		$this->assertSame( 'consumer-plugin', $result['basename'] );
+	}
+}

--- a/tests/Integration/Includes/Connector_Approval/Http_GuardTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Http_GuardTest.php
@@ -169,7 +169,7 @@ class Http_GuardTest extends WP_UnitTestCase {
 	 * @since 1.0.0
 	 */
 	private function force_unidentifiable_caller(): void {
-		$property = new ReflectionProperty( Caller_Identifier::class, 'skip_substrings' );
+		$property = new ReflectionProperty( Caller_Identifier::class, 'skip_prefixes' );
 		$property->setAccessible( true );
 
 		$current   = (array) $property->getValue( $this->identifier );

--- a/tests/e2e/specs/experiments/connector-approval.spec.js
+++ b/tests/e2e/specs/experiments/connector-approval.spec.js
@@ -93,7 +93,7 @@ test.describe( 'Connector Approval Experiment', () => {
 			.filter( { hasText: 'OpenAI' } );
 
 		if ( ( await pendingRow.count() ) === 0 ) {
-			await admin.visitAdminPage( 'tools.php?page=ai-wp-admin' );
+			await admin.visitAdminPage( 'index.php' );
 			await admin.visitAdminPage(
 				'tools.php?page=ai-connector-approval'
 			);


### PR DESCRIPTION
## What?

 See https://github.com/WordPress/ai/pull/467#issuecomment-4493850705

Add a few more paths that we always allow through for the Connector Approval experiment (to avoid blocking authentication requests). And change our approval matching to look through the entire stack and find the deepest match instead of the first match.

## Why?

Right now the Connector Approval matching is a little too aggressive. First, in some situations it will block the WP AI Client from doing authentication requests without first approving the AI plugin. And second, it some situations it will block the individual AI Provider plugins from being used without first being approved.

Ideally any requests that originate from WP Core (like authentication of credentials) or requests that filter through a Provider plugin (but don't originate there) are allowed through without approvals.

## How?

- Add more allowed paths to our list: `/includes/Logging/`, `/includes/Settings/` and `/includes/helpers.php`. This allows things like the Logging experiment and credential authentication to work without first needing the AI plugin to be approved
- Change our resolve functionality to look through the entire stack and find the deepest match which hopefully gets us closer to the originating code

### Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): GPT-5.5
Used for: Review of the current code, coming up with a plan and implementing that plan. Iteration and testing done by me

## Testing Instructions

1. On the current release, turn on the Connector Approval and Request Logging experiments
2. Ensure nothing is approved under `Tools > Connector Approvals`
3. Remove credentials from any Connector
4. Try adding credentials back. You should get an error message when saving and you should see a request to allow the AI plugin on the Connector Approvals page
5. Approve the AI plugin and turn on a feature like Title Generation
6. Try to generate a title. You should get an error that the AI Provider isn't approved
7. Go to the Connector Approvals screen and you should see a request there to approve the AI Provider plugin
8. Check out this branch
9. Ensure nothing is approved under `Tools > Connector Approvals`
10. Remove credentials from any Connector
11. Try adding credentials back and save. It should work now and you shouldn't see any request to allow the AI plugin
12. Try generating a title and it should be blocked and you should now be prompted to approve the AI plugin
13. Approve the AI plugin and try generating titles again
14. It should work now without having to approve the AI Provider plugin

## Changelog Entry

> Fixed - If the Connector Approval experiment is turned on, ensure we don't over aggressively block functionality in the AI plugin that isn't actually making requests, like request logging.
> Fixed - Better matching of the originating code when the Connector Approval experiment is on.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-595-76c41d9fd3ca5cfbbbd374a8943623905b81ced4.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->