### PR TITLE
Localize wp-build script module strings on the settings page

### DIFF
--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -58,6 +58,7 @@ class Settings_Page {
 	public static function init( Registry $registry ): void {
 		add_action( 'admin_init', array( self::class, 'maybe_redirect_legacy_page' ), 1 );
 		add_action( 'admin_page_access_denied', array( self::class, 'maybe_redirect_legacy_page' ) );
+		add_action( 'ai-wp-admin_init', array( self::class, 'register_route_script_module_translations' ) );
 
 		if ( function_exists( 'ai_ai_wp_admin_render_page' ) ) {
 			add_action(
@@ -105,6 +106,22 @@ class Settings_Page {
 			);
 		}
 	}
+
+	/**
+	 * Registers the `ai` text domain for the route script modules.
+	 *
+	 * Pages built by wp-build enqueue their JS as script modules. Localizing the
+	 * strings in those modules requires `wp_set_script_module_translations()`
+	 * rather than `wp_set_script_translations()`.
+	 *
+	 * @since X.X.X
+	 *
+	 * @return void
+	 */
+	public static function register_route_script_module_translations(): void {
+		wp_set_script_module_translations( 'ai/routes/ai-home/content', 'ai' );
+	}
+
 
 	/**
 	 * Redirects legacy settings page slug to the current settings route.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -36,6 +36,7 @@ parameters:
 			- '#Function wp_get_connectors not found\.#'
 			- '#class cli\\progress\\Bar#'
 			- '#Function wp_supports_ai not found\.#'
+			- '#Function wp_set_script_module_translations not found\.#'
 		excludePaths:
 			analyse:
 				- tests/


### PR DESCRIPTION
## What?

Follow up to #582

Localize the JS strings on the settings page, which were still rendered in English even after #582.

## Why?

#582 fixed JS translation loading by calling `wp_set_script_translations()` for every script enqueued through `Asset_Loader::enqueue_script()`. That covers classic scripts, but the settings page and other `wp-build` routes are enqueued as script modules*, which `wp_set_script_translations()` does not apply to.

## How?

Register the `ai` text domain for the route content script module via `wp_set_script_module_translations()`. For the background of this function's addition, please refer to https://core.trac.wordpress.org/ticket/65015#comment:45.

PHPStan does not yet ship a stub for `wp_set_script_module_translations()`, so it is added to the existing WP 7.0 `ignoreErrors` list.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Tracing the script module i18n path through WordPress core and drafting the fix. All changes were reviewed and verified by me.

## Testing Instructions

1. Switch the site to the Japanese (`ja`) locale and make sure the plugin's Japanese translations are installed.
2. Access `wp-admin/update-core.php` and download any available translations.
3. Open **Settings → AI** and confirm that strings are now displayed in Japanese.

## Screenshots or screencast

### Before

<img width="1305" height="909" alt="before" src="https://github.com/user-attachments/assets/d764a058-afd3-41dd-ac11-84b796358ead" />

### After

<img width="1302" height="909" alt="after" src="https://github.com/user-attachments/assets/0cdcbee3-06bf-4363-b274-99e0c24ba2e3" />

## Changelog Entry

> Fixed - Settings page strings, which are enqueued as script modules, are now localized at runtime.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-613-6d255029921762eeb48ad8e64bc3d6c0697e5be2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->