### PR TITLE
Hide empty provider capabilities section

### DIFF
--- a/includes/Admin/Dashboard/AI_Capabilities_Widget.php
+++ b/includes/Admin/Dashboard/AI_Capabilities_Widget.php
@@ -137,51 +137,60 @@ class AI_Capabilities_Widget {
 			return;
 		}
 
+		$providers = array();
+
+		foreach ( $provider_ids as $provider_id ) {
+			try {
+				$provider_class = $registry->getProviderClassName( $provider_id );
+
+				/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
+				$metadata     = $provider_class::metadata();
+				$model_dir    = $provider_class::modelMetadataDirectory();
+				$models       = $model_dir->listModelMetadata();
+				$capabilities = array();
+
+				foreach ( $models as $model ) {
+					foreach ( $model->getSupportedCapabilities() as $capability ) {
+						$capabilities[ $capability->value ] = true;
+					}
+				}
+
+				if ( empty( $capabilities ) ) {
+					continue;
+				}
+
+				$providers[] = array(
+					'name'         => $metadata->getName(),
+					'capabilities' => $capabilities,
+				);
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+		}
+
+		if ( empty( $providers ) ) {
+			return;
+		}
+
 		?>
 		<h4 class="ai-dashboard-capabilities__section-title">
 			<?php esc_html_e( 'Provider Capabilities', 'ai' ); ?>
 		</h4>
 		<div class="ai-dashboard-capabilities__providers">
-			<?php
-			foreach ( $provider_ids as $provider_id ) {
-				try {
-					$provider_class = $registry->getProviderClassName( $provider_id );
-
-					/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
-					$metadata     = $provider_class::metadata();
-					$model_dir    = $provider_class::modelMetadataDirectory();
-					$models       = $model_dir->listModelMetadata();
-					$capabilities = array();
-
-					foreach ( $models as $model ) {
-						foreach ( $model->getSupportedCapabilities() as $capability ) {
-							$capabilities[ $capability->value ] = true;
-						}
-					}
-
-					if ( empty( $capabilities ) ) {
-						continue;
-					}
-
-					?>
+			<?php foreach ( $providers as $provider ) : ?>
 					<div class="ai-dashboard-capabilities__provider">
 						<span class="ai-dashboard-capabilities__provider-name">
-							<?php echo esc_html( $metadata->getName() ); ?>
+							<?php echo esc_html( $provider['name'] ); ?>
 						</span>
 						<span class="ai-dashboard-capabilities__provider-caps">
-							<?php foreach ( $capabilities as $cap_value => $unused ) : ?>
+							<?php foreach ( $provider['capabilities'] as $cap_value => $unused ) : ?>
 								<span class="ai-dashboard-capabilities__cap-tag">
 									<?php echo esc_html( $this->get_capability_label( (string) $cap_value ) ); ?>
 								</span>
 							<?php endforeach; ?>
 						</span>
 					</div>
-					<?php
-				} catch ( \Throwable $e ) {
-					continue;
-				}
-			}
-			?>
+			<?php endforeach; ?>
 		</div>
 		<?php
 	}

--- a/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
@@ -7,10 +7,15 @@
 
 namespace WordPress\AI\Tests\Integration\Dashboard;
 
