### PR TITLE
Gate image generation UI on provider support detection

### DIFF
--- a/includes/Features/Image_Generation/Image_Generation.php
+++ b/includes/Features/Image_Generation/Image_Generation.php
@@ -16,6 +16,8 @@ use WordPress\AI\Abstracts\Abstract_Feature;
 use WordPress\AI\Asset_Loader;
 use WordPress\AI\Experiments\Alt_Text_Generation\Alt_Text_Generation;
 
+use function WordPress\AI\has_image_generation_support;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -226,8 +228,9 @@ class Image_Generation extends Abstract_Feature {
 			'image_generation',
 			'ImageGenerationData',
 			array(
-				'enabled'        => $this->is_enabled(),
-				'altTextEnabled' => ( new Alt_Text_Generation() )->is_enabled(),
+				'enabled'                   => $this->is_enabled(),
+				'altTextEnabled'            => ( new Alt_Text_Generation() )->is_enabled(),
+				'hasImageGenerationSupport' => has_image_generation_support(),
 			)
 		);
 	}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -13,6 +13,7 @@ use Throwable;
 use WordPress\AI\Services\AI_Service;
 use WordPress\AI\Services\Guidelines;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 /**
  * Purposely using return instead of exit here.
@@ -492,6 +493,47 @@ function has_ai_credentials(): bool {
 	 * @param array $connectors      The registered connectors.
 	 */
 	return (bool) apply_filters( 'wpai_has_ai_credentials', $has_credentials, $connectors );
