### PR TITLE
Fix: a11y Add focus again to Generate Title button on modal close

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -96,8 +96,6 @@ export default function TitleToolbar( {
 	const [ isOpen, setOpen ] = useState< boolean >( false );
 	const [ generatedTitle, setGeneratedTitle ] = useState< string >( '' );
 
-	// Reference to the Generate/Regenerate toolbar button so focus can be
-	// returned to it after the modal closes.
 	const generateButtonRef = useRef< HTMLButtonElement | null >( null );
 
 	// Tracks the pending focus-restore timeout so it can be cancelled on unmount.
@@ -116,30 +114,18 @@ export default function TitleToolbar( {
 	const openModal = () => setOpen( true );
 
 	/**
-	 * Returns focus to the Generate/Regenerate button after the modal closes.
-	 *
-	 * While the modal is open, the wrapper hides the toolbar on blur, so the
-	 * button lives in a `display: none` container and cannot receive focus.
-	 * We make the toolbar visible again, then focus the button on the next
-	 * tick (after the modal has unmounted and released focus).
+	 * Returns focus to the title input after the modal closes.
 	 */
 	const restoreFocus = () => {
 		focusTimeoutRef.current = setTimeout( () => {
 			focusTimeoutRef.current = null;
 
-			const button = generateButtonRef.current;
-			if ( ! button ) {
-				return;
-			}
+			const titleInput =
+				generateButtonRef.current?.ownerDocument.querySelector(
+					'.editor-post-title__input'
+				) as HTMLElement | null;
 
-			const container = button.closest(
-				'.ai-title-toolbar-container'
-			) as HTMLElement | null;
-			if ( container ) {
-				container.style.display = 'flex';
-			}
-
-			button.focus();
+			titleInput?.focus();
 		}, 0 );
 	};
 

--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/components';
 import { dispatch, select, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { update } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -96,10 +96,57 @@ export default function TitleToolbar( {
 	const [ isOpen, setOpen ] = useState< boolean >( false );
 	const [ generatedTitle, setGeneratedTitle ] = useState< string >( '' );
 
+	// Reference to the Generate/Regenerate toolbar button so focus can be
+	// returned to it after the modal closes.
+	const generateButtonRef = useRef< HTMLButtonElement | null >( null );
+
+	// Tracks the pending focus-restore timeout so it can be cancelled on unmount.
+	const focusTimeoutRef = useRef< ReturnType< typeof setTimeout > | null >(
+		null
+	);
+
+	useEffect( () => {
+		return () => {
+			if ( focusTimeoutRef.current ) {
+				clearTimeout( focusTimeoutRef.current );
+			}
+		};
+	}, [] );
+
 	const openModal = () => setOpen( true );
+
+	/**
+	 * Returns focus to the Generate/Regenerate button after the modal closes.
+	 *
+	 * While the modal is open, the wrapper hides the toolbar on blur, so the
+	 * button lives in a `display: none` container and cannot receive focus.
+	 * We make the toolbar visible again, then focus the button on the next
+	 * tick (after the modal has unmounted and released focus).
+	 */
+	const restoreFocus = () => {
+		focusTimeoutRef.current = setTimeout( () => {
+			focusTimeoutRef.current = null;
+
+			const button = generateButtonRef.current;
+			if ( ! button ) {
+				return;
+			}
+
+			const container = button.closest(
+				'.ai-title-toolbar-container'
+			) as HTMLElement | null;
+			if ( container ) {
+				container.style.display = 'flex';
+			}
+
+			button.focus();
+		}, 0 );
+	};
+
 	const closeModal = () => {
 		setOpen( false );
 		setGeneratedTitle( '' );
+		restoreFocus();
 	};
 
 	const hasTitle = title.trim().length > 0;
@@ -189,6 +236,7 @@ export default function TitleToolbar( {
 		<PostTypeSupportCheck supportKeys="title">
 			{ isStandalone ? (
 				<Button
+					ref={ generateButtonRef }
 					icon={ update }
 					variant="secondary"
 					label={ buttonLabel }
@@ -203,6 +251,7 @@ export default function TitleToolbar( {
 			) : (
 				<ToolbarGroup>
 					<ToolbarButton
+						ref={ generateButtonRef }
 						icon={ update }
 						label={ buttonLabel }
 						onClick={ handleGenerate }


### PR DESCRIPTION

<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of : https://github.com/WordPress/ai/issues/589

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR resolves the a11y issue mentioned in the comment - https://github.com/WordPress/ai/issues/589#issuecomment-4572972547

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds the ref to the button and restore the focus on modal close.
- Also displays the container in which the button is placed, as it is hidden via JS.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Claude Code, Opus 4.8
- Used for initial research and to provide a fix for a11y.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open any post/page
2. Make sure title generation experiment is active.
3. Click on generate, once inserted the focus would be on generate again.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/c976e2e5-a95f-412e-a1ca-fd7ac990cbfb

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Fix a11y issue after generating title the focus was lost.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-644-0b09bbdb450db8bd1df680fa8919f35143754279.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->