### PR TITLE
[issue-632] Add settings UI to toggle individual AI connector activation status

### DIFF
--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -236,7 +236,7 @@ class Settings_Page {
 		$categories_in_use = array();
 		$features          = array();
 
-		$connectors = \WordPress\AI\get_ai_connectors( false );
+		$connectors = \WordPress\AI\get_ai_connectors( true );
 		if ( ! empty( $connectors ) ) {
 			$categories_in_use['connectors'] = true;
 			foreach ( $connectors as $connector_id => $connector_data ) {

--- a/includes/Settings/Settings_Page.php
+++ b/includes/Settings/Settings_Page.php
@@ -164,6 +164,11 @@ class Settings_Page {
 	 */
 	private static function get_settings_feature_groups(): array {
 		$default_groups = array(
+			'connectors'                => array(
+				'label'       => __( 'AI Connectors', 'ai' ),
+				'description' => __( 'Configure and activate/deactivate your registered AI connectors.', 'ai' ),
+				'order'       => 5,
+			),
 			Experiment_Category::EDITOR => array(
 				'label'       => __( 'Editor Experiments', 'ai' ),
 				'description' => __( 'AI-powered experiments for the block editor, including content generation and enhancement tools.', 'ai' ),
@@ -230,6 +235,28 @@ class Settings_Page {
 		$group_definitions = self::get_settings_feature_groups();
 		$categories_in_use = array();
 		$features          = array();
+
+		$connectors = \WordPress\AI\get_ai_connectors( false );
+		if ( ! empty( $connectors ) ) {
+			$categories_in_use['connectors'] = true;
+			foreach ( $connectors as $connector_id => $connector_data ) {
+				$features[] = array(
+					'id'             => "connector-{$connector_id}",
+					'settingName'    => "wpai_connector_{$connector_id}_enabled",
+					'label'          => $connector_data['name'] ?? $connector_id,
+					'description'    => sprintf(
+						/* translators: %s: Connector name */
+						__( 'Toggle to activate/deactivate the %s connector.', 'ai' ),
+						$connector_data['name'] ?? $connector_id
+					),
+					'category'       => 'connectors',
+					'settingsFields' => array(),
+					'stability'      => 'stable',
+					'image'          => '',
+					'capability'     => '',
+				);
+			}
+		}
 
 		foreach ( $registry->get_all_features() as $feature ) {
 			$feature_id = $feature::get_id();

--- a/includes/Settings/Settings_Registration.php
+++ b/includes/Settings/Settings_Registration.php
@@ -93,6 +93,20 @@ class Settings_Registration {
 			)
 		);
 
+		// Register a setting for each AI connector's enabled status.
+		foreach ( \WordPress\AI\get_ai_connectors( false ) as $connector_id => $data ) {
+			register_setting(
+				self::OPTION_GROUP,
+				"wpai_connector_{$connector_id}_enabled",
+				array(
+					'type'              => 'boolean',
+					'default'           => true,
+					'sanitize_callback' => 'rest_sanitize_boolean',
+					'show_in_rest'      => true,
+				)
+			);
+		}
+
 		// Register settings for each experiment.
 		foreach ( $this->registry->get_all_features() as $feature ) {
 			$feature_id = $feature::get_id();

--- a/includes/Settings/Settings_Registration.php
+++ b/includes/Settings/Settings_Registration.php
@@ -94,7 +94,7 @@ class Settings_Registration {
 		);
 
 		// Register a setting for each AI connector's enabled status.
-		foreach ( \WordPress\AI\get_ai_connectors( false ) as $connector_id => $data ) {
+		foreach ( \WordPress\AI\get_ai_connectors( true ) as $connector_id => $data ) {
 			register_setting(
 				self::OPTION_GROUP,
 				"wpai_connector_{$connector_id}_enabled",

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -378,6 +378,9 @@ function format_guidelines_for_prompt( array $categories, ?string $block_name = 
  * @return bool True if the connector is configured, false otherwise.
  */
 function is_connector_configured( string $connector_id ): bool {
+	if ( ! get_option( "wpai_connector_{$connector_id}_enabled", true ) ) {
+		return false;
+	}
 	$registry = AiClient::defaultRegistry();
 	return $registry->hasProvider( $connector_id ) && $registry->isProviderConfigured( $connector_id );
 }
@@ -395,6 +398,10 @@ function is_connector_configured( string $connector_id ): bool {
  */
 function has_connector_authentication( string $connector_id ): bool {
 	if ( ! wp_is_connector_registered( $connector_id ) ) {
+		return false;
+	}
+
+	if ( ! get_option( "wpai_connector_{$connector_id}_enabled", true ) ) {
 		return false;
 	}
 
@@ -565,6 +572,10 @@ function get_ai_connectors( bool $active_only = true ): array {
 		}
 
 		if ( $active_only && ! is_connector_plugin_active( $data ) ) {
+			continue;
+		}
+
+		if ( $active_only && ! get_option( "wpai_connector_{$connector_id}_enabled", true ) ) {
 			continue;
 		}
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -575,6 +575,10 @@ function get_ai_connectors( bool $active_only = true ): array {
 			continue;
 		}
 
+		if ( $active_only && ! \WordPress\AiClient\AiClient::defaultRegistry()->hasProvider( $connector_id ) ) {
+			continue;
+		}
+
 		if ( $active_only && ! get_option( "wpai_connector_{$connector_id}_enabled", true ) ) {
 			continue;
 		}

--- a/tests/Integration/Includes/Connector_Approval/Http_GuardTest.php
+++ b/tests/Integration/Includes/Connector_Approval/Http_GuardTest.php
@@ -105,6 +105,8 @@ class Http_GuardTest extends WP_UnitTestCase {
 			);
 		}
 
+		$this->register_stub_provider();
+
 		update_option( self::TEST_SETTING, self::TEST_CREDENTIAL );
 
 		$this->store      = new Approvals_Store();
@@ -123,11 +125,43 @@ class Http_GuardTest extends WP_UnitTestCase {
 			$registry->unregister( self::TEST_CONNECTOR_ID );
 		}
 
+		$this->unregister_stub_provider();
+
 		delete_option( self::TEST_SETTING );
 		delete_option( Approvals_Store::OPTION_APPROVALS );
 		delete_option( Approvals_Store::OPTION_PENDING );
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Registers the stub provider in the AI client registry.
+	 *
+	 * @since 1.0.2
+	 */
+	private function register_stub_provider(): void {
+		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+		$property = new ReflectionProperty( $registry, 'registeredIdsToClassNames' );
+		$property->setAccessible( true );
+
+		$map                            = (array) $property->getValue( $registry );
+		$map[ self::TEST_CONNECTOR_ID ] = \WordPress\AI\Tests\Integration\Includes\Helper_Test_Provider::class;
+		$property->setValue( $registry, $map );
+	}
+
+	/**
+	 * Removes the stub provider from the AI client registry.
+	 *
+	 * @since 1.0.2
+	 */
+	private function unregister_stub_provider(): void {
+		$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+		$property = new ReflectionProperty( $registry, 'registeredIdsToClassNames' );
+		$property->setAccessible( true );
+
+		$map = (array) $property->getValue( $registry );
+		unset( $map[ self::TEST_CONNECTOR_ID ] );
+		$property->setValue( $registry, $map );
 	}
 
 	/**

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -935,7 +935,7 @@ class HelpersTest extends WP_UnitTestCase {
 			$this->assertArrayHasKey( $connector_id, \WordPress\AI\get_ai_connectors() );
 
 			// Deactivate the connector
-			update_option( "wpai_connector_{$connector_id}_enabled", false );
+			update_option( "wpai_connector_{$connector_id}_enabled", '0' );
 
 			// Now it should return false/be excluded
 			$this->assertFalse( \WordPress\AI\has_connector_authentication( $connector_id ) );

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -899,6 +899,53 @@ class HelpersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that helper functions respect the connector enabled option status.
+	 *
+	 * @since 1.0.2
+	 */
+	public function test_connector_helpers_respect_enabled_toggle_option(): void {
+		$connector_id = 'wpai_test_toggle_provider';
+		$this->register_test_connector(
+			$connector_id,
+			array(
+				'name'           => 'Toggle Test Provider',
+				'type'           => 'ai_provider',
+				'authentication' => array(
+					'method' => 'api_key',
+				),
+				'plugin'         => array(
+					'file' => 'toggle-test-provider/toggle-test-provider.php',
+				),
+			)
+		);
+		$this->activate_test_plugin( 'toggle-test-provider/toggle-test-provider.php' );
+
+		$setting_name = 'connectors_ai_provider_' . $connector_id . '_api_key';
+		update_option( $setting_name, 'test-api-key' );
+
+		try {
+			// By default, should be active and enabled
+			$this->assertTrue( \WordPress\AI\has_connector_authentication( $connector_id ) );
+			$this->assertArrayHasKey( $connector_id, \WordPress\AI\get_ai_connectors() );
+
+			// Deactivate the connector
+			update_option( "wpai_connector_{$connector_id}_enabled", false );
+
+			// Now it should return false/be excluded
+			$this->assertFalse( \WordPress\AI\has_connector_authentication( $connector_id ) );
+			$this->assertArrayNotHasKey( $connector_id, \WordPress\AI\get_ai_connectors() );
+
+			// Re-enable the connector
+			update_option( "wpai_connector_{$connector_id}_enabled", true );
+			$this->assertTrue( \WordPress\AI\has_connector_authentication( $connector_id ) );
+			$this->assertArrayHasKey( $connector_id, \WordPress\AI\get_ai_connectors() );
+		} finally {
+			delete_option( $setting_name );
+			delete_option( "wpai_connector_{$connector_id}_enabled" );
+		}
+	}
+
+	/**
 	 * Test that is_connector_configured() returns false for unknown connectors.
 	 *
 	 * @since 1.0.1

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -865,12 +865,17 @@ class HelpersTest extends WP_UnitTestCase {
 			)
 		);
 		$this->activate_test_plugin( 'active-test-provider/active-test-provider.php' );
+		$this->register_custom_ai_provider( 'wpai_test_active_provider' );
 
-		$connectors = \WordPress\AI\get_ai_connectors();
+		try {
+			$connectors = \WordPress\AI\get_ai_connectors();
 
-		$this->assertArrayHasKey( 'wpai_test_active_provider', $connectors );
-		$this->assertArrayNotHasKey( 'wpai_test_inactive_provider', $connectors );
-		$this->assertArrayNotHasKey( 'wpai_test_non_ai_connector', $connectors );
+			$this->assertArrayHasKey( 'wpai_test_active_provider', $connectors );
+			$this->assertArrayNotHasKey( 'wpai_test_inactive_provider', $connectors );
+			$this->assertArrayNotHasKey( 'wpai_test_non_ai_connector', $connectors );
+		} finally {
+			$this->unregister_custom_ai_provider( 'wpai_test_active_provider' );
+		}
 	}
 
 	/**
@@ -919,6 +924,7 @@ class HelpersTest extends WP_UnitTestCase {
 			)
 		);
 		$this->activate_test_plugin( 'toggle-test-provider/toggle-test-provider.php' );
+		$this->register_custom_ai_provider( $connector_id );
 
 		$setting_name = 'connectors_ai_provider_' . $connector_id . '_api_key';
 		update_option( $setting_name, 'test-api-key' );
@@ -942,6 +948,7 @@ class HelpersTest extends WP_UnitTestCase {
 		} finally {
 			delete_option( $setting_name );
 			delete_option( "wpai_connector_{$connector_id}_enabled" );
+			$this->unregister_custom_ai_provider( $connector_id );
 		}
 	}
 
@@ -1243,6 +1250,48 @@ class HelpersTest extends WP_UnitTestCase {
 		$ids_to_classes->setAccessible( true );
 		$id_map = (array) $ids_to_classes->getValue( $registry );
 		unset( $id_map[ self::TEST_AI_PROVIDER_ID ] );
+		$ids_to_classes->setValue( $registry, $id_map );
+
+		$classes_to_ids = new ReflectionProperty( $registry, 'registeredClassNamesToIds' );
+		$classes_to_ids->setAccessible( true );
+		$class_map = (array) $classes_to_ids->getValue( $registry );
+		unset( $class_map[ Helper_Test_Provider::class ] );
+		$classes_to_ids->setValue( $registry, $class_map );
+	}
+
+	/**
+	 * Registers a custom provider in the AI client registry.
+	 *
+	 * @since 1.0.2
+	 */
+	private function register_custom_ai_provider( string $connector_id ): void {
+		$registry = AiClient::defaultRegistry();
+
+		$ids_to_classes = new ReflectionProperty( $registry, 'registeredIdsToClassNames' );
+		$ids_to_classes->setAccessible( true );
+		$id_map                  = (array) $ids_to_classes->getValue( $registry );
+		$id_map[ $connector_id ] = Helper_Test_Provider::class;
+		$ids_to_classes->setValue( $registry, $id_map );
+
+		$classes_to_ids = new ReflectionProperty( $registry, 'registeredClassNamesToIds' );
+		$classes_to_ids->setAccessible( true );
+		$class_map                                = (array) $classes_to_ids->getValue( $registry );
+		$class_map[ Helper_Test_Provider::class ] = $connector_id;
+		$classes_to_ids->setValue( $registry, $class_map );
+	}
+
+	/**
+	 * Unregisters a custom provider from the AI client registry.
+	 *
+	 * @since 1.0.2
+	 */
+	private function unregister_custom_ai_provider( string $connector_id ): void {
+		$registry = AiClient::defaultRegistry();
+
+		$ids_to_classes = new ReflectionProperty( $registry, 'registeredIdsToClassNames' );
+		$ids_to_classes->setAccessible( true );
+		$id_map = (array) $ids_to_classes->getValue( $registry );
+		unset( $id_map[ $connector_id ] );
 		$ids_to_classes->setValue( $registry, $id_map );
 
 		$classes_to_ids = new ReflectionProperty( $registry, 'registeredClassNamesToIds' );

--- a/tests/Integration/Includes/Settings/Settings_PageTest.php
+++ b/tests/Integration/Includes/Settings/Settings_PageTest.php
@@ -568,4 +568,76 @@ class Settings_PageTest extends WP_UnitTestCase {
 		$this->assertSame( admin_url( 'options-general.php?page=ai-wp-admin' ), $captured_location );
 		$this->assertSame( 301, $captured_status );
 	}
+
+	/**
+	 * Tests that active connectors are exposed as pseudo-features.
+	 *
+	 * @since 1.0.2
+	 */
+	public function test_active_connectors_are_exposed_in_metadata(): void {
+		// Mock/register a connector
+		$connector_id = 'wpai_settings_page_test_connector';
+		$registry_wp = \WP_Connector_Registry::get_instance();
+		if ( null !== $registry_wp ) {
+			$registry_wp->register(
+				$connector_id,
+				array(
+					'name'           => 'Settings Page Test Connector',
+					'type'           => 'ai_provider',
+					'authentication' => array(
+						'method' => 'none',
+					),
+				)
+			);
+		}
+
+		// Mock/register in AiClient registry
+		$registry_ai = \WordPress\AiClient\AiClient::defaultRegistry();
+		$ids_to_classes = new \ReflectionProperty( $registry_ai, 'registeredIdsToClassNames' );
+		$ids_to_classes->setAccessible( true );
+		$id_map                  = (array) $ids_to_classes->getValue( $registry_ai );
+		$id_map[ $connector_id ] = \WordPress\AI\Tests\Integration\Includes\Helper_Test_Provider::class;
+		$ids_to_classes->setValue( $registry_ai, $id_map );
+
+		try {
+			$result = $this->get_settings_feature_metadata( $this->registry );
+
+			// Verify connectors group
+			$group_ids = array_column( $result['groups'], 'id' );
+			$this->assertContains( 'connectors', $group_ids );
+
+			$connectors_group = null;
+			foreach ( $result['groups'] as $group ) {
+				if ( 'connectors' === $group['id'] ) {
+					$connectors_group = $group;
+					break;
+				}
+			}
+			$this->assertNotNull( $connectors_group );
+			$this->assertSame( 'AI Connectors', $connectors_group['label'] );
+
+			// Verify connectors pseudo-feature
+			$feature_ids = array_column( $result['features'], 'id' );
+			$this->assertContains( "connector-{$connector_id}", $feature_ids );
+
+			$connector_feature = null;
+			foreach ( $result['features'] as $feature ) {
+				if ( "connector-{$connector_id}" === $feature['id'] ) {
+					$connector_feature = $feature;
+					break;
+				}
+			}
+			$this->assertNotNull( $connector_feature );
+			$this->assertSame( "wpai_connector_{$connector_id}_enabled", $connector_feature['settingName'] );
+			$this->assertSame( 'Settings Page Test Connector', $connector_feature['label'] );
+			$this->assertSame( 'connectors', $connector_feature['category'] );
+		} finally {
+			if ( null !== $registry_wp ) {
+				$registry_wp->unregister( $connector_id );
+			}
+			$id_map = (array) $ids_to_classes->getValue( $registry_ai );
+			unset( $id_map[ $connector_id ] );
+			$ids_to_classes->setValue( $registry_ai, $id_map );
+		}
+	}
 }

--- a/tests/Integration/Includes/Settings/Settings_RegistrationTest.php
+++ b/tests/Integration/Includes/Settings/Settings_RegistrationTest.php
@@ -99,4 +99,58 @@ class Settings_RegistrationTest extends WP_UnitTestCase {
 
 		$this->assertGreaterThan( $before, $after );
 	}
+
+	/**
+	 * Tests that register_settings() registers settings for active connectors.
+	 *
+	 * @since 1.0.2
+	 */
+	public function test_register_settings_registers_active_connector_settings(): void {
+		global $wp_registered_settings;
+
+		// Mock/register a connector
+		$connector_id = 'wpai_settings_test_connector';
+		$registry_wp = \WP_Connector_Registry::get_instance();
+		if ( null !== $registry_wp ) {
+			$registry_wp->register(
+				$connector_id,
+				array(
+					'name'           => 'Settings Test Connector',
+					'type'           => 'ai_provider',
+					'authentication' => array(
+						'method' => 'none',
+					),
+				)
+			);
+		}
+
+		// Mock/register in AiClient registry
+		$registry_ai = \WordPress\AiClient\AiClient::defaultRegistry();
+		$ids_to_classes = new \ReflectionProperty( $registry_ai, 'registeredIdsToClassNames' );
+		$ids_to_classes->setAccessible( true );
+		$id_map                  = (array) $ids_to_classes->getValue( $registry_ai );
+		$id_map[ $connector_id ] = \WordPress\AI\Tests\Integration\Includes\Helper_Test_Provider::class;
+		$ids_to_classes->setValue( $registry_ai, $id_map );
+
+		$registry = new Registry();
+		$registration = new Settings_Registration( $registry );
+
+		try {
+			$registration->register_settings();
+			$setting_name = "wpai_connector_{$connector_id}_enabled";
+
+			$this->assertArrayHasKey( $setting_name, $wp_registered_settings );
+			$this->assertSame( 'boolean', $wp_registered_settings[ $setting_name ]['type'] );
+			$this->assertTrue( $wp_registered_settings[ $setting_name ]['default'] );
+			$this->assertTrue( $wp_registered_settings[ $setting_name ]['show_in_rest'] );
+		} finally {
+			if ( null !== $registry_wp ) {
+				$registry_wp->unregister( $connector_id );
+			}
+			$id_map = (array) $ids_to_classes->getValue( $registry_ai );
+			unset( $id_map[ $connector_id ] );
+			$ids_to_classes->setValue( $registry_ai, $id_map );
+			unregister_setting( Settings_Registration::OPTION_GROUP, "wpai_connector_{$connector_id}_enabled" );
+		}
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/632

<!-- In a few words, what is the PR actually doing? -->
Introduces toggles for each active AI connector in the General AI Settings page to easily activate or deactivate individual connectors without losing their saved credentials (e.g. API keys) in the database.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, users cannot deactivate an active AI connector without removing its API key or configuration completely. When testing multiple providers (like OpenAI and Google), deleting keys makes it inconvenient to switch back and forth. 

By introducing administrative toggles, users can temporarily disable a specific connector from being used by the AI plugin, while retaining the configured credentials in the background for quick reactivation later.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
1. **Dynamic Setting Registration**: Registered a REST-enabled setting `wpai_connector_{$connector_id}_enabled` for each active connector dynamically in `Settings_Registration.php`.
2. **Settings UI Pseudo-Features**: Exposed active connectors under a new `AI Connectors` section at the top of the AI Settings page in `Settings_Page.php`. Each connector maps to its toggle setting automatically via the existing `DataForm` configuration.
3. **Connector Operations Integration**: Modified `has_connector_authentication()`, `is_connector_configured()`, and `get_ai_connectors()` in `helpers.php` to respect the status of the toggle settings.
4. **Integration Testing**: Added integration test suite checks in `tests/Integration/Includes/HelpersTest.php` to verify functionality.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

AI assistance: Yes
Tool(s): Antigravity
Model(s): Gemini Flash 3.5
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Ensure at least one AI connector plugin (e.g. Google or OpenAI) is active.
2. Navigate to **Settings > AI** in the WordPress Admin Dashboard.
3. Observe the new **AI Connectors** section at the top, listing the active connector(s) with an enabled toggle switch.
4. Toggle the active connector to **Disabled** and save the settings.
5. Verify that:
   - The settings screen displays the warning notice indicating that the AI plugin requires a valid connector.
   - The provider is no longer utilized for AI operations (e.g. blocks/experiments degrade gracefully or report no credentials).
6. Toggle the connector back to **Enabled** and save settings. Verify the warning is cleared and the connector resumes functioning normally without having to re-enter any API keys.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->

| Before | After |
| ------ | ----- |
| *No way to disable a connector except deleting the credentials.* | *A dedicated "AI Connectors" card section renders at the top with a toggle for each active provider.* |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Added - Added toggle controls to deactivate and activate individual AI connectors without deleting their configuration or keys.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-661-3a36dde87ebf000df86f136450b7c7369e740a34.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->