### PR TITLE
Fix canceled meta description suggestion state

### DIFF
--- a/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
@@ -36,9 +36,6 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ editableText, setEditableText ] = useState( '' );
-	const [ modalMode, setModalMode ] = useState< 'edit' | 'generate' >(
-		'generate'
-	);
 
 	const hasDescription =
 		currentDescription && currentDescription.trim().length > 0;
@@ -51,7 +48,6 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 			if ( ! ensureProviderAvailable() ) {
 				return;
 			}
-			setModalMode( 'generate' );
 			setIsModalOpen( true );
 			await generateDescription();
 			return;
@@ -62,7 +58,6 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 
 	const handleOpenEditModal = () => {
 		clearSuggestion();
-		setModalMode( 'edit' );
 		setEditableText( currentDescription );
 		setIsModalOpen( true );
 	};
@@ -72,13 +67,7 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 		if ( ! ensureProviderAvailable() ) {
 			return;
 		}
-		setModalMode( 'generate' );
 		setIsModalOpen( true );
-		await generateDescription();
-	};
-
-	const handleGenerate = async () => {
-		setModalMode( 'generate' );
 		await generateDescription();
 	};
 
@@ -125,14 +114,13 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 			{ isModalOpen && (
 				<MetaDescriptionModal
 					isGenerating={ isGenerating }
-					suggestion={ 'generate' === modalMode ? suggestion : null }
+					suggestion={ suggestion }
 					editableText={ editableText }
 					onEditableTextChange={ setEditableText }
-					onGenerate={ handleGenerate }
+					onGenerate={ generateDescription }
 					onApply={ applyDescription }
 					onClose={ () => {
 						clearSuggestion();
-						setModalMode( 'generate' );
 						setIsModalOpen( false );
 					} }
 				/>

--- a/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
@@ -31,10 +31,14 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 		ensureProviderAvailable,
 		generateDescription,
 		applyDescription,
+		clearSuggestion,
 	} = useMetaDescription();
 
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ editableText, setEditableText ] = useState( '' );
+	const [ modalMode, setModalMode ] = useState< 'edit' | 'generate' >(
+		'generate'
+	);
 
 	const hasDescription =
 		currentDescription && currentDescription.trim().length > 0;
@@ -47,6 +51,7 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 			if ( ! ensureProviderAvailable() ) {
 				return;
 			}
+			setModalMode( 'generate' );
 			setIsModalOpen( true );
 			await generateDescription();
 			return;
@@ -56,6 +61,8 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 	};
 
 	const handleOpenEditModal = () => {
+		clearSuggestion();
+		setModalMode( 'edit' );
 		setEditableText( currentDescription );
 		setIsModalOpen( true );
 	};
@@ -65,7 +72,13 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 		if ( ! ensureProviderAvailable() ) {
 			return;
 		}
+		setModalMode( 'generate' );
 		setIsModalOpen( true );
+		await generateDescription();
+	};
+
+	const handleGenerate = async () => {
+		setModalMode( 'generate' );
 		await generateDescription();
 	};
 
@@ -112,12 +125,16 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 			{ isModalOpen && (
 				<MetaDescriptionModal
 					isGenerating={ isGenerating }
-					suggestion={ suggestion }
+					suggestion={ 'generate' === modalMode ? suggestion : null }
 					editableText={ editableText }
 					onEditableTextChange={ setEditableText }
-					onGenerate={ generateDescription }
+					onGenerate={ handleGenerate }
 					onApply={ applyDescription }
-					onClose={ () => setIsModalOpen( false ) }
+					onClose={ () => {
+						clearSuggestion();
+						setModalMode( 'generate' );
+						setIsModalOpen( false );
+					} }
 				/>
 			) }
 		</div>

