### PR TITLE
Fix Abilities Explorer schema constraint validation

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -300,44 +300,9 @@ class Ability_Handler {
 					continue;
 				}
 
-				$value = $input[ $prop_name ];
-
-				if ( isset( $prop_schema['type'] ) ) {
-					$valid = self::validate_type( $value, $prop_schema['type'] );
-					if ( ! $valid ) {
-						$errors[] = sprintf(
-							'Field "%s" should be of type "%s"',
-							$prop_name,
-							$prop_schema['type']
-						);
-						continue;
-					}
-				}
-
-				if ( isset( $prop_schema['enum'] ) && is_array( $prop_schema['enum'] ) && ! in_array( $value, $prop_schema['enum'], true ) ) {
-					$errors[] = sprintf(
-						'Field "%s" must be one of: %s',
-						$prop_name,
-						implode( ', ', $prop_schema['enum'] )
-					);
-				}
-
-				if ( is_numeric( $value ) && isset( $prop_schema['minimum'] ) && $value < $prop_schema['minimum'] ) {
-					$errors[] = sprintf(
-						'Field "%s" must be at least %s',
-						$prop_name,
-						$prop_schema['minimum']
-					);
-				}
-
-				if ( ! is_numeric( $value ) || ! isset( $prop_schema['maximum'] ) || $value <= $prop_schema['maximum'] ) {
-					continue;
-				}
-
-				$errors[] = sprintf(
-					'Field "%s" must be at most %s',
-					$prop_name,
-					$prop_schema['maximum']
+				$errors = array_merge(
+					$errors,
+					self::validate_property( (string) $prop_name, $input[ $prop_name ], $prop_schema )
 				);
 			}
 		}
@@ -346,6 +311,59 @@ class Ability_Handler {
 			'valid'  => empty( $errors ),
 			'errors' => $errors,
 		);
