### PR TITLE
Fix: Add accessible label to ability test payload textarea in Abiliti…

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -310,6 +310,7 @@ class Admin_Page {
 					</div>
 				<?php endif; ?>
 
+				<label for="ability-test-payload" class="screen-reader-text"><?php esc_html_e( 'Ability test input (JSON)', 'ai' ); ?></label>
 				<textarea id="ability-test-payload" rows="12"><?php echo esc_textarea( (string) wp_json_encode( $example_input, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></textarea>
 
 				<div class="ability-test-actions">


### PR DESCRIPTION
## What?
Closes #648

Adds an accessible label to the JSON payload `<textarea>` in the Abilities Explorer test screen.

## Why?
The test input `<textarea id="ability-test-payload">` had no associated label, `aria-label`, or `aria-labelledby`. Screen readers announced only "text area" with no indication of the field's purpose, which is a WCAG 2.1 AA violation (SC 1.3.1 and SC 4.1.2).

## How?
Added a visually hidden `<label class="screen-reader-text">` before the textarea, linked via the `for` attribute matching the existing `id`. This uses WordPress's standard `screen-reader-text` pattern, so there is no visual change the label is only exposed to assistive technology.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Used for: Identifying the issue location, and verifying coding standards. Final implementation and testing were done by me.

## Testing Instructions
1. Navigate to **Tools → Abilities Explorer** and open any ability's test view
2. Focus the JSON payload textarea with a screen reader
3. Confirm it announces "Ability test input (JSON)" instead of just "text area"
4. Confirm there is no visual change to the textarea

## Screenshots or screencast
Before
<img width="1068" height="727" alt="image" src="https://github.com/user-attachments/assets/21c100ce-d8c1-4ae4-ae09-2e6d60587de6" /> 
(screen reader announces "You are currently on a text area")

After
<img width="1088" height="728" alt="image" src="https://github.com/user-attachments/assets/0b6faaa4-2894-40b7-a878-97ff079687e0" /> 
(screen reader announces "Ability test input (JSON), edit text")

## Changelog Entry
> Fixed - Added an accessible label to the ability test payload textarea in the Abilities Explorer.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-649-666d797ff2cf1776fbbb9f339c3d8526dfb6cf76.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->