### PR TITLE
Fix: Summary counters show zero for “Last Hour” when requests are recent in AI Request Logs

### DIFF
--- a/includes/Logging/AI_Request_Log_Repository.php
+++ b/includes/Logging/AI_Request_Log_Repository.php
@@ -375,7 +375,7 @@ class AI_Request_Log_Repository {
 		do {
 			$deleted = $wpdb->query(
 				$wpdb->prepare(
-					"DELETE FROM {$table_name} WHERE timestamp < DATE_SUB(NOW(), INTERVAL %d DAY) LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+					"DELETE FROM {$table_name} WHERE timestamp < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d DAY) LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 					$retention_days,
 					self::DELETE_BATCH_SIZE
 				)

--- a/includes/Logging/AI_Request_Log_Repository.php
+++ b/includes/Logging/AI_Request_Log_Repository.php
@@ -723,15 +723,15 @@ class AI_Request_Log_Repository {
 	private function get_date_condition( string $period ): string {
 		switch ( $period ) {
 			case 'minute':
-				return 'AND timestamp >= DATE_SUB(NOW(), INTERVAL 1 MINUTE)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 MINUTE)';
 			case 'hour':
-				return 'AND timestamp >= DATE_SUB(NOW(), INTERVAL 1 HOUR)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 HOUR)';
 			case 'day':
-				return 'AND timestamp >= DATE_SUB(NOW(), INTERVAL 1 DAY)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 DAY)';
 			case 'week':
-				return 'AND timestamp >= DATE_SUB(NOW(), INTERVAL 1 WEEK)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 WEEK)';
 			case 'month':
-				return 'AND timestamp >= DATE_SUB(NOW(), INTERVAL 1 MONTH)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 MONTH)';
 			default:
 				return '';
 		}

--- a/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
@@ -533,6 +533,32 @@ class AI_Request_Log_RepositoryTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that get_summary windowed periods compare against UTC, not the MySQL session time zone.
+	 *
+	 * Timestamps are written with current_time( 'mysql', true ) (UTC), so the period
+	 * cutoff in get_date_condition() must also be evaluated in UTC. Otherwise on a
+	 * MySQL session whose time zone is ahead of UTC, recent rows are excluded from
+	 * "Last Minute"/"Last Hour"/etc. summaries.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_summary_windowed_period_uses_utc_session_timezone(): void {
+		global $wpdb;
+
+		$this->insert_log();
+
+		$wpdb->query( "SET time_zone = '+13:00'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		try {
+			$summary = $this->repository->get_summary( 'hour', true );
+
+			$this->assertSame( 1, $summary['total_requests'] );
+		} finally {
+			$wpdb->query( "SET time_zone = '+00:00'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		}
+	}
+
+	/**
 	 * Tests that get_filter_options returns distinct values from logs.
 	 *
 	 * @since 1.0.0
@@ -594,6 +620,51 @@ class AI_Request_Log_RepositoryTest extends WP_UnitTestCase {
 		// The recent log should still exist.
 		$remaining = $this->repository->query();
 		$this->assertSame( 1, $remaining['total'] );
+	}
+
+	/**
+	 * Tests that cleanup_by_retention measures the cutoff in UTC, not the MySQL session time zone.
+	 *
+	 * A row whose UTC age is still inside the retention window must not be deleted
+	 * just because the session time zone shifts NOW() ahead. Using a +13:00 session
+	 * with a row 29 days 18 hours old triggers the bug when the cutoff is built
+	 * from NOW() but not from UTC_TIMESTAMP().
+	 *
+	 * @since x.x.x
+	 */
+	public function test_cleanup_by_retention_uses_utc_session_timezone(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . AI_Request_Log_Schema::TABLE_NAME;
+
+		$stored_timestamp = gmdate(
+			'Y-m-d H:i:s',
+			time() - ( 29 * DAY_IN_SECONDS + 18 * HOUR_IN_SECONDS )
+		);
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$table,
+			array(
+				'log_id'    => wp_generate_uuid4(),
+				'timestamp' => $stored_timestamp,
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			),
+			array( '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		$wpdb->query( "SET time_zone = '+13:00'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		try {
+			$deleted = $this->repository->cleanup_by_retention( 30 );
+
+			$this->assertSame( 0, $deleted );
+
+			$remaining = $this->repository->query();
+			$this->assertSame( 1, $remaining['total'] );
+		} finally {
+			$wpdb->query( "SET time_zone = '+00:00'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #666

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
On AI Request Logs, the header time-period dropdown correctly filters the log table for short windows. Still, the summary cards at the top show 0 when “Last Hour” is selected, even when requests were made within the last hour.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace NOW() with UTC_TIMESTAMP() in all get_date_condition() cases so the period cutoff aligns with the stored GMT timestamps.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Use a WordPress install where the server/MySQL timezone is not UTC (e.g. US/New York, Europe/Berlin) - this makes the bug easiest to see.
2. Ensure the AI plugin is active, and AI request logging is enabled.
3. Trigger at least one AI request (e.g., use an AI feature in the plugin) and confirm a new row appears in AI Request Logs within the last hour.
4. Open AI Request Logs in wp-admin.
5. Change the header dropdown to “Last Hour”.
6. Check the summary cards' values are non-zero

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1470" height="837" alt="Screenshot 2026-06-05 at 11 09 17 AM" src="https://github.com/user-attachments/assets/ebca31e3-6bfe-46b2-a9ad-87caba49dfe5" />|<img width="1470" height="881" alt="Screenshot 2026-06-05 at 12 35 36 PM" src="https://github.com/user-attachments/assets/fe014a48-9161-4f80-afc4-4210d0621e9b" />|

## Changelog Entry

> Fixed  - Summary statistics showing zero for short time periods on non-UTC MySQL servers.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-671-75717dd9e341f0c30e8ca172faae7abad3de69bc.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->