### PR TITLE
Fix: a11y: Connector Approval Matrix input toggle button

### DIFF
--- a/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
+++ b/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
@@ -48,17 +48,14 @@ const ApprovalMatrixCard = ( {
 }: ApprovalMatrixCardProps ): JSX.Element => {
 	const matrixCallers = buildMatrixCallerList( plugins, themes, approvals );
 
-	const tableRef = useRef< HTMLTableElement | null >( null );
+	const lastToggledRef = useRef< HTMLElement | null >( null );
 	const wasSavingRef = useRef< boolean >( false );
-	const lastToggledKeyRef = useRef< string | null >( null );
+	const tableRef = useRef< HTMLTableElement | null >( null );
 
 	useEffect( () => {
-		if ( wasSavingRef.current && ! isSaving && lastToggledKeyRef.current ) {
-			const input = tableRef.current?.querySelector< HTMLElement >(
-				`[data-toggle-key="${ lastToggledKeyRef.current }"] input`
-			);
-			input?.focus();
-			lastToggledKeyRef.current = null;
+		if ( wasSavingRef.current && ! isSaving ) {
+			lastToggledRef.current?.focus();
+			lastToggledRef.current = null;
 		}
 
 		wasSavingRef.current = isSaving;
@@ -110,13 +107,8 @@ const ApprovalMatrixCard = ( {
 											]
 										);
 
-										const toggleKey = `${ caller.basename }__${ connector.id }`;
-
 										return (
-											<td
-												key={ connector.id }
-												data-toggle-key={ toggleKey }
-											>
+											<td key={ connector.id }>
 												<ToggleControl
 													checked={ approved }
 													disabled={ isSaving }
@@ -124,8 +116,10 @@ const ApprovalMatrixCard = ( {
 													onChange={ (
 														value: boolean
 													) => {
-														lastToggledKeyRef.current =
-															toggleKey;
+														lastToggledRef.current =
+															tableRef.current
+																?.ownerDocument
+																.activeElement as HTMLElement;
 														onToggle(
 															caller.basename,
 															connector.id,

--- a/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
+++ b/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
@@ -11,6 +11,7 @@ import {
 	CardHeader,
 	ToggleControl,
 } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -47,6 +48,27 @@ const ApprovalMatrixCard = ( {
 }: ApprovalMatrixCardProps ): JSX.Element => {
 	const matrixCallers = buildMatrixCallerList( plugins, themes, approvals );
 
+	// The matrix table, used to locate a toggle's input for focus restoration.
+	const tableRef = useRef< HTMLTableElement | null >( null );
+	// Tracks the previous saving state so we can detect the save->idle edge.
+	const wasSavingRef = useRef< boolean >( false );
+	// The key of the toggle that was last changed, so focus can be returned to
+	// it once saving completes and the control is re-enabled. The ToggleControl
+	// does not support `accessibleWhenDisabled`, so it loses focus while disabled.
+	const lastToggledKeyRef = useRef< string | null >( null );
+
+	useEffect( () => {
+		if ( wasSavingRef.current && ! isSaving && lastToggledKeyRef.current ) {
+			const input = tableRef.current?.querySelector< HTMLElement >(
+				`[data-toggle-key="${ lastToggledKeyRef.current }"] input`
+			);
+			input?.focus();
+			lastToggledKeyRef.current = null;
+		}
+
+		wasSavingRef.current = isSaving;
+	}, [ isSaving ] );
+
 	return (
 		<Card className="ai-connector-approval__matrix">
 			<CardHeader>
@@ -61,7 +83,7 @@ const ApprovalMatrixCard = ( {
 						) }
 					</p>
 				) : (
-					<table className="widefat striped">
+					<table className="widefat striped" ref={ tableRef }>
 						<thead>
 							<tr>
 								<th>{ __( 'Caller', 'ai' ) }</th>
@@ -93,21 +115,28 @@ const ApprovalMatrixCard = ( {
 											]
 										);
 
+										const toggleKey = `${ caller.basename }__${ connector.id }`;
+
 										return (
-											<td key={ connector.id }>
+											<td
+												key={ connector.id }
+												data-toggle-key={ toggleKey }
+											>
 												<ToggleControl
 													checked={ approved }
 													disabled={ isSaving }
 													label=""
 													onChange={ (
 														value: boolean
-													) =>
+													) => {
+														lastToggledKeyRef.current =
+															toggleKey;
 														onToggle(
 															caller.basename,
 															connector.id,
 															value
-														)
-													}
+														);
+													} }
 												/>
 											</td>
 										);

--- a/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
+++ b/src/experiments/connector-approval/components/ApprovalMatrixCard.tsx
@@ -48,13 +48,8 @@ const ApprovalMatrixCard = ( {
 }: ApprovalMatrixCardProps ): JSX.Element => {
 	const matrixCallers = buildMatrixCallerList( plugins, themes, approvals );
 
-	// The matrix table, used to locate a toggle's input for focus restoration.
 	const tableRef = useRef< HTMLTableElement | null >( null );
-	// Tracks the previous saving state so we can detect the save->idle edge.
 	const wasSavingRef = useRef< boolean >( false );
-	// The key of the toggle that was last changed, so focus can be returned to
-	// it once saving completes and the control is re-enabled. The ToggleControl
-	// does not support `accessibleWhenDisabled`, so it loses focus while disabled.
 	const lastToggledKeyRef = useRef< string | null >( null );
 
 	useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/ai/issues/589

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR fixes the focus issue mentioned here - https://github.com/WordPress/ai/issues/589#issuecomment-4572972547

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR adds the ref to table and used the last ref and used ownerDocument to find the active element and make it focus.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Yes, Claude Code, Opus 4.8
- Used on initial research and probable approch to fix the ref issue.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open the page, `wp-admin/tools.php?page=ai-connector-approval`
2. On the approval matrix, toggle the checkboxes.
3. See the focus is still at the same input and you can use tab also to move.
4. No focus is lost.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


https://github.com/user-attachments/assets/e934c980-cef2-4b4c-942c-b89eeab5dbaf



## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Fixed - Fix connector approval matrix toggle button focus lost.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-646-2f10b8c69f4033c91fa5b43392eb699103086b80.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->