+}
+
+/**
+ * Checks whether any configured connector exposes an image-generation-capable model.
+ *
+ * @since X.X.X
+ *
+ * @return bool True if at least one configured connector has an image-generation-capable model.
+ */
+function has_image_generation_support(): bool {
+	if ( ! class_exists( AiClient::class ) ) {
+		return false;
+	}
+
+	$registry   = AiClient::defaultRegistry();
+	$connectors = get_ai_connectors();
+
+	foreach ( array_keys( $connectors ) as $connector_id ) {
+		if ( ! has_connector_authentication( $connector_id ) ) {
+			continue;
+		}
+
+		try {
+			$provider_class = $registry->getProviderClassName( $connector_id );
+
+			/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
+			$models = $provider_class::modelMetadataDirectory()->listModelMetadata();
+
+			foreach ( $models as $model ) {
+				foreach ( $model->getSupportedCapabilities() as $capability ) {
+					if ( CapabilityEnum::IMAGE_GENERATION === $capability->value ) {
+						return true;
+					}
+				}
+			}
+		} catch ( Throwable $e ) {
+			continue;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -503,8 +503,15 @@ function has_ai_credentials(): bool {
  * @return bool True if at least one configured connector has an image-generation-capable model.
  */
 function has_image_generation_support(): bool {
+	static $result = null;
+
+	if ( null !== $result ) {
+		return $result;
+	}
+
 	if ( ! class_exists( AiClient::class ) ) {
-		return false;
+		$result = false;
+		return $result;
 	}
 
 	$registry   = AiClient::defaultRegistry();
@@ -524,7 +531,8 @@ function has_image_generation_support(): bool {
 			foreach ( $models as $model ) {
 				foreach ( $model->getSupportedCapabilities() as $capability ) {
 					if ( CapabilityEnum::IMAGE_GENERATION === $capability->value ) {
-						return true;
+						$result = true;
+						return $result;
 					}
 				}
 			}
@@ -533,7 +541,8 @@ function has_image_generation_support(): bool {
 		}
 	}
 
-	return false;
+	$result = false;
+	return $result;
 }
 
 /**

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -498,7 +498,7 @@ function has_ai_credentials(): bool {
 /**
  * Checks whether any configured connector exposes an image-generation-capable model.
  *
- * @since X.X.X
+ * @since x.x.x
  *
  * @return bool True if at least one configured connector has an image-generation-capable model.
  */

--- a/src/features/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/features/image-generation/components/GenerateFeaturedImage.tsx
@@ -13,9 +13,14 @@ import { store as noticesStore } from '@wordpress/notices';
  */
 import { generateImage } from '../functions/generate-image';
 import { uploadImage } from '../functions/upload-image';
-import { ensureProvider } from '../../../utils/provider-status';
+import {
+	ensureProvider,
+	getProviderData,
+} from '../../../utils/provider-status';
 
 const NOTICE_ID = 'ai_image_generation_error';
+
+const { aiImageGenerationData } = window as any;
 
 /**
  * GenerateFeaturedImage component.
@@ -39,6 +44,28 @@ export default function GenerateFeaturedImage(): React.JSX.Element | null {
 	 */
 	const handleGenerate = async () => {
 		if ( ! ensureProvider( NOTICE_ID ) ) {
+			return;
+		}
+
+		if ( ! aiImageGenerationData?.hasImageGenerationSupport ) {
+			( dispatch( noticesStore ) as any ).createErrorNotice(
+				__(
+					'No connected provider supports image generation. Connect a provider with image generation to use this feature.',
+					'ai'
+				),
+				{
+					id: NOTICE_ID,
+					isDismissible: true,
+					actions: getProviderData().connectorsUrl
+						? [
+								{
+									label: __( 'Manage Connectors', 'ai' ),
+									url: getProviderData().connectorsUrl,
+								},
+						  ]
+						: [],
+				}
+			);
 			return;
 		}
 

--- a/src/features/image-generation/components/GenerateFeaturedImage.tsx
+++ b/src/features/image-generation/components/GenerateFeaturedImage.tsx
@@ -50,7 +50,7 @@ export default function GenerateFeaturedImage(): React.JSX.Element | null {
 		if ( ! aiImageGenerationData?.hasImageGenerationSupport ) {
 			( dispatch( noticesStore ) as any ).createErrorNotice(
 				__(
-					'No connected provider supports image generation. Connect a provider with image generation to use this feature.',
+					'This feature requires an AI Connector that supports image generation. Review your Connectors to ensure you have a valid AI Connector configured.',
 					'ai'
 				),
 				{

--- a/src/features/image-generation/components/GenerateImageInlineModal.tsx
+++ b/src/features/image-generation/components/GenerateImageInlineModal.tsx
@@ -129,6 +129,9 @@ export function GenerateImageInlineModal( {
 					onPromptChange={ setPrompt }
 					onGenerate={ () => generate( prompt.trim() ) }
 					error={ error }
+					hasImageGenerationSupport={ Boolean(
+						aiImageGenerationData?.hasImageGenerationSupport
+					) }
 				/>
 			) }
 

--- a/src/features/image-generation/components/GenerateImageStandalone.tsx
+++ b/src/features/image-generation/components/GenerateImageStandalone.tsx
@@ -126,6 +126,9 @@ export function GenerateImageStandalone() {
 					onPromptChange={ setPrompt }
 					onGenerate={ () => safeGenerate( prompt.trim() ) }
 					error={ error }
+					hasImageGenerationSupport={ Boolean(
+						aiImageGenerationData?.hasImageGenerationSupport
+					) }
 				/>
 			) }
 

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -13,6 +13,7 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
+import { getProviderData } from '../../../../utils/provider-status';
 import type { HistoryEntry } from '../../types';
 
 // ─── GeneratingState ─────────────────────────────────────────────────────────
@@ -66,6 +67,7 @@ interface PromptFormProps {
 	onPromptChange: ( value: string ) => void;
 	onGenerate: () => void;
 	error?: string | null;
+	hasImageGenerationSupport?: boolean;
 }
 
 /**
@@ -76,32 +78,55 @@ export function PromptForm( {
 	onPromptChange,
 	onGenerate,
 	error,
+	hasImageGenerationSupport = true,
 }: PromptFormProps ) {
+	const { connectorsUrl } = getProviderData();
+
 	return (
 		<div className="ai-image-generation__idle">
-			<p className="description">
-				{ __( 'Describe the image you want to generate.', 'ai' ) }
-			</p>
-			<TextareaControl
-				label={ __( 'Prompt', 'ai' ) }
-				value={ prompt }
-				onChange={ onPromptChange }
-				rows={ 4 }
-				hideLabelFromVision
-			/>
-			<div className="ai-image-generation__actions">
-				<Button
-					variant="primary"
-					disabled={ ! prompt.trim() }
-					onClick={ onGenerate }
-				>
-					{ __( 'Generate', 'ai' ) }
-				</Button>
-			</div>
-			{ error && (
-				<Notice status="error" isDismissible={ false }>
-					{ error }
+			{ ! hasImageGenerationSupport ? (
+				<Notice status="warning" isDismissible={ false }   actions={[
+    {
+      label: __( 'Manage Connectors', 'ai' ),
+      url: connectorsUrl,
+      variant: 'link'
+    }
+  ]}>
+					{ __(
+						'No connected provider supports image generation. Connect a provider with image generation to use this feature.',
+						'ai'
+					) }
 				</Notice>
+			) : (
+				<>
+					<p className="description">
+						{ __(
+							'Describe the image you want to generate.',
+							'ai'
+						) }
+					</p>
+					<TextareaControl
+						label={ __( 'Prompt', 'ai' ) }
+						value={ prompt }
+						onChange={ onPromptChange }
+						rows={ 4 }
+						hideLabelFromVision
+					/>
+					<div className="ai-image-generation__actions">
+						<Button
+							variant="primary"
+							disabled={ ! prompt.trim() }
+							onClick={ onGenerate }
+						>
+							{ __( 'Generate', 'ai' ) }
+						</Button>
+					</div>
+					{ error && (
+						<Notice status="error" isDismissible={ false }>
+							{ error }
+						</Notice>
+					) }
+				</>
 			) }
 		</div>
 	);

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -103,7 +103,7 @@ export function PromptForm( {
 					}
 				>
 					{ __(
-						'No connected provider supports image generation. Connect a provider with image generation to use this feature.',
+						'This feature requires an AI Connector that supports image generation. Review your Connectors to ensure you have a valid AI Connector configured.',
 						'ai'
 					) }
 				</Notice>

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -85,13 +85,17 @@ export function PromptForm( {
 	return (
 		<div className="ai-image-generation__idle">
 			{ ! hasImageGenerationSupport ? (
-				<Notice status="warning" isDismissible={ false }   actions={[
-    {
-      label: __( 'Manage Connectors', 'ai' ),
-      url: connectorsUrl,
-      variant: 'link'
-    }
-  ]}>
+				<Notice
+					status="warning"
+					isDismissible={ false }
+					actions={ [
+						{
+							label: __( 'Manage Connectors', 'ai' ),
+							url: connectorsUrl,
+							variant: 'link',
+						},
+					] }
+				>
 					{ __(
 						'No connected provider supports image generation. Connect a provider with image generation to use this feature.',
 						'ai'

--- a/src/features/image-generation/components/shared/index.tsx
+++ b/src/features/image-generation/components/shared/index.tsx
@@ -90,13 +90,17 @@ export function PromptForm( {
 				<Notice
 					status="warning"
 					isDismissible={ false }
-					actions={ [
-						{
-							label: __( 'Manage Connectors', 'ai' ),
-							url: connectorsUrl,
-							variant: 'link',
-						},
-					] }
+					actions={
+						connectorsUrl
+							? [
+									{
+										label: __( 'Manage Connectors', 'ai' ),
+										url: connectorsUrl,
+										variant: 'link',
+									},
+							  ]
+							: []
+					}
 				>
 					{ __(
 						'No connected provider supports image generation. Connect a provider with image generation to use this feature.',

--- a/src/features/image-generation/index.scss
+++ b/src/features/image-generation/index.scss
@@ -259,7 +259,7 @@
 }
 
 .ai-generate-image-inline-modal {
-	.components-notice {
+	.ai-image-generation__actions + .components-notice {
 		margin-top: 15px;
 	}
 }

--- a/src/utils/provider-status.ts
+++ b/src/utils/provider-status.ts
@@ -20,7 +20,7 @@ declare global {
 	}
 }
 
-function getProviderData(): ProviderStatus {
+export function getProviderData(): ProviderStatus {
 	return (
 		window.aiProviderData ?? {
 			hasProvider: false,


### PR DESCRIPTION
Related to https://core.trac.wordpress.org/ticket/64917#comment:14

> Ideally the UI would reveal that image generation isn't available _before_ the user types the prompt and clicks the button. Otherwise they waste time, risk losing the prompt, and hit a dead end while in the flow.

## What?

The server checks if any connectors supporting image generation are registered and passes this information to the client side. If no connectors supporting image generation are found, a warning is displayed without sending a REST request.

## Why?

It is unhelpful that users can attempt to generate images by entering prompts, even though there are no connectors supporting image generation.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Drafting this pull request description. Implementation was reviewed by me.

## Testing Instructions

- Only register the Anthropic API key.
- Image Block:
  - Insert an Image block and click the Generate Image button.
  - A warning should be displayed.
- Media Library:
  - Access Media > Generate Image.
  - A warning should be displayed.
- Featured Image:
  - Open the post editor and click the Generate featured image button.
  - A warning should be displayed.

## Screenshot

Image Block:
<img width="908" height="348" alt="image" src="https://github.com/user-attachments/assets/e5e03d84-9014-4ad0-a304-22e066674b0f" />

Media Library:
<img width="937" height="306" alt="image" src="https://github.com/user-attachments/assets/9e9efdbb-d294-4b1c-89c2-b5f306b013a3" />

Featured Image:
<img width="915" height="324" alt="image" src="https://github.com/user-attachments/assets/f0fc8435-7903-47f4-8737-c7cc15f93f77" />



## Changelog Entry

> Changed - Gate the image generation UI on detected provider support for image generation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-679-07fa198b7132106188035bd655a7050117f44d04.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->