### PR TITLE
[Content Resizing]: Fix focus loss when regenerating content resizing suggestions

### DIFF
--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -15,7 +15,13 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useCallback,
+	useMemo,
+	useRef,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as editorStore } from '@wordpress/editor';
@@ -54,6 +60,20 @@ export default function ContentResizingToolbar( {
 	);
 	const [ lastAction, setLastAction ] =
 		useState< ContentResizingAction | null >( null );
+
+	const acceptButtonRef = useRef< HTMLDivElement | null >( null );
+
+	// Keep the modal scrolled to the action buttons when it opens or updates.
+	useLayoutEffect( () => {
+		if ( ! isModalOpen ) {
+			return;
+		}
+
+		acceptButtonRef.current?.scrollIntoView( {
+			block: 'start',
+			behavior: 'auto',
+		} );
+	}, [ isModalOpen, suggestedContent ] );
 
 	const { blockContent, isResized, postId } = useSelect(
 		( select ) => {
@@ -321,6 +341,7 @@ export default function ContentResizingToolbar( {
 							onClick={ handleAccept }
 							disabled={ isLoading || suggestedContent === null }
 							accessibleWhenDisabled
+							ref={ acceptButtonRef }
 						>
 							{ __( 'Accept', 'ai' ) }
 						</Button>
@@ -331,7 +352,9 @@ export default function ContentResizingToolbar( {
 							isBusy={ isLoading }
 							accessibleWhenDisabled
 						>
-							{ __( 'Regenerate', 'ai' ) }
+							{ isLoading
+								? __( 'Generating…', 'ai' )
+								: __( 'Regenerate', 'ai' ) }
 						</Button>
 					</Flex>
 				</Modal>

--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -147,10 +147,10 @@ export default function ContentResizingToolbar( {
 	}, [] );
 
 	const handleRetry = useCallback( () => {
-		if ( lastAction ) {
+		if ( lastAction && ! isLoading ) {
 			handleAction( lastAction );
 		}
-	}, [ handleAction, lastAction ] );
+	}, [ handleAction, isLoading, lastAction ] );
 
 	// Calculate the word difference between the original and suggested content.
 	const wordDiff = useMemo( () => {
@@ -248,69 +248,90 @@ export default function ContentResizingToolbar( {
 					size="medium"
 					className="ai-content-resizing-modal"
 				>
-					{ isLoading ? (
-						<div className="ai-content-resizing-modal__loading">
-							<Spinner />
-							<p>{ __( 'Generating…', 'ai' ) }</p>
+					<section
+						className="ai-content-resizing-modal__panel"
+						aria-label={ __( 'Original content', 'ai' ) }
+					>
+						<div className="ai-content-resizing-modal__label">
+							<span>{ __( 'Original', 'ai' ) }</span>
 						</div>
-					) : (
-						<>
-							<section
-								className="ai-content-resizing-modal__panel"
-								aria-label={ __( 'Original content', 'ai' ) }
+						<div
+							className="ai-content-resizing-modal__text ai-content-resizing-modal__text--original"
+							dangerouslySetInnerHTML={ {
+								__html: blockContent,
+							} }
+						/>
+					</section>
+					<section
+						className="ai-content-resizing-modal__panel"
+						aria-label={ __( 'Suggested content', 'ai' ) }
+					>
+						<div className="ai-content-resizing-modal__label">
+							<span>{ __( 'Suggested', 'ai' ) }</span>
+							{ ! isLoading && wordDiff && (
+								<span
+									className={ `ai-content-resizing-modal__diff ai-content-resizing-modal__diff--${ wordDiff.modifier }` }
+									aria-label={ wordDiff.ariaLabel }
+								>
+									{ wordDiff.label }
+								</span>
+							) }
+						</div>
+						{ isLoading ? (
+							<div
+								className="ai-content-resizing-modal__text ai-content-resizing-modal__loading"
+								role="status"
+								aria-live="polite"
 							>
-								<div className="ai-content-resizing-modal__label">
-									<span>{ __( 'Original', 'ai' ) }</span>
+								<div className="ai-content-resizing-modal__loading-status">
+									<Spinner />
+									<span>{ __( 'Generating…', 'ai' ) }</span>
 								</div>
 								<div
-									className="ai-content-resizing-modal__text ai-content-resizing-modal__text--original"
-									dangerouslySetInnerHTML={ {
-										__html: blockContent,
-									} }
-								/>
-							</section>
-							<section
-								className="ai-content-resizing-modal__panel"
-								aria-label={ __( 'Suggested content', 'ai' ) }
-							>
-								<div className="ai-content-resizing-modal__label">
-									<span>{ __( 'Suggested', 'ai' ) }</span>
-									{ wordDiff && (
-										<span
-											className={ `ai-content-resizing-modal__diff ai-content-resizing-modal__diff--${ wordDiff.modifier }` }
-											aria-label={ wordDiff.ariaLabel }
-										>
-											{ wordDiff.label }
-										</span>
+									className="ai-content-resizing-modal__loading-skeleton"
+									aria-hidden="true"
+								>
+									{ Array.from( { length: 3 } ).map(
+										( _, index ) => (
+											<span
+												key={ index }
+												className="ai-content-resizing-modal__loading-skeleton-line"
+											/>
+										)
 									) }
 								</div>
-								<div
-									className="ai-content-resizing-modal__text"
-									dangerouslySetInnerHTML={ {
-										__html: suggestedContent ?? '',
-									} }
-								/>
-							</section>
-							<Flex
-								justify="flex-start"
-								gap={ 2 }
-								className="ai-content-resizing-modal__actions"
-							>
-								<Button
-									variant="primary"
-									onClick={ handleAccept }
-								>
-									{ __( 'Accept', 'ai' ) }
-								</Button>
-								<Button
-									variant="secondary"
-									onClick={ handleRetry }
-								>
-									{ __( 'Regenerate', 'ai' ) }
-								</Button>
-							</Flex>
-						</>
-					) }
+							</div>
+						) : (
+							<div
+								className="ai-content-resizing-modal__text"
+								dangerouslySetInnerHTML={ {
+									__html: suggestedContent ?? '',
+								} }
+							/>
+						) }
+					</section>
+					<Flex
+						justify="flex-start"
+						gap={ 2 }
+						className="ai-content-resizing-modal__actions"
+					>
+						<Button
+							variant="primary"
+							onClick={ handleAccept }
+							disabled={ isLoading || suggestedContent === null }
+						>
+							{ __( 'Accept', 'ai' ) }
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={ handleRetry }
+							disabled={ isLoading || lastAction === null }
+							isBusy={ isLoading }
+							accessibleWhenDisabled
+						>
+							{ __( 'Regenerate', 'ai' ) }
+						</Button>
+					</Flex>
 				</Modal>
 			) }
 		</>

--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -247,6 +247,7 @@ export default function ContentResizingToolbar( {
 					isFullScreen={ false }
 					size="medium"
 					className="ai-content-resizing-modal"
+					focusOnMount="firstContentElement"
 				>
 					<section
 						className="ai-content-resizing-modal__panel"
@@ -319,6 +320,7 @@ export default function ContentResizingToolbar( {
 							variant="primary"
 							onClick={ handleAccept }
 							disabled={ isLoading || suggestedContent === null }
+							accessibleWhenDisabled
 						>
 							{ __( 'Accept', 'ai' ) }
 						</Button>

--- a/src/experiments/content-resizing/index.scss
+++ b/src/experiments/content-resizing/index.scss
@@ -1,19 +1,11 @@
+@keyframes ai-content-resizing-skeleton {
+	0% { background-position: 100% 0; }
+	100% { background-position: 0 0; }
+}
+
 .ai-content-resizing-toolbar--has-changes {
 	.components-button {
 		color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
-	}
-}
-
-.ai-content-resizing-modal__loading {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	gap: 12px;
-	padding: 32px 0;
-
-	p {
-		color: var(--wp-components-color-gray-700, #757575);
-		margin: 0;
 	}
 }
 
@@ -76,6 +68,47 @@
 	&--original {
 		background: rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.06);
 		border-left-color: rgba(var(--wp-admin-theme-color--rgb, 56, 88, 233), 0.4);
+	}
+}
+
+.ai-content-resizing-modal__loading {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-md, 12px);
+	color: var(--wp-components-color-gray-700, #757575);
+
+	&-status {
+		display: flex;
+		align-items: center;
+		gap: var(--wpds-dimension-gap-sm, 8px);
+
+		svg {
+			margin: 0;
+		}
+	}
+
+	&-skeleton {
+		display: flex;
+		flex-direction: column;
+		gap: var(--wpds-dimension-gap-sm, 8px);
+	}
+
+	&-skeleton-line {
+		display: block;
+		width: 100%;
+		height: var(--wpds-dimension-gap-md, 12px);
+		border-radius: var(--wpds-border-radius-sm, 2px);
+		background: linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 8%, transparent) 25%,
+			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 18%, transparent) 37%,
+			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 8%, transparent) 63%
+		);
+		background-size: 400% 100%;
+
+		@media (prefers-reduced-motion: no-preference) {
+			animation: ai-content-resizing-skeleton 1.4s ease infinite;
+		}
 	}
 }
 


### PR DESCRIPTION
## What?
See https://github.com/WordPress/ai/issues/589

Fixes a focus-loss issue in the Content Resizing modal where clicking **Regenerate** after a successful generation could move focus behind the modal.

## Why?

The previous loading state replaced the modal content while regeneration was running. Since the focused `Regenerate` button disappeared from the DOM, keyboard focus could escape to the background page, leaving keyboard and screen reader users unable to tab back into the modal.

## How?

- Keeps the modal structure and action buttons mounted during regeneration.
- Renders an inline loading state inside the suggested-content panel instead of replacing the whole modal body.
- Disables the modal actions while loading, with `accessibleWhenDisabled` on `Regenerate` so focus remains stable.
- Adds a skeleton loading treatment with reduced-motion support.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Initial code skeleton; final implementation and tests were reviewed and edited by me.

## Testing Instructions
1. Create a new post.
2. Add a Paragraph block with enough text to resize.
3. Select the Paragraph block and open the **Resize Content** toolbar menu.
4. Choose **Shorten**, **Expand**, or **Rephrase**.
5. Wait for the suggested replacement modal to finish generating.
6. Click **Regenerate**.
7. While regeneration is in progress and after it completes, press `Tab` several times.

## Screencast

https://github.com/user-attachments/assets/b62902cb-2254-4f9d-b51c-5653a325bbe8

## Changelog Entry

> Fixed - Focus lost in generating state.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-663-bbf4d10971cfa1326f71f396145c978de0a4c622.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->