### PR TITLE
Fix[Editorial Notes]: Clarify Editorial Notes save flow and hide stale updates action

### DIFF
--- a/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
+++ b/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
@@ -85,6 +85,7 @@ export default function EditorialNotesPlugin() {
 								justifyContent: 'center',
 								width: '100%',
 							} }
+							accessibleWhenDisabled
 							__next40pxDefaultSize
 						>
 							{ buttonLabel }

--- a/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
+++ b/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
@@ -65,6 +65,15 @@ interface ReviewResult {
 	suggestions: Suggestion[];
 }
 
+interface ReviewSingleBlockResult {
+	suggestionCount: number;
+	didLinkNoteId: boolean;
+}
+
+interface CreateNoteResult {
+	didLinkNoteId: boolean;
+}
+
 interface NoteRecord {
 	id: number;
 	[ key: string ]: unknown;
@@ -79,7 +88,7 @@ interface NoteRecord {
  * @param resolvedNoteIds Set of Note IDs that have been resolved (approved).
  * @param noteContentById Map of Note ID → rendered Note content (pending only).
  * @param pendingNotes    All pending Notes for the post (for reply lookup).
- * @return The number of suggestions created, or 0 if the block was skipped.
+ * @return The suggestion count and whether a new Note thread was linked.
  */
 async function reviewSingleBlock(
 	block: Block,
@@ -88,19 +97,19 @@ async function reviewSingleBlock(
 	resolvedNoteIds: Set< number >,
 	noteContentById: Map< number, string >,
 	pendingNotes: ExistingNote[]
-): Promise< number > {
+): Promise< ReviewSingleBlockResult > {
 	// Look up any existing Note thread on this block.
 	const existingNoteId = block.attributes.metadata?.noteId ?? null;
 
 	// Skip blocks whose Note thread has been resolved.
 	if ( existingNoteId && resolvedNoteIds.has( existingNoteId ) ) {
-		return 0;
+		return { suggestionCount: 0, didLinkNoteId: false };
 	}
 
 	const blockText = getBlockText( block );
 
 	if ( blockText.length === 0 ) {
-		return 0;
+		return { suggestionCount: 0, didLinkNoteId: false };
 	}
 
 	// Collect pending Note texts for this block's thread as context.
@@ -148,11 +157,20 @@ async function reviewSingleBlock(
 	} );
 
 	if ( result?.suggestions && result.suggestions.length > 0 ) {
-		await createNote( block, postId, result.suggestions, existingNoteId );
-		return result.suggestions.length;
+		const { didLinkNoteId } = await createNote(
+			block,
+			postId,
+			result.suggestions,
+			existingNoteId
+		);
+
+		return {
+			suggestionCount: result.suggestions.length,
+			didLinkNoteId,
+		};
 	}
 
-	return 0;
+	return { suggestionCount: 0, didLinkNoteId: false };
 }
 
 /**
@@ -228,6 +246,7 @@ export function useEditorialNotes(): {
 			}
 
 			let totalSuggestions = 0;
+			let didLinkAnyNoteId = false;
 
 			// Process blocks in batches.
 			for (
@@ -252,7 +271,11 @@ export function useEditorialNotes(): {
 						)
 					)
 				);
-				totalSuggestions += results.reduce( ( sum, n ) => sum + n, 0 );
+
+				for ( const result of results ) {
+					totalSuggestions += result.suggestionCount;
+					didLinkAnyNoteId ||= result.didLinkNoteId;
+				}
 
 				setProgress(
 					Math.min( batchStart + BATCH_SIZE, reviewableBlocks.length )
@@ -262,6 +285,12 @@ export function useEditorialNotes(): {
 			setLastRunCount( totalSuggestions );
 
 			if ( totalSuggestions > 0 ) {
+				if ( didLinkAnyNoteId ) {
+					// Save once so newly linked noteIds survive reloads and later
+					// review/refinement passes.
+					await ( dispatch( editorStore ) as any ).savePost();
+				}
+
 				(
 					dispatch( coreStore ) as any
 				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
@@ -330,7 +359,7 @@ export function useEditorialBlock(): {
 				noteContentById.set( note.id, note.content?.rendered ?? '' );
 			}
 
-			const suggestionCount = await reviewSingleBlock(
+			const { suggestionCount, didLinkNoteId } = await reviewSingleBlock(
 				block,
 				postId,
 				content,
@@ -340,6 +369,12 @@ export function useEditorialBlock(): {
 			);
 
 			if ( suggestionCount > 0 ) {
+				if ( didLinkNoteId ) {
+					// Save once so newly linked noteIds survive reloads and later
+					// review/refinement passes.
+					await ( dispatch( editorStore ) as any ).savePost();
+				}
+
 				(
 					dispatch( coreStore ) as any
 				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
@@ -393,13 +428,14 @@ export function useEditorialBlock(): {
  * @param postId         The current post ID.
  * @param suggestions    The suggestions to include in the Note.
  * @param existingNoteId The ID of an existing Note thread, or null for a new thread.
+ * @return Whether a new Note thread was linked to the block.
  */
 async function createNote(
 	block: Block,
 	postId: number,
 	suggestions: Suggestion[],
 	existingNoteId: number | null
-): Promise< void > {
+): Promise< CreateNoteResult > {
 	const noteContent = suggestions
 		.map( ( s ) => `[${ s.review_type.toUpperCase() }] ${ s.text }` )
 		.join( '\n\n' );
@@ -430,5 +466,9 @@ async function createNote(
 				metadata: { ...existingMeta, noteId: note.id },
 			}
 		);
+
+		return { didLinkNoteId: true };
 	}
+
+	return { didLinkNoteId: false };
 }

--- a/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
+++ b/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
@@ -65,15 +65,6 @@ interface ReviewResult {
 	suggestions: Suggestion[];
 }
 
-interface ReviewSingleBlockResult {
-	suggestionCount: number;
-	didLinkNoteId: boolean;
-}
-
-interface CreateNoteResult {
-	didLinkNoteId: boolean;
-}
-
 interface NoteRecord {
 	id: number;
 	[ key: string ]: unknown;
@@ -88,7 +79,7 @@ interface NoteRecord {
  * @param resolvedNoteIds Set of Note IDs that have been resolved (approved).
  * @param noteContentById Map of Note ID → rendered Note content (pending only).
  * @param pendingNotes    All pending Notes for the post (for reply lookup).
- * @return The suggestion count and whether a new Note thread was linked.
+ * @return The number of suggestions created, or 0 if the block was skipped.
  */
 async function reviewSingleBlock(
 	block: Block,
@@ -97,19 +88,19 @@ async function reviewSingleBlock(
 	resolvedNoteIds: Set< number >,
 	noteContentById: Map< number, string >,
 	pendingNotes: ExistingNote[]
-): Promise< ReviewSingleBlockResult > {
+): Promise< number > {
 	// Look up any existing Note thread on this block.
 	const existingNoteId = block.attributes.metadata?.noteId ?? null;
 
 	// Skip blocks whose Note thread has been resolved.
 	if ( existingNoteId && resolvedNoteIds.has( existingNoteId ) ) {
-		return { suggestionCount: 0, didLinkNoteId: false };
+		return 0;
 	}
 
 	const blockText = getBlockText( block );
 
 	if ( blockText.length === 0 ) {
-		return { suggestionCount: 0, didLinkNoteId: false };
+		return 0;
 	}
 
 	// Collect pending Note texts for this block's thread as context.
@@ -157,20 +148,11 @@ async function reviewSingleBlock(
 	} );
 
 	if ( result?.suggestions && result.suggestions.length > 0 ) {
-		const { didLinkNoteId } = await createNote(
-			block,
-			postId,
-			result.suggestions,
-			existingNoteId
-		);
-
-		return {
-			suggestionCount: result.suggestions.length,
-			didLinkNoteId,
-		};
+		await createNote( block, postId, result.suggestions, existingNoteId );
+		return result.suggestions.length;
 	}
 
-	return { suggestionCount: 0, didLinkNoteId: false };
+	return 0;
 }
 
 /**
@@ -246,7 +228,6 @@ export function useEditorialNotes(): {
 			}
 
 			let totalSuggestions = 0;
-			let didLinkAnyNoteId = false;
 
 			// Process blocks in batches.
 			for (
@@ -271,11 +252,7 @@ export function useEditorialNotes(): {
 						)
 					)
 				);
-
-				for ( const result of results ) {
-					totalSuggestions += result.suggestionCount;
-					didLinkAnyNoteId ||= result.didLinkNoteId;
-				}
+				totalSuggestions += results.reduce( ( sum, n ) => sum + n, 0 );
 
 				setProgress(
 					Math.min( batchStart + BATCH_SIZE, reviewableBlocks.length )
@@ -285,12 +262,6 @@ export function useEditorialNotes(): {
 			setLastRunCount( totalSuggestions );
 
 			if ( totalSuggestions > 0 ) {
-				if ( didLinkAnyNoteId ) {
-					// Save once so newly linked noteIds survive reloads and later
-					// review/refinement passes.
-					await ( dispatch( editorStore ) as any ).savePost();
-				}
-
 				(
 					dispatch( coreStore ) as any
 				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
@@ -359,7 +330,7 @@ export function useEditorialBlock(): {
 				noteContentById.set( note.id, note.content?.rendered ?? '' );
 			}
 
-			const { suggestionCount, didLinkNoteId } = await reviewSingleBlock(
+			const suggestionCount = await reviewSingleBlock(
 				block,
 				postId,
 				content,
@@ -369,12 +340,6 @@ export function useEditorialBlock(): {
 			);
 
 			if ( suggestionCount > 0 ) {
-				if ( didLinkNoteId ) {
-					// Save once so newly linked noteIds survive reloads and later
-					// review/refinement passes.
-					await ( dispatch( editorStore ) as any ).savePost();
-				}
-
 				(
 					dispatch( coreStore ) as any
 				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
@@ -428,14 +393,13 @@ export function useEditorialBlock(): {
  * @param postId         The current post ID.
  * @param suggestions    The suggestions to include in the Note.
  * @param existingNoteId The ID of an existing Note thread, or null for a new thread.
- * @return Whether a new Note thread was linked to the block.
  */
 async function createNote(
 	block: Block,
 	postId: number,
 	suggestions: Suggestion[],
 	existingNoteId: number | null
-): Promise< CreateNoteResult > {
+): Promise< void > {
 	const noteContent = suggestions
 		.map( ( s ) => `[${ s.review_type.toUpperCase() }] ${ s.text }` )
 		.join( '\n\n' );
@@ -466,9 +430,5 @@ async function createNote(
 				metadata: { ...existingMeta, noteId: note.id },
 			}
 		);
-
-		return { didLinkNoteId: true };
 	}
-
-	return { didLinkNoteId: false };
 }

--- a/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
+++ b/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
@@ -265,6 +265,20 @@ export function useEditorialNotes(): {
 				(
 					dispatch( coreStore ) as any
 				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
+
+				( dispatch( noticesStore ) as any ).createSuccessNotice(
+					sprintf(
+						/* translators: %d: number of suggestions added. */
+						_n(
+							'%d suggestion added. Save to keep changes.',
+							'%d suggestions added. Save to keep changes.',
+							totalSuggestions,
+							'ai'
+						),
+						totalSuggestions
+					),
+					{ type: 'snackbar' }
+				);
 			}
 		} catch ( error: any ) {
 			( dispatch( noticesStore ) as any ).createErrorNotice(
@@ -350,8 +364,8 @@ export function useEditorialBlock(): {
 					sprintf(
 						/* translators: %d: number of suggestions added. */
 						_n(
-							'%d suggestion added.',
-							'%d suggestions added.',
+							'%d suggestion added. Save to keep changes.',
+							'%d suggestions added. Save to keep changes.',
 							suggestionCount,
 							'ai'
 						),

--- a/src/experiments/editorial-updates/components/EditorialUpdatesPlugin.tsx
+++ b/src/experiments/editorial-updates/components/EditorialUpdatesPlugin.tsx
@@ -63,6 +63,7 @@ export default function EditorialUpdatesPlugin() {
 							width: '100%',
 							justifyContent: 'center',
 						} }
+						accessibleWhenDisabled
 					>
 						{ buttonLabel }
 					</Button>

--- a/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
+++ b/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
@@ -99,6 +99,26 @@ export function useEditorialUpdates(): {
 			if ( ! postId ) {
 				return false;
 			}
+
+			// Collect Note IDs linked from block metadata, then check whether any are
+			// still pending. This avoids showing the action for stale Notes left behind
+			// after refreshing before the generated Note metadata was explicitly saved.
+			const allBlocks = sel( blockEditorStore ).getBlocks() as Block[];
+			const linkedNoteIds = Array.from(
+				new Set(
+					flattenBlocks( allBlocks )
+						.filter( ( block ) =>
+							REVIEWABLE_BLOCK_TYPES.includes( block.name )
+						)
+						.map( ( block ) => block.attributes.metadata?.noteId )
+						.filter( ( id ) => typeof id === 'number' )
+				)
+			);
+
+			if ( linkedNoteIds.length === 0 ) {
+				return false;
+			}
+
 			const notes = ( sel( coreStore ) as any ).getEntityRecords(
 				'root',
 				'comment',
@@ -106,6 +126,7 @@ export function useEditorialUpdates(): {
 					type: 'note',
 					status: 'hold',
 					post: postId,
+					include: Array.from( linkedNoteIds ),
 					per_page: 1,
 					_fields: 'id',
 				}

--- a/tests/e2e/specs/experiments/editorial-updates.spec.js
+++ b/tests/e2e/specs/experiments/editorial-updates.spec.js
@@ -232,8 +232,14 @@ test.describe( 'Editorial Updates Experiment', () => {
 
 		await admin.createNewPost( {
 			title: 'Grouped Editorial Controls Test',
-			content:
-				'This post has enough content to meet the minimum character requirement for the summarization feature and show the editor sidebar controls.',
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'This post has enough content to meet the minimum character requirement for the summarization feature and show the editor sidebar controls.',
+			},
 		} );
 		await editor.saveDraft();
 
@@ -295,6 +301,19 @@ test.describe( 'Editorial Updates Experiment', () => {
 
 		await page.reload();
 		await editor.openDocumentSettingsSidebar();
+
+		// Re-inject noteId after reload.
+		await page.evaluate( ( id ) => {
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+
+			window.wp.data
+				.dispatch( 'core/block-editor' )
+				.updateBlockAttributes( blocks[ 0 ].clientId, {
+					metadata: { noteId: id },
+				} );
+		}, noteId );
 
 		const notesButton = page.getByRole( 'button', {
 			name: 'Generate Editorial Notes',


### PR DESCRIPTION
## What?
Closes https://github.com/WordPress/ai/issues/678

This PR improves the Editorial Updates flow in two related ways:
1. Adds a concise save prompt to the Editorial Notes snackbar after suggestions are generated.
2. Updates the `Apply Editorial Updates` button state so it only appears when there is at least one pending Note still linked to a block in the current editor state.

## Why?
Blocks store their related Note IDs in block metadata. If a user generates Notes and then refreshes before saving the post, the Notes themselves can persist, but the block metadata linking those Notes back to their blocks is lost. There is an upstream issue for this behavior, and the long-term fix should come from that decision (Ref: https://github.com/WordPress/gutenberg/issues/72717). Until then, the UI should avoid implying that orphaned Notes can still be applied to content.

## How?
The snackbar now nudges users to save after suggestions are added, helping preserve the block-to-Note links. The Editorial Updates button now derives its visibility from an actionable state: it checks the current blocks for linked Note IDs and only shows when one of those linked Notes is still pending.

Together, these changes reduce confusion by prompting the user to save at the right moment and hiding the update action when there is no linked block Note to apply.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Initial code skeleton; final implementation was reviewed and edited by me.

## Testing Instructions
1. Create or open a post with reviewable content.
2. Generate Editorial Notes and confirm the Snackbar prompts saving.
3. Refresh the editor without saving the post.
4. Confirm Apply Editorial Updates is hidden when the generated Notes are no longer linked to blocks.

## Screencast

https://github.com/user-attachments/assets/f482575f-1593-4ef3-9941-7a4a3f05b1c3

## Changelog Entry

> Fixed - Clarify the Editorial Notes save prompt and only show Editorial Updates when pending Notes are linked to current blocks.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-682-94e2f53a11bdadf3a3b29a7f25b343aae2b2a787.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->