### PR TITLE
Fix WordPress 7.0 preview and test configs

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run plugin check
         uses: wordpress/plugin-check-action@18573eb38f13543484a1f095672dae3849a4fbb0 # v1.1.6
         with:
-          wp-version: 'trunk'
+          wp-version: 'latest'
           # Exclude file_type because of the dev files present in the repository.
           exclude-checks: |
             file_type

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -83,7 +83,7 @@ jobs:
 
           const blueprint = {
             preferredVersions: {
-              wp: 'beta',
+              wp: '7.0',
             },
             steps: [
               {

--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -83,7 +83,7 @@ jobs:
 
           const blueprint = {
             preferredVersions: {
-              wp: '7.0',
+              wp: 'latest',
             },
             steps: [
               {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,11 +172,11 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
-        wp: [trunk]
+        wp: [latest, trunk]
         coverage: [false]
         include:
           - php: '8.4'
-            wp: trunk
+            wp: latest
             coverage: true
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -3,7 +3,7 @@
 	"landingPage": "/wp-admin/options-general.php?page=ai-wp-admin",
 	"preferredVersions": {
 		"php": "7.4",
-		"wp": "7.0"
+		"wp": "latest"
 	},
 	"features": {
 		"networking": true

--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -3,7 +3,7 @@
 	"landingPage": "/wp-admin/options-general.php?page=ai-wp-admin",
 	"preferredVersions": {
 		"php": "7.4",
-		"wp": "beta"
+		"wp": "7.0"
 	},
 	"features": {
 		"networking": true

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 	"testsEnvironment": false,
-	"core": "WordPress/WordPress#master",
+	"core": null,
 	"plugins": [
 		".",
 		"https://downloads.wordpress.org/plugin/ai-provider-for-google.zip",

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
 	"testsEnvironment": false,
 	"port": 8889,
-	"core": "WordPress/WordPress#master",
+	"core": null,
 	"plugins": [
 		".",
 		"./tests/e2e-request-mocking",


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?

Closes https://github.com/WordPress/ai/issues/623

Updates the Playground, Plugin Check, PHPUnit, and wp-env configs now that WordPress 7.0 is available as the latest stable release.

## Why?

The AI plugin requires WP 7.0, but some configs still contained temporary pre-release or trunk settings that were added before WP 7.0 was released.

This could cause the AI plugin Playground preview to load WP 7.0 RC5 instead of the final WP 7.0 release. Now that 7.0 is released, these configs can use stable release defaults again while keeping explicit trunk coverage where it is still useful.

## How?

- Pins the WordPress.org Playground blueprint to WordPress `7.0`.
- Pins the PR Playground preview blueprint to WordPress `7.0`.
- Restores Plugin Check to run against `latest`.
- Restores the PHPUnit matrix to run against both `latest` and `trunk`.
- Restores `.wp-env` configs to `core: null`, which uses the latest production WordPress release.

### Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Identifying the affected config files, preparing the local patch, and drafting validation steps. The changes were reviewed and confirmed by me.

## Testing Instructions
- Confirm blueprint.json after running the blueprint on WP Playground

## Screenshots or screencast

Not applicable. This is a configuration-only change.

## Changelog Entry

> Fixed - Playground and test configs now target the stable WordPress 7.0/latest release instead of temporary pre-release or trunk defaults where appropriate.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-626-b09a37b48b91c750a854ec056fd78c3ba07ce155.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->