### PR TITLE
[Request Logs]: Fix focus loss on interaction with Purge Actions

### DIFF
--- a/src/admin/ai-request-logs/components/SettingsPanel.tsx
+++ b/src/admin/ai-request-logs/components/SettingsPanel.tsx
@@ -6,11 +6,13 @@ import { __ } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
 
 interface SettingsPanelProps {
+	hasLogs: boolean;
 	onPurgeLogs: () => void;
 	purging: boolean;
 }
 
 const SettingsPanel: React.FC< SettingsPanelProps > = ( {
+	hasLogs,
 	onPurgeLogs,
 	purging,
 } ) => {
@@ -89,7 +91,7 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 							isDestructive
 							ref={ focusPurgeButtonOnMount }
 							onClick={ handlePurge }
-							disabled={ purging }
+							disabled={ purging || ! hasLogs }
 							accessibleWhenDisabled
 						>
 							{ __( 'Purge All Logs', 'ai' ) }

--- a/src/admin/ai-request-logs/components/SettingsPanel.tsx
+++ b/src/admin/ai-request-logs/components/SettingsPanel.tsx
@@ -3,7 +3,7 @@
  */
 import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 
 interface SettingsPanelProps {
 	onPurgeLogs: () => void;
@@ -15,12 +15,30 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 	purging,
 } ) => {
 	const [ showPurgeConfirm, setShowPurgeConfirm ] = useState( false );
+	const focusPurgeButtonRef = useRef< boolean >( false );
+	const focusCancelButtonRef = useRef< boolean >( false );
+
+	function focusPurgeButtonOnMount( node: HTMLButtonElement | null ) {
+		if ( focusPurgeButtonRef.current && node ) {
+			node.focus();
+			focusPurgeButtonRef.current = false;
+		}
+	}
+
+	function focusCancelButtonOnMount( node: HTMLButtonElement | null ) {
+		if ( focusCancelButtonRef.current && node ) {
+			node.focus();
+			focusCancelButtonRef.current = false;
+		}
+	}
 
 	const handlePurge = () => {
 		if ( showPurgeConfirm ) {
 			onPurgeLogs();
 			setShowPurgeConfirm( false );
+			focusPurgeButtonRef.current = true;
 		} else {
+			focusCancelButtonRef.current = true;
 			setShowPurgeConfirm( true );
 		}
 	};
@@ -48,13 +66,19 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 								onClick={ handlePurge }
 								disabled={ purging }
 								isBusy={ purging }
+								accessibleWhenDisabled
 							>
 								{ __( 'Yes, Purge All', 'ai' ) }
 							</Button>
 							<Button
 								variant="secondary"
-								onClick={ () => setShowPurgeConfirm( false ) }
+								ref={ focusCancelButtonOnMount }
+								onClick={ () => {
+									setShowPurgeConfirm( false );
+									focusPurgeButtonRef.current = true;
+								} }
 								disabled={ purging }
+								accessibleWhenDisabled
 							>
 								{ __( 'Cancel', 'ai' ) }
 							</Button>
@@ -63,8 +87,10 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 						<Button
 							variant="secondary"
 							isDestructive
+							ref={ focusPurgeButtonOnMount }
 							onClick={ handlePurge }
 							disabled={ purging }
+							accessibleWhenDisabled
 						>
 							{ __( 'Purge All Logs', 'ai' ) }
 						</Button>

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -350,6 +350,7 @@ const App: React.FC = () => {
 					/>
 
 					<SettingsPanel
+						hasLogs={ total > 0 }
 						onPurgeLogs={ handlePurge }
 						purging={ purging }
 					/>


### PR DESCRIPTION
## What, and Why?

Adds focus management for the request logs purge confirmation flow. When Purge All Logs is clicked, focus moves to Cancel in the confirmation UI. When either `Cancel` or `Yes, Purge All` closes the confirmation UI, focus returns to Purge All Logs.

See #589  

## How?

Uses simple callback refs to focus conditionally rendered buttons as they mount.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Initial code skeleton; final implementation was reviewed and edited by me.

## Testing Instructions
1. Enable the "AI Request Logging" Experiment from Settings → AI.
2. Navigate to Tools → AI Request Logging.
3. Verify that no focus loss occurs when interacting with the confirmation buttons, including focus restoration after clicking Cancel.

## Screencast

### Before

https://github.com/user-attachments/assets/d744e462-8154-40f9-bd7b-66e401dd5b4b

### After

https://github.com/user-attachments/assets/832cb67e-2f70-4f52-9d73-6cbaeb5547e5

## Changelog Entry

> Fixed - Focus loss issues when interacting with Purge actions in the Request Logs experiments page.
> Fixed - Disabled the “Purge All” button when no logs are available to purge.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-599-91d96ce1a68d81190d95b7ef2ce6745622eb2446.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->