### PR TITLE
[Image Gen]: Improve focus handling in image generation flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14915,6 +14915,18 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/ui/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/@wordpress/undo-manager": {
 			"version": "1.46.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.46.0.tgz",
@@ -32459,7 +32471,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@wordpress/data": "^10.44.0",
 				"@wordpress/dataviews": "^14.1.0",
 				"@wordpress/date": "^5.44.0",
+				"@wordpress/dom": "^4.47.0",
 				"@wordpress/dom-ready": "^4.44.0",
 				"@wordpress/edit-post": "^8.44.0",
 				"@wordpress/editor": "^14.44.0",
@@ -11434,12 +11435,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.46.0.tgz",
-			"integrity": "sha512-d4Dy9GeJ/VIORTgYKYXT026/hhpV6VOf3VUDj10f+QFoIJ86VMBrzV6KQn8KUVH4T3oH1MSpo/A5t8ttYFemsg==",
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.47.0.tgz",
+			"integrity": "sha512-SPmYu3Ihqfaqve4xEKf8+SAhae9UuYLncFovXHHEHeNrKwldYyNy3fm+3Aifd/RK5r7Vc7nr0zONYkuhWkDlNw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.46.0"
+				"@wordpress/hooks": "^4.47.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -11447,12 +11448,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.46.0.tgz",
-			"integrity": "sha512-XngkvNJpf0JnpZuOcsbBl/cTprfYQTfSykttIL4laXcFXfZe8rU3bGgv8K7AEoYigDwxfw3g/yMPi4fn195Kpw==",
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.47.0.tgz",
+			"integrity": "sha512-HD9pdNpS8dJnA70ZSBjx6FBbC4dChNaWWE+OxlvhgKisgETSIZaxvvc+W23WPIfC1WsKfD4amKtfLHXo+38TrQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.46.0"
+				"@wordpress/deprecated": "^4.47.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12462,9 +12463,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.46.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.46.0.tgz",
-			"integrity": "sha512-fsKw4dmw4voIRoKc8t0XRREQlFvwj9XS/jTXvkh6mqRYCDpaEnrdB2Ji5jgbRXEMPU0GKVGMeAn5Wwi56gjBMg==",
+			"version": "4.47.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.47.0.tgz",
+			"integrity": "sha512-OTbg9axYyz585FvrNzyi3hBV2LHfl2oYr2M8xmQKndkOftxQra/04Hqnrflim7IKOzKR4EfL/KpyoqhQ0mrVHQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -14912,18 +14913,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/ui/node_modules/date-fns": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.3.0.tgz",
-			"integrity": "sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==",
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -32470,7 +32459,7 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"@wordpress/data": "^10.44.0",
 		"@wordpress/dataviews": "^14.1.0",
 		"@wordpress/date": "^5.44.0",
+		"@wordpress/dom": "^4.47.0",
 		"@wordpress/dom-ready": "^4.44.0",
 		"@wordpress/edit-post": "^8.44.0",
 		"@wordpress/editor": "^14.44.0",

