### PR TITLE
Fix: a11y: Add focus button back to generate/regenerate button on alt text generation

### DIFF
--- a/src/experiments/alt-text-generation/components/AltTextControls.tsx
+++ b/src/experiments/alt-text-generation/components/AltTextControls.tsx
@@ -8,7 +8,7 @@
 import { Button, TextareaControl, Notice } from '@wordpress/components';
 import { update } from '@wordpress/icons';
 import { InspectorControls } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { dispatch, select } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
@@ -89,13 +89,34 @@ export function AltTextControls( {
 	const [ generatedAlt, setGeneratedAlt ] = useState< string | null >( null );
 	const [ isDecorative, setIsDecorative ] = useState< boolean >( false );
 
+	const hasGeneratedAlt = generatedAlt !== null;
+
+	// Refs used to manage keyboard focus as the suggestion UI appears/disappears.
+	const generateButtonRef = useRef< HTMLButtonElement | null >( null );
+	const applyButtonRef = useRef< HTMLButtonElement | null >( null );
+
+	// Set when Apply/Dismiss is clicked so focus returns to the generate button.
+	const shouldFocusGenerateRef = useRef< boolean >( false );
+
+	// Move focus when the suggestion UI appears (after generation) or
+	// disappears (after Apply/Dismiss).
+	useEffect( () => {
+		if ( hasGeneratedAlt || isDecorative ) {
+			// Generation complete: move focus to the Apply button.
+			applyButtonRef.current?.focus();
+		} else if ( shouldFocusGenerateRef.current ) {
+			// After Apply/Dismiss: return focus to the Generate/Regenerate button.
+			shouldFocusGenerateRef.current = false;
+			generateButtonRef.current?.focus();
+		}
+	}, [ hasGeneratedAlt, isDecorative ] );
+
 	// Don't show controls if there's no image.
 	if ( ! attachmentId && ! imageUrl ) {
 		return null;
 	}
 
 	const hasExistingAlt = alt && alt.trim().length > 0;
-	const hasGeneratedAlt = generatedAlt !== null;
 
 	/**
 	 * Handles the generate button click.
@@ -161,6 +182,7 @@ export function AltTextControls( {
 		} else if ( generatedAlt ) {
 			setAttributes( { alt: generatedAlt } );
 		}
+		shouldFocusGenerateRef.current = true;
 		setGeneratedAlt( null );
 		setIsDecorative( false );
 	};
@@ -169,6 +191,7 @@ export function AltTextControls( {
 	 * Dismisses the generated alt text suggestion.
 	 */
 	const handleDismiss = () => {
+		shouldFocusGenerateRef.current = true;
 		setGeneratedAlt( null );
 		setIsDecorative( false );
 	};
@@ -196,7 +219,11 @@ export function AltTextControls( {
 								marginTop: '8px',
 							} }
 						>
-							<Button variant="primary" onClick={ handleApply }>
+							<Button
+								ref={ applyButtonRef }
+								variant="primary"
+								onClick={ handleApply }
+							>
 								{ __( 'Apply', 'ai' ) }
 							</Button>
 							<Button
@@ -220,7 +247,11 @@ export function AltTextControls( {
 								marginTop: '8px',
 							} }
 						>
-							<Button variant="primary" onClick={ handleApply }>
+							<Button
+								ref={ applyButtonRef }
+								variant="primary"
+								onClick={ handleApply }
+							>
 								{ __( 'Apply', 'ai' ) }
 							</Button>
 							<Button
@@ -236,6 +267,7 @@ export function AltTextControls( {
 				{ /* Generate button */ }
 				{ ! hasGeneratedAlt && ! isDecorative && (
 					<Button
+						ref={ generateButtonRef }
 						variant="secondary"
 						onClick={ handleGenerate }
 						disabled={ isGenerating }


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/ai/issues/589

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR aims to resolve and fix the issue mentioned in comment - https://github.com/WordPress/ai/issues/589#issuecomment-4572972547

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR adds ref to button and check once generated apply the focus to the buttons.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Claude Code, Opus 4.8
- Used on initial research and findings. 
- Also used to identify and fix the same issue.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable alt text generation experiment and configure the API key and model.
2. Go to any page/post.
3. Add the image bloc and switch to block settings (inspector panel).
4. There would be button to generate alt text, Click that.
5. Once generated, the focus will move to Apply button, After apply/dismiss, focus will move to Regnerate/generate button.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


https://github.com/user-attachments/assets/94a4d359-9db7-4f08-ac0c-02b66cd35c86



## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Focus lost when generating the alt text in image block inspector controls.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-645-f22bf527bf658980aca17577010f815b7f6a5e23.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->