### PR TITLE
Code Quality: Remove deprecated `__nextHasNoMarginBottom` prop

### DIFF
--- a/src/admin/ai-request-logs/components/HeaderPeriodSelector.tsx
+++ b/src/admin/ai-request-logs/components/HeaderPeriodSelector.tsx
@@ -34,7 +34,6 @@ const HeaderPeriodSelector: React.FC< HeaderPeriodSelectorProps > = ( {
 		] }
 		onChange={ ( value ) => onPeriodChange( value as SummaryPeriod ) }
 		disabled={ loading }
-		__nextHasNoMarginBottom
 		__next40pxDefaultSize
 	/>
 );

--- a/src/experiments/alt-text-generation/components/AltTextControls.tsx
+++ b/src/experiments/alt-text-generation/components/AltTextControls.tsx
@@ -188,7 +188,6 @@ export function AltTextControls( {
 							value={ generatedAlt || '' }
 							onChange={ ( value ) => setGeneratedAlt( value ) }
 							rows={ 3 }
-							__nextHasNoMarginBottom
 						/>
 						<div
 							style={ {

--- a/src/experiments/alt-text-generation/components/MediaEditorAltTextControl.tsx
+++ b/src/experiments/alt-text-generation/components/MediaEditorAltTextControl.tsx
@@ -99,7 +99,6 @@ export function MediaEditorAltTextControl( {
 				value={ currentAlt || '' }
 				onChange={ ( value ) => onChange( { alt_text: value } ) }
 				rows={ 2 }
-				__nextHasNoMarginBottom
 			/>
 
 			{ /* Decorative image notice. */ }

--- a/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
+++ b/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
@@ -96,7 +96,6 @@ const ApprovalMatrixCard = ( {
 										return (
 											<td key={ connector.id }>
 												<ToggleControl
-													__nextHasNoMarginBottom
 													checked={ approved }
 													disabled={ isSaving }
 													label=""

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -125,7 +125,6 @@ export default function MetaDescriptionModal( {
 							'Aim for 140–160 characters for optimal display in search results.',
 							'ai'
 						) }
-						__nextHasNoMarginBottom
 					/>
 					<CharacterCount count={ editableText.length } />
 				</div>

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -234,7 +234,6 @@ export default function TitleToolbar( {
 						value={ generatedTitle }
 						onChange={ setGeneratedTitle }
 						disabled={ isRegenerating }
-						__nextHasNoMarginBottom
 					/>
 					<Flex
 						justify="flex-end"

--- a/src/features/image-generation/components/MediaLibraryImageEditor.tsx
+++ b/src/features/image-generation/components/MediaLibraryImageEditor.tsx
@@ -423,7 +423,6 @@ export function MediaLibraryImageEditor( {
 								value={ prompt }
 								onChange={ setPrompt }
 								rows={ 3 }
-								__nextHasNoMarginBottom
 							/>
 							<div className="ai-media-library-editor__actions">
 								<Button
@@ -454,7 +453,6 @@ export function MediaLibraryImageEditor( {
 					/>
 					<div className="ai-media-library-editor__masking-sidebar">
 						<RangeControl
-							__nextHasNoMarginBottom
 							label={ __( 'Brush size', 'ai' ) }
 							value={ brushSize }
 							onChange={ ( value ) =>
@@ -487,7 +485,6 @@ export function MediaLibraryImageEditor( {
 								value={ replacePrompt }
 								onChange={ setReplacePrompt }
 								rows={ 2 }
-								__nextHasNoMarginBottom
 							/>
 						) }
 						<div className="ai-media-library-editor__masking-sidebar-actions">
@@ -726,7 +723,6 @@ export function MediaLibraryImageEditor( {
 						value={ refinePrompt }
 						onChange={ setRefinePrompt }
 						rows={ 3 }
-						__nextHasNoMarginBottom
 					/>
 					<div className="ai-media-library-editor__actions">
 						<Button

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -88,7 +88,6 @@ export function PromptForm( {
 				onChange={ onPromptChange }
 				rows={ 4 }
 				hideLabelFromVision
-				__nextHasNoMarginBottom
 			/>
 			<div className="ai-image-generation__actions">
 				<Button
@@ -247,7 +246,6 @@ export function RefinePromptForm( {
 				value={ refinePrompt }
 				onChange={ onRefinePromptChange }
 				rows={ 3 }
-				__nextHasNoMarginBottom
 			/>
 			<div className="ai-image-generation__actions">
 				<Button


### PR DESCRIPTION
## What, Why, and How?

Removes the usage of the deprecated `__nextHasNoMarginBottom` prop as it's the default behavior since WordPress 7.0. The soft deprecation was introduced in WP 6.7 and scheduled to be removed in WP 7.0.

Related:
https://github.com/WordPress/gutenberg/issues/73848
https://github.com/WordPress/gutenberg/pull/75139

### Use of AI Tools
None

## Testing Instructions
1. Tests should pass
2. No visual diff

## Changelog Entry

> Removed - deprecated `__nextHasNoMarginBottom` prop

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-609-acb212dd8fdc323d2d892ecb64ad29ea5e6630da.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->