### PR TITLE
Clarify AI Connector provider setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,7 @@ This [Canonical Plugin](https://make.wordpress.org/core/2022/09/11/canonical-plu
 
 The AI plugin does not include provider credentials or provider implementations by itself. To use AI-powered features, install and activate at least one AI Connector plugin, then configure its credentials in `Settings -> Connectors`. Features may appear unavailable until a connector is installed, authenticated, and capable of the required operation.
 
-Provider connector plugins include:
-
-* [AI Provider for OpenAI](https://github.com/WordPress/ai-provider-for-openai)
-* [AI Provider for Google](https://github.com/WordPress/ai-provider-for-google)
-* [AI Provider for Anthropic](https://github.com/WordPress/ai-provider-for-anthropic)
+Provider connector plugins include [Anthropic](https://wordpress.org/plugins/ai-provider-for-anthropic), [Google](https://wordpress.org/plugins/ai-provider-for-google), [OpenAI](https://wordpress.org/plugins/ai-provider-for-openai), and [others](https://wordpress.org/plugins/tags/connector/).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,18 @@ This [Canonical Plugin](https://make.wordpress.org/core/2022/09/11/canonical-plu
 * **Guidelines** - Allows abilities to respect site-wide editorial standards.
 * **[Image Generation and Editing](docs/features/image-generation.md)** - Create and edit images from post content in the editor, also via the Media Library.
 * **[Meta Description Generation](docs/experiments/meta-description.md)** - Generates meta description suggestions and integrates those with various SEO plugins.
-* **[Multi-Provider Support](docs/experiments/multi-provider-support.md)** - Works with popular AI providers like OpenAI, Google, and Anthropic.
+* **[Multi-Provider Support](docs/experiments/multi-provider-support.md)** - Works with AI Connector plugins for providers such as OpenAI, Google, and Anthropic.
 * **[Title Generation](docs/experiments/title-generation.md)** -  Generates title suggestions from content.
+
+## Provider Setup
+
+The AI plugin does not include provider credentials or provider implementations by itself. To use AI-powered features, install and activate at least one AI Connector plugin, then configure its credentials in `Settings -> Connectors`. Features may appear unavailable until a connector is installed, authenticated, and capable of the required operation.
+
+Provider connector plugins include:
+
+* [AI Provider for OpenAI](https://github.com/WordPress/ai-provider-for-openai)
+* [AI Provider for Google](https://github.com/WordPress/ai-provider-for-google)
+* [AI Provider for Anthropic](https://github.com/WordPress/ai-provider-for-anthropic)
 
 ## Roadmap
 
@@ -66,7 +76,7 @@ Overview of planned features:
 
 ## Developer Experience
 
-The AI plugin is meant to be studied, forked, and extended.  If you’re a host or agency, you can configure AI providers on behalf of your users so they don’t need to bring their own API keys.
+The AI plugin is meant to be studied, forked, and extended.  If you’re a host or agency, you can install and configure AI Connector plugins on behalf of your users so they don’t need to bring their own API keys.
 
 If you’re a plugin developer, you’ll be able to:
 

--- a/docs/experiments/multi-provider-support.md
+++ b/docs/experiments/multi-provider-support.md
@@ -2,17 +2,18 @@
 
 ## Summary
 
-The plugin supports multiple AI providers through the WordPress AI Client and connector system. Features and experiments can run against a prioritized provider/model list, automatically fall back when a preferred model is unavailable, and validate capability support before execution.
+The plugin supports multiple AI providers through the WordPress AI Client and connector system. Provider access is supplied by separate AI Connector plugins. Features and experiments can run against a prioritized provider/model list, automatically fall back when a preferred model is unavailable, and validate capability support before execution.
 
 ## Overview
 
 ### For End Users
 
-You can configure one or more AI connectors (for example OpenAI, Google, Anthropic) in WordPress settings. Once configured:
+Install and activate one or more AI Connector plugins, such as OpenAI, Google, or Anthropic, then configure their credentials in `Settings -> Connectors`. Once configured:
 
 - Experiments can use any compatible connected provider.
 - Capability checks prevent running requests on unsupported connectors.
 - If a preferred model is unavailable, another configured model/provider can be used.
+- Features may appear unavailable until a connector is installed, authenticated, and capable of the required operation.
 
 This allows flexibility in cost, performance, and reliability across provider ecosystems.
 
@@ -36,6 +37,8 @@ Credential detection is connector-aware:
 - `has_ai_credentials()` inspects `wp_get_connectors()` for `ai_provider` connectors with configured authentication.
 - `wpai_has_ai_credentials` filter allows custom connector implementations to report configured status.
 - `has_valid_ai_credentials()` performs a runtime support probe using AI client prompt checks.
+
+The AI plugin depends on registered `ai_provider` connectors. It does not ship provider credentials or provider implementations directly.
 
 ### Model Selection and Fallback
 
@@ -93,6 +96,7 @@ add_filter( 'wpai_has_ai_credentials', function( $has_credentials, $connectors )
 ## Operational Notes
 
 - Configure at least one connector that supports the feature's required capability.
+- If a feature is unavailable, confirm that a provider connector plugin is active, authenticated, and listed under `Settings -> Connectors`.
 - Multi-provider setups can improve resilience when individual providers are unavailable.
 - Keep model preference filters aligned with currently available provider model IDs.
 - If no provider supports the requested capability, abilities should return explicit `WP_Error` responses.

--- a/readme.txt
+++ b/readme.txt
@@ -34,8 +34,12 @@ This plugin is built on the [AI Building Blocks for WordPress](https://make.word
 * **Guidelines** - Allows abilities to respect site-wide editorial standards.
 * **Image Generation and Editing** - Create and edit images from post content in the editor, also via the Media Library.
 * **Meta Description Generation** - Generates meta description suggestions and integrates those with various SEO plugins.
-* **Multi-Provider Support** - Works with popular AI providers like OpenAI, Google, and Anthropic.
+* **Multi-Provider Support** - Works with AI Connector plugins for providers such as OpenAI, Google, and Anthropic.
 * **Title Generation** - Generate title suggestions for your posts with a single click. Perfect for brainstorming headlines or finding the right tone for your content.
+
+**Provider Setup:**
+
+The AI plugin does not include provider credentials or provider implementations by itself. To use AI-powered features, install and activate at least one AI Connector plugin, then configure its credentials in `Settings -> Connectors`. Features may appear unavailable until a connector is installed, authenticated, and capable of the required operation.
 
 **Coming Soon:**
 
@@ -57,7 +61,7 @@ You can view the active plugin roadmap in a filtered view in the WordPress AI [G
 
 1. Upload the plugin files to the `/wp-content/plugins/ai` directory, or install the plugin through the WordPress plugins screen directly.
 2. Activate the plugin through the 'Plugins' screen in WordPress.
-3. Go to `Settings -> Connectors` and set up at least one AI connector.
+3. Install and activate at least one AI Connector plugin, then go to `Settings -> Connectors` and configure its credentials.
 4. Go to `Settings -> AI` and globally enable functionality and then enable the individual features or experiments you want to test.
 5. Start experimenting with AI features! For the Title Generation experiment, edit a post and click into the title field. You should see a `Generate/Regenerate` button above the field. Click that button and after the request is complete, title suggestions will be displayed in a modal. Choose the title you like and click the `Select` button to insert it into the title field.
 
@@ -68,7 +72,7 @@ The AI plugin is designed to be studied, extended, and built upon. Whether you'r
 **Extend the Plugin:**
 
 * **Build Custom Experiments** - Use the `Abstract_Feature` base class to create your own AI-powered features.
-* **Pre-configure Providers** - Hosts and agencies can set up AI providers so users don't need their own API keys.
+* **Pre-configure Providers** - Hosts and agencies can set up AI Connector plugins so users don't need their own API keys.
 * **Abilities Explorer** - Test and explore registered AI abilities (available when experiments are enabled).
 * **Register Custom Abilities** - Hook into the Abilities API to add new AI capabilities.
 * **Override Default Behavior** - Use filters to customize prompts, responses, and UI elements.
@@ -101,11 +105,11 @@ This is an experimental plugin, so we recommend testing in a staging environment
 
 = Which AI providers are supported? =
 
-The plugin supports OpenAI, Google AI (Gemini), and Anthropic (Claude). You can configure one or multiple providers in Settings -> Connectors.
+The plugin can work with provider connector plugins for OpenAI, Google AI (Gemini), and Anthropic (Claude). Install and activate the relevant connector plugin, then configure it in Settings -> Connectors.
 
 = Do I need an API key to use the features? =
 
-Yes, currently you need to provide your own API key from a supported AI provider (OpenAI, Google AI, or Anthropic).
+Yes, currently you need to provide your own API key for the configured AI Connector plugin, such as OpenAI, Google AI, or Anthropic.
 
 = How much does it cost? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -107,7 +107,7 @@ This is an experimental plugin, so we recommend testing in a staging environment
 
 = Which AI providers are supported? =
 
-The plugin can work with provider connector plugins for OpenAI, Google AI (Gemini), and Anthropic (Claude). Install and activate the relevant connector plugin, then configure it in Settings -> Connectors.
+The plugin can work with provider connector plugins from [Anthropic](https://wordpress.org/plugins/ai-provider-for-anthropic) (Claude), [Google](https://wordpress.org/plugins/ai-provider-for-google) (Gemini), [OpenAI](https://wordpress.org/plugins/ai-provider-for-openai), and [others](https://wordpress.org/plugins/tags/connector/). Install and activate the relevant connector plugin, then configure it in `Settings -> Connectors`.
 
 = Do I need an API key to use the features? =
 
@@ -115,7 +115,7 @@ Yes, currently you need to provide your own API key for the configured AI Connec
 
 = How much does it cost? =
 
-The plugin itself is free, but you'll need to pay for API usage from your chosen AI provider. Costs vary by provider and usage. Most providers offer free trial credits to get started.
+The plugin itself is free, but you'll need to pay for API usage from your chosen AI provider. Costs vary by provider and usage. Most providers offer free trial credits to get started. There are some local, open source, and free providers (like [Ollama](https://wordpress.org/plugins/ai-provider-for-ollama/)) that can be used as well.
 
 = Can I use this without coding knowledge? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,8 @@ This plugin is built on the [AI Building Blocks for WordPress](https://make.word
 
 The AI plugin does not include provider credentials or provider implementations by itself. To use AI-powered features, install and activate at least one AI Connector plugin, then configure its credentials in `Settings -> Connectors`. Features may appear unavailable until a connector is installed, authenticated, and capable of the required operation.
 
+Provider connector plugins include [Anthropic](https://wordpress.org/plugins/ai-provider-for-anthropic), [Google](https://wordpress.org/plugins/ai-provider-for-google), [OpenAI](https://wordpress.org/plugins/ai-provider-for-openai), and [others](https://wordpress.org/plugins/tags/connector/).
+
 **Coming Soon:**
 
 We're actively developing new features to enhance your WordPress workflow:


### PR DESCRIPTION
## Summary

Clarifies that AI provider support depends on separate AI Connector plugins, not provider implementations bundled directly with the AI plugin.

## Changes

- Updates README and WordPress.org readme wording for multi-provider support.
- Adds a provider setup section explaining that users need to install and configure an AI Connector plugin.
- Links the OpenAI, Google, and Anthropic provider connector repositories.
- Updates the multi-provider experiment docs to match the current connector-based provider detection flow.

Partially addresses #502.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-638-f9c3f3a5723954d80e45dc828330771277482b85.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->