--- a/src/features/image-generation/components/GenerateImageInlineModal.tsx
+++ b/src/features/image-generation/components/GenerateImageInlineModal.tsx
@@ -4,6 +4,7 @@
 import { Button, Modal, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { image } from '@wordpress/icons';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -73,6 +74,8 @@ export function GenerateImageInlineModal( {
 		comparisonLeftLabel,
 		comparisonRightLabel,
 	} = useImageGeneration();
+
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	async function handleUseImage(): Promise< void > {
 		if ( ! activeEntry ) {
@@ -155,7 +158,10 @@ export function GenerateImageInlineModal( {
 						comparisonLeftLabel={ comparisonLeftLabel }
 						comparisonRightLabel={ comparisonRightLabel }
 					/>
-					<div className="ai-image-generation__actions">
+					<div
+						className="ai-image-generation__actions"
+						ref={ focusOnMountRef }
+					>
 						<Button variant="primary" onClick={ handleUseImage }>
 							{ __( 'Use Image', 'ai' ) }
 						</Button>

--- a/src/features/image-generation/components/GenerateImageInlineModal.tsx
+++ b/src/features/image-generation/components/GenerateImageInlineModal.tsx
@@ -4,7 +4,9 @@
 import { Button, Modal, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { image } from '@wordpress/icons';
+import { useEffect, useRef } from '@wordpress/element';
 import { useFocusOnMount } from '@wordpress/compose';
+import { focus } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -76,6 +78,18 @@ export function GenerateImageInlineModal( {
 	} = useImageGeneration();
 
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
+	const containerRef = useRef( null );
+
+	useEffect( () => {
+		// Entering the generating state can unmount the currently focused element;
+		// keep focus inside the modal by moving it to the first available focusable element.
+		if ( containerRef.current && state === 'generating' ) {
+			const [ firstFocusable ] = focus.focusable.find(
+				containerRef.current
+			);
+			firstFocusable?.focus();
+		}
+	}, [ state ] );
 
 	async function handleUseImage(): Promise< void > {
 		if ( ! activeEntry ) {
@@ -125,6 +139,7 @@ export function GenerateImageInlineModal( {
 			icon={ image }
 			size="large"
 			className="ai-generate-image-inline-modal"
+			ref={ containerRef }
 		>
 			{ state === 'idle' && (
 				<PromptForm

--- a/src/features/image-generation/components/GenerateImageStandalone.tsx
+++ b/src/features/image-generation/components/GenerateImageStandalone.tsx
@@ -4,6 +4,7 @@
 import { Button, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -58,6 +59,8 @@ export function GenerateImageStandalone() {
 		comparisonLeftLabel,
 		comparisonRightLabel,
 	} = useImageGeneration();
+
+	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	async function handleSaveImage(): Promise< void > {
 		if ( ! activeEntry ) {
@@ -152,11 +155,15 @@ export function GenerateImageStandalone() {
 						comparisonLeftLabel={ comparisonLeftLabel }
 						comparisonRightLabel={ comparisonRightLabel }
 					/>
-					<div className="ai-image-generation__actions">
+					<div
+						className="ai-image-generation__actions"
+						ref={ focusOnMountRef }
+					>
 						<Button
 							variant="primary"
 							onClick={ handleSaveImage }
 							disabled={ savedHistoryIndices.has( historyIndex ) }
+							accessibleWhenDisabled
 						>
 							{ __( 'Save to Media Library', 'ai' ) }
 						</Button>

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@wordpress/components';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { useFocusOnMount } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -77,8 +78,10 @@ export function PromptForm( {
 	onGenerate,
 	error,
 }: PromptFormProps ) {
+	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
+
 	return (
-		<div className="ai-image-generation__idle">
+		<div className="ai-image-generation__idle" ref={ focusOnMountRef }>
 			<p className="description">
 				{ __( 'Describe the image you want to generate.', 'ai' ) }
 			</p>
@@ -148,6 +151,7 @@ export function ImageHistoryNav( {
 					disabled={ ! canGoBack }
 					onClick={ onGoBack }
 					label={ __( 'Previous version', 'ai' ) }
+					accessibleWhenDisabled
 				/>
 				<div className="ai-image-history-nav__content">
 					{ showComparison ? (
@@ -189,6 +193,7 @@ export function ImageHistoryNav( {
 					disabled={ ! canGoForward }
 					onClick={ onGoForward }
 					label={ __( 'Next version', 'ai' ) }
+					accessibleWhenDisabled
 				/>
 			</div>
 			{ historyLength > 1 && (
@@ -231,8 +236,10 @@ export function RefinePromptForm( {
 	cancelIsDestructive = false,
 	error,
 }: RefinePromptFormProps ) {
+	const focusOnMountRef = useFocusOnMount( 'firstInputElement' );
+
 	return (
-		<div className="ai-image-generation__refining">
+		<div className="ai-image-generation__refining" ref={ focusOnMountRef }>
 			<img
 				src={ previewSrc }
 				alt={ previewAlt }

--- a/src/features/image-generation/index.scss
+++ b/src/features/image-generation/index.scss
@@ -44,6 +44,10 @@
 		justify-content: center;
 		gap: 10px;
 		padding: 20px 0;
+
+		svg {
+			margin: 0;
+		}
 	}
 
 	&__spinner-label {


### PR DESCRIPTION
## What?

See #589 

Fixes focus handling across the inline image generation modal and standalone image generation flow. Each state-specific screen now focuses its first "relevant" control when it mounts.

## Why?

The image generation UI changes screens based on the generation state, but focus was not being moved consistently after those screen changes. This could leave keyboard focus behind on the previous trigger/control or fail to place users at the next logical action in the flow.

## How?

Uses `useFocusOnMount` on state-specific screen containers that mount when the UI changes.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review

## Testing Instructions

1. In the WP dashboard, go to Posts → Add New.
2. Insert an Image block.
3. In the Image block, select Generate Image.
4. Verify keyboard focus behavior and tab navigation throughout the Generate Image flow.
5. Return to the WP dashboard.
6. Go to Media → Generate Image.
7. Verify keyboard focus behavior and tab navigation on the Generate Image screen.

## Screencast

https://github.com/user-attachments/assets/d2cb6e0a-c732-4cf0-87fe-8f83bef22225

## Changelog Entry

> Fixed - Focus handling on Image Generation components.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-647-5ec9c7667ac823613bf7fc228abc730d509520c2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->