### PR TITLE
Change our AI connector check from looking at configuration to looking at if authentication is set

### DIFF
--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -19,7 +19,7 @@ use WordPress\AI\Settings\Settings_Registration;
 
 use function WordPress\AI\get_ai_connectors;
 use function WordPress\AI\has_ai_credentials;
-use function WordPress\AI\has_connector_authentication;
+use function WordPress\AI\is_connector_configured;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -210,7 +210,7 @@ class AI_Status_Widget {
 		foreach ( get_ai_connectors() as $slug => $connector_data ) {
 			$auth       = $connector_data['authentication'];
 			$configured = 'api_key' === $auth['method']
-				&& has_connector_authentication( $slug );
+				&& is_connector_configured( $slug );
 
 			/**
 			 * Filters whether an AI connector is configured.

--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -19,7 +19,7 @@ use WordPress\AI\Settings\Settings_Registration;
 
 use function WordPress\AI\get_ai_connectors;
 use function WordPress\AI\has_ai_credentials;
-use function WordPress\AI\is_connector_configured;
+use function WordPress\AI\has_connector_authentication;
 
 // Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -210,7 +210,7 @@ class AI_Status_Widget {
 		foreach ( get_ai_connectors() as $slug => $connector_data ) {
 			$auth       = $connector_data['authentication'];
 			$configured = 'api_key' === $auth['method']
-				&& is_connector_configured( $slug );
+				&& has_connector_authentication( $slug );
 
 			/**
 			 * Filters whether an AI connector is configured.

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -383,6 +383,79 @@ function is_connector_configured( string $connector_id ): bool {
 }
 
 /**
+ * Determines if a connector has authentication in place.
+ *
+ * This checks for API-key credentials by source only (environment variable,
+ * PHP constant, or stored option) and does not make external API requests.
+ *
+ * @since x.x.x
+ *
+ * @param string $connector_id The connector ID.
+ * @return bool True if connector authentication is present, false otherwise.
+ */
+function has_connector_authentication( string $connector_id ): bool {
+	if ( ! wp_is_connector_registered( $connector_id ) ) {
+		return false;
+	}
+
+	$connector = wp_get_connector( $connector_id );
+	if ( ! is_array( $connector ) ) {
+		return false;
+	}
+
+	$auth = $connector['authentication'] ?? null;
+	if ( ! is_array( $auth ) || ( $auth['method'] ?? '' ) !== 'api_key' ) {
+		return false;
+	}
+
+	$setting_name = $auth['setting_name'] ?? '';
+	if ( ! is_string( $setting_name ) || '' === $setting_name ) {
+		return false;
+	}
+
+	return 'none' !== get_connector_api_key_source(
+		$setting_name,
+		$auth['env_var_name'] ?? '',
+		$auth['constant_name'] ?? ''
+	);
+}
+
+/**
+ * Determines the source of a connector API key.
+ *
+ * Checks in order: environment variable, PHP constant, database option.
+ *
+ * @since x.x.x
+ *
+ * @param string $setting_name  The option name for the API key.
+ * @param string $env_var_name  Optional environment variable name.
+ * @param string $constant_name Optional PHP constant name.
+ * @return string The key source: 'env', 'constant', 'database', or 'none'.
+ */
+function get_connector_api_key_source( string $setting_name, string $env_var_name = '', string $constant_name = '' ): string {
+	if ( '' !== $env_var_name ) {
+		$env_value = getenv( $env_var_name );
+		if ( false !== $env_value && '' !== $env_value ) {
+			return 'env';
+		}
+	}
+
+	if ( '' !== $constant_name && defined( $constant_name ) ) {
+		$const_value = constant( $constant_name );
+		if ( is_string( $const_value ) && '' !== $const_value ) {
+			return 'constant';
+		}
+	}
+
+	$db_value = get_option( $setting_name, '' );
+	if ( '' !== $db_value ) {
+		return 'database';
+	}
+
+	return 'none';
+}
+
+/**
  * Checks if we have AI credentials set.
  *
  * @since 0.1.0
@@ -399,7 +472,7 @@ function has_ai_credentials(): bool {
 			continue;
 		}
 
-		if ( ! is_connector_configured( $connector_id ) ) {
+		if ( ! has_connector_authentication( $connector_id ) ) {
 			continue;
 		}
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -34,6 +34,8 @@ parameters:
 			- '#WP_AI_Client_[A-Za-z0-9_]+#'
 			- '#WordPress\\AiClient\\#'
 			- '#Function wp_get_connectors not found\.#'
+			- '#Function wp_is_connector_registered not found\.#'
+			- '#Function wp_get_connector not found\.#'
 			- '#class cli\\progress\\Bar#'
 			- '#Function wp_supports_ai not found\.#'
 		excludePaths:

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -948,17 +948,21 @@ class HelpersTest extends WP_UnitTestCase {
 				),
 			)
 		);
-		Helper_Test_Provider_Availability::$is_configured = true;
+		$setting_name = 'connectors_ai_provider_' . self::TEST_AI_PROVIDER_ID . '_api_key';
+		update_option( $setting_name, 'test-api-key' );
 
-		$this->assertTrue( \WordPress\AI\has_ai_credentials() );
+		try {
+			$this->assertTrue( \WordPress\AI\has_ai_credentials() );
+		} finally {
+			delete_option( $setting_name );
+		}
 	}
 
 	/**
-	 * Test that has_ai_credentials() returns false when no API-key connector is configured.
+	 * Test that has_ai_credentials() returns false when no API-key connector has authentication.
 	 *
-	 * Exercises the loop's continue path: a registered api_key connector whose provider
-	 * is not configured (no option, env var, or constant set) must not be treated as
-	 * credentialed.
+	 * Exercises the loop's continue path: a registered api_key connector with no option,
+	 * env var, or constant set must not be treated as credentialed.
 	 *
 	 * @since x.x.x
 	 */
@@ -974,9 +978,72 @@ class HelpersTest extends WP_UnitTestCase {
 				),
 			)
 		);
