### PR TITLE
Fix post terms ability output schema

### DIFF
--- a/includes/Abilities/Utilities/Posts.php
+++ b/includes/Abilities/Utilities/Posts.php
@@ -206,53 +206,50 @@ class Posts {
 					'required'   => array( 'post_id' ),
 				),
 				'output_schema'       => array(
-					'type'        => 'object',
+					'type'        => 'array',
 					'description' => esc_html__( 'An array of WP_Term objects assigned to the post.', 'ai' ),
-					'properties'  => array(
-						'type'  => 'array',
-						'items' => array(
-							'type'  => 'array',
-							'items' => array(
-								'term_id'          => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The ID of the term.', 'ai' ),
-								),
-								'name'             => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The name of the term.', 'ai' ),
-								),
-								'slug'             => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The slug of the term.', 'ai' ),
-								),
-								'term_group'       => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The group ID of the term.', 'ai' ),
-								),
-								'term_taxonomy_id' => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The taxonomy ID of the term.', 'ai' ),
-								),
-								'taxonomy'         => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The taxonomy name of the term.', 'ai' ),
-								),
-								'description'      => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The description of the term.', 'ai' ),
-								),
-								'parent'           => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The parent ID of the term.', 'ai' ),
-								),
-								'count'            => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'How many times the term is used.', 'ai' ),
-								),
-								'filter'           => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'How the term should be filtered.', 'ai' ),
-								),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'term_id'          => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The ID of the term.', 'ai' ),
+							),
+							'name'             => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The name of the term.', 'ai' ),
+							),
+							'slug'             => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The slug of the term.', 'ai' ),
+							),
+							'term_group'       => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The group ID of the term.', 'ai' ),
+							),
+							'term_taxonomy_id' => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The taxonomy ID of the term.', 'ai' ),
+							),
+							'taxonomy'         => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The taxonomy name of the term.', 'ai' ),
+							),
+							'description'      => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The description of the term.', 'ai' ),
+							),
+							'parent'           => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The parent ID of the term.', 'ai' ),
+							),
+							'count'            => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'How many times the term is used.', 'ai' ),
+							),
+							'filter'           => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'How the term should be filtered.', 'ai' ),
 							),
 						),
 					),


### PR DESCRIPTION
## What?
Fixes the output schema for the `ai/get-post-terms` ability so it describes the array returned by the callback.

## Why?
The callback returns an array of term objects, but the schema described an object containing a nested array shape. Consumers of the abilities API rely on accurate schemas to understand and validate responses.

## How?
Changes the output schema from an object with a nested array definition to a top-level array whose items are term objects with the existing term properties.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex / ChatGPT
Model(s): GPT-5
Used for: Comparing ability schemas against callback return values and drafting the minimal schema correction. I reviewed the change and PR description before submitting.

## Testing Instructions
1. Install and activate this PR build of the AI plugin.
2. Ensure WordPress abilities are available.
3. Inspect or call the `ai/get-post-terms` ability for a post that has terms assigned.
4. Confirm the ability response is still an array of terms.
5. Confirm the ability schema now describes that response as an array of term objects.

## Screenshots or screencast
Not applicable. This PR does not change the UI.

## Changelog Entry

> Fixed - Correct the output schema for the post terms ability.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-656-e45fd394a17352976bc40ad4ef46eeca9c780397.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->