### PR TITLE
Fix AI Status feature checklist state

### DIFF
--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -202,8 +202,9 @@ abstract class Abstract_Feature implements Feature {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * Features require both the global toggle and individual feature toggle to be enabled.
-	 * Results are cached per instance to avoid redundant option lookups and filter calls.
+	 * Features require both the global toggle and individual
+	 * feature toggle to be enabled. Results are cached per
+	 * instance to avoid redundant option lookups and filter calls.
 	 */
 	final public function is_enabled(): bool {
 		// Return cached result if available.

--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -167,24 +167,15 @@ abstract class Abstract_Feature implements Feature {
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * Features require both the global toggle and individual feature toggle to be enabled.
-	 * Results are cached per instance to avoid redundant option lookups and filter calls.
 	 */
-	final public function is_enabled(): bool {
-		// Return cached result if available.
-		if ( null !== $this->enabled_cache ) {
-			return $this->enabled_cache;
-		}
+	final public function is_globally_enabled(): bool {
+		return (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
+	}
 
-		// Check global features toggle first.
-		$global_enabled = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
-		if ( ! $global_enabled ) {
-			$this->enabled_cache = false;
-			return false;
-		}
-
-		// Check feature-specific option.
+	/**
+	 * {@inheritDoc}
+	 */
+	final public function is_individually_enabled(): bool {
 		$feature_enabled = (bool) get_option( "wpai_feature_{$this->id}_enabled", false );
 
 		// @todo remove in v1.0
@@ -205,12 +196,25 @@ abstract class Abstract_Feature implements Feature {
 		 *
 		 * @param bool $feature_enabled Whether the feature is enabled.
 		 */
-		$is_enabled = (bool) apply_filters( "wpai_feature_{$this->id}_enabled", $is_enabled );
+		return (bool) apply_filters( "wpai_feature_{$this->id}_enabled", $is_enabled );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Features require both the global toggle and individual feature toggle to be enabled.
+	 * Results are cached per instance to avoid redundant option lookups and filter calls.
+	 */
+	final public function is_enabled(): bool {
+		// Return cached result if available.
+		if ( null !== $this->enabled_cache ) {
+			return $this->enabled_cache;
+		}
 
 		// Cache the result.
-		$this->enabled_cache = $is_enabled;
+		$this->enabled_cache = $this->is_globally_enabled() && $this->is_individually_enabled();
 
-		return $is_enabled;
+		return $this->enabled_cache;
 	}
 
 	/**

--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -62,14 +62,14 @@ class AI_Status_Widget {
 	 * @since 0.8.0
 	 */
 	public function render(): void {
-		$has_credentials = has_ai_credentials();
-		$global_enabled  = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
-		$any_feature_on  = $this->has_any_enabled_feature();
+		$has_credentials         = has_ai_credentials();
+		$global_enabled          = (bool) get_option( Settings_Registration::GLOBAL_OPTION, false );
+		$feature_setting_enabled = $this->has_any_enabled_feature_setting();
 
-		if ( $has_credentials && $global_enabled && $any_feature_on ) {
+		if ( $has_credentials && $global_enabled && $feature_setting_enabled ) {
 			$this->render_status();
 		} else {
-			$this->render_getting_started( $has_credentials, $global_enabled, $any_feature_on );
+			$this->render_getting_started( $has_credentials, $global_enabled, $feature_setting_enabled );
 		}
 	}
 
@@ -78,11 +78,11 @@ class AI_Status_Widget {
 	 *
 	 * @since 0.8.0
 	 *
-	 * @param bool $has_credentials   Whether any AI provider credentials are configured.
-	 * @param bool $global_enabled    Whether the global features toggle is on.
-	 * @param bool $any_feature_on Whether at least one feature is enabled.
+	 * @param bool $has_credentials         Whether any AI provider credentials are configured.
+	 * @param bool $global_enabled          Whether the global features toggle is on.
+	 * @param bool $feature_setting_enabled Whether at least one feature setting is enabled.
 	 */
-	private function render_getting_started( bool $has_credentials, bool $global_enabled, bool $any_feature_on ): void {
+	private function render_getting_started( bool $has_credentials, bool $global_enabled, bool $feature_setting_enabled ): void {
 		$steps = array(
 			array(
 				'done'  => $has_credentials,
@@ -95,7 +95,7 @@ class AI_Status_Widget {
 				'url'   => admin_url( 'options-general.php?page=ai-wp-admin' ),
 			),
 			array(
-				'done'  => $any_feature_on,
+				'done'  => $feature_setting_enabled,
 				'label' => __( 'Enable a feature or experiment', 'ai' ),
 				'url'   => admin_url( 'options-general.php?page=ai-wp-admin' ),
 			),
@@ -239,15 +239,16 @@ class AI_Status_Widget {
 	}
 
 	/**
-	 * Checks whether any registered feature is individually enabled.
+	 * Checks whether any registered feature has its individual setting enabled.
 	 *
 	 * @since 0.8.0
 	 *
-	 * @return bool True if at least one feature is enabled.
+	 * @return bool True if at least one feature setting is enabled.
 	 */
-	private function has_any_enabled_feature(): bool {
+	private function has_any_enabled_feature_setting(): bool {
 		foreach ( $this->registry->get_all_features() as $feature ) {
-			if ( $feature->is_enabled() ) {
+			$option_name = 'wpai_feature_' . $feature::get_id() . '_enabled';
+			if ( (bool) get_option( $option_name, false ) ) {
 				return true;
 			}
 		}

--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -247,8 +247,7 @@ class AI_Status_Widget {
 	 */
 	private function has_any_enabled_feature_setting(): bool {
 		foreach ( $this->registry->get_all_features() as $feature ) {
-			$option_name = 'wpai_feature_' . $feature::get_id() . '_enabled';
-			if ( (bool) get_option( $option_name, false ) ) {
+			if ( $feature->is_individually_enabled() ) {
 				return true;
 			}
 		}

--- a/includes/Contracts/Feature.php
+++ b/includes/Contracts/Feature.php
@@ -81,9 +81,9 @@ interface Feature {
 	public function register(): void;
 
 	/**
-	 * Checks if AI features are globally enabled.
+	 * Checks if features are globally enabled.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @return bool True if globally enabled, false otherwise.
 	 */
@@ -92,7 +92,7 @@ interface Feature {
 	/**
 	 * Checks if the feature is individually enabled.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @return bool True if individually enabled, false otherwise.
 	 */

--- a/includes/Contracts/Feature.php
+++ b/includes/Contracts/Feature.php
@@ -81,6 +81,24 @@ interface Feature {
 	public function register(): void;
 
 	/**
+	 * Checks if AI features are globally enabled.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if globally enabled, false otherwise.
+	 */
+	public function is_globally_enabled(): bool;
+
+	/**
+	 * Checks if the feature is individually enabled.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool True if individually enabled, false otherwise.
+	 */
+	public function is_individually_enabled(): bool;
+
+	/**
 	 * Checks if the feature is currently enabled.
 	 *
 	 * @since 0.6.0

--- a/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
@@ -349,7 +349,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 	/**
 	 * Tests that is_globally_enabled() returns the global enabled state.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_is_globally_enabled_returns_global_enabled_state(): void {
 		$experiment = new Test_Categorized_Experiment();
@@ -364,7 +364,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 	/**
 	 * Tests that is_individually_enabled() applies the feature enabled filter.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_is_individually_enabled_applies_feature_filter(): void {
 		update_option( 'wpai_feature_test-categorized_enabled', false );
@@ -378,7 +378,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 	/**
 	 * Tests that is_enabled() still requires the global enabled state.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_is_enabled_still_requires_global_enabled_state(): void {
 		update_option( 'wpai_features_enabled', false );

--- a/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_ExperimentTest.php
@@ -254,6 +254,7 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 		delete_option( 'wpai_feature_test-categorized_enabled' );
 		delete_option( 'wpai_feature_test-uncategorized_enabled' );
 		delete_option( 'wpai_feature_test-empty-category_enabled' );
+		remove_all_filters( 'wpai_feature_test-categorized_enabled' );
 		parent::tearDown();
 	}
 
@@ -343,6 +344,50 @@ class Abstract_FeatureTest extends WP_UnitTestCase {
 	public function test_get_stability_custom() {
 		$experiment = new Mock_Custom_Stability_Experiment();
 		$this->assertEquals( 'stable', $experiment->get_stability(), 'Custom stability should be returned from metadata' );
+	}
+
+	/**
+	 * Tests that is_globally_enabled() returns the global enabled state.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_is_globally_enabled_returns_global_enabled_state(): void {
+		$experiment = new Test_Categorized_Experiment();
+
+		update_option( 'wpai_features_enabled', false );
+		$this->assertFalse( $experiment->is_globally_enabled() );
+
+		update_option( 'wpai_features_enabled', true );
+		$this->assertTrue( $experiment->is_globally_enabled() );
+	}
+
+	/**
+	 * Tests that is_individually_enabled() applies the feature enabled filter.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_is_individually_enabled_applies_feature_filter(): void {
+		update_option( 'wpai_feature_test-categorized_enabled', false );
+		add_filter( 'wpai_feature_test-categorized_enabled', '__return_true' );
+
+		$experiment = new Test_Categorized_Experiment();
+
+		$this->assertTrue( $experiment->is_individually_enabled() );
+	}
+
+	/**
+	 * Tests that is_enabled() still requires the global enabled state.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_is_enabled_still_requires_global_enabled_state(): void {
+		update_option( 'wpai_features_enabled', false );
+		update_option( 'wpai_feature_test-categorized_enabled', true );
+
+		$experiment = new Test_Categorized_Experiment();
+
+		$this->assertTrue( $experiment->is_individually_enabled() );
+		$this->assertFalse( $experiment->is_enabled() );
 	}
 
 	/**

--- a/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
@@ -206,6 +206,33 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the feature step uses the individual feature setting.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_getting_started_shows_success_for_enabled_feature_when_global_ai_is_disabled() {
+		update_option( Settings_Registration::GLOBAL_OPTION, false );
+		update_option( 'wpai_feature_test-feature-a_enabled', true );
+
+		$registry = new Registry();
+		$registry->register_feature( new Status_Test_Feature_A() );
+
+		$widget = new AI_Status_Widget( $registry );
+
+		ob_start();
+		$widget->render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'ai-dashboard-status__checklist', $output );
+
+		$this->assertMatchesRegularExpression(
+			'/dashicons-yes-alt.*Enable a feature or experiment/s',
+			$output,
+			'Should show the feature step as complete when its individual setting is enabled'
+		);
+	}
+
+	/**
 	 * Tests that the checklist links to the correct admin pages.
 	 *
 	 * @since 0.8.0

--- a/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
@@ -89,6 +89,7 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 		delete_option( Settings_Registration::GLOBAL_OPTION );
 		delete_option( 'wpai_feature_test-feature-a_enabled' );
 		delete_option( 'wpai_feature_test-feature-b_enabled' );
+		remove_all_filters( 'wpai_feature_test-feature-a_enabled' );
 		parent::tearDown();
 	}
 
@@ -229,6 +230,34 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 			'/dashicons-yes-alt.*Enable a feature or experiment/s',
 			$output,
 			'Should show the feature step as complete when its individual setting is enabled'
+		);
+	}
+
+	/**
+	 * Tests that the feature step respects the individual feature enabled filter.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_getting_started_shows_success_for_filtered_enabled_feature() {
+		update_option( Settings_Registration::GLOBAL_OPTION, false );
+		update_option( 'wpai_feature_test-feature-a_enabled', false );
+		add_filter( 'wpai_feature_test-feature-a_enabled', '__return_true' );
+
+		$registry = new Registry();
+		$registry->register_feature( new Status_Test_Feature_A() );
+
+		$widget = new AI_Status_Widget( $registry );
+
+		ob_start();
+		$widget->render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'ai-dashboard-status__checklist', $output );
+
+		$this->assertMatchesRegularExpression(
+			'/dashicons-yes-alt.*Enable a feature or experiment/s',
+			$output,
+			'Should show the feature step as complete when the individual feature filter enables it'
 		);
 	}
 

--- a/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
@@ -209,7 +209,7 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Tests that the feature step uses the individual feature setting.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_getting_started_shows_success_for_enabled_feature_when_global_ai_is_disabled() {
 		update_option( Settings_Registration::GLOBAL_OPTION, false );
@@ -236,7 +236,7 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Tests that the feature step respects the individual feature enabled filter.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_getting_started_shows_success_for_filtered_enabled_feature() {
 		update_option( Settings_Registration::GLOBAL_OPTION, false );


### PR DESCRIPTION
## What?

Fixes the AI Status dashboard checklist so the "Enable a feature or experiment" step reflects whether an individual feature setting is enabled.

## Why?

The checklist currently uses the feature runtime enabled state for this step. That state also depends on the global Enable AI toggle, so when global AI is off the dashboard can show the feature step as incomplete even if a feature or experiment is already enabled in Settings > AI.

This makes the setup checklist confusing because the global AI step and the individual feature step are separate checklist items.

## How?

The dashboard widget now checks the saved individual feature options for the checklist step. The full status view still requires credentials, the global AI toggle, and at least one enabled feature setting.

## Testing Instructions

Manual testing:

1. Go to Settings > AI.
2. Enable at least one feature or experiment.
3. Turn the global Enable AI toggle off.
4. Go to Dashboard.
5. Confirm the AI Status checklist shows:
   - Configure an AI provider: complete, if a connector is configured.
   - Globally enable AI Features: incomplete.
   - Enable a feature or experiment: complete.

Automated checks run locally:

```bash
npm run test:php -- --filter AI_Status_WidgetTest
npm run lint:php -- includes/Admin/Dashboard/AI_Status_Widget.php tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
npm run lint:php:stan -- includes/Admin/Dashboard/AI_Status_Widget.php tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
npm run test:e2e -- tests/e2e/specs/admin/dashboard.spec.js
```

## Screenshots/Screencast

Before:

The Dashboard AI Status checklist showed "Enable a feature or experiment" as incomplete when global AI was off, even though an individual feature was enabled.

<img width="934" height="388" alt="before" src="https://github.com/user-attachments/assets/849b0d09-e6e9-4070-9f4f-01fe4f35d077" />


After:

The same checklist now shows "Enable a feature or experiment" as complete when an individual feature setting is enabled, while "Globally enable AI Features" remains incomplete.

<img width="916" height="380" alt="after" src="https://github.com/user-attachments/assets/e3855c37-f238-4d3d-9146-c986f79b6f56" />



## Use of AI Tools

AI assistance: Yes
Tool(s): ChatGPT / Codex
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-604-f7a0d6049c4a96eb51d90851eff10f875f2d9eeb.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->