-		Helper_Test_Provider_Availability::$is_configured = false;
 
 		$this->assertFalse( \WordPress\AI\has_ai_credentials() );
+	}
+
+	/**
+	 * Test that has_connector_authentication() returns false for unknown connectors.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_has_connector_authentication_returns_false_for_unknown_connector(): void {
+		$this->assertFalse( \WordPress\AI\has_connector_authentication( 'wpai_unknown_provider' ) );
+	}
+
+	/**
+	 * Test that has_connector_authentication() detects option-based API key auth.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_has_connector_authentication_detects_database_option(): void {
+		$connector_id  = 'wpai_test_auth_provider';
+		$setting_name  = 'connectors_ai_provider_wpai_test_auth_provider_api_key';
+		$connector_data = array(
+			'name'           => 'Auth Test Provider',
+			'type'           => 'ai_provider',
+			'authentication' => array(
+				'method' => 'api_key',
+			),
+		);
+
+		$this->register_test_connector( $connector_id, $connector_data );
+		update_option( $setting_name, 'test-api-key' );
+
+		try {
+			$this->assertTrue( \WordPress\AI\has_connector_authentication( $connector_id ) );
+		} finally {
+			delete_option( $setting_name );
+		}
+	}
+
+	/**
+	 * Test that has_connector_authentication() detects env var API key auth.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_has_connector_authentication_detects_environment_variable(): void {
+		$connector_id = 'wpai_env_auth_provider';
+		$this->register_test_connector(
+			$connector_id,
+			array(
+				'name'           => 'Env Auth Test Provider',
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method'       => 'api_key',
+					'env_var_name' => 'WPAI_ENV_AUTH_PROVIDER_API_KEY',
+				),
+			)
+		);
+
+		$env_var_name = 'WPAI_ENV_AUTH_PROVIDER_API_KEY';
+		putenv( "{$env_var_name}=test-env-key" );
+
+		try {
+			$this->assertTrue( \WordPress\AI\has_connector_authentication( $connector_id ) );
+		} finally {
+			putenv( $env_var_name );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## What?

Adds new helper functions that check if a connector has authentication in place, going from ENV var to constant to API key in the database. Use this in place of our new `is_connector_configured` check.

## Why?

In #537 we added a new `is_connector_configured` function and use that when determining if we have AI credentials. In testing something else, I was seeing lots of extra requests being made and realized that the `$registry->isProviderConfigured( $connector_id )` check that we run in `is_connector_configured` makes an actual API request to validate credentials.

While this can be great in some circumstances, by attaching that to our `has_ai_credentials` function, this ends up running all the time (basically every admin page load).

The original code here never verified credentials, it just checked if we had an API key set. As reported in #536, the issue with that check is it didn't consider ENV vars or constants and we fixed that with this new `is_connector_configured` function.

But I don't think it's ideal to make all of these requests so this PR adds new functions that are now used instead of `is_connector_configured` that bring us back to just checking for the existence of credentials, though now checking ENV var, constants and API keys in the database to resolve the original issue. This matches the original intent discussed [here](https://github.com/WordPress/ai/issues/536#issuecomment-4432010747).

## How?

- Adds a new `has_connector_authentication` and `get_connector_api_key_source`, the latter mirroring what WordPress Core does in `_wp_connectors_get_api_key_source` and the former being used as a replacement for `is_connector_configured`
- We retain the `is_connector_configured` function in case we want to use this at some point in the future. For example, likely could replace our `has_valid_ai_credentials` with this, or use it within that

### Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): GPT-5.5
Used for: Investigating the issue and researching a few approaches to resolving. Execution and testing done by me

## Testing Instructions

See testing instructions on #537 to ensure that issue is still resolved

## Changelog Entry

> Added - New helper functions that are used to determine if we have valid AI Connector credentials.
> Changed - Use the new `has_connector_authentication` instead of `is_connector_configured` to avoid unnecessary API requests.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-603-b99f38f65281b771890a1765e98df3cbab5d8beb.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->