### PR TITLE
Return decorative flag for generated alt text

### DIFF
--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -150,7 +150,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 
 		// Return the alt text in the format the Ability expects.
 		return array(
-			'alt_text' => sanitize_text_field( $result ),
+			'alt_text'      => sanitize_text_field( $result ),
+			'is_decorative' => false,
 		);
 	}
 

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -50,6 +50,59 @@ class Test_Alt_Text_Generation_Experiment extends Abstract_Feature {
 }
 
 /**
+ * Testable alt text generation ability.
+ *
+ * @since x.x.x
+ */
+class Testable_Alt_Text_Generation extends Alt_Text_Generation {
+	/**
+	 * Mock generated alt text.
+	 *
+	 * @var string
+	 */
+	private string $generated_alt_text;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $generated_alt_text Mock generated alt text.
+	 */
+	public function __construct( string $generated_alt_text ) {
+		$this->generated_alt_text = $generated_alt_text;
+
+		parent::__construct(
+			'ai/alt-text-generation',
+			array(
+				'label'       => 'Alt Text Generation',
+				'description' => 'Generates accessible alternative text for images using AI vision models.',
+			)
+		);
+	}
+
+	/**
+	 * Returns a mock image reference.
+	 *
+	 * @param array<string, mixed> $args The input arguments.
+	 * @return array{reference: string} Mock image reference.
+	 */
+	protected function get_image_reference( array $args ) {
+		return array( 'reference' => 'data:image/png;base64,dGVzdA==' );
+	}
+
+	/**
+	 * Returns mock generated alt text.
+	 *
+	 * @param array{reference: string} $image_reference Prepared image reference.
+	 * @param string                   $context         Optional context.
+	 * @param string                   $image_meta      Optional image metadata.
+	 * @return string Mock generated alt text.
+	 */
+	protected function generate_alt_text( array $image_reference, string $context = '', string $image_meta = '' ) {
+		return $this->generated_alt_text;
+	}
+}
+
+/**
  * Alt_Text_Generation Ability test case.
  *
  * @since 0.3.0
@@ -263,6 +316,30 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result, 'Result should be WP_Error' );
 		$this->assertEquals( 'not_an_image', $result->get_error_code(), 'Error code should be not_an_image' );
+	}
+
+	/**
+	 * Test that execute_callback() returns false for non-decorative generated alt text.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_returns_decorative_flag_false_for_generated_alt_text() {
+		$ability    = new Testable_Alt_Text_Generation( 'A person writing in a notebook.' );
+		$reflection = new \ReflectionClass( $ability );
+		$method     = $reflection->getMethod( 'execute_callback' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke(
+			$ability,
+			array(
+				'image_url' => 'https://example.com/image.png',
+			)
+		);
+
+		$this->assertIsArray( $result, 'Result should be an array' );
+		$this->assertSame( 'A person writing in a notebook', $result['alt_text'], 'Alt text should be returned without trailing punctuation.' );
+		$this->assertArrayHasKey( 'is_decorative', $result, 'Result should include is_decorative.' );
+		$this->assertFalse( $result['is_decorative'], 'Non-decorative generated alt text should return is_decorative as false.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -324,7 +324,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 	 * @since x.x.x
 	 */
 	public function test_execute_callback_returns_decorative_flag_false_for_generated_alt_text() {
-		$ability    = new Testable_Alt_Text_Generation( 'A person writing in a notebook.' );
+		$ability    = new Testable_Alt_Text_Generation( 'A person writing in a notebook' );
 		$reflection = new \ReflectionClass( $ability );
 		$method     = $reflection->getMethod( 'execute_callback' );
 		$method->setAccessible( true );
@@ -337,7 +337,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertSame( 'A person writing in a notebook', $result['alt_text'], 'Alt text should be returned without trailing punctuation.' );
+		$this->assertSame( 'A person writing in a notebook', $result['alt_text'], 'Alt text should be returned.' );
 		$this->assertArrayHasKey( 'is_decorative', $result, 'Result should include is_decorative.' );
 		$this->assertFalse( $result['is_decorative'], 'Non-decorative generated alt text should return is_decorative as false.' );
 	}


### PR DESCRIPTION
## What?
Returns `is_decorative: false` for non-decorative alt text generation results.

## Why?
The alt text ability output schema includes `is_decorative` as a boolean. The decorative-image path already returns `is_decorative: true`, but the normal generated-alt-text path omitted the field. Returning `false` makes the runtime response shape consistent with the schema and easier for consumers to handle.

## How?
Adds `is_decorative => false` to the non-decorative return value from the alt text generation ability. Adds an integration test with a test-only subclass that stubs image lookup and AI generation, then verifies the non-decorative response includes `is_decorative: false`.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex / ChatGPT
Model(s): GPT-5
Used for: Comparing the output schema with runtime return values, drafting the minimal response-shape fix, and adding focused test coverage. I reviewed the change and PR description before submitting.

## Testing Instructions
1. Install and activate this PR build of the AI plugin.
2. Enable Alt Text Generation and connect a provider that supports vision/text generation.
3. Generate alt text for a normal non-decorative image.
4. Confirm the generated alt text still appears as before.
5. Inspect the ability response and confirm it includes `is_decorative: false`.
6. Generate or mock a decorative-image response and confirm the existing `is_decorative: true` behavior is unchanged.

## Screenshots or screencast
Not applicable. This PR does not change the UI.

## Changelog Entry

> Fixed - Return a consistent decorative flag from alt text generation results.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-659-677125e18c4d508c0c6b3c0f178ad46126afb265.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->