### PR TITLE
Fix[Alt Generation]: Generate button becomes unresponsive after using Next/Previous in media modal

### DIFF
--- a/src/experiments/alt-text-generation/media.ts
+++ b/src/experiments/alt-text-generation/media.ts
@@ -298,14 +298,14 @@ window.jQuery?.( document ).ready( function () {
 		if ( ! isEditAttachmentRefreshBound ) {
 			initAltTextMediaControls();
 
-			isEditAttachmentRefreshBound = true;
-
 			// Fired when the edit modal refreshes for next/previous navigation,
 			// and when the same edit frame is reused after reopening the modal.
 			wpMedia.media?.frames?.edit?.on(
 				'refresh',
 				initAltTextMediaControls
 			);
+
+			isEditAttachmentRefreshBound = true;
 		}
 	} );
 

--- a/src/experiments/alt-text-generation/media.ts
+++ b/src/experiments/alt-text-generation/media.ts
@@ -304,6 +304,7 @@ window.jQuery?.( document ).ready( function () {
 				'refresh',
 				initAltTextMediaControls
 			);
+
 			isEditAttachmentRefreshBound = true;
 		}
 	} );

--- a/src/experiments/alt-text-generation/media.ts
+++ b/src/experiments/alt-text-generation/media.ts
@@ -304,7 +304,6 @@ window.jQuery?.( document ).ready( function () {
 				'refresh',
 				initAltTextMediaControls
 			);
-
 			isEditAttachmentRefreshBound = true;
 		}
 	} );

--- a/src/experiments/alt-text-generation/media.ts
+++ b/src/experiments/alt-text-generation/media.ts
@@ -35,6 +35,9 @@ type WordPressMedia = {
 			};
 		};
 		frame?: { on: ( event: string, cb: unknown ) => void };
+		frames?: {
+			edit?: { on: ( event: string, cb: unknown ) => void };
+		};
 	};
 	Uploader?: { queue?: { on: ( event: string, cb: unknown ) => void } };
 };
@@ -286,8 +289,25 @@ window.jQuery?.( document ).ready( function () {
 		);
 	} );
 
-	// When editing an attachment in the media library.
-	wpMedia.media?.frame?.on( 'edit:attachment', initAltTextMediaControls );
+	// The edit attachment frame is created lazily when the modal opens.
+	let isEditAttachmentRefreshBound = false;
+
+	// Initialize controls the first time the attachment edit modal opens, then
+	// bind the edit frame refresh event once for later attachment changes.
+	wpMedia.media?.frame?.on( 'edit:attachment', () => {
+		if ( ! isEditAttachmentRefreshBound ) {
+			initAltTextMediaControls();
+
+			isEditAttachmentRefreshBound = true;
+
+			// Fired when the edit modal refreshes for next/previous navigation,
+			// and when the same edit frame is reused after reopening the modal.
+			wpMedia.media?.frames?.edit?.on(
+				'refresh',
+				initAltTextMediaControls
+			);
+		}
+	} );
 
 	// For newly uploaded media.
 	wpMedia.Uploader?.queue?.on( 'reset', initAltTextMediaControls );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/ai/issues/627

Fixes the Alt Text Generation button becoming unresponsive after using Previous/Next inside the media modal.

## Why?

The media modal replaces or refreshes the attachment details UI during navigation. The existing initialization only handled the initial modal state, so the Generate/Regenerate button could lose its event binding after moving to another attachment.

## How?

Bind to the media edit frame’s refresh event after the edit attachment modal is first opened. This re-initializes the alt text controls when the modal refreshes for Previous/Next navigation, while ensuring the refresh handler is registered only once to avoid duplicate generation requests.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Initial code skeleton; final implementation was reviewed and edited by me.

## Testing Instructions
1. Go to Media → Library.
2. Select an image and generate alt text.
3. Use the modal’s Previous/Next controls to navigate to another image.
4. Confirm the Generate/Regenerate button still works.
5. Close and reopen the media modal, then generate alt text again.
6. In the Network tab, confirm each Generate/Regenerate click sends exactly one request.

## Screencasts

### Before
https://github.com/user-attachments/assets/0373c941-8647-4de2-b614-1f1ea04aa5d2

### After
https://github.com/user-attachments/assets/a55b877f-b2fe-4dd0-84e1-a8c3395cfa3a

## Changelog Entry

> Fixed - Alt Text Generation button becomes unresponsive after using Next/Previous in the media modal.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-631-f93f0e5b61855857f75e0c8a5957691dc82f111c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->