### PR TITLE
Fix connector approval dismiss for keys containing slashes

### DIFF
--- a/includes/Connector_Approval/REST_Controller.php
+++ b/includes/Connector_Approval/REST_Controller.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  * Endpoints (namespace `ai/v1`):
  * - GET  /connector-approvals                        returns connectors, approvals, pending, active plugins, and active theme
  * - POST /connector-approvals                        sets or revokes approval for a plugin/connector pair
- * - DELETE /connector-approvals/pending/(?P<key>...) dismisses a pending entry without approving
+ * - DELETE /connector-approvals/pending?key=...      dismisses a pending entry without approving
  *
  * @since 1.0.0
  */
@@ -100,7 +100,7 @@ final class REST_Controller {
 
 		register_rest_route(
 			self::REST_NAMESPACE,
-			'/connector-approvals/pending/(?P<key>[^/]+)',
+			'/connector-approvals/pending',
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
 				'callback'            => array( $this, 'delete_pending' ),
@@ -195,7 +195,7 @@ final class REST_Controller {
 	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function delete_pending( WP_REST_Request $request ) {
-		$key = rawurldecode( (string) $request->get_param( 'key' ) );
+		$key = (string) $request->get_param( 'key' );
 
 		if ( ! $this->store->remove_pending( $key ) ) {
 			return new WP_Error(

--- a/src/experiments/connector-approval/functions/api.ts
+++ b/src/experiments/connector-approval/functions/api.ts
@@ -6,6 +6,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -60,7 +61,7 @@ export function postApproval(
 export function deletePending( key: string ): Promise< ApprovalState > {
 	ensureNonceMiddleware();
 	return apiFetch< ApprovalState >( {
-		path: `${ REST_ROOT }/pending/${ encodeURIComponent( key ) }`,
+		path: addQueryArgs( `${ REST_ROOT }/pending`, { key } ),
 		method: 'DELETE',
 	} );
 }

--- a/tests/Integration/Includes/Connector_Approval/REST_ControllerTest.php
+++ b/tests/Integration/Includes/Connector_Approval/REST_ControllerTest.php
@@ -228,8 +228,9 @@ class REST_ControllerTest extends WP_UnitTestCase {
 			'openai'
 		);
 
-		$key      = $this->store->pending_key( 'example/example.php', 'openai' );
-		$request  = new WP_REST_Request( 'DELETE', '/ai/v1/connector-approvals/pending/' . rawurlencode( $key ) );
+		$key     = $this->store->pending_key( 'example/example.php', 'openai' );
+		$request = new WP_REST_Request( 'DELETE', '/ai/v1/connector-approvals/pending' );
+		$request->set_query_params( array( 'key' => $key ) );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertSame( 200, $response->get_status() );

--- a/tests/Integration/Includes/Experiments/Connector_Approval/Connector_ApprovalTest.php
+++ b/tests/Integration/Includes/Experiments/Connector_Approval/Connector_ApprovalTest.php
@@ -106,7 +106,7 @@ class Connector_ApprovalTest extends WP_UnitTestCase {
 
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey( '/ai/v1/connector-approvals', $routes );
-		$this->assertArrayHasKey( '/ai/v1/connector-approvals/pending/(?P<key>[^/]+)', $routes );
+		$this->assertArrayHasKey( '/ai/v1/connector-approvals/pending', $routes );
 
 		$collection_methods = array();
 		foreach ( $routes['/ai/v1/connector-approvals'] as $handler ) {
@@ -121,7 +121,7 @@ class Connector_ApprovalTest extends WP_UnitTestCase {
 		$this->assertContains( 'POST', $collection_methods );
 
 		$pending_methods = array();
-		foreach ( $routes['/ai/v1/connector-approvals/pending/(?P<key>[^/]+)'] as $handler ) {
+		foreach ( $routes['/ai/v1/connector-approvals/pending'] as $handler ) {
 			$methods = $handler['methods'] ?? array();
 			if ( is_array( $methods ) ) {
 				$pending_methods = array_merge( $pending_methods, array_keys( $methods ) );


### PR DESCRIPTION
## What?

Fix the Dismiss button on the Connector Approvals settings page, which failed with `Failed to dismiss request.`

https://github.com/user-attachments/assets/e8c86fb4-2e04-4b82-a5b5-6da38accacb3

## Why?

The dismiss key is a composite of the caller basename and connector ID (example: `wp-json/ai/v1/connector-approvals/pending/ai%2Fai.php%3A%3Agoogle`), so it contains a slash. The frontend sent it as a URL path segment. [WordPress decodes the encoded slash (`%2F`) back to `/` before REST route matching](https://github.com/WordPress/wordpress-develop/blob/ac539ca198ccef82c26d79a716cc22cf3750f240/src/wp-includes/class-wp.php#L278C5-L278C14), so the route pattern `(?P<key>[^/]+)` no longer matched and the request returned `rest_no_route` (404).

The Approve action was unaffected because it already sends its identifier in the request body, not in the path.

## How?

Send the key as a query argument instead of a path segment. Query arguments are decoded as plain values and never take part in path-based route matching, so dismiss works regardless of web server configuration.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.7
Used for: Diagnosing the encoded-slash route-matching failure and implementing the fix. Reviewed and verified by me (`tsc`, ESLint, and PHPUnit all pass).

## Testing Instructions

1. Create a pending approval request from a plugin.
2. On the Connector Approvals settings page, click Dismiss on that pending request.
   - Before: shows `Failed to dismiss request.`
   - After: the pending request is removed and the list updates.

## Changelog Entry

> Fixed - Connector Approvals "Dismiss" button failing for pending requests whose key contains a slash.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-615-f13c4610b06da0636e85a0636e14241fd6371e53.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->