### PR TITLE
Replace global Enable AI toggle with tri-state section master toggles

### DIFF
--- a/routes/ai-home/components/SectionMasterToggle.tsx
+++ b/routes/ai-home/components/SectionMasterToggle.tsx
@@ -1,0 +1,110 @@
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, FormToggle } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+type AISettings = Record< string, boolean >;
+
+interface SectionMasterToggleProps {
+	groupId: string;
+	groupLabel: string;
+	experimentSettings: string[];
+	data: AISettings;
+	onBulkChange: ( edits: Record< string, boolean > ) => void;
+}
+
+/**
+ * Section-level master toggle with off, indeterminate, and on states.
+ *
+ * @param props The component props.
+ */
+export function SectionMasterToggle( {
+	groupId,
+	groupLabel,
+	experimentSettings,
+	data,
+	onBulkChange,
+}: SectionMasterToggleProps ) {
+	const toggleId = `section-master-toggle-${ groupId }`;
+	const inputRef = useRef< HTMLInputElement >( null );
+	const allEnabled = experimentSettings.every(
+		( settingName ) => data[ settingName ]
+	);
+	const allDisabled = experimentSettings.every(
+		( settingName ) => ! data[ settingName ]
+	);
+	const isIndeterminate = ! allEnabled && ! allDisabled;
+	const label = sprintf(
+		// translators: %s: Feature group label.
+		__( 'Enable %s', 'ai' ),
+		groupLabel
+	);
+	const help = sprintf(
+		// translators: %s: Feature group label.
+		__(
+			'Enable or disable all features in %s. When partially enabled, the toggle shows a mixed state.',
+			'ai'
+		),
+		groupLabel
+	);
+
+	useEffect( () => {
+		if ( inputRef.current ) {
+			inputRef.current.indeterminate = isIndeterminate;
+		}
+	}, [ isIndeterminate, allEnabled ] );
+
+	const handleToggle = () => {
+		const edits: Record< string, boolean > = {};
+
+		if ( allEnabled ) {
+			for ( const settingName of experimentSettings ) {
+				if ( data[ settingName ] ) {
+					edits[ settingName ] = false;
+				}
+			}
+		} else {
+			for ( const settingName of experimentSettings ) {
+				if ( ! data[ settingName ] ) {
+					edits[ settingName ] = true;
+				}
+			}
+		}
+
+		if ( Object.keys( edits ).length > 0 ) {
+			onBulkChange( edits );
+		}
+	};
+
+	return (
+		<BaseControl
+			className="ai-section-master-toggle"
+			help={ help }
+			__nextHasNoMarginBottom
+		>
+			<div
+				className={
+					isIndeterminate
+						? 'ai-section-master-toggle__control is-indeterminate'
+						: 'ai-section-master-toggle__control'
+				}
+			>
+				<FormToggle
+					ref={ inputRef }
+					id={ toggleId }
+					checked={ allEnabled }
+					onChange={ handleToggle }
+					aria-label={ label }
+				/>
+				<label
+					className="ai-section-master-toggle__label"
+					htmlFor={ toggleId }
+				>
+					{ label }
+				</label>
+			</div>
+		</BaseControl>
+	);
+}

--- a/routes/ai-home/components/SectionMasterToggle.tsx
+++ b/routes/ai-home/components/SectionMasterToggle.tsx
@@ -18,7 +18,13 @@ interface SectionMasterToggleProps {
 /**
  * Section-level master toggle with off, indeterminate, and on states.
  *
- * @param props The component props.
+ * @param {SectionMasterToggleProps} props                    The component props.
+ * @param {string}                   props.groupId            The feature group ID.
+ * @param {string}                   props.groupLabel         The feature group label.
+ * @param {string[]}                 props.experimentSettings Feature setting names in the group.
+ * @param {AISettings}               props.data               Current settings values.
+ * @param {Function}                 props.onBulkChange       Bulk settings change handler.
+ * @return {React.JSX.Element} The component.
  */
 export function SectionMasterToggle( {
 	groupId,

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -725,7 +725,10 @@ function AISettingsPage() {
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
 			editEntityRecord( 'root', 'site', undefined, syncedEdits );
 
-			const message = buildToggleMessage( syncedEdits, featureDefinitions );
+			const message = buildToggleMessage(
+				syncedEdits,
+				featureDefinitions
+			);
 
 			try {
 				await saveSpecifiedEdits( 'root', 'site', undefined, keys, {

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -2,16 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
-import {
-	Button,
-	Card,
-	Icon,
-	Link,
-	Notice,
-	Popover,
-	Stack,
-	VisuallyHidden,
-} from '@wordpress/ui';
+import { Button, Card, Link, Notice, Stack } from '@wordpress/ui';
 import {
 	DropdownMenu,
 	MenuGroup,
@@ -27,7 +18,6 @@ import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	check as checkIcon,
-	info as infoIcon,
 	moreVertical as moreVerticalIcon,
 } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
@@ -38,6 +28,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import AIIcon from './ai-icon';
 import { DeveloperSettings } from './components/DeveloperSettings';
 import { FeatureToggle } from './components/FeatureToggle';
+import { SectionMasterToggle } from './components/SectionMasterToggle';
 import {
 	DeveloperModeContext,
 	useDeveloperMode,
@@ -84,7 +75,6 @@ interface PageData {
 
 const FEATURE_SETTING_PATTERN = /^wpai_feature_(.+)_enabled$/;
 const GLOBAL_FIELD_ID = 'wpai_features_enabled';
-const noop = () => {};
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
@@ -254,39 +244,24 @@ const STABLE_FEATURE_DEFINITIONS: FeatureData[] = ( () => {
 	return unique;
 } )();
 
-interface InfoTipProps {
-	content: string;
-}
-
-function InfoTip( { content }: InfoTipProps ) {
-	const title = __( 'More information', 'ai' );
-
-	return (
-		<Popover.Root>
-			<Popover.Trigger
-				openOnHover
-				delay={ 200 }
-				closeDelay={ 200 }
-				aria-label={ title }
-				className="ai-settings-page__infotip-trigger"
-			>
-				<Icon icon={ infoIcon } size={ 20 } />
-			</Popover.Trigger>
-			<Popover.Popup
-				side="bottom"
-				align="end"
-				className="ai-settings-page__infotip-popover"
-			>
-				<Popover.Arrow />
-				<VisuallyHidden render={ <Popover.Title /> }>
-					{ title }
-				</VisuallyHidden>
-				<Popover.Description className="ai-settings-page__infotip-description">
-					{ content }
-				</Popover.Description>
-			</Popover.Popup>
-		</Popover.Root>
+function appendGlobalSyncEdits(
+	edits: Record< string, boolean >,
+	currentData: AISettings,
+	featureSettingNames: string[]
+): Record< string, boolean > {
+	const merged: AISettings = { ...currentData, ...edits };
+	const anyFeatureEnabled = featureSettingNames.some(
+		( settingName ) => merged[ settingName ]
 	);
+
+	if ( merged[ GLOBAL_FIELD_ID ] === anyFeatureEnabled ) {
+		return edits;
+	}
+
+	return {
+		...edits,
+		[ GLOBAL_FIELD_ID ]: anyFeatureEnabled,
+	};
 }
 
 function buildToggleMessage(
@@ -363,29 +338,14 @@ function buildToggleMessage(
 		  sprintf( __( '%s disabled.', 'ai' ), label );
 }
 
-function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
-	return (
-		<ToggleControl
-			label={ field.label }
-			help={ field.description }
-			checked={ !! field.getValue( { item: data } ) }
-			// No-op handler required to satisfy React's controlled-component warning; the toggle is disabled.
-			onChange={ noop }
-			disabled
-		/>
-	);
-}
-
 interface SectionActionsProps extends DataFormControlProps< AISettings > {
 	experimentSettings: string[];
-	globalEnabled: boolean;
 	onBulkChange: ( edits: Record< string, boolean > ) => void;
 }
 
 function SectionActions( {
 	experimentSettings,
 	data,
-	globalEnabled,
 	onBulkChange,
 }: SectionActionsProps ) {
 	const allEnabled = useMemo( () => {
@@ -438,7 +398,7 @@ function SectionActions( {
 				variant="outline"
 				size="compact"
 				onClick={ handleEnableAll }
-				disabled={ ! globalEnabled || allEnabled }
+				disabled={ allEnabled }
 			>
 				{ __( 'Enable all', 'ai' ) }
 			</Button>
@@ -446,7 +406,7 @@ function SectionActions( {
 				variant="outline"
 				size="compact"
 				onClick={ handleDisableAll }
-				disabled={ ! globalEnabled || allDisabled }
+				disabled={ allDisabled }
 			>
 				{ __( 'Disable all', 'ai' ) }
 			</Button>
@@ -631,16 +591,11 @@ function VisualCardToggle( {
 	onChange,
 }: DataFormControlProps< AISettings > ) {
 	const feature = VISUAL_CARD_FEATURES.get( field.id );
-	const globalEnabled = !! data[ GLOBAL_FIELD_ID ];
 	const checked = !! field.getValue( { item: data } );
 	const isDeveloperMode = useDeveloperModeContext();
 
 	return (
-		<Card.Root
-			className={ `${
-				! globalEnabled ? ' ai-showcase-card--disabled' : ''
-			}` }
-		>
+		<Card.Root>
 			{ feature?.image && (
 				<img alt="" loading="lazy" src={ feature.image } />
 			) }
@@ -651,7 +606,6 @@ function VisualCardToggle( {
 					onChange={ ( value ) =>
 						onChange( { [ field.id ]: value } )
 					}
-					disabled={ ! globalEnabled }
 					help={ field.description }
 				/>
 				{ checked && isDeveloperMode && feature && (
@@ -747,21 +701,31 @@ function AISettingsPage() {
 		return aiSettings;
 	}, [ aiSettingKeys, editedRecord ] );
 
-	const globalEnabled = Boolean( data[ GLOBAL_FIELD_ID ] );
-	const globalToggleDescription = __(
-		'Control whether AI is enabled for your site. When disabled, all features and experiments will be inactive regardless of their individual settings.',
-		'ai'
+	const featureSettingNames = useMemo(
+		() => featureDefinitions.map( ( feature ) => feature.settingName ),
+		[ featureDefinitions ]
 	);
 
 	const handleChange = useCallback(
 		async ( edits: Record< string, unknown > ) => {
-			const keys = Object.keys( edits );
+			const booleanEdits = Object.fromEntries(
+				Object.entries( edits ).filter(
+					( entry ): entry is [ string, boolean ] =>
+						typeof entry[ 1 ] === 'boolean'
+				)
+			);
+			const syncedEdits = appendGlobalSyncEdits(
+				booleanEdits,
+				data,
+				featureSettingNames
+			);
+			const keys = Object.keys( syncedEdits );
 
 			// Optimistic update — the UI reflects the new value immediately.
 			// @ts-expect-error -- core-data types don't expose editEntityRecord for 'root'/'site' args.
-			editEntityRecord( 'root', 'site', undefined, edits );
+			editEntityRecord( 'root', 'site', undefined, syncedEdits );
 
-			const message = buildToggleMessage( edits, featureDefinitions );
+			const message = buildToggleMessage( syncedEdits, featureDefinitions );
 
 			try {
 				await saveSpecifiedEdits( 'root', 'site', undefined, keys, {
@@ -792,12 +756,15 @@ function AISettingsPage() {
 			createSuccessNotice,
 			createErrorNotice,
 			featureDefinitions,
+			featureSettingNames,
+			data,
 			registry,
 		]
 	);
 
 	const fields = useMemo< Field< AISettings >[] >( () => {
 		const sectionActionsFields: Field< AISettings >[] = [];
+		const sectionMasterFields: Field< AISettings >[] = [];
 		const groupedFields = new Map< string, string[] >();
 
 		// Group features by category
@@ -808,14 +775,56 @@ function AISettingsPage() {
 			groupedFields.set( category, categoryFields );
 		}
 
-		// Create section action fields for each group
+		const showcaseSettings = featureDefinitions
+			.filter( ( feature ) =>
+				VISUAL_CARD_FEATURES.has( feature.settingName )
+			)
+			.map( ( feature ) => feature.settingName );
+
+		const groupLabels = new Map< string, string >();
 		for ( const group of featureGroups ) {
-			const experimentSettings = groupedFields.get( group.id ) ?? [];
+			groupLabels.set( group.id, group.label );
+		}
+		for ( const category of groupedFields.keys() ) {
+			if ( groupLabels.has( category ) ) {
+				continue;
+			}
+			groupLabels.set(
+				category,
+				category === 'other'
+					? __( 'Other Features', 'ai' )
+					: getDefaultLabel( category )
+			);
+		}
+
+		// Create section action and master toggle fields for each group.
+		for ( const [ groupId, experimentSettings ] of groupedFields ) {
+			if ( experimentSettings.length === 0 ) {
+				continue;
+			}
+
+			const groupLabel = groupLabels.get( groupId ) ?? groupId;
+			const masterFieldId = `section-master-${ groupId }`;
+			sectionMasterFields.push( {
+				id: masterFieldId,
+				label: '',
+				type: 'text',
+				Edit: ( props ) => (
+					<SectionMasterToggle
+						{ ...props }
+						groupId={ groupId }
+						groupLabel={ groupLabel }
+						experimentSettings={ experimentSettings }
+						onBulkChange={ handleChange }
+					/>
+				),
+			} );
+
 			if ( experimentSettings.length <= 1 ) {
 				continue;
 			}
 
-			const actionFieldId = `section-actions-${ group.id }`;
+			const actionFieldId = `section-actions-${ groupId }`;
 			sectionActionsFields.push( {
 				id: actionFieldId,
 				label: '',
@@ -824,7 +833,24 @@ function AISettingsPage() {
 					<SectionActions
 						{ ...props }
 						experimentSettings={ experimentSettings }
-						globalEnabled={ globalEnabled }
+						onBulkChange={ handleChange }
+					/>
+				),
+			} );
+		}
+
+		if ( showcaseSettings.length > 0 ) {
+			const masterFieldId = 'section-master-showcase';
+			sectionMasterFields.push( {
+				id: masterFieldId,
+				label: '',
+				type: 'text',
+				Edit: ( props ) => (
+					<SectionMasterToggle
+						{ ...props }
+						groupId="showcase"
+						groupLabel={ __( 'Featured Experiments', 'ai' ) }
+						experimentSettings={ showcaseSettings }
 						onBulkChange={ handleChange }
 					/>
 				),
@@ -842,8 +868,6 @@ function AISettingsPage() {
 
 			if ( VISUAL_CARD_FEATURES.has( feature.settingName ) ) {
 				baseField.Edit = VisualCardToggle;
-			} else if ( ! globalEnabled ) {
-				baseField.Edit = DisabledToggle;
 			} else if ( feature.settingsFields.length > 0 ) {
 				baseField.Edit = FeatureToggleWithSettings;
 			} else {
@@ -861,8 +885,12 @@ function AISettingsPage() {
 			return baseField;
 		} );
 
-		return [ ...sectionActionsFields, ...featureFields ];
-	}, [ featureDefinitions, featureGroups, globalEnabled, handleChange ] );
+		return [
+			...sectionMasterFields,
+			...sectionActionsFields,
+			...featureFields,
+		];
+	}, [ featureDefinitions, featureGroups, handleChange ] );
 
 	const form = useMemo< Form >( () => {
 		const showcaseChildren: string[] = [];
@@ -897,7 +925,10 @@ function AISettingsPage() {
 					type: 'regular',
 					labelPosition: 'none',
 				},
-				children: rows,
+				children:
+					showcaseChildren.length > 0
+						? [ 'section-master-showcase', ...rows ]
+						: rows,
 			} );
 		}
 
@@ -911,7 +942,12 @@ function AISettingsPage() {
 			}
 
 			seenCategories.add( group.id );
+			const masterFieldId = `section-master-${ group.id }`;
 			const actionFieldId = `section-actions-${ group.id }`;
+			const sectionChildren = [ masterFieldId, ...children ];
+			if ( children.length > 1 ) {
+				sectionChildren.push( actionFieldId );
+			}
 			sectionFields.push( {
 				id: getSectionId( group.id ),
 				label: group.label,
@@ -922,10 +958,7 @@ function AISettingsPage() {
 					isOpened: true,
 					isCollapsible: true,
 				},
-				children:
-					children.length > 1
-						? [ ...children, actionFieldId ]
-						: children,
+				children: sectionChildren,
 			} );
 		}
 
@@ -934,7 +967,12 @@ function AISettingsPage() {
 				continue;
 			}
 
+			const masterFieldId = `section-master-${ category }`;
 			const actionFieldId = `section-actions-${ category }`;
+			const sectionChildren = [ masterFieldId, ...children ];
+			if ( children.length > 1 ) {
+				sectionChildren.push( actionFieldId );
+			}
 			sectionFields.push( {
 				id: getSectionId( category ),
 				label: getDefaultLabel( category ),
@@ -945,10 +983,7 @@ function AISettingsPage() {
 					isOpened: true,
 					isCollapsible: true,
 				},
-				children:
-					children.length > 1
-						? [ ...children, actionFieldId ]
-						: children,
+				children: sectionChildren,
 			} );
 		}
 
@@ -968,19 +1003,6 @@ function AISettingsPage() {
 				) }
 				actions={
 					<>
-						<Stack align="center" gap="xs">
-							<ToggleControl
-								label={ __( 'Enable AI', 'ai' ) }
-								checked={ globalEnabled }
-								onChange={ ( checked ) => {
-									void handleChange( {
-										[ GLOBAL_FIELD_ID ]: checked,
-									} );
-								} }
-								disabled={ isLoading }
-							/>
-							<InfoTip content={ globalToggleDescription } />
-						</Stack>
 						<Link
 							href="https://github.com/WordPress/ai/tree/develop/docs"
 							openInNewTab

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -51,6 +51,36 @@
 	max-width: 480px;
 }
 
+.ai-section-master-toggle {
+	margin-bottom: var(--wpds-dimension-padding-md);
+	padding-bottom: var(--wpds-dimension-padding-sm);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+}
+
+.ai-section-master-toggle__control {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm, 8px);
+}
+
+.ai-section-master-toggle__label {
+	font-weight: 500;
+	cursor: var(--wpds-cursor-control);
+}
+
+.ai-section-master-toggle__control.is-indeterminate {
+	.components-form-toggle .components-form-toggle__track {
+		background: var(--wp-admin-theme-color);
+		opacity: 0.55;
+	}
+
+	.components-form-toggle .components-form-toggle__thumb {
+		inset-inline-start: 50%;
+		transform: translateX(-50%);
+		margin-inline-start: -8px;
+	}
+}
+
 .ai-section-actions {
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	margin-top: var(--wpds-dimension-padding-md);

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -112,9 +112,7 @@ test.describe( 'Plugin settings', () => {
 		await expect( editorMasterToggle ).not.toBeChecked();
 
 		// Ensure feature toggles remain interactive when the section is disabled.
-		await expect(
-			page.getByLabel( 'Title Generation' )
-		).toBeEnabled();
+		await expect( page.getByLabel( 'Title Generation' ) ).toBeEnabled();
 
 		// Globally turn on experiments via the section master toggle.
 		await enableExperiments( admin, page );

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -20,6 +20,7 @@ const {
 	getExperimentTogglesInGroup,
 	getEnableAllButton,
 	getDisableAllButton,
+	getSectionMasterToggle,
 } = require( '../../utils/helpers' );
 
 const EXPERIMENT_GROUPS = {
@@ -101,23 +102,24 @@ test.describe( 'Plugin settings', () => {
 		// Globally disable experiments.
 		await disableExperiments( admin, page );
 
-		// Ensure global AI setting is disabled.
-		await expect( page.getByLabel( 'Enable AI' ) ).not.toBeChecked();
+		const editorMasterToggle = getSectionMasterToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
 
-		// Ensure feature toggles are disabled when AI is disabled.
+		// Ensure section master toggles are visible and off when all features are disabled.
+		await expect( editorMasterToggle ).toBeVisible();
+		await expect( editorMasterToggle ).not.toBeChecked();
+
+		// Ensure feature toggles remain interactive when the section is disabled.
 		await expect(
-			page
-				.locator(
-					'#ai-wp-admin-app .components-form-toggle.is-disabled'
-				)
-				.first()
-		).toBeVisible();
+			page.getByLabel( 'Title Generation' )
+		).toBeEnabled();
 
-		// Globally turn on experiments.
+		// Globally turn on experiments via the section master toggle.
 		await enableExperiments( admin, page );
 
-		// Ensure global AI setting is enabled.
-		await expect( page.getByLabel( 'Enable AI' ) ).toBeChecked();
+		await expect( editorMasterToggle ).toBeChecked();
 
 		// Ensure we see the editor experiments section.
 		await expect(
@@ -272,14 +274,61 @@ test.describe( 'Plugin settings', () => {
 		}
 	} );
 
-	test( 'Cannot bulk manage experiments when global AI is disabled', async ( {
+	test( 'Section master toggle reflects mixed experiment state', async ( {
 		admin,
 		page,
 	} ) => {
-		// Disable global AI.
-		await disableExperiments( admin, page );
+		await enableExperiments( admin, page );
 
-		// Verify both buttons are disabled.
+		await disableAllExperimentsInGroup(
+			admin,
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		const experimentToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		if ( experimentToggles.length > 1 ) {
+			await experimentToggles[ 0 ].check();
+		}
+
+		const editorMasterToggle = getSectionMasterToggle(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		await expect( editorMasterToggle ).toBeVisible();
+		await expect( editorMasterToggle ).not.toBeChecked();
+		await expect( editorMasterToggle ).toHaveJSProperty(
+			'indeterminate',
+			true
+		);
+	} );
+
+	test( 'Bulk action buttons stay available when a section is partially enabled', async ( {
+		admin,
+		page,
+	} ) => {
+		await enableExperiments( admin, page );
+
+		await disableAllExperimentsInGroup(
+			admin,
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		const experimentToggles = await getExperimentTogglesInGroup(
+			page,
+			EXPERIMENT_GROUPS.editor
+		);
+
+		if ( experimentToggles.length > 0 ) {
+			await experimentToggles[ 0 ].check();
+		}
+
 		const enableAllButton = getEnableAllButton(
 			page,
 			EXPERIMENT_GROUPS.editor
@@ -290,8 +339,8 @@ test.describe( 'Plugin settings', () => {
 			EXPERIMENT_GROUPS.editor
 		);
 
-		await expect( enableAllButton ).toBeDisabled();
-		await expect( disableAllButton ).toBeDisabled();
+		await expect( enableAllButton ).toBeEnabled();
+		await expect( disableAllButton ).toBeEnabled();
 	} );
 
 	test( 'Each experiment group has its own bulk action buttons', async ( {

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -175,11 +175,7 @@ export const getSectionMasterToggle = ( page: Page, groupName: string ) => {
  * @param page  The page object.
  */
 export const disableExperiments = async ( admin: Admin, page: Page ) => {
-	await disableAllExperimentsInGroup(
-		admin,
-		page,
-		'Editor Experiments'
-	);
+	await disableAllExperimentsInGroup( admin, page, 'Editor Experiments' );
 	await disableAllExperimentsInGroup( admin, page, 'Admin Experiments' );
 };
 
@@ -190,11 +186,7 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
  * @param page  The page object.
  */
 export const enableExperiments = async ( admin: Admin, page: Page ) => {
-	await enableAllExperimentsInGroup(
-		admin,
-		page,
-		'Editor Experiments'
-	);
+	await enableAllExperimentsInGroup( admin, page, 'Editor Experiments' );
 };
 
 /**

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -155,29 +155,32 @@ export const clearConnector = async (
 };
 
 /**
+ * Gets the section master toggle for a specific experiment group.
+ *
+ * @param page      The page object.
+ * @param groupName The name of the experiment group (e.g., 'Editor Experiments').
+ * @return The section master toggle locator.
+ */
+export const getSectionMasterToggle = ( page: Page, groupName: string ) => {
+	return page.getByRole( 'checkbox', {
+		name: `Enable ${ groupName }`,
+		exact: true,
+	} );
+};
+
+/**
  * Globally disables experiments.
  *
  * @param admin The admin fixture from the test context.
  * @param page  The page object.
  */
 export const disableExperiments = async ( admin: Admin, page: Page ) => {
-	await visitSettingsPage( admin );
-
-	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByLabel( 'Enable AI' );
-	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
-	await expect( globalToggle ).toBeEnabled( { timeout: 10000 } );
-
-	// Nothing to do if experiments are already disabled.
-	if ( ! ( await globalToggle.isChecked() ) ) {
-		return;
-	}
-	await globalToggle.uncheck();
-	await expect(
-		page.locator( '.components-snackbar__content', {
-			hasText: 'AI disabled.',
-		} )
-	).toBeVisible();
+	await disableAllExperimentsInGroup(
+		admin,
+		page,
+		'Editor Experiments'
+	);
+	await disableAllExperimentsInGroup( admin, page, 'Admin Experiments' );
 };
 
 /**
@@ -187,23 +190,11 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
  * @param page  The page object.
  */
 export const enableExperiments = async ( admin: Admin, page: Page ) => {
-	await visitSettingsPage( admin );
-
-	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByLabel( 'Enable AI' );
-	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
-	await expect( globalToggle ).toBeEnabled( { timeout: 10000 } );
-
-	// Nothing to do if experiments are already enabled.
-	if ( await globalToggle.isChecked() ) {
-		return;
-	}
-	await globalToggle.check();
-	await expect(
-		page.locator( '.components-snackbar__content', {
-			hasText: 'AI enabled.',
-		} )
-	).toBeVisible();
+	await enableAllExperimentsInGroup(
+		admin,
+		page,
+		'Editor Experiments'
+	);
 };
 
 /**


### PR DESCRIPTION
Fixes #600 by implementing Option B from the issue: remove the global **Enable AI** header toggle and add a **tri-state section master toggle** to each experiment group.
- **Off** — no features enabled in the section
- **Indeterminate** — some but not all features enabled (distinct visual treatment)
- **On** — all features in the section enabled
The header toggle was misleading because it reflected only `wpai_features_enabled`, not the aggregate state of sub-features. Section-level controls scale better as more experiment groups are added and align with existing **Enable all** / **Disable all** actions.
Changes also:
- Sync `wpai_features_enabled` automatically when feature toggles change (enabled when any feature is on, disabled when none are)
- Keep individual feature toggles interactive regardless of global option state
- Remove bulk-action disabling tied to the old global header toggle
## Test plan
- [ ] Open AI settings and confirm there is **no** global **Enable AI** toggle in the page header
- [ ] Confirm each section (Editor Experiments, Admin Experiments, etc.) shows an **Enable {Section}** master toggle
- [ ] Enable only a subset of features in Editor Experiments → section master toggle shows **indeterminate** (not fully on)
- [ ] Click indeterminate section toggle → all features in that section enable
- [ ] Click fully-on section toggle → all features in that section disable
- [ ] **Enable all** / **Disable all** still work and remain enabled in mixed states
- [ ] Individual feature toggles remain interactive when a section is fully disabled
- [ ] Run `npm run test:e2e -- tests/e2e/specs/admin/settings.spec.js`
- [ ] Run `npm run test:php`

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-617-3c2a8a6df4438e4a1f810a5b449b00f508477688.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->