### PR TITLE
Fix: a11y: Focus lost when clicking regenerate on content resizing experiments

### DIFF
--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -15,7 +15,13 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	useState,
+	useCallback,
+	useMemo,
+	useEffect,
+	useRef,
+} from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as editorStore } from '@wordpress/editor';
@@ -54,6 +60,21 @@ export default function ContentResizingToolbar( {
 	);
 	const [ lastAction, setLastAction ] =
 		useState< ContentResizingAction | null >( null );
+
+	const loadingRef = useRef< HTMLDivElement | null >( null );
+	const acceptButtonRef = useRef< HTMLButtonElement | null >( null );
+
+	useEffect( () => {
+		if ( ! isModalOpen ) {
+			return;
+		}
+
+		if ( isLoading ) {
+			loadingRef.current?.focus();
+		} else if ( suggestedContent !== null ) {
+			acceptButtonRef.current?.focus();
+		}
+	}, [ isModalOpen, isLoading, suggestedContent ] );
 
 	const { blockContent, isResized, postId } = useSelect(
 		( select ) => {
@@ -249,7 +270,11 @@ export default function ContentResizingToolbar( {
 					className="ai-content-resizing-modal"
 				>
 					{ isLoading ? (
-						<div className="ai-content-resizing-modal__loading">
+						<div
+							ref={ loadingRef }
+							className="ai-content-resizing-modal__loading"
+							tabIndex={ -1 }
+						>
 							<Spinner />
 							<p>{ __( 'Generating…', 'ai' ) }</p>
 						</div>
@@ -297,6 +322,7 @@ export default function ContentResizingToolbar( {
 								className="ai-content-resizing-modal__actions"
 							>
 								<Button
+									ref={ acceptButtonRef }
 									variant="primary"
 									onClick={ handleAccept }
 								>


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Part of: https://github.com/WordPress/ai/issues/589

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR aims to resolve the focus issue for the content resize experiments added in the comment here - https://github.com/WordPress/ai/issues/589#issuecomment-4572972547

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR adds the focus to loading spinner div when regenerating and move focus back to accept button once generated.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
Yes, Claude Code, Opus 4.8.
Used for initial research and provide the fix for the focus issue.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable content resize experiment.
2. Open post/page.
3. Add the content in paragraph.
4. Select the block, either do any of the one, `shorten, expand, rephrase`.
5. Once generated, click on regenerate and then tab, focus would be inside the modal.
6. Once regenration is complete, focus moves to `Apply` button.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->


https://github.com/user-attachments/assets/5bc05e66-8bc6-43d0-a7e9-3647a7b5041f



## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Focus lost in content resize experiments when clicking regenrate, focus moves out of modal.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-664-4d0d593ef837115b2ee157504ae1fcc76baef7d7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->