+	}
+
+	/**
+	 * Validate a property value against a schema.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string              $prop_name   Property name.
+	 * @param mixed               $value       Property value.
+	 * @param array<string,mixed> $prop_schema Property schema.
+	 * @return array<string> Validation errors.
+	 */
+	private static function validate_property( string $prop_name, $value, array $prop_schema ): array {
+		$errors = array();
+
+		if ( isset( $prop_schema['type'] ) ) {
+			$valid = self::validate_type( $value, $prop_schema['type'] );
+			if ( ! $valid ) {
+				return array(
+					sprintf(
+						'Field "%s" should be of type "%s"',
+						$prop_name,
+						$prop_schema['type']
+					),
+				);
+			}
+		}
+
+		if ( isset( $prop_schema['enum'] ) && is_array( $prop_schema['enum'] ) && ! in_array( $value, $prop_schema['enum'], true ) ) {
+			$errors[] = sprintf(
+				'Field "%s" must be one of: %s',
+				$prop_name,
+				implode( ', ', $prop_schema['enum'] )
+			);
+		}
+
+		if ( is_numeric( $value ) && isset( $prop_schema['minimum'] ) && $value < $prop_schema['minimum'] ) {
+			$errors[] = sprintf(
+				'Field "%s" must be at least %s',
+				$prop_name,
+				$prop_schema['minimum']
+			);
+		}
+
+		if ( is_numeric( $value ) && isset( $prop_schema['maximum'] ) && $value > $prop_schema['maximum'] ) {
+			$errors[] = sprintf(
+				'Field "%s" must be at most %s',
+				$prop_name,
+				$prop_schema['maximum']
+			);
+		}
+
+		return $errors;
 	}
 
 	/**

--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -293,22 +293,51 @@ class Ability_Handler {
 			}
 		}
 
-		// Type validation for properties.
+		// Type and constraint validation for properties.
 		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) ) {
 			foreach ( $schema['properties'] as $prop_name => $prop_schema ) {
-				if ( ! isset( $input[ $prop_name ] ) || ! isset( $prop_schema['type'] ) ) {
+				if ( ! isset( $input[ $prop_name ] ) || ! is_array( $prop_schema ) ) {
 					continue;
 				}
 
-				$valid = self::validate_type( $input[ $prop_name ], $prop_schema['type'] );
-				if ( $valid ) {
+				$value = $input[ $prop_name ];
+
+				if ( isset( $prop_schema['type'] ) ) {
+					$valid = self::validate_type( $value, $prop_schema['type'] );
+					if ( ! $valid ) {
+						$errors[] = sprintf(
+							'Field "%s" should be of type "%s"',
+							$prop_name,
+							$prop_schema['type']
+						);
+						continue;
+					}
+				}
+
+				if ( isset( $prop_schema['enum'] ) && is_array( $prop_schema['enum'] ) && ! in_array( $value, $prop_schema['enum'], true ) ) {
+					$errors[] = sprintf(
+						'Field "%s" must be one of: %s',
+						$prop_name,
+						implode( ', ', $prop_schema['enum'] )
+					);
+				}
+
+				if ( is_numeric( $value ) && isset( $prop_schema['minimum'] ) && $value < $prop_schema['minimum'] ) {
+					$errors[] = sprintf(
+						'Field "%s" must be at least %s',
+						$prop_name,
+						$prop_schema['minimum']
+					);
+				}
+
+				if ( ! is_numeric( $value ) || ! isset( $prop_schema['maximum'] ) || $value <= $prop_schema['maximum'] ) {
 					continue;
 				}
 
 				$errors[] = sprintf(
-					'Field "%s" should be of type "%s"',
+					'Field "%s" must be at most %s',
 					$prop_name,
-					$prop_schema['type']
+					$prop_schema['maximum']
 				);
 			}
 		}
@@ -333,8 +362,9 @@ class Ability_Handler {
 			case 'string':
 				return is_string( $value );
 			case 'number':
+				return is_int( $value ) || is_float( $value );
 			case 'integer':
-				return is_numeric( $value );
+				return is_int( $value ) || ( is_float( $value ) && floor( $value ) === $value );
 			case 'boolean':
 				return is_bool( $value );
 			case 'array':

--- a/src/experiments/abilities-explorer/index.js
+++ b/src/experiments/abilities-explorer/index.js
@@ -296,29 +296,70 @@ import './index.scss';
 				} );
 			}
 
-			// Check property types
+			// Check property types and constraints
 			if ( schema.properties ) {
 				Object.keys( schema.properties ).forEach(
 					function ( propName ) {
-						if ( propName in input ) {
-							const propSchema = schema.properties[ propName ];
-							const value = input[ propName ];
+						if ( ! ( propName in input ) ) {
+							return;
+						}
 
-							if ( propSchema.type ) {
-								const isValid = this.validateType(
-									value,
-									propSchema.type
+						const propSchema = schema.properties[ propName ];
+						const value = input[ propName ];
+
+						if ( propSchema.type ) {
+							const isValid = this.validateType(
+								value,
+								propSchema.type
+							);
+							if ( ! isValid ) {
+								errors.push(
+									'Field "' +
+										propName +
+										'" should be of type "' +
+										propSchema.type +
+										'"'
 								);
-								if ( ! isValid ) {
-									errors.push(
-										'Field "' +
-											propName +
-											'" should be of type "' +
-											propSchema.type +
-											'"'
-									);
-								}
+								return;
 							}
+						}
+
+						if (
+							Array.isArray( propSchema.enum ) &&
+							! propSchema.enum.includes( value )
+						) {
+							errors.push(
+								'Field "' +
+									propName +
+									'" must be one of: ' +
+									propSchema.enum.join( ', ' )
+							);
+						}
+
+						if (
+							typeof value === 'number' &&
+							typeof propSchema.minimum === 'number' &&
+							value < propSchema.minimum
+						) {
+							errors.push(
+								'Field "' +
+									propName +
+									'" must be at least ' +
+									propSchema.minimum
+							);
+						}
+
+						if (
+							typeof value === 'number' &&
+							typeof propSchema.maximum === 'number' &&
+							value > propSchema.maximum
+						) {
+							errors.push(
+								'Field "' +
+									propName +
+									'" must be at most ' +
+									propSchema.maximum
+							);
 						}
 					}.bind( this )
 				);
@@ -339,8 +380,11 @@ import './index.scss';
 				case 'string':
 					return typeof value === 'string';
 				case 'number':
+					return (
+						typeof value === 'number' && Number.isFinite( value )
+					);
 				case 'integer':
-					return typeof value === 'number';
+					return Number.isInteger( value );
 				case 'boolean':
 					return typeof value === 'boolean';
 				case 'array':

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
@@ -156,9 +156,9 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 		$result = Ability_Handler::validate_input( $schema, array( 'age' => 25 ) );
 		$this->assertTrue( $result['valid'] );
 
-		// Valid numeric string (is_numeric returns true).
+		// Invalid: numeric strings are still strings.
 		$result = Ability_Handler::validate_input( $schema, array( 'age' => '25' ) );
-		$this->assertTrue( $result['valid'] );
+		$this->assertFalse( $result['valid'] );
 
 		// Invalid: non-numeric string.
 		$result = Ability_Handler::validate_input( $schema, array( 'age' => 'twenty-five' ) );
@@ -233,6 +233,79 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 		// Invalid: string instead of object.
 		$result = Ability_Handler::validate_input( $schema, array( 'data' => 'not an object' ) );
 		$this->assertFalse( $result['valid'] );
+	}
+
+	/**
+	 * Test validate_input validates integer type.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_validate_input_validates_integer_type() {
+		$schema = array(
+			'properties' => array(
+				'count' => array( 'type' => 'integer' ),
+			),
+		);
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => 5 ) );
+		$this->assertTrue( $result['valid'] );
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => 1.5 ) );
+		$this->assertFalse( $result['valid'] );
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => '5' ) );
+		$this->assertFalse( $result['valid'] );
+	}
+
+	/**
+	 * Test validate_input validates numeric minimum and maximum constraints.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_validate_input_validates_numeric_constraints() {
+		$schema = array(
+			'properties' => array(
+				'count' => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+					'maximum' => 10,
+				),
+			),
+		);
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => 5 ) );
+		$this->assertTrue( $result['valid'] );
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => 0 ) );
+		$this->assertFalse( $result['valid'] );
+		$this->assertStringContainsString( 'at least 1', $result['errors'][0] );
+
+		$result = Ability_Handler::validate_input( $schema, array( 'count' => 11 ) );
+		$this->assertFalse( $result['valid'] );
+		$this->assertStringContainsString( 'at most 10', $result['errors'][0] );
+	}
+
+	/**
+	 * Test validate_input validates enum constraints.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_validate_input_validates_enum_constraints() {
+		$schema = array(
+			'properties' => array(
+				'strategy' => array(
+					'type' => 'string',
+					'enum' => array( 'existing_only', 'allow_new' ),
+				),
+			),
+		);
+
+		$result = Ability_Handler::validate_input( $schema, array( 'strategy' => 'existing_only' ) );
+		$this->assertTrue( $result['valid'] );
+
+		$result = Ability_Handler::validate_input( $schema, array( 'strategy' => 'invalid' ) );
+		$this->assertFalse( $result['valid'] );
+		$this->assertStringContainsString( 'must be one of', $result['errors'][0] );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
@@ -238,7 +238,7 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	/**
 	 * Test validate_input validates integer type.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_validate_input_validates_integer_type() {
 		$schema = array(
@@ -260,7 +260,7 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	/**
 	 * Test validate_input validates numeric minimum and maximum constraints.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_validate_input_validates_numeric_constraints() {
 		$schema = array(
@@ -288,7 +288,7 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	/**
 	 * Test validate_input validates enum constraints.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_validate_input_validates_enum_constraints() {
 		$schema = array(

--- a/tests/e2e/specs/experiments/abilities-explorer.spec.js
+++ b/tests/e2e/specs/experiments/abilities-explorer.spec.js
@@ -224,6 +224,69 @@ test.describe( 'Abilities Explorer Experiment', () => {
 		).not.toBeVisible();
 	} );
 
+	test( 'Validate Input enforces schema constraints', async ( {
+		admin,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Abilities Explorer and Content Classification experiments.
+		await enableExperiment( admin, page, 'Abilities Explorer' );
+		await enableExperiment( admin, page, 'Content Classification' );
+
+		await admin.visitAdminPage(
+			'tools.php?page=ai-abilities-explorer&action=test&ability=ai/content-classification'
+		);
+
+		const payload = page.locator( '#ability-test-payload' );
+		const validateButton = page.locator( '#ability-test-validate' );
+		const validation = page.locator( '#ability-test-validation' );
+
+		await payload.fill(
+			JSON.stringify(
+				{
+					content:
+						'This is enough content to classify for validation testing.',
+					post_id: 1,
+					taxonomy: 'post_tag',
+					strategy: 'existing_only',
+					max_suggestions: 11,
+				},
+				null,
+				2
+			)
+		);
+
+		await validateButton.click();
+
+		await expect( validation ).toBeVisible();
+		await expect( validation ).toContainText(
+			'Field "max_suggestions" must be at most 10'
+		);
+
+		await payload.fill(
+			JSON.stringify(
+				{
+					content:
+						'This is enough content to classify for validation testing.',
+					post_id: 1,
+					taxonomy: 'post_tag',
+					strategy: 'existing_only',
+					max_suggestions: 5,
+				},
+				null,
+				2
+			)
+		);
+
+		await validateButton.click();
+
+		await expect( validation ).toContainText(
+			'Input is valid according to the schema'
+		);
+	} );
+
 	test( 'Ensure the Abilities Explorer Experiment UI is not visible when Experiments are globally disabled', async ( {
 		admin,
 		page,


### PR DESCRIPTION
## What?

Fixes the Abilities Explorer test runner so the **Validate Input** button checks JSON schema constraints, not only basic field types.

This updates validation for:

- `minimum`
- `maximum`
- `enum`
- stricter `number` / `integer` handling

## Why?

Some ability input schemas include constraints that were displayed in the UI but not enforced by the validator.

For example, the Content Classification ability shows:

```json
"max_suggestions": {
  "type": "integer",
  "minimum": 1,
  "maximum": 10
}
```

Before this change, entering `"max_suggestions": 11` still showed the input as valid.

## How?

- Updates the PHP validation helper used by the Abilities Explorer AJAX handler.
- Updates the client-side validator used by the visible **Validate Input** button.
- Adds focused PHP coverage for integer, min/max, and enum validation.
- Adds E2E coverage for the visible Content Classification validation flow.

## Testing Instructions

1. Enable AI.
2. Enable the Abilities Explorer experiment.
3. Enable the Content Classification experiment.
4. Go to Tools > Abilities Explorer.
5. Open the test runner for `ai/content-classification`.
6. Set `max_suggestions` to `11`.
7. Click **Validate Input**.
8. Confirm the UI shows a validation error.
9. Change `max_suggestions` to `5`.
10. Click **Validate Input** again.
11. Confirm the UI shows the input is valid.

Automated checks run locally:

```bash
npm run lint:php -- includes/Experiments/Abilities_Explorer/Ability_Handler.php tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
npm run test:php -- --filter Ability_HandlerTest
npm run lint:php:stan -- includes/Experiments/Abilities_Explorer/Ability_Handler.php tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
npm run lint:js -- src/experiments/abilities-explorer/index.js tests/e2e/specs/experiments/abilities-explorer.spec.js
npm run test:e2e -- tests/e2e/specs/experiments/abilities-explorer.spec.js
npm run build
git diff --check
```

## Screenshots/Screencast

Before:
<img width="1848" height="2778" alt="Before" src="https://github.com/user-attachments/assets/04d647bc-166e-493a-bad0-74cf895a5269" />


After:
<img width="1676" height="2480" alt="After" src="https://github.com/user-attachments/assets/786fc998-dd26-409a-a3fb-0ed7678ce2ca" />


## Use of AI Tools

AI assistance: Yes

Tool(s): ChatGPT / Codex

Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-612-0a4294ba15c7c89a52a6737aef8970386bd72dfd.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->