### PR TITLE
Fix: Focus loss when generation buttons enter disabled state

### DIFF
--- a/src/experiments/alt-text-generation/components/AltTextControls.tsx
+++ b/src/experiments/alt-text-generation/components/AltTextControls.tsx
@@ -240,6 +240,7 @@ export function AltTextControls( {
 						variant="secondary"
 						onClick={ handleGenerate }
 						disabled={ isGenerating }
+						accessibleWhenDisabled
 						style={ { width: '100%', justifyContent: 'center' } }
 						isBusy={ isGenerating }
 						icon={ update }

--- a/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
@@ -45,6 +45,7 @@ export default function ExcerptGeneration(): React.JSX.Element | null {
 			variant="secondary"
 			onClick={ handleGenerate }
 			disabled={ isGenerating }
+			accessibleWhenDisabled
 			isBusy={ isGenerating }
 		>
 			{ buttonLabel }

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -29,19 +29,19 @@ export default function SummarizationPlugin() {
 		minContentLength,
 	} = useSummaryGeneration();
 
-	let buttonLabel: string = __('Generate Summary', 'ai');
+	let buttonLabel: string = __( 'Generate Summary', 'ai' );
 
-	if (isSummarizing) {
-		buttonLabel = __('Generating…', 'ai');
-	} else if (hasSummary) {
-		buttonLabel = __('Regenerate Summary', 'ai');
+	if ( isSummarizing ) {
+		buttonLabel = __( 'Generating…', 'ai' );
+	} else if ( hasSummary ) {
+		buttonLabel = __( 'Regenerate Summary', 'ai' );
 	}
 
 	const isDisabled = isSummarizing || isContentTooShort;
 
 	let buttonDescription: string;
 
-	if (isContentTooShort) {
+	if ( isContentTooShort ) {
 		buttonDescription = sprintf(
 			/* translators: %d: minimum number of characters required */
 			__(
@@ -50,7 +50,7 @@ export default function SummarizationPlugin() {
 			),
 			minContentLength
 		);
-	} else if (hasSummary) {
+	} else if ( hasSummary ) {
 		buttonDescription = __(
 			'This will update the generated summary block with a new summary of the content of this post.',
 			'ai'
@@ -63,7 +63,7 @@ export default function SummarizationPlugin() {
 	}
 
 	// Don't render if disabled.
-	if (!aiSummarizationData?.enabled) {
+	if ( ! aiSummarizationData?.enabled ) {
 		return null;
 	}
 
@@ -72,25 +72,25 @@ export default function SummarizationPlugin() {
 			<Flex
 				direction="column"
 				className="ai-summarization-plugin-container"
-				gap={2}
+				gap={ 2 }
 			>
 				<FlexItem>
 					<Button
 						className="ai-summarization-plugin-button"
 						variant="secondary"
-						label={buttonLabel}
-						icon={update}
-						onClick={handleSummarize}
-						disabled={isDisabled}
+						label={ buttonLabel }
+						icon={ update }
+						onClick={ handleSummarize }
+						disabled={ isDisabled }
 						accessibleWhenDisabled
-						isBusy={isSummarizing}
+						isBusy={ isSummarizing }
 						__next40pxDefaultSize
 					>
-						{buttonLabel}
+						{ buttonLabel }
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<span className="description">{buttonDescription}</span>
+					<span className="description">{ buttonDescription }</span>
 				</FlexItem>
 			</Flex>
 		</PluginPostStatusInfo>

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -29,19 +29,19 @@ export default function SummarizationPlugin() {
 		minContentLength,
 	} = useSummaryGeneration();
 
-	let buttonLabel: string = __('Generate Summary', 'ai');
+	let buttonLabel: string = __( 'Generate Summary', 'ai' );
 
-	if (isSummarizing) {
-		buttonLabel = __('Generating…', 'ai');
-	} else if (hasSummary) {
-		buttonLabel = __('Regenerate Summary', 'ai');
+	if ( isSummarizing ) {
+		buttonLabel = __( 'Generating…', 'ai' );
+	} else if ( hasSummary ) {
+		buttonLabel = __( 'Regenerate Summary', 'ai' );
 	}
 
 	const isDisabled = isSummarizing || isContentTooShort;
 
 	let buttonDescription: string;
 
-	if (isContentTooShort) {
+	if ( isContentTooShort ) {
 		buttonDescription = sprintf(
 			/* translators: %d: minimum number of characters required */
 			__(
@@ -50,7 +50,7 @@ export default function SummarizationPlugin() {
 			),
 			minContentLength
 		);
-	} else if (hasSummary) {
+	} else if ( hasSummary ) {
 		buttonDescription = __(
 			'This will update the generated summary block with a new summary of the content of this post.',
 			'ai'
@@ -63,7 +63,7 @@ export default function SummarizationPlugin() {
 	}
 
 	// Don't render if disabled.
-	if (!aiSummarizationData?.enabled) {
+	if ( ! aiSummarizationData?.enabled ) {
 		return null;
 	}
 
@@ -72,24 +72,24 @@ export default function SummarizationPlugin() {
 			<Flex
 				direction="column"
 				className="ai-summarization-plugin-container"
-				gap={2}
+				gap={ 2 }
 			>
 				<FlexItem>
 					<Button
 						className="ai-summarization-plugin-button"
 						variant="secondary"
-						label={buttonLabel}
-						icon={update}
-						onClick={handleSummarize}
-						disabled={isDisabled}
-						isBusy={isSummarizing}
+						label={ buttonLabel }
+						icon={ update }
+						onClick={ handleSummarize }
+						disabled={ isDisabled }
+						isBusy={ isSummarizing }
 						__next40pxDefaultSize
 					>
-						{buttonLabel}
+						{ buttonLabel }
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<span className="description">{buttonDescription}</span>
+					<span className="description">{ buttonDescription }</span>
 				</FlexItem>
 			</Flex>
 		</PluginPostStatusInfo>

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -29,19 +29,19 @@ export default function SummarizationPlugin() {
 		minContentLength,
 	} = useSummaryGeneration();
 
-	let buttonLabel: string = __( 'Generate Summary', 'ai' );
+	let buttonLabel: string = __('Generate Summary', 'ai');
 
-	if ( isSummarizing ) {
-		buttonLabel = __( 'Generating…', 'ai' );
-	} else if ( hasSummary ) {
-		buttonLabel = __( 'Regenerate Summary', 'ai' );
+	if (isSummarizing) {
+		buttonLabel = __('Generating…', 'ai');
+	} else if (hasSummary) {
+		buttonLabel = __('Regenerate Summary', 'ai');
 	}
 
 	const isDisabled = isSummarizing || isContentTooShort;
 
 	let buttonDescription: string;
 
-	if ( isContentTooShort ) {
+	if (isContentTooShort) {
 		buttonDescription = sprintf(
 			/* translators: %d: minimum number of characters required */
 			__(
@@ -50,7 +50,7 @@ export default function SummarizationPlugin() {
 			),
 			minContentLength
 		);
-	} else if ( hasSummary ) {
+	} else if (hasSummary) {
 		buttonDescription = __(
 			'This will update the generated summary block with a new summary of the content of this post.',
 			'ai'
@@ -63,7 +63,7 @@ export default function SummarizationPlugin() {
 	}
 
 	// Don't render if disabled.
-	if ( ! aiSummarizationData?.enabled ) {
+	if (!aiSummarizationData?.enabled) {
 		return null;
 	}
 
@@ -72,24 +72,25 @@ export default function SummarizationPlugin() {
 			<Flex
 				direction="column"
 				className="ai-summarization-plugin-container"
-				gap={ 2 }
+				gap={2}
 			>
 				<FlexItem>
 					<Button
 						className="ai-summarization-plugin-button"
 						variant="secondary"
-						label={ buttonLabel }
-						icon={ update }
-						onClick={ handleSummarize }
-						disabled={ isDisabled }
-						isBusy={ isSummarizing }
+						label={buttonLabel}
+						icon={update}
+						onClick={handleSummarize}
+						disabled={isDisabled}
+						accessibleWhenDisabled
+						isBusy={isSummarizing}
 						__next40pxDefaultSize
 					>
-						{ buttonLabel }
+						{buttonLabel}
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<span className="description">{ buttonDescription }</span>
+					<span className="description">{buttonDescription}</span>
 				</FlexItem>
 			</Flex>
 		</PluginPostStatusInfo>

--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -29,19 +29,19 @@ export default function SummarizationPlugin() {
 		minContentLength,
 	} = useSummaryGeneration();
 
-	let buttonLabel: string = __( 'Generate Summary', 'ai' );
+	let buttonLabel: string = __('Generate Summary', 'ai');
 
-	if ( isSummarizing ) {
-		buttonLabel = __( 'Generating…', 'ai' );
-	} else if ( hasSummary ) {
-		buttonLabel = __( 'Regenerate Summary', 'ai' );
+	if (isSummarizing) {
+		buttonLabel = __('Generating…', 'ai');
+	} else if (hasSummary) {
+		buttonLabel = __('Regenerate Summary', 'ai');
 	}
 
 	const isDisabled = isSummarizing || isContentTooShort;
 
 	let buttonDescription: string;
 
-	if ( isContentTooShort ) {
+	if (isContentTooShort) {
 		buttonDescription = sprintf(
 			/* translators: %d: minimum number of characters required */
 			__(
@@ -50,7 +50,7 @@ export default function SummarizationPlugin() {
 			),
 			minContentLength
 		);
-	} else if ( hasSummary ) {
+	} else if (hasSummary) {
 		buttonDescription = __(
 			'This will update the generated summary block with a new summary of the content of this post.',
 			'ai'
@@ -63,7 +63,7 @@ export default function SummarizationPlugin() {
 	}
 
 	// Don't render if disabled.
-	if ( ! aiSummarizationData?.enabled ) {
+	if (!aiSummarizationData?.enabled) {
 		return null;
 	}
 
@@ -72,25 +72,24 @@ export default function SummarizationPlugin() {
 			<Flex
 				direction="column"
 				className="ai-summarization-plugin-container"
-				gap={ 2 }
+				gap={2}
 			>
 				<FlexItem>
 					<Button
 						className="ai-summarization-plugin-button"
 						variant="secondary"
-						label={ buttonLabel }
-						icon={ update }
-						onClick={ handleSummarize }
-						disabled={ isDisabled }
-						accessibleWhenDisabled
-						isBusy={ isSummarizing }
+						label={buttonLabel}
+						icon={update}
+						onClick={handleSummarize}
+						disabled={isDisabled}
+						isBusy={isSummarizing}
 						__next40pxDefaultSize
 					>
-						{ buttonLabel }
+						{buttonLabel}
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<span className="description">{ buttonDescription }</span>
+					<span className="description">{buttonDescription}</span>
 				</FlexItem>
 			</Flex>
 		</PluginPostStatusInfo>

--- a/src/features/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/features/image-generation/components/GenerateFeaturedImage.tsx
@@ -82,6 +82,7 @@ export default function GenerateFeaturedImage(): React.JSX.Element | null {
 					className="ai-generate-featured-image editor-post-featured-image__toggle"
 					onClick={ handleGenerate }
 					disabled={ isGenerating }
+					accessibleWhenDisabled
 					isBusy={ isGenerating }
 				>
 					{ isGenerating


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of #589 

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
PR is necessary to retain visible focus indication when buttons enter disabled state during generation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Testing showed the primary user-facing issue in these cases was loss of visible focus indication during disabled states. Adding `accessibleWhenDisabled` preserves the visible focus indicator during generation. 

- Adds the `accessibleWhenDisabled` prop so focus is not lost while the button goes into disabled mode during generation.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
- **Alt Text Generation**
   - Add an Image block and select an image.
   - Focus the "Generate Alt Text" button using keyboard navigation.
   - Trigger generation.
   - Verify focus is retained during generation.

Same for Excerpt and Featured Image generation.

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Focus loss when buttons enter disabled state during generation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-611-e63b50632d451ad3d4d3dcdf2ece504261ef482d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->