### PR TITLE
Handle image import setup failures

### DIFF
--- a/includes/Abilities/Image/Import_Base64_Image.php
+++ b/includes/Abilities/Image/Import_Base64_Image.php
@@ -233,6 +233,29 @@ class Import_Base64_Image extends Abstract_Ability {
 	}
 
 	/**
+	 * Creates a temporary file path for the imported image.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string|false Temporary file path, or false on failure.
+	 */
+	protected function create_temp_file() {
+		return wp_tempnam( 'ai-image' );
+	}
+
+	/**
+	 * Gets the default file extension for a MIME type.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $mime_type The MIME type.
+	 * @return string|false File extension, or false when unknown.
+	 */
+	protected function get_default_extension_for_mime_type( string $mime_type ) {
+		return wp_get_default_extension_for_mime_type( $mime_type );
+	}
+
+	/**
 	 * Imports an image from a base64 encoded string into the media library.
 	 *
 	 * @since 0.2.0
@@ -263,7 +286,7 @@ class Import_Base64_Image extends Abstract_Ability {
 		}
 
 		// Create a temporary file.
-		$temp_file = wp_tempnam( 'ai-image' );
+		$temp_file = $this->create_temp_file();
 
 		if ( ! $temp_file ) {
 			return new WP_Error(
@@ -284,7 +307,7 @@ class Import_Base64_Image extends Abstract_Ability {
 		}
 
 		// Determine file extension from MIME type.
-		$extension = wp_get_default_extension_for_mime_type( $args['mime_type'] );
+		$extension = $this->get_default_extension_for_mime_type( $args['mime_type'] );
 
 		if ( ! $extension ) {
 			wp_delete_file( $temp_file );

--- a/includes/Abilities/Image/Import_Base64_Image.php
+++ b/includes/Abilities/Image/Import_Base64_Image.php
@@ -265,6 +265,13 @@ class Import_Base64_Image extends Abstract_Ability {
 		// Create a temporary file.
 		$temp_file = wp_tempnam( 'ai-image' );
 
+		if ( ! $temp_file ) {
+			return new WP_Error(
+				'temp_file_failed',
+				esc_html__( 'Failed to create a temporary image file.', 'ai' )
+			);
+		}
+
 		// Write the decoded data to the temporary file.
 		$bytes_written = file_put_contents( $temp_file, $decoded_data ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 
@@ -278,6 +285,14 @@ class Import_Base64_Image extends Abstract_Ability {
 
 		// Determine file extension from MIME type.
 		$extension = wp_get_default_extension_for_mime_type( $args['mime_type'] );
+
+		if ( ! $extension ) {
+			wp_delete_file( $temp_file );
+			return new WP_Error(
+				'invalid_mime_type',
+				esc_html__( 'Could not determine the image file extension from the MIME type.', 'ai' )
+			);
+		}
 
 		/**
 		 * Filters the base filename (without extension) used when importing an

--- a/tests/Integration/Includes/Abilities/Image_ImportTest.php
+++ b/tests/Integration/Includes/Abilities/Image_ImportTest.php
@@ -46,6 +46,84 @@ class Test_Image_Import_Experiment extends Abstract_Feature {
 }
 
 /**
+ * Testable image import ability.
+ *
+ * @since x.x.x
+ */
+class Testable_Image_Import extends Import {
+	/**
+	 * Temporary file path to return.
+	 *
+	 * @var string|false|null
+	 */
+	private $temp_file = null;
+
+	/**
+	 * Extension to return.
+	 *
+	 * @var string|false|null
+	 */
+	private $extension = null;
+
+	/**
+	 * Sets the temporary file path to return.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string|false $temp_file Temporary file path, or false.
+	 */
+	public function set_temp_file( $temp_file ): void {
+		$this->temp_file = $temp_file;
+	}
+
+	/**
+	 * Sets the extension to return.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string|false $extension Extension, or false.
+	 */
+	public function set_extension( $extension ): void {
+		$this->extension = $extension;
+	}
+
+	/**
+	 * Calls the protected image import method.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string               $data Base64 image data.
+	 * @param array<string, mixed> $args Import arguments.
+	 * @return array<string, mixed>|\WP_Error Attachment data, or error.
+	 */
+	public function call_import_image( string $data, array $args = array() ) {
+		return $this->import_image( $data, $args );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function create_temp_file() {
+		if ( null !== $this->temp_file ) {
+			return $this->temp_file;
+		}
+
+		return parent::create_temp_file();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function get_default_extension_for_mime_type( string $mime_type ) {
+		if ( null !== $this->extension ) {
+			return $this->extension;
+		}
+
+		return parent::get_default_extension_for_mime_type( $mime_type );
+	}
+}
+
+/**
  * Image_Import Ability test case.
  *
  * @since 0.2.0
@@ -223,6 +301,66 @@ class Image_ImportTest extends WP_UnitTestCase {
 		$this->assertIsInt( $result['image']['id'], 'Image ID should be an integer' );
 		$this->assertIsString( $result['image']['url'], 'Image URL should be a string' );
 		$this->assertNotEmpty( $result['image']['url'], 'Image URL should not be empty' );
+	}
+
+	/**
+	 * Test that import_image() returns an error when a temp file cannot be created.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_import_image_returns_error_when_temp_file_creation_fails() {
+		$ability = new Testable_Image_Import(
+			'ai/image-import',
+			array(
+				'label'       => $this->experiment->get_label(),
+				'description' => $this->experiment->get_description(),
+			)
+		);
+		$ability->set_temp_file( false );
+
+		$result = $ability->call_import_image(
+			$this->valid_base64_image,
+			array(
+				'filename'    => 'test-image',
+				'title'       => 'Test Image',
+				'description' => '',
+				'alt_text'    => '',
+				'mime_type'   => 'image/png',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Result should be WP_Error' );
+		$this->assertEquals( 'temp_file_failed', $result->get_error_code(), 'Error code should be temp_file_failed' );
+	}
+
+	/**
+	 * Test that import_image() returns an error when MIME extension cannot be determined.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_import_image_returns_error_when_mime_extension_is_unknown() {
+		$ability = new Testable_Image_Import(
+			'ai/image-import',
+			array(
+				'label'       => $this->experiment->get_label(),
+				'description' => $this->experiment->get_description(),
+			)
+		);
+		$ability->set_extension( false );
+
+		$result = $ability->call_import_image(
+			$this->valid_base64_image,
+			array(
+				'filename'    => 'test-image',
+				'title'       => 'Test Image',
+				'description' => '',
+				'alt_text'    => '',
+				'mime_type'   => 'image/png',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result, 'Result should be WP_Error' );
+		$this->assertEquals( 'invalid_mime_type', $result->get_error_code(), 'Error code should be invalid_mime_type' );
 	}
 
 	/**


### PR DESCRIPTION
## What?
Adds explicit error handling for image import setup failures.

## Why?
The image import ability writes generated image data to a temporary file and then sideloads it into the media library. If WordPress cannot create the temporary file, or if the image MIME type cannot be mapped to a file extension, the ability should return a clear `WP_Error` instead of continuing with invalid file state.

## How?
Checks the result of `wp_tempnam()` before writing image data. Also checks the file extension returned by `wp_get_default_extension_for_mime_type()` and deletes the temporary file before returning an error when the MIME type cannot be mapped.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex / ChatGPT
Model(s): GPT-5
Used for: Reviewing the image import control flow for unhandled failure paths and drafting the minimal guards. I reviewed the change and PR description before submitting.

## Testing Instructions
1. Install and activate this PR build of the AI plugin.
2. Enable image generation and connect a provider that supports image generation.
3. Generate an image and import it into the media library.
4. Confirm the image is imported successfully and its media fields are preserved as before.
5. To validate the failure handling, simulate an unmapped image MIME type when calling the image import ability and confirm it returns a `WP_Error` instead of attempting to sideload a file with an invalid extension.

## Screenshots or screencast
Not applicable. This PR does not change the UI.

## Changelog Entry

> Fixed - Return clear errors when generated image import setup fails.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-657-d078baa888300c9071e899a36e385358bb0d98be.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->