### PR TITLE
Fix meta description UTF-8 character count

### DIFF
--- a/includes/Abilities/Meta_Description/Meta_Description.php
+++ b/includes/Abilities/Meta_Description/Meta_Description.php
@@ -284,7 +284,7 @@ class Meta_Description extends Abstract_Ability {
 
 		return array(
 			'text'            => $text,
-			'character_count' => mb_strlen( $text ),
+			'character_count' => mb_strlen( $text, 'UTF-8' ),
 		);
 	}
 

--- a/includes/Abilities/Meta_Description/Meta_Description.php
+++ b/includes/Abilities/Meta_Description/Meta_Description.php
@@ -284,20 +284,8 @@ class Meta_Description extends Abstract_Ability {
 
 		return array(
 			'text'            => $text,
-			'character_count' => $this->get_character_count( $text ),
+			'character_count' => mb_strlen( $text, 'UTF-8' ),
 		);
-	}
-
-	/**
-	 * Gets the UTF-8 character count for generated text.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string $text The generated text.
-	 * @return int UTF-8 character count.
-	 */
-	protected function get_character_count( string $text ): int {
-		return mb_strlen( $text, 'UTF-8' );
 	}
 
 	/**

--- a/includes/Abilities/Meta_Description/Meta_Description.php
+++ b/includes/Abilities/Meta_Description/Meta_Description.php
@@ -284,8 +284,20 @@ class Meta_Description extends Abstract_Ability {
 
 		return array(
 			'text'            => $text,
-			'character_count' => mb_strlen( $text, 'UTF-8' ),
+			'character_count' => $this->get_character_count( $text ),
 		);
+	}
+
+	/**
+	 * Gets the UTF-8 character count for generated text.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $text The generated text.
+	 * @return int UTF-8 character count.
+	 */
+	protected function get_character_count( string $text ): int {
+		return mb_strlen( $text, 'UTF-8' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Meta_DescriptionTest.php
+++ b/tests/Integration/Includes/Abilities/Meta_DescriptionTest.php
@@ -502,32 +502,6 @@ class Meta_DescriptionTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that get_character_count() always counts generated text as UTF-8.
-	 *
-	 * @since x.x.x
-	 */
-	public function test_get_character_count_uses_utf8_encoding() {
-		$reflection = new \ReflectionClass( $this->ability );
-		$method     = $reflection->getMethod( 'get_character_count' );
-		$method->setAccessible( true );
-
-		$text              = 'ಕನ್ನಡ meta description';
-		$previous_encoding = mb_internal_encoding();
-
-		mb_internal_encoding( 'ISO-8859-1' );
-
-		try {
-			$internal_encoding_count = mb_strlen( $text );
-			$result                  = $method->invoke( $this->ability, $text );
-		} finally {
-			mb_internal_encoding( $previous_encoding );
-		}
-
-		$this->assertSame( mb_strlen( $text, 'UTF-8' ), $result, 'Character count should use UTF-8 encoding' );
-		$this->assertNotSame( $internal_encoding_count, $result, 'Character count should not depend on the internal encoding' );
-	}
-
-	/**
 	 * Test that execute_callback() uses post title when no title is provided.
 	 *
 	 * @since 0.7.0

--- a/tests/Integration/Includes/Abilities/Meta_DescriptionTest.php
+++ b/tests/Integration/Includes/Abilities/Meta_DescriptionTest.php
@@ -502,6 +502,32 @@ class Meta_DescriptionTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that get_character_count() always counts generated text as UTF-8.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_character_count_uses_utf8_encoding() {
+		$reflection = new \ReflectionClass( $this->ability );
+		$method     = $reflection->getMethod( 'get_character_count' );
+		$method->setAccessible( true );
+
+		$text              = 'ಕನ್ನಡ meta description';
+		$previous_encoding = mb_internal_encoding();
+
+		mb_internal_encoding( 'ISO-8859-1' );
+
+		try {
+			$internal_encoding_count = mb_strlen( $text );
+			$result                  = $method->invoke( $this->ability, $text );
+		} finally {
+			mb_internal_encoding( $previous_encoding );
+		}
+
+		$this->assertSame( mb_strlen( $text, 'UTF-8' ), $result, 'Character count should use UTF-8 encoding' );
+		$this->assertNotSame( $internal_encoding_count, $result, 'Character count should not depend on the internal encoding' );
+	}
+
+	/**
 	 * Test that execute_callback() uses post title when no title is provided.
 	 *
 	 * @since 0.7.0


### PR DESCRIPTION
## What?
Updates meta description generation to pass `UTF-8` explicitly when calculating the generated description character count.

## Why?
The generated meta description response includes a `character_count` value. Other multibyte length checks in the plugin already pass `UTF-8` explicitly, and this keeps meta description output consistent for multilingual content.

## How?
Changes the `mb_strlen()` call used for the generated meta description output from relying on PHP internal encoding to explicitly using `UTF-8`.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex / ChatGPT
Model(s): GPT-5
Used for: Scanning the codebase for small correctness issues and drafting the minimal change. I reviewed the change and PR description before submitting.

## Testing Instructions
1. Install and activate this PR build of the AI plugin.
2. Connect a provider that supports text generation.
3. Enable the Meta Description experiment.
4. Open or create a post with non-English / multibyte content.
5. Generate a meta description.
6. Confirm the generated result still appears normally and the returned `character_count` reflects the generated UTF-8 text.

## Screenshots or screencast
Not applicable. This PR does not change the UI.

## Changelog Entry

> Fixed - Use explicit UTF-8 encoding for generated meta description character counts.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-655-24347afddc39e8349646a050441101f103d02734.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->