+use BadMethodCallException;
+use ReflectionProperty;
 use WP_UnitTestCase;
 use WordPress\AI\Abstracts\Abstract_Feature;
 use WordPress\AI\Admin\Dashboard\AI_Capabilities_Widget;
 use WordPress\AI\Features\Registry;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 
 /**
  * Stub feature for capabilities widget tests.
@@ -43,11 +48,63 @@ class Capabilities_Test_Feature extends Abstract_Feature {
 }
 
 /**
+ * Stub provider with unavailable model metadata for capabilities widget tests.
+ *
+ * @since n.e.x.t
+ */
+final class Capabilities_Unavailable_Test_Provider {
+
+	/**
+	 * Returns stub provider metadata.
+	 *
+	 * @since n.e.x.t
+	 */
+	public static function metadata(): ProviderMetadata {
+		return new ProviderMetadata(
+			'test-provider',
+			'Test Provider',
+			ProviderTypeEnum::cloud(),
+			'https://example.com'
+		);
+	}
+
+	/**
+	 * Simulates a provider whose model metadata is unavailable.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @throws \BadMethodCallException Always thrown for this stub.
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client provider API.
+	public static function modelMetadataDirectory(): void {
+		throw new BadMethodCallException( 'Model metadata unavailable.' );
+	}
+}
+
+/**
  * AI_Capabilities_Widget test case.
  *
  * @since 0.8.0
  */
 class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
+
+	/**
+	 * Stub provider ID.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string
+	 */
+	private const TEST_PROVIDER_ID = 'wpai_capabilities_test_provider';
+
+	/**
+	 * Original AI client provider registry map.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var array<string, string>|null
+	 */
+	private ?array $original_registered_providers = null;
 
 	/**
 	 * Tear down after each test.
@@ -57,6 +114,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		delete_option( 'wpai_features_enabled' );
 		delete_option( 'wpai_feature_abilities-explorer_enabled' );
+		$this->restore_registered_providers();
 		parent::tearDown();
 	}
 
@@ -169,11 +227,11 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	 * @since 0.8.0
 	 */
 	public function test_render_provider_capabilities() {
-		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
+		if ( ! class_exists( AiClient::class ) ) {
 			$this->markTestSkipped( 'AiClient not available.' );
 		}
 
-		$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
+		$registry     = AiClient::defaultRegistry();
 		$provider_ids = $registry->getRegisteredProviderIds();
 
 		if ( empty( $provider_ids ) ) {
@@ -200,16 +258,51 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that provider capabilities section is hidden when no provider row can render.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function test_provider_capabilities_section_hidden_when_no_provider_rows_render() {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'AiClient not available.' );
+		}
+
+		$this->replace_registered_providers(
+			array(
+				self::TEST_PROVIDER_ID => Capabilities_Unavailable_Test_Provider::class,
+			)
+		);
+
+		$registry = new Registry();
+		$widget   = new AI_Capabilities_Widget( $registry );
+
+		ob_start();
+		$widget->render();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString(
+			'Provider Capabilities',
+			$output,
+			'Should not render an empty Provider Capabilities section.'
+		);
+		$this->assertStringNotContainsString(
+			'ai-dashboard-capabilities__providers',
+			$output,
+			'Should not render an empty providers container.'
+		);
+	}
+
+	/**
 	 * Tests that capability labels are human-readable.
 	 *
 	 * @since 0.8.0
 	 */
 	public function test_capability_labels_are_human_readable() {
-		if ( ! class_exists( \WordPress\AiClient\AiClient::class ) ) {
+		if ( ! class_exists( AiClient::class ) ) {
 			$this->markTestSkipped( 'AiClient not available.' );
 		}
 
-		$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
+		$registry     = AiClient::defaultRegistry();
 		$provider_ids = $registry->getRegisteredProviderIds();
 
 		if ( empty( $provider_ids ) ) {
@@ -229,5 +322,50 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 			$output,
 			'Should not show raw enum values'
 		);
+	}
+
+	/**
+	 * Replaces registered providers in the AI client registry for a test.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<string, string> $providers Registered provider IDs to class names.
+	 */
+	private function replace_registered_providers( array $providers ): void {
+		$property = $this->get_registered_providers_property();
+
+		if ( null === $this->original_registered_providers ) {
+			$this->original_registered_providers = (array) $property->getValue( AiClient::defaultRegistry() );
+		}
+
+		$property->setValue( AiClient::defaultRegistry(), $providers );
+	}
+
+	/**
+	 * Restores registered providers in the AI client registry.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function restore_registered_providers(): void {
+		if ( null === $this->original_registered_providers || ! class_exists( AiClient::class ) ) {
+			return;
+		}
+
+		$this->get_registered_providers_property()->setValue(
+			AiClient::defaultRegistry(),
+			$this->original_registered_providers
+		);
+		$this->original_registered_providers = null;
+	}
+
+	/**
+	 * Returns the registered providers registry property.
+	 *
+	 * @since n.e.x.t
+	 */
+	private function get_registered_providers_property(): ReflectionProperty {
+		$property = new ReflectionProperty( AiClient::defaultRegistry(), 'registeredIdsToClassNames' );
+		$property->setAccessible( true );
+		return $property;
 	}
 }

--- a/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
@@ -16,6 +16,7 @@ use WordPress\AI\Features\Registry;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
 use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 /**
  * Stub feature for capabilities widget tests.
@@ -78,6 +79,82 @@ final class Capabilities_Unavailable_Test_Provider {
 	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client provider API.
 	public static function modelMetadataDirectory(): void {
 		throw new BadMethodCallException( 'Model metadata unavailable.' );
+	}
+}
+
+/**
+ * Stub provider with available model metadata for capabilities widget tests.
+ *
+ * @since n.e.x.t
+ */
+final class Capabilities_Available_Test_Provider {
+
+	/**
+	 * Returns stub provider metadata.
+	 *
+	 * @since n.e.x.t
+	 */
+	public static function metadata(): ProviderMetadata {
+		return new ProviderMetadata(
+			'test-provider',
+			'Test Provider',
+			ProviderTypeEnum::cloud(),
+			'https://example.com'
+		);
+	}
+
+	/**
+	 * Returns stub model metadata directory.
+	 *
+	 * @since n.e.x.t
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client provider API.
+	public static function modelMetadataDirectory(): Capabilities_Test_Model_Metadata_Directory {
+		return new Capabilities_Test_Model_Metadata_Directory();
+	}
+}
+
+/**
+ * Stub model metadata directory for capabilities widget tests.
+ *
+ * @since n.e.x.t
+ */
+final class Capabilities_Test_Model_Metadata_Directory {
+
+	/**
+	 * Lists stub model metadata.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array<int, \WordPress\AI\Tests\Integration\Dashboard\Capabilities_Test_Model_Metadata>
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client model metadata directory API.
+	public function listModelMetadata(): array {
+		return array( new Capabilities_Test_Model_Metadata() );
+	}
+}
+
+/**
+ * Stub model metadata for capabilities widget tests.
+ *
+ * @since n.e.x.t
+ */
+final class Capabilities_Test_Model_Metadata {
+
+	/**
+	 * Gets supported capabilities.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array<int, object{value:string}>
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client model metadata API.
+	public function getSupportedCapabilities(): array {
+		return array(
+			(object) array(
+				'value' => CapabilityEnum::TEXT_GENERATION,
+			),
+		);
 	}
 }
 
@@ -231,12 +308,11 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'AiClient not available.' );
 		}
 
-		$registry     = AiClient::defaultRegistry();
-		$provider_ids = $registry->getRegisteredProviderIds();
-
-		if ( empty( $provider_ids ) ) {
-			$this->markTestSkipped( 'No AI providers registered.' );
-		}
+		$this->replace_registered_providers(
+			array(
+				self::TEST_PROVIDER_ID => Capabilities_Available_Test_Provider::class,
+			)
+		);
 
 		$exp_registry = new Registry();
 		$widget       = new AI_Capabilities_Widget( $exp_registry );

--- a/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
@@ -51,14 +51,14 @@ class Capabilities_Test_Feature extends Abstract_Feature {
 /**
  * Stub provider with unavailable model metadata for capabilities widget tests.
  *
- * @since n.e.x.t
+ * @since x.x.x
  */
 final class Capabilities_Unavailable_Test_Provider {
 
 	/**
 	 * Returns stub provider metadata.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public static function metadata(): ProviderMetadata {
 		return new ProviderMetadata(
@@ -72,7 +72,7 @@ final class Capabilities_Unavailable_Test_Provider {
 	/**
 	 * Simulates a provider whose model metadata is unavailable.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @throws \BadMethodCallException Always thrown for this stub.
 	 */
@@ -85,14 +85,14 @@ final class Capabilities_Unavailable_Test_Provider {
 /**
  * Stub provider with available model metadata for capabilities widget tests.
  *
- * @since n.e.x.t
+ * @since x.x.x
  */
 final class Capabilities_Available_Test_Provider {
 
 	/**
 	 * Returns stub provider metadata.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public static function metadata(): ProviderMetadata {
 		return new ProviderMetadata(
@@ -106,7 +106,7 @@ final class Capabilities_Available_Test_Provider {
 	/**
 	 * Returns stub model metadata directory.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Matches the AI client provider API.
 	public static function modelMetadataDirectory(): Capabilities_Test_Model_Metadata_Directory {
@@ -117,14 +117,14 @@ final class Capabilities_Available_Test_Provider {
 /**
  * Stub model metadata directory for capabilities widget tests.
  *
- * @since n.e.x.t
+ * @since x.x.x
  */
 final class Capabilities_Test_Model_Metadata_Directory {
 
 	/**
 	 * Lists stub model metadata.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @return array<int, \WordPress\AI\Tests\Integration\Dashboard\Capabilities_Test_Model_Metadata>
 	 */
@@ -137,14 +137,14 @@ final class Capabilities_Test_Model_Metadata_Directory {
 /**
  * Stub model metadata for capabilities widget tests.
  *
- * @since n.e.x.t
+ * @since x.x.x
  */
 final class Capabilities_Test_Model_Metadata {
 
 	/**
 	 * Gets supported capabilities.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @return array<int, object{value:string}>
 	 */
@@ -168,7 +168,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Stub provider ID.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @var string
 	 */
@@ -177,7 +177,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Original AI client provider registry map.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @var array<string, string>|null
 	 */
@@ -336,7 +336,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Tests that provider capabilities section is hidden when no provider row can render.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	public function test_provider_capabilities_section_hidden_when_no_provider_rows_render() {
 		if ( ! class_exists( AiClient::class ) ) {
@@ -403,7 +403,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Replaces registered providers in the AI client registry for a test.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 *
 	 * @param array<string, string> $providers Registered provider IDs to class names.
 	 */
@@ -420,7 +420,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Restores registered providers in the AI client registry.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	private function restore_registered_providers(): void {
 		if ( null === $this->original_registered_providers || ! class_exists( AiClient::class ) ) {
@@ -437,7 +437,7 @@ class AI_Capabilities_WidgetTest extends WP_UnitTestCase {
 	/**
 	 * Returns the registered providers registry property.
 	 *
-	 * @since n.e.x.t
+	 * @since x.x.x
 	 */
 	private function get_registered_providers_property(): ReflectionProperty {
 		$property = new ReflectionProperty( AiClient::defaultRegistry(), 'registeredIdsToClassNames' );


### PR DESCRIPTION
## What?

Hides the dashboard widget's `Provider Capabilities` section when no provider capability rows can be rendered.

## Why?

The `AI Capabilities` dashboard widget already conditionally renders some UI based on available content. For example, the `Abilities Explorer` link only appears when that feature is enabled.

The `Provider Capabilities` section was different: it could render the section heading even when no provider capability rows were available. This left an empty section in the dashboard widget, which looked incomplete.

## How?

This updates the provider capabilities rendering so it first collects providers that have renderable capabilities.

If no provider rows are available, the section is not rendered. If provider capabilities are available, the heading and rows continue to render as before.

A regression test was added for the empty provider capability state.

## Testing Instructions

Automated checks run locally:

```bash
npm run lint:php -- includes/Admin/Dashboard/AI_Capabilities_Widget.php tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
npm run test:php -- --filter AI_Capabilities_WidgetTest
npm run lint:php:stan -- includes/Admin/Dashboard/AI_Capabilities_Widget.php tests/Integration/Includes/Dashboard/AI_Capabilities_WidgetTest.php
git diff --check
```

Result:

- PHP coding standards passed.
- Focused PHPUnit test passed.
- PHPStan passed.
- Diff whitespace check passed.

Manual verification:

1. Open the WordPress dashboard.
2. Confirm the `AI Capabilities` widget is visible.
3. With no provider capabilities available to render, confirm the widget does not show an empty `Provider Capabilities` section.
4. When provider capabilities are available, confirm the section still renders normally.

## Screenshots/Screencast

### Before

The `Provider Capabilities` heading appeared even though no provider capability rows were shown.

<img width="796" height="884" alt="BEFORE" src="https://github.com/user-attachments/assets/efbe33ca-cbf6-42a4-b12b-3cca582ef44a" />


### After

The empty `Provider Capabilities` section is no longer rendered.

<img width="760" height="708" alt="AFTER" src="https://github.com/user-attachments/assets/ea28286a-d3f9-4b48-ae00-fd774448d48f" />

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-616-9724cf5bf3bf4ed4545e51623a53594e42b852f0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->