--- a/src/experiments/meta-description/components/useMetaDescription.ts
+++ b/src/experiments/meta-description/components/useMetaDescription.ts
@@ -37,6 +37,7 @@ interface UseMetaDescriptionReturn {
 	ensureProviderAvailable: () => boolean;
 	generateDescription: () => Promise< void >;
 	applyDescription: ( text: string ) => void;
+	clearSuggestion: () => void;
 }
 
 /**
@@ -135,6 +136,10 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 		[ editPost, metaKey, meta ]
 	);
 
+	const clearSuggestion = useCallback( () => {
+		setSuggestion( null );
+	}, [] );
+
 	return {
 		isGenerating,
 		suggestion,
@@ -144,5 +149,6 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 		ensureProviderAvailable,
 		generateDescription,
 		applyDescription,
+		clearSuggestion,
 	};
 }

--- a/tests/e2e/specs/experiments/meta-description.spec.js
+++ b/tests/e2e/specs/experiments/meta-description.spec.js
@@ -300,6 +300,91 @@ test.describe( 'Meta Description Experiment', () => {
 		await editor.saveDraft();
 	} );
 
+	test( 'Editing after canceling a regenerated suggestion shows the saved description', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		const savedDescription =
+			'A custom saved description that should remain editable.';
+
+		await admin.createNewPost( {
+			title: 'Meta Description Cancel Regenerate Test',
+			content:
+				'This is some test content for the Meta Description Experiment.',
+		} );
+
+		await editor.saveDraft();
+		await page.reload();
+
+		// Open the Meta Description panel.
+		await openMetaDescriptionPanel( editor, page );
+
+		// Generate and apply the initial description so the edit actions appear.
+		await page
+			.locator( '.ai-meta-description-panel button', {
+				hasText: 'Generate Meta Description',
+			} )
+			.click();
+
+		await expect(
+			page.locator( '.ai-meta-description-modal textarea' )
+		).toHaveValue( MOCK_DESCRIPTION_PATTERN, {
+			timeout: 10000,
+		} );
+
+		await page
+			.locator( '.ai-meta-description-modal' )
+			.getByRole( 'button', { name: 'Apply' } )
+			.click();
+
+		// Replace it with a custom saved value that differs from the mock.
+		await page
+			.locator( '.ai-meta-description-panel__actions' )
+			.getByRole( 'button', { name: 'Edit description' } )
+			.click();
+
+		await page
+			.locator( '.ai-meta-description-modal textarea' )
+			.fill( savedDescription );
+
+		await page
+			.locator( '.ai-meta-description-modal' )
+			.getByRole( 'button', { name: 'Apply' } )
+			.click();
+
+		await expect(
+			page.locator( '.ai-meta-description-panel__text' )
+		).toHaveText( savedDescription );
+
+		// Generate a new suggestion, but cancel without applying it.
+		await page
+			.locator( '.ai-meta-description-panel__actions' )
+			.getByRole( 'button', { name: 'Regenerate meta description' } )
+			.click();
+
+		await expect(
+			page.locator( '.ai-meta-description-modal textarea' )
+		).toHaveValue( MOCK_DESCRIPTION_PATTERN, {
+			timeout: 10000,
+		} );
+
+		await page
+			.locator( '.ai-meta-description-modal' )
+			.getByRole( 'button', { name: 'Cancel' } )
+			.click();
+
+		// Opening Edit should show the saved value, not the canceled suggestion.
+		await page
+			.locator( '.ai-meta-description-panel__actions' )
+			.getByRole( 'button', { name: 'Edit description' } )
+			.click();
+
+		await expect(
+			page.locator( '.ai-meta-description-modal textarea' )
+		).toHaveValue( savedDescription );
+	} );
+
 	test( 'Shows Copy to clipboard button in the modal', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What?

Fix the Meta Description modal so a canceled regenerated suggestion does not appear when reopening the modal through “Edit description”.

## Why?

When a post already had a saved meta description, regenerating a new suggestion and canceling it left that suggestion in component state.

After that, reopening “Edit description” could show the canceled suggestion in the textarea instead of the saved meta description shown in the sidebar.

## How?

The panel now tracks whether the modal is opened for editing the saved description or for generating a suggestion.

Suggestions are only passed into the modal while it is in generate mode, and stale suggestion state is cleared when leaving the modal.

## Testing Instructions

Automated checks run locally:

```bash
npm run lint:js -- src/experiments/meta-description/components/useMetaDescription.ts src/experiments/meta-description/components/MetaDescriptionPanel.tsx tests/e2e/specs/experiments/meta-description.spec.js
npm run typecheck
npm run build
WP_BASE_URL=http://localhost:8888 npm run test:e2e -- tests/e2e/specs/experiments/meta-description.spec.js
```

Manual verification:

1. Open a post with a saved meta description.
2. Click “Regenerate meta description”.
3. Wait for the generated suggestion.
4. Click “Cancel”.
5. Click “Edit description”.
6. Confirm the modal textarea shows the saved meta description, not the canceled suggestion.

## Screenshots/Screencast

Before:

<img width="800" height="471" alt="BEFORE" src="https://github.com/user-attachments/assets/3001b87b-cb54-4f4d-a324-5adf52ed1c24" />

After:

<img width="800" height="471" alt="AFTER" src="https://github.com/user-attachments/assets/bdb87ff7-395c-46b2-948c-7ad05d469d68" />

## Use of AI Tools

AI assistance: Yes  
Tool(s): ChatGPT / Codex  
Used for: Repository review, reproduction planning, implementation guidance, test updates, and local verification. I reviewed the changes, tested the behavior locally, and take responsibility for the final submission.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-653-534bcca0514176f7f7a2126a9a7b60fc9920e725.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->