### PR TITLE
AI Request Logs: column “move left / move right” has no effect

### DIFF
--- a/src/admin/ai-request-logs/components/LogsTable.tsx
+++ b/src/admin/ai-request-logs/components/LogsTable.tsx
@@ -17,6 +17,7 @@ import { useCallback, useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import type { ProviderMetadata } from '../../types/providers';
+import { DEFAULT_VIEW_FIELDS } from '../query';
 import type { FilterOptions, LogEntry, LogsQuery } from '../types';
 
 interface LogsTableProps {
@@ -41,15 +42,6 @@ interface ViewConfig {
 	fields: string[];
 	layout: NonNullable< ViewTable[ 'layout' ] >;
 }
-
-const DEFAULT_VIEW_FIELDS = [
-	'timestamp',
-	'operation',
-	'provider',
-	'tokens_total',
-	'duration_ms',
-	'status',
-];
 
 const formatTimestamp = ( timestamp: string ): string => {
 	const { formats } = getSettings();
@@ -241,6 +233,7 @@ const viewToQuery = ( view: View ): LogsQuery => {
 		userId: extractStringFilter( filters, 'user_id' ),
 		orderby: typeof sortField === 'string' ? sortField : 'timestamp',
 		order: sortDir,
+		fields: view.fields ?? [ ...DEFAULT_VIEW_FIELDS ],
 	};
 };
 
@@ -262,7 +255,7 @@ const queryToView = ( query: LogsQuery, viewConfig: ViewConfig ): View => {
 			field: query.orderby,
 			direction: query.order,
 		},
-		fields: viewConfig.fields,
+		fields: query.fields,
 		layout: viewConfig.layout,
 	};
 };

--- a/src/admin/ai-request-logs/components/LogsTable.tsx
+++ b/src/admin/ai-request-logs/components/LogsTable.tsx
@@ -51,17 +51,6 @@ const DEFAULT_VIEW_FIELDS = [
 	'status',
 ];
 
