### PR TITLE
Fix readme connector setup wording

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -57,7 +57,7 @@ You can view the active plugin roadmap in a filtered view in the WordPress AI [G
 
 1. Upload the plugin files to the `/wp-content/plugins/ai` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to `Settings -> Connectors` and setup at least one AI connector.
+3. Go to `Settings -> Connectors` and set up at least one AI connector.
 4. Go to `Settings -> AI` and globally enable functionality and then enable the individual features or experiments you want to test.
 5. Start experimenting with AI features! For the Title Generation experiment, edit a post and click into the title field. You should see a `Generate/Regenerate` button above the field. Click that button and after the request is complete, title suggestions will be displayed in a modal. Choose the title you like and click the `Select` button to insert it into the title field.
 


### PR DESCRIPTION
## What?
Corrects the connector setup wording in the `readme.txt` installation instructions.

## Why?
The installation step uses `setup` as a verb. `Set up` is the correct verb phrase in this context.

## How?
Updates the installation step from `setup at least one AI connector` to `set up at least one AI connector`.

### Use of AI Tools
AI assistance: Yes
Tool(s): Sisyphus / OhMyOpenCode
Model(s): GPT-5.5
Used for: Repository triage, the one-line documentation edit, validation, commit preparation, and draft PR preparation. The final change was reviewed before submission.

## Testing Instructions
1. Confirm the diff changes only `readme.txt`.
2. Confirm installation step 3 now reads `set up at least one AI connector`.
3. Confirm `npm run plugin-zip` packages the corrected text in `ai/readme.txt`.

## Screenshots or screencast
Not applicable; this is a documentation-only change.

## Changelog Entry
> Fixed - Corrected wording in readme installation instructions.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-619-fc9dcdc80ee3b419534d8064ce497860cf9b54b6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->