### PR TITLE
Fix: connector approval notice placement in request logs

### DIFF
--- a/includes/Connector_Approval/Admin_Notice.php
+++ b/includes/Connector_Approval/Admin_Notice.php
@@ -125,7 +125,7 @@ final class Admin_Notice {
 		}
 
 		$screen = get_current_screen();
-		if ( $screen && 'tools_page_ai-connector-approval' === $screen->id ) {
+		if ( $screen && in_array( $screen->id, array( 'tools_page_ai-connector-approval', 'tools_page_ai-request-logs' ), true ) ) {
 			return;
 		}
 

--- a/includes/Logging/AI_Request_Log_Page.php
+++ b/includes/Logging/AI_Request_Log_Page.php
@@ -104,6 +104,7 @@ class AI_Request_Log_Page {
 				),
 				'connectorsUrl'    => admin_url( 'options-connectors.php' ),
 				'providerMetadata' => $this->get_provider_metadata(),
+				'connectorApprovalNotice' => $this->get_connector_approval_notice_data(),
 			)
 		);
 	}
@@ -120,6 +121,50 @@ class AI_Request_Log_Page {
 			<div id="ai-request-logs-root"></div>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Returns connector approval pending-notice data for the React app.
+	 *
+	 * Returns null when the Connector Approval experiment is not active,
+	 * there are no pending requests, or the notice has already been dismissed
+	 * for the current pending set, so the React app only renders the notice
+	 * when it is actually needed.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return array{count: int, reviewUrl: string, dismissUrl: string}|null
+	 */
+	private function get_connector_approval_notice_data(): ?array {
+		if ( ! class_exists( \WordPress\AI\Connector_Approval\Approvals_Store::class ) ) {
+			return null;
+		}
+
+		$store   = new \WordPress\AI\Connector_Approval\Approvals_Store();
+		$pending = $store->get_pending();
+
+		if ( empty( $pending ) ) {
+			return null;
+		}
+
+		// Honour the same dismissal state that Admin_Notice uses.
+		$keys = array_keys( $pending );
+		sort( $keys );
+		$signature = md5( implode( '|', $keys ) );
+		$dismissed = (string) get_user_meta( get_current_user_id(), 'wpai_connector_approval_notice_dismissed', true );
+
+		if ( $signature === $dismissed ) {
+			return null;
+		}
+
+		return array(
+			'count'      => count( $pending ),
+			'reviewUrl'  => \WordPress\AI\Experiments\Connector_Approval\Admin_Page::url(),
+			'dismissUrl' => wp_nonce_url(
+				add_query_arg( 'wpai_ca_notice_dismiss', '1' ),
+				'wpai_ca_notice'
+			),
+		);
 	}
 
 	/**

--- a/includes/Logging/AI_Request_Log_Page.php
+++ b/includes/Logging/AI_Request_Log_Page.php
@@ -89,7 +89,7 @@ class AI_Request_Log_Page {
 			'ai_request_logs',
 			'RequestLogsSettings',
 			array(
-				'rest'             => array(
+				'rest'                    => array(
 					'nonce'  => wp_create_nonce( 'wp_rest' ),
 					'root'   => esc_url_raw( rest_url() ),
 					'routes' => array(
@@ -98,12 +98,12 @@ class AI_Request_Log_Page {
 						'filters' => 'ai/v1/logs/filters',
 					),
 				),
-				'initialState'     => array(
+				'initialState'            => array(
 					'summary' => $this->manager->get_summary( 'day' ),
 					'filters' => $this->manager->get_filter_options(),
 				),
-				'connectorsUrl'    => admin_url( 'options-connectors.php' ),
-				'providerMetadata' => $this->get_provider_metadata(),
+				'connectorsUrl'           => admin_url( 'options-connectors.php' ),
+				'providerMetadata'        => $this->get_provider_metadata(),
 				'connectorApprovalNotice' => $this->get_connector_approval_notice_data(),
 			)
 		);

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -35,7 +35,6 @@ import {
 import SettingsPanel from './components/SettingsPanel';
 import SummaryCards from './components/SummaryCards';
 import type {
-	ConnectorApprovalNotice,
 	FilterOptions,
 	LocalizedSettings,
 	LogEntry,
@@ -329,10 +328,7 @@ const App: React.FC = () => {
 		>
 			<div className="ai-request-logs__app">
 				{ settings.connectorApprovalNotice && (
-					<Notice
-						status="warning"
-						isDismissible={ false }
-					>
+					<Notice status="warning" isDismissible={ false }>
 						{ sprintf(
 							/* translators: %d: number of pending approval requests. */
 							_n(
@@ -345,7 +341,8 @@ const App: React.FC = () => {
 						) }{ ' ' }
 						<a href={ settings.connectorApprovalNotice.reviewUrl }>
 							{ __( 'Review requests', 'ai' ) }
-						</a>{ ' · ' }
+						</a>
+						{ ' · ' }
 						<a href={ settings.connectorApprovalNotice.dismissUrl }>
 							{ __( 'Dismiss', 'ai' ) }
 						</a>

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -10,7 +10,7 @@ import { Page } from '@wordpress/admin-ui';
 import apiFetch from '@wordpress/api-fetch';
 import { Notice } from '@wordpress/components';
 import { dispatch } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import {
 	createRoot,
@@ -35,6 +35,7 @@ import {
 import SettingsPanel from './components/SettingsPanel';
 import SummaryCards from './components/SummaryCards';
 import type {
+	ConnectorApprovalNotice,
 	FilterOptions,
 	LocalizedSettings,
 	LogEntry,
@@ -327,6 +328,30 @@ const App: React.FC = () => {
 			}
 		>
 			<div className="ai-request-logs__app">
+				{ settings.connectorApprovalNotice && (
+					<Notice
+						status="warning"
+						isDismissible={ false }
+					>
+						{ sprintf(
+							/* translators: %d: number of pending approval requests. */
+							_n(
+								'%d plugin or theme is requesting access to an AI connector.',
+								'%d plugins or themes are requesting access to AI connectors.',
+								settings.connectorApprovalNotice.count,
+								'ai'
+							),
+							settings.connectorApprovalNotice.count
+						) }{ ' ' }
+						<a href={ settings.connectorApprovalNotice.reviewUrl }>
+							{ __( 'Review requests', 'ai' ) }
+						</a>{ ' · ' }
+						<a href={ settings.connectorApprovalNotice.dismissUrl }>
+							{ __( 'Dismiss', 'ai' ) }
+						</a>
+					</Notice>
+				) }
+
 				{ error && (
 					<Notice status="error" onRemove={ () => setError( null ) }>
 						{ error }

--- a/src/admin/ai-request-logs/types.ts
+++ b/src/admin/ai-request-logs/types.ts
@@ -82,6 +82,12 @@ export interface LogsQuery {
 	order: 'asc' | 'desc';
 }
 
+export interface ConnectorApprovalNotice {
+	count: number;
+	reviewUrl: string;
+	dismissUrl: string;
+}
+
 export interface LocalizedSettings {
 	rest: {
 		nonce: string;
@@ -98,6 +104,7 @@ export interface LocalizedSettings {
 	};
 	connectorsUrl: string;
 	providerMetadata: ProviderMetadataMap;
+	connectorApprovalNotice: ConnectorApprovalNotice | null;
 }
 
 declare global {


### PR DESCRIPTION
## What?

Closes: #596 

Fixes the connector approval notice appearing inside the page header on the AI Request Logs screen

## Why?

WordPress Core's `common.js` moves `.notice` elements to after the first `h1` in `.wrap`. The `@wordpress/admin-ui` `Page` component renders its `h1` inside a flex header, so the notice ends up as an inline flex child in the header row instead of in the content area.

## How?

Instead of displaying the notice via PHP (which triggers Core's relocation script), the PHP notice is suppressed on this screen and the pending approval data is passed to the React app. The notice is then rendered directly in the page content area, in the right place.

Changes:
- **`Admin_Notice.php`** — suppress PHP notice on the Request Logs screen
- **`AI_Request_Log_Page.php`** — pass `connectorApprovalNotice` data to JS; add `get_connector_approval_notice_data()` 
- **`types.ts`** — add `ConnectorApprovalNotice` interface and field to `LocalizedSettings`
- **`index.tsx`** — render the notice in the content canvas

### Use of AI Tools

AI assistance: Yes  
Tool(s): Antigravity 
Used for: Root cause analysis and implementation. Tested by me.

## Testing Instructions

## Screenshots or screencast

# Before
<img width="941" height="111" alt="Screenshot 2026-05-21 at 12 06 54 PM" src="https://github.com/user-attachments/assets/7b76fa8c-dc01-4f17-9764-56a9749c3881" />

# After
<img width="1393" height="201" alt="Screenshot 2026-05-21 at 12 07 14 PM" src="https://github.com/user-attachments/assets/6732e9b3-c07f-4999-ae7e-0bd20146d9a9" />


## Changelog Entry

> Fixed - Connector approval notice now correctly appears below the page subtitle on the AI Request Logs screen instead of overlapping the page header.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-598-687daef7f0b676a3a622564fd95d0c28cf5571bd.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->