### PR TITLE
Fix: AI Request Logging: token count understated for thinking models (thoughtsTokenCount ignored)

### DIFF
--- a/includes/Logging/Log_Data_Extractor.php
+++ b/includes/Logging/Log_Data_Extractor.php
@@ -239,7 +239,7 @@ class Log_Data_Extractor {
 		if ( isset( $response['usageMetadata'] ) && is_array( $response['usageMetadata'] ) ) {
 			$usage  = $response['usageMetadata'];
 			$input  = $usage['promptTokenCount'] ?? null;
-			$output = $usage['candidatesTokenCount'] ?? null;
+			$output = ($usage['candidatesTokenCount'] ?? 0) + ($usage['thoughtsTokenCount'] ?? 0);
 		}
 
 		/**

--- a/includes/Logging/Log_Data_Extractor.php
+++ b/includes/Logging/Log_Data_Extractor.php
@@ -239,7 +239,9 @@ class Log_Data_Extractor {
 		if ( isset( $response['usageMetadata'] ) && is_array( $response['usageMetadata'] ) ) {
 			$usage  = $response['usageMetadata'];
 			$input  = $usage['promptTokenCount'] ?? null;
-			$output = ( $usage['candidatesTokenCount'] ?? 0 ) + ( $usage['thoughtsTokenCount'] ?? 0 );
+			$output = isset( $usage['candidatesTokenCount'] ) || isset( $usage['thoughtsTokenCount'] )
+			? ( $usage['candidatesTokenCount'] ?? 0 ) + ( $usage['thoughtsTokenCount'] ?? 0 )
+			: null;
 		}
 
 		/**

--- a/includes/Logging/Log_Data_Extractor.php
+++ b/includes/Logging/Log_Data_Extractor.php
@@ -239,7 +239,7 @@ class Log_Data_Extractor {
 		if ( isset( $response['usageMetadata'] ) && is_array( $response['usageMetadata'] ) ) {
 			$usage  = $response['usageMetadata'];
 			$input  = $usage['promptTokenCount'] ?? null;
-			$output = ($usage['candidatesTokenCount'] ?? 0) + ($usage['thoughtsTokenCount'] ?? 0);
+			$output = ( $usage['candidatesTokenCount'] ?? 0 ) + ( $usage['thoughtsTokenCount'] ?? 0 );
 		}
 
 		/**

--- a/tests/Integration/Includes/Logging/Log_Data_ExtractorTest.php
+++ b/tests/Integration/Includes/Logging/Log_Data_ExtractorTest.php
@@ -390,12 +390,13 @@ class Log_Data_ExtractorTest extends WP_UnitTestCase {
 				'usageMetadata' => array(
 					'promptTokenCount'     => 300,
 					'candidatesTokenCount' => 150,
+					'thoughtsTokenCount'   => 20,
 				),
 			)
 		);
 
 		$this->assertSame( 300, $tokens['input'] );
-		$this->assertSame( 150, $tokens['output'] );
+		$this->assertSame( 170, $tokens['output'] );
 	}
 
 	/**

--- a/tests/Integration/Includes/Logging/Log_Data_ExtractorTest.php
+++ b/tests/Integration/Includes/Logging/Log_Data_ExtractorTest.php
@@ -390,6 +390,25 @@ class Log_Data_ExtractorTest extends WP_UnitTestCase {
 				'usageMetadata' => array(
 					'promptTokenCount'     => 300,
 					'candidatesTokenCount' => 150,
+				),
+			)
+		);
+
+		$this->assertSame( 300, $tokens['input'] );
+		$this->assertSame( 150, $tokens['output'] );
+	}
+
+	/**
+	 * Tests Google token usage sums candidatesTokenCount and thoughtsTokenCount.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_extract_token_usage_google_format_with_thoughts(): void {
+		$tokens = $this->extractor->extract_token_usage(
+			array(
+				'usageMetadata' => array(
+					'promptTokenCount'     => 300,
+					'candidatesTokenCount' => 150,
 					'thoughtsTokenCount'   => 20,
 				),
 			)
@@ -397,6 +416,24 @@ class Log_Data_ExtractorTest extends WP_UnitTestCase {
 
 		$this->assertSame( 300, $tokens['input'] );
 		$this->assertSame( 170, $tokens['output'] );
+	}
+
+	/**
+	 * Tests Google token usage returns null output when no output fields exist.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_extract_token_usage_google_format_without_output_fields(): void {
+		$tokens = $this->extractor->extract_token_usage(
+			array(
+				'usageMetadata' => array(
+					'promptTokenCount' => 300,
+				),
+			)
+		);
+
+		$this->assertSame( 300, $tokens['input'] );
+		$this->assertNull( $tokens['output'] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #662

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Token count mismatched in AI Request Logging and in Google console logs

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updated Google token extraction in Log Data Extractor to compute output tokens as:
candidatesTokenCount + thoughtsTokenCount

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Enable the AI Request Logging experiment
Configure the Google provider with a thinking model (e.g. gemini-3-flash-preview)
Trigger a text generation (e.g. via the Title Generation experiment)
Compare the token count in Tools → AI Request Logs with the usage in Google AI Studio → Usage

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| After AI Logs | Gemini Logs |
| ------ | ----- |
|<img width="1060" height="137" alt="Screenshot 2026-06-08 at 1 59 15 PM" src="https://github.com/user-attachments/assets/eacbbaef-9f07-475e-849c-fa74a2bfbc93" />|<img width="1150" height="450" alt="Screenshot 2026-06-08 at 2 32 15 PM" src="https://github.com/user-attachments/assets/d39fd3a2-3039-430f-9304-19662166ad89" />|

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed: Google gemini token counts in request logs now match provider usage totals.


<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-680-8b12c88373f8d1a85057ee3fa711dd47e779d2d2.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->