-const FIELD_ORDER = new Map(
-	DEFAULT_VIEW_FIELDS.map( ( id, index ) => [ id, index ] )
-);
-
-const sortFieldsByCanonicalOrder = ( ids: string[] ): string[] =>
-	[ ...ids ].sort( ( a, b ) => {
-		const ai = FIELD_ORDER.get( a ) ?? Infinity;
-		const bi = FIELD_ORDER.get( b ) ?? Infinity;
-		return ai - bi;
-	} );
-
 const formatTimestamp = ( timestamp: string ): string => {
 	const { formats } = getSettings();
 	return dateI18n( `${ formats.date } ${ formats.time }`, timestamp + 'Z' );
@@ -437,9 +426,7 @@ const LogsTable: React.FC< LogsTableProps > = ( {
 
 			setViewConfig( {
 				filters: nextView.filters ?? [],
-				fields: sortFieldsByCanonicalOrder(
-					nextView.fields ?? [ ...DEFAULT_VIEW_FIELDS ]
-				),
+				fields: nextView.fields ?? [ ...DEFAULT_VIEW_FIELDS ],
 				layout: nextLayout,
 			} );
 

--- a/src/admin/ai-request-logs/query.ts
+++ b/src/admin/ai-request-logs/query.ts
@@ -61,11 +61,18 @@ const normalizeOperationSelection = (
 };
 
 const normalizeFields = ( raw: unknown ): string[] => {
+	// When no field order is stored yet, fall back to the default order.
+	if ( undefined === raw || null === raw ) {
+		return [ ...DEFAULT_VIEW_FIELDS ];
+	}
+
 	const sanitized = sanitizeStringArray( raw ).filter( ( field ) =>
 		DEFAULT_VIEW_FIELDS.includes( field )
 	);
 
-	if ( sanitized.length !== DEFAULT_VIEW_FIELDS.length ) {
+	// If nothing valid was stored, fall back to the default order.
+	// A shorter list is valid: the user may have hidden some columns.
+	if ( 0 === sanitized.length ) {
 		return [ ...DEFAULT_VIEW_FIELDS ];
 	}
 

--- a/src/admin/ai-request-logs/query.ts
+++ b/src/admin/ai-request-logs/query.ts
@@ -9,6 +9,15 @@ import type { LogsQuery } from './types';
 const DEFAULT_PAGE = 1;
 const DEFAULT_PER_PAGE = 25;
 
+export const DEFAULT_VIEW_FIELDS = [
+	'timestamp',
+	'operation',
+	'provider',
+	'tokens_total',
+	'duration_ms',
+	'status',
+];
+
 const sanitizeStringArray = ( value: unknown ): string[] => {
 	if ( ! Array.isArray( value ) ) {
 		return [];
@@ -51,6 +60,18 @@ const normalizeOperationSelection = (
 	);
 };
 
+const normalizeFields = ( raw: unknown ): string[] => {
+	const sanitized = sanitizeStringArray( raw ).filter( ( field ) =>
+		DEFAULT_VIEW_FIELDS.includes( field )
+	);
+
+	if ( sanitized.length !== DEFAULT_VIEW_FIELDS.length ) {
+		return [ ...DEFAULT_VIEW_FIELDS ];
+	}
+
+	return sanitized;
+};
+
 export const getDefaultLogsQuery = (): LogsQuery => ( {
 	page: DEFAULT_PAGE,
 	perPage: DEFAULT_PER_PAGE,
@@ -63,6 +84,7 @@ export const getDefaultLogsQuery = (): LogsQuery => ( {
 	userId: '',
 	orderby: 'timestamp',
 	order: 'desc',
+	fields: [ ...DEFAULT_VIEW_FIELDS ],
 } );
 
 export const normalizeLogsQuery = (
@@ -115,6 +137,7 @@ export const normalizeLogsQuery = (
 			'asc' === parsed.order || 'desc' === parsed.order
 				? parsed.order
 				: defaultQuery.order,
+		fields: normalizeFields( parsed.fields ),
 	};
 };
 

--- a/src/admin/ai-request-logs/types.ts
+++ b/src/admin/ai-request-logs/types.ts
@@ -80,6 +80,7 @@ export interface LogsQuery {
 	userId: string;
 	orderby: string;
 	order: 'asc' | 'desc';
+	fields: string[];
 }
 
 export interface LocalizedSettings {


### PR DESCRIPTION
## What?
Closes #667

Fixes the AI Request Logs table so that "move left / move right" column reordering persists instead of snapping back to the default order.

## Why?
In `LogsTable.tsx`, `onChangeView` ran `sortFieldsByCanonicalOrder()` on every view update, which re-sorted the fields back to `DEFAULT_VIEW_FIELDS` immediately after the user reordered a column. As a result, column order changes had no effect.

## How?
Removed the canonical resort from `onChangeView` so the user's chosen field order (`nextView.fields`) is preserved. The initial field order is already set to `DEFAULT_VIEW_FIELDS` when state is initialized, so canonical ordering on the first render is unaffected. The now-unused `FIELD_ORDER` map and `sortFieldsByCanonicalOrder` helper were removed.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Used for: Locating the cause in onChangeView and drafting the fix. Final implementation and manual testing were done by me.

## Testing Instructions
1. Open **AI Request Logs** in wp-admin with at least one log entry
2. Open the column header menu on any column (e.g. Provider)
3. Choose "Move left" or "Move right"
4. Confirm the column order changes and persists (no snap-back to default)

## Screenshots or screencast
After the fix column reordering now persists:

https://github.com/user-attachments/assets/582c0217-844d-4238-b0cc-39d546b9d7a9


## Changelog Entry
> Fixed - Column reordering in the AI Request Logs table now persists instead of resetting to the default order.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-669-873de116ba839fab9632826dc6afa377248cc25d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->