### PR TITLE
fix: add inline class to connector approval admin notice for proper l…

### DIFF
--- a/includes/Connector_Approval/Admin_Notice.php
+++ b/includes/Connector_Approval/Admin_Notice.php
@@ -147,7 +147,7 @@ final class Admin_Notice {
 			self::DISMISS_NONCE
 		);
 
-		$class = 'notice notice-warning';
+		$class = 'notice notice-warning ai-connector-approval-notice';
 		if ( $screen && 'tools_page_ai-request-logs' === $screen->id ) {
 			$class .= ' inline';
 		}

--- a/includes/Connector_Approval/Admin_Notice.php
+++ b/includes/Connector_Approval/Admin_Notice.php
@@ -147,8 +147,14 @@ final class Admin_Notice {
 			self::DISMISS_NONCE
 		);
 
+		$class = 'notice notice-warning';
+		if ( $screen && 'tools_page_ai-request-logs' === $screen->id ) {
+			$class .= ' inline';
+		}
+
 		printf(
-			'<div class="notice notice-warning inline"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
+			'<div class="%s"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
+			esc_attr( $class ),
 			esc_html(
 				sprintf(
 					/* translators: %d: number of pending approval requests. */

--- a/includes/Connector_Approval/Admin_Notice.php
+++ b/includes/Connector_Approval/Admin_Notice.php
@@ -148,7 +148,7 @@ final class Admin_Notice {
 		);
 
 		printf(
-			'<div class="notice notice-warning"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
+			'<div class="notice notice-warning inline"><p>%s <a href="%s">%s</a> &middot; <a href="%s">%s</a></p></div>',
 			esc_html(
 				sprintf(
 					/* translators: %d: number of pending approval requests. */

--- a/src/admin/ai-request-logs/index.scss
+++ b/src/admin/ai-request-logs/index.scss
@@ -1,5 +1,11 @@
 @use '../common';
 
+.tools_page_ai-request-logs {
+	.ai-connector-approval-notice {
+		margin: 10px 15px 15px 0;
+	}
+}
+
 .ai-request-logs__app {
 	max-width: 1400px;
 

--- a/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
@@ -114,7 +114,7 @@ class Admin_NoticeTest extends WP_UnitTestCase {
 		$notice->render();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'class="notice notice-warning"', $output );
+		$this->assertStringContainsString( 'class="notice notice-warning ai-connector-approval-notice"', $output );
 		$this->assertStringNotContainsString( 'inline', $output );
 	}
 
@@ -149,6 +149,6 @@ class Admin_NoticeTest extends WP_UnitTestCase {
 		$notice->render();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'class="notice notice-warning inline"', $output );
+		$this->assertStringContainsString( 'class="notice notice-warning ai-connector-approval-notice inline"', $output );
 	}
 }

--- a/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
@@ -82,4 +82,73 @@ class Admin_NoticeTest extends WP_UnitTestCase {
 
 		$this->assertSame( '', $output );
 	}
+
+	/**
+	 * Tests that the notice does not include the inline class on other pages.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_render_does_not_use_inline_class_by_default(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->store->record_pending(
+			array(
+				'type'     => 'plugin',
+				'basename' => 'example/example.php',
+				'name'     => 'Example',
+			),
+			'openai'
+		);
+
+		set_current_screen( 'dashboard' );
+
+		$notice = new Admin_Notice(
+			$this->store,
+			static function (): string {
+				return admin_url( 'tools.php?page=ai-connector-approval' );
+			}
+		);
+
+		ob_start();
+		$notice->render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="notice notice-warning"', $output );
+		$this->assertStringNotContainsString( 'inline', $output );
+	}
+
+	/**
+	 * Tests that the notice includes the inline class on the Request Logs screen.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_render_uses_inline_class_on_request_logs_screen(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->store->record_pending(
+			array(
+				'type'     => 'plugin',
+				'basename' => 'example/example.php',
+				'name'     => 'Example',
+			),
+			'openai'
+		);
+
+		set_current_screen( 'tools_page_ai-request-logs' );
+
+		$notice = new Admin_Notice(
+			$this->store,
+			static function (): string {
+				return admin_url( 'tools.php?page=ai-connector-approval' );
+			}
+		);
+
+		ob_start();
+		$notice->render();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'class="notice notice-warning inline"', $output );
+	}
 }

--- a/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Admin_NoticeTest.php
@@ -86,7 +86,7 @@ class Admin_NoticeTest extends WP_UnitTestCase {
 	/**
 	 * Tests that the notice does not include the inline class on other pages.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function test_render_does_not_use_inline_class_by_default(): void {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
@@ -121,7 +121,7 @@ class Admin_NoticeTest extends WP_UnitTestCase {
 	/**
 	 * Tests that the notice includes the inline class on the Request Logs screen.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function test_render_uses_inline_class_on_request_logs_screen(): void {
 		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
## What?

Closes: #596 

Fixes the connector approval notice overlapping the header on the AI Request Logs screen when both the Connector Approvals and AI Request Logging experiments are enabled.

## Why?

WordPress Core's `common.js` automatically relocates `.notice` elements to after the first `h1` in `.wrap`. The `@wordpress/admin-ui` `Page` component renders its `h1` inside a flex header container, so the notice ends up as an inline flex child in the header row.

## How?

Added the `inline` class to the notice output in `Admin_Notice::render()`. WordPress Core's `common.js` explicitly skips elements with the `inline` class when relocating notices, so the notice stays in its natural output position instead of being moved into the flex header.


### Use of AI Tools

AI assistance: Yes  
Tool(s): Antigravity  
Used for: Deciding most optimal approach 

## Screenshots or screencast
### Before
<img width="824" height="136" alt="Screenshot 2026-05-27 at 5 08 38 PM" src="https://github.com/user-attachments/assets/7402e300-58d5-408c-9199-c4fb5220f4c4" />

### After
<img width="1418" height="208" alt="Screenshot 2026-05-27 at 5 09 13 PM" src="https://github.com/user-attachments/assets/a7af7969-eab4-4010-98dd-cf6f9e2c0fbb" />

## Changelog Entry

> Fixed - Connector approval notice no longer overlaps the page header on the AI Request Logs screen.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22beta%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-628-4872fc61d02e0767b7c9d87eb96197c7c788df5d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->