### PR TITLE
Add native vector search

### DIFF
--- a/includes/CLI/RAG_Command.php
+++ b/includes/CLI/RAG_Command.php
@@ -257,6 +257,35 @@ class RAG_Command {
 	}
 
 	/**
+	 * Deletes RAG index data.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--yes]
+	 * : Confirm deletion without prompting.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp ai rag cleanup --yes
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function cleanup( $args, $assoc_args ): void {
+		unset( $args );
+
+		if ( ! (bool) Utils\get_flag_value( $assoc_args, 'yes', false ) ) {
+			WP_CLI::confirm( 'Delete all RAG index data and scheduled indexing work?' );
+		}
+
+		$this->index_manager->cleanup_index_data();
+
+		WP_CLI::success( 'Deleted RAG index data.' );
+	}
+
+	/**
 	 * Ensures RAG indexing can run.
 	 *
 	 * @since 1.1.0

--- a/includes/CLI/RAG_Command.php
+++ b/includes/CLI/RAG_Command.php
@@ -1,0 +1,291 @@
+<?php
+/**
+ * WP-CLI utilities for RAG indexing.
+ *
+ * @package WordPress\AI
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\CLI;
+
+use WP_CLI;
+use WP_CLI\Utils;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages MariaDB vector RAG indexing utilities.
+ *
+ * @since 1.1.0
+ */
+class RAG_Command {
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Index manager.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Manager
+	 */
+	private Index_Manager $index_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability|null  $availability  Availability service.
+	 * @param \WordPress\AI\RAG\Index_Manager|null $index_manager Index manager.
+	 */
+	public function __construct( ?Availability $availability = null, ?Index_Manager $index_manager = null ) {
+		$this->availability  = $availability ?? new Availability();
+		$this->index_manager = $index_manager ?? new Index_Manager( $this->availability );
+	}
+
+	/**
+	 * Shows RAG index status.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp ai rag status
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function status( $args, $assoc_args ): void {
+		unset( $args, $assoc_args );
+
+		$available = $this->availability->is_available();
+		$table_ok  = $available && $this->index_manager->ensure_index_table();
+		$counts    = $this->index_manager->get_status_counts();
+		$scheduled = $this->index_manager->get_next_scheduled_indexing();
+
+		WP_CLI::log( 'RAG search status:' );
+		WP_CLI::log( sprintf( '  Available: %s', $available ? 'yes' : 'no' ) );
+
+		if ( ! $available ) {
+			WP_CLI::log( sprintf( '  Reason: %s', $this->availability->get_unavailable_reason() ) );
+		}
+
+		WP_CLI::log( sprintf( '  Index table: %s', $table_ok ? 'present' : 'missing' ) );
+		WP_CLI::log( sprintf( '  Dirty: %d', $counts[ Index_Manager::STATUS_DIRTY ] ?? 0 ) );
+		WP_CLI::log( sprintf( '  Processing: %d', $counts[ Index_Manager::STATUS_PROCESSING ] ?? 0 ) );
+		WP_CLI::log( sprintf( '  Clean: %d', $counts[ Index_Manager::STATUS_CLEAN ] ?? 0 ) );
+		WP_CLI::log( sprintf( '  Error: %d', $counts[ Index_Manager::STATUS_ERROR ] ?? 0 ) );
+		WP_CLI::log(
+			sprintf(
+				'  Next scheduled run: %s',
+				null === $scheduled ? 'none' : gmdate( 'Y-m-d H:i:s', $scheduled ) . ' UTC'
+			)
+		);
+	}
+
+	/**
+	 * Marks eligible posts as dirty.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--ids=<ids>]
+	 * : Comma-separated list of post IDs to mark dirty. Defaults to all eligible posts.
+	 *
+	 * [--limit=<number>]
+	 * : Maximum number of eligible posts to mark when --ids is not supplied.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Mark all eligible posts/pages dirty
+	 *     $ wp ai rag mark-dirty
+	 *
+	 *     # Mark selected posts dirty
+	 *     $ wp ai rag mark-dirty --ids=42,99
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function mark_dirty( $args, $assoc_args ): void {
+		unset( $args );
+
+		$this->ensure_available();
+
+		$ids   = $this->parse_ids_flag( (string) Utils\get_flag_value( $assoc_args, 'ids', '' ) );
+		$limit = max( 0, (int) Utils\get_flag_value( $assoc_args, 'limit', 0 ) );
+		$stats = $this->index_manager->mark_posts_dirty_for_indexing( $ids, $limit );
+
+		WP_CLI::success(
+			sprintf(
+				'Marked %d post(s) dirty. Skipped %d, removed %d from the index.',
+				$stats['marked'],
+				$stats['skipped'],
+				$stats['removed']
+			)
+		);
+	}
+
+	/**
+	 * Runs RAG indexing immediately.
+	 *
+	 * Processes dirty posts synchronously. Use `mark-dirty` first to bootstrap
+	 * an initial index for existing content.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--batch-size=<number>]
+	 * : Number of dirty posts to process per batch.
+	 * ---
+	 * default: 50
+	 * ---
+	 *
+	 * [--all]
+	 * : Continue running batches until no dirty posts remain.
+	 *
+	 * [--schedule]
+	 * : Schedule a follow-up cron event if dirty posts remain.
+	 * ---
+	 * default: true
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Process one dirty-post batch now
+	 *     $ wp ai rag index
+	 *
+	 *     # Process all dirty posts now
+	 *     $ wp ai rag index --all
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function index( $args, $assoc_args ): void {
+		unset( $args );
+
+		$this->ensure_available();
+
+		$batch_size    = max( 1, min( 200, (int) Utils\get_flag_value( $assoc_args, 'batch-size', 50 ) ) );
+		$process_all   = (bool) Utils\get_flag_value( $assoc_args, 'all', false );
+		$schedule_tail = (bool) Utils\get_flag_value( $assoc_args, 'schedule', true );
+
+		$totals = array(
+			'processed' => 0,
+			'clean'     => 0,
+			'error'     => 0,
+			'removed'   => 0,
+			'remaining' => 0,
+		);
+
+		do {
+			$stats = $this->index_manager->run_indexing_batch( $batch_size, $schedule_tail && ! $process_all );
+
+			if ( is_wp_error( $stats ) ) {
+				WP_CLI::error( $stats->get_error_message() );
+				return;
+			}
+
+			foreach ( array( 'processed', 'clean', 'error', 'removed' ) as $key ) {
+				$totals[ $key ] += $stats[ $key ];
+			}
+			$totals['remaining'] = $stats['remaining'];
+
+			WP_CLI::log(
+				sprintf(
+					'Processed %d post(s): %d clean, %d error, %d removed. %d dirty post(s) remain.',
+					$stats['processed'],
+					$stats['clean'],
+					$stats['error'],
+					$stats['removed'],
+					$stats['remaining']
+				)
+			);
+		} while ( $process_all && $totals['remaining'] > 0 );
+
+		WP_CLI::success(
+			sprintf(
+				'RAG indexing complete for %d post(s): %d clean, %d error, %d removed. %d dirty post(s) remain.',
+				$totals['processed'],
+				$totals['clean'],
+				$totals['error'],
+				$totals['removed'],
+				$totals['remaining']
+			)
+		);
+	}
+
+	/**
+	 * Schedules the RAG indexing cron event.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--delay=<seconds>]
+	 * : Delay before the event runs.
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     $ wp ai rag schedule
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function schedule( $args, $assoc_args ): void {
+		unset( $args );
+
+		$this->ensure_available();
+
+		$delay = max( 1, (int) Utils\get_flag_value( $assoc_args, 'delay', 1 ) );
+		$this->index_manager->schedule_indexing( $delay );
+
+		WP_CLI::success( sprintf( 'Scheduled RAG indexing in %d second(s).', $delay ) );
+	}
+
+	/**
+	 * Ensures RAG indexing can run.
+	 *
+	 * @since 1.1.0
+	 */
+	private function ensure_available(): void {
+		if ( ! $this->availability->is_available() ) {
+			WP_CLI::error( $this->availability->get_unavailable_reason() );
+			return;
+		}
+
+		if ( $this->index_manager->ensure_index_table() ) {
+			return;
+		}
+
+		WP_CLI::error( 'The RAG index table could not be created.' );
+	}
+
+	/**
+	 * Parses a comma-separated ID flag.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $ids_flag Comma-separated IDs.
+	 * @return list<int> IDs.
+	 */
+	private function parse_ids_flag( string $ids_flag ): array {
+		if ( '' === trim( $ids_flag ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( array_map( 'absint', explode( ',', $ids_flag ) ) ) );
+	}
+}

--- a/includes/CLI/RAG_Command.php
+++ b/includes/CLI/RAG_Command.php
@@ -66,10 +66,10 @@ class RAG_Command {
 	public function status( $args, $assoc_args ): void {
 		unset( $args, $assoc_args );
 
-		$available = $this->availability->is_available();
+		$available  = $this->availability->is_available();
 		$storage_ok = $available && $this->index_manager->ensure_index_storage();
-		$counts    = $this->index_manager->get_status_counts();
-		$scheduled = $this->index_manager->get_next_scheduled_indexing();
+		$counts     = $this->index_manager->get_status_counts();
+		$scheduled  = $this->index_manager->get_next_scheduled_indexing();
 
 		WP_CLI::log( 'RAG search status:' );
 		WP_CLI::log( sprintf( '  Available: %s', $available ? 'yes' : 'no' ) );

--- a/includes/CLI/RAG_Command.php
+++ b/includes/CLI/RAG_Command.php
@@ -19,7 +19,7 @@ use WordPress\AI\RAG\Index_Manager;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Manages MariaDB vector RAG indexing utilities.
+ * Manages RAG indexing utilities.
  *
  * @since 1.1.0
  */
@@ -67,18 +67,19 @@ class RAG_Command {
 		unset( $args, $assoc_args );
 
 		$available = $this->availability->is_available();
-		$table_ok  = $available && $this->index_manager->ensure_index_table();
+		$storage_ok = $available && $this->index_manager->ensure_index_storage();
 		$counts    = $this->index_manager->get_status_counts();
 		$scheduled = $this->index_manager->get_next_scheduled_indexing();
 
 		WP_CLI::log( 'RAG search status:' );
 		WP_CLI::log( sprintf( '  Available: %s', $available ? 'yes' : 'no' ) );
+		WP_CLI::log( sprintf( '  Backend: %s', $this->availability->get_index_backend_label() ) );
 
 		if ( ! $available ) {
 			WP_CLI::log( sprintf( '  Reason: %s', $this->availability->get_unavailable_reason() ) );
 		}
 
-		WP_CLI::log( sprintf( '  Index table: %s', $table_ok ? 'present' : 'missing' ) );
+		WP_CLI::log( sprintf( '  Index storage: %s', $storage_ok ? 'ready' : 'missing' ) );
 		WP_CLI::log( sprintf( '  Dirty: %d', $counts[ Index_Manager::STATUS_DIRTY ] ?? 0 ) );
 		WP_CLI::log( sprintf( '  Processing: %d', $counts[ Index_Manager::STATUS_PROCESSING ] ?? 0 ) );
 		WP_CLI::log( sprintf( '  Clean: %d', $counts[ Index_Manager::STATUS_CLEAN ] ?? 0 ) );
@@ -266,11 +267,11 @@ class RAG_Command {
 			return;
 		}
 
-		if ( $this->index_manager->ensure_index_table() ) {
+		if ( $this->index_manager->ensure_index_storage() ) {
 			return;
 		}
 
-		WP_CLI::error( 'The RAG index table could not be created.' );
+		WP_CLI::error( 'The RAG index storage could not be prepared.' );
 	}
 
 	/**

--- a/includes/Experiments/Experiments.php
+++ b/includes/Experiments/Experiments.php
@@ -40,6 +40,7 @@ final class Experiments {
 		\WordPress\AI\Experiments\Summarization\Summarization::class,
 		\WordPress\AI\Experiments\Title_Generation\Title_Generation::class,
 		\WordPress\AI\Experiments\Comment_Moderation\Comment_Moderation::class,
+		\WordPress\AI\Experiments\RAG_Search\RAG_Search::class,
 	);
 
 	/**

--- a/includes/Experiments/RAG_Search/RAG_Search.php
+++ b/includes/Experiments/RAG_Search/RAG_Search.php
@@ -120,7 +120,7 @@ class RAG_Search extends Abstract_Feature {
 		$fields = array(
 			array(
 				'id'      => 'augment_search',
-				'label'   => __( 'Augment WordPress search results', 'ai' ),
+				'label'   => __( 'Augment WordPress search page results with semantic search', 'ai' ),
 				'type'    => 'boolean',
 				'default' => self::DEFAULT_AUGMENT_SEARCH,
 			),
@@ -224,8 +224,8 @@ class RAG_Search extends Abstract_Feature {
 	 */
 	private function get_backend_field_elements( array $backends ): array {
 		$labels = array(
-			Availability::BACKEND_MARIADB => __( 'MariaDB vector index', 'ai' ),
-			Availability::BACKEND_MEMORY  => __( 'Memory exact scan', 'ai' ),
+			Availability::BACKEND_MARIADB => __( 'Optimal search method backed by MariaDB', 'ai' ),
+			Availability::BACKEND_MEMORY  => __( 'Fallback in-memory search backed by PHP', 'ai' ),
 		);
 
 		$elements = array();

--- a/includes/Experiments/RAG_Search/RAG_Search.php
+++ b/includes/Experiments/RAG_Search/RAG_Search.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * MariaDB vector RAG search experiment.
+ *
+ * @package WordPress\AI\Experiments\RAG_Search
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\RAG_Search;
+
+use WordPress\AI\Abstracts\Abstract_Feature;
+use WordPress\AI\CLI\RAG_Command;
+use WordPress\AI\Experiments\Experiment_Category;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\REST\RAG_Search_Controller;
+use WordPress\AI\RAG\Search_Augmenter;
+use WordPress\AI\Settings\Settings_Registration;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds semantic RAG search backed by MariaDB vector indexes.
+ *
+ * @since 1.1.0
+ */
+class RAG_Search extends Abstract_Feature {
+	/**
+	 * Default search augmentation setting.
+	 */
+	private const DEFAULT_AUGMENT_SEARCH = false;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_id(): string {
+		return 'rag-search';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function load_metadata(): array {
+		return array(
+			'label'       => __( 'RAG Search', 'ai' ),
+			'description' => __( 'Semantic search using OpenAI embeddings and native MariaDB 11.8+ vector indexes.', 'ai' ),
+			'category'    => Experiment_Category::ADMIN,
+			'capability'  => 'embedding_generation',
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): void {
+		$availability = new Availability();
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( 'ai rag', RAG_Command::class );
+		}
+
+		if ( ! $availability->is_available() ) {
+			add_action( 'admin_notices', array( $this, 'render_unavailable_notice' ) );
+			return;
+		}
+
+		$index_manager = new Index_Manager( $availability );
+		$index_manager->init();
+
+		( new RAG_Search_Controller( $availability ) )->init();
+
+		if ( ! $this->is_search_augmentation_enabled() ) {
+			return;
+		}
+
+		( new Search_Augmenter() )->init();
+	}
+
+	/**
+	 * Registers feature settings.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register_settings(): void {
+		register_setting(
+			Settings_Registration::OPTION_GROUP,
+			static::get_field_option_name( 'augment_search' ),
+			array(
+				'type'              => 'boolean',
+				'default'           => self::DEFAULT_AUGMENT_SEARCH,
+				'sanitize_callback' => 'rest_sanitize_boolean',
+				'show_in_rest'      => true,
+			)
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_settings_fields(): array {
+		return array(
+			array(
+				'id'      => 'augment_search',
+				'label'   => __( 'Augment WordPress search results', 'ai' ),
+				'type'    => 'boolean',
+				'default' => self::DEFAULT_AUGMENT_SEARCH,
+			),
+		);
+	}
+
+	/**
+	 * Returns whether front-end search should be augmented.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when enabled.
+	 */
+	public function is_search_augmentation_enabled(): bool {
+		return (bool) get_option( static::get_field_option_name( 'augment_search' ), self::DEFAULT_AUGMENT_SEARCH );
+	}
+
+	/**
+	 * Renders an admin notice when requirements are unmet.
+	 *
+	 * @since 1.1.0
+	 */
+	public function render_unavailable_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$availability = new Availability();
+		$message      = $availability->get_unavailable_reason();
+
+		if ( '' === $message ) {
+			return;
+		}
+
+		printf(
+			'<div class="notice notice-warning"><p>%s</p></div>',
+			esc_html(
+				sprintf(
+					/* translators: %s: Unavailable reason. */
+					__( 'RAG Search is enabled but inactive: %s', 'ai' ),
+					$message
+				)
+			)
+		);
+	}
+}

--- a/includes/Experiments/RAG_Search/RAG_Search.php
+++ b/includes/Experiments/RAG_Search/RAG_Search.php
@@ -15,6 +15,7 @@ use WordPress\AI\CLI\RAG_Command;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\REST\RAG_Maintenance_Controller;
 use WordPress\AI\RAG\REST\RAG_Search_Controller;
 use WordPress\AI\RAG\Related_Posts;
 use WordPress\AI\RAG\Search_Augmenter;
@@ -32,6 +33,11 @@ class RAG_Search extends Abstract_Feature {
 	 * Default search augmentation setting.
 	 */
 	private const DEFAULT_AUGMENT_SEARCH = false;
+
+	/**
+	 * Tracks WP-CLI command registration.
+	 */
+	private static bool $cli_registered = false;
 
 	/**
 	 * {@inheritDoc}
@@ -58,9 +64,7 @@ class RAG_Search extends Abstract_Feature {
 	public function register(): void {
 		$availability = $this->create_availability();
 
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			\WP_CLI::add_command( 'ai rag', RAG_Command::class );
-		}
+		$this->register_cli_command();
 
 		if ( ! $availability->is_available() ) {
 			add_action( 'admin_notices', array( $this, 'render_unavailable_notice' ) );
@@ -89,6 +93,9 @@ class RAG_Search extends Abstract_Feature {
 	 */
 	public function register_settings(): void {
 		$availability = $this->create_availability();
+
+		$this->register_cli_command();
+		( new RAG_Maintenance_Controller( $availability ) )->init();
 
 		register_setting(
 			Settings_Registration::OPTION_GROUP,
@@ -141,7 +148,7 @@ class RAG_Search extends Abstract_Feature {
 					'label'    => __( 'RAG backend', 'ai' ),
 					'type'     => 'text',
 					'default'  => $availability->get_default_index_backend(),
-					'elements' => $this->get_backend_field_elements( $backends ),
+					'elements' => $this->get_backend_field_elements( $availability, $backends ),
 				)
 			);
 		}
@@ -233,16 +240,14 @@ class RAG_Search extends Abstract_Feature {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param list<string> $backends Available backends.
+	 * @param \WordPress\AI\RAG\Availability $availability Availability service.
+	 * @param list<string>                    $backends     Available backends.
 	 * @return list<array{value: string, label: string}> Backend field elements.
 	 */
-	private function get_backend_field_elements( array $backends ): array {
-		$labels = array(
-			Availability::BACKEND_MARIADB => __( 'Optimal search method backed by MariaDB', 'ai' ),
-			Availability::BACKEND_MEMORY  => __( 'Fallback in-memory search backed by PHP', 'ai' ),
-		);
-
+	private function get_backend_field_elements( Availability $availability, array $backends ): array {
+		$labels   = $availability->get_index_backend_labels();
 		$elements = array();
+
 		foreach ( $backends as $backend ) {
 			if ( ! isset( $labels[ $backend ] ) ) {
 				continue;
@@ -255,5 +260,19 @@ class RAG_Search extends Abstract_Feature {
 		}
 
 		return $elements;
+	}
+
+	/**
+	 * Registers the WP-CLI command once.
+	 *
+	 * @since 1.1.0
+	 */
+	private function register_cli_command(): void {
+		if ( self::$cli_registered || ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		\WP_CLI::add_command( 'ai rag', RAG_Command::class );
+		self::$cli_registered = true;
 	}
 }

--- a/includes/Experiments/RAG_Search/RAG_Search.php
+++ b/includes/Experiments/RAG_Search/RAG_Search.php
@@ -10,11 +10,13 @@ declare( strict_types=1 );
 namespace WordPress\AI\Experiments\RAG_Search;
 
 use WordPress\AI\Abstracts\Abstract_Feature;
+use WordPress\AI\Asset_Loader;
 use WordPress\AI\CLI\RAG_Command;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
 use WordPress\AI\RAG\REST\RAG_Search_Controller;
+use WordPress\AI\RAG\Related_Posts;
 use WordPress\AI\RAG\Search_Augmenter;
 use WordPress\AI\Settings\Settings_Registration;
 
@@ -69,6 +71,9 @@ class RAG_Search extends Abstract_Feature {
 		$index_manager->init();
 
 		( new RAG_Search_Controller( $availability ) )->init();
+		( new Related_Posts() )->init();
+
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 
 		if ( ! $this->is_search_augmentation_enabled() ) {
 			return;
@@ -172,6 +177,15 @@ class RAG_Search extends Abstract_Feature {
 	 */
 	public function is_search_augmentation_enabled(): bool {
 		return (bool) get_option( static::get_field_option_name( 'augment_search' ), self::DEFAULT_AUGMENT_SEARCH );
+	}
+
+	/**
+	 * Enqueues the Related Posts Query Loop variation in block editors.
+	 *
+	 * @since 1.1.0
+	 */
+	public function enqueue_editor_assets(): void {
+		Asset_Loader::enqueue_script( 'rag_search', 'experiments/rag-search' );
 	}
 
 	/**

--- a/includes/Experiments/RAG_Search/RAG_Search.php
+++ b/includes/Experiments/RAG_Search/RAG_Search.php
@@ -21,7 +21,7 @@ use WordPress\AI\Settings\Settings_Registration;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Adds semantic RAG search backed by MariaDB vector indexes.
+ * Adds semantic RAG search backed by MariaDB vector indexes or compact exact scan.
  *
  * @since 1.1.0
  */
@@ -44,7 +44,7 @@ class RAG_Search extends Abstract_Feature {
 	protected function load_metadata(): array {
 		return array(
 			'label'       => __( 'RAG Search', 'ai' ),
-			'description' => __( 'Semantic search using OpenAI embeddings and native MariaDB 11.8+ vector indexes.', 'ai' ),
+			'description' => __( 'Semantic search using OpenAI embeddings with native MariaDB vector indexes or a compact exact-scan fallback.', 'ai' ),
 			'category'    => Experiment_Category::ADMIN,
 			'capability'  => 'embedding_generation',
 		);
@@ -54,7 +54,7 @@ class RAG_Search extends Abstract_Feature {
 	 * {@inheritDoc}
 	 */
 	public function register(): void {
-		$availability = new Availability();
+		$availability = $this->create_availability();
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'ai rag', RAG_Command::class );
@@ -83,6 +83,24 @@ class RAG_Search extends Abstract_Feature {
 	 * @since 1.1.0
 	 */
 	public function register_settings(): void {
+		$availability = $this->create_availability();
+
+		register_setting(
+			Settings_Registration::OPTION_GROUP,
+			Availability::BACKEND_OPTION,
+			array(
+				'type'              => 'string',
+				'default'           => $availability->get_default_index_backend(),
+				'sanitize_callback' => array( $this, 'sanitize_backend' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type' => 'string',
+						'enum' => array( Availability::BACKEND_MARIADB, Availability::BACKEND_MEMORY ),
+					),
+				),
+			)
+		);
+
 		register_setting(
 			Settings_Registration::OPTION_GROUP,
 			static::get_field_option_name( 'augment_search' ),
@@ -99,7 +117,7 @@ class RAG_Search extends Abstract_Feature {
 	 * {@inheritDoc}
 	 */
 	public function get_settings_fields(): array {
-		return array(
+		$fields = array(
 			array(
 				'id'      => 'augment_search',
 				'label'   => __( 'Augment WordPress search results', 'ai' ),
@@ -107,6 +125,42 @@ class RAG_Search extends Abstract_Feature {
 				'default' => self::DEFAULT_AUGMENT_SEARCH,
 			),
 		);
+
+		$availability = $this->create_availability();
+		$backends     = $availability->get_available_index_backends();
+		if ( count( $backends ) > 1 ) {
+			array_unshift(
+				$fields,
+				array(
+					'id'       => 'backend',
+					'label'    => __( 'RAG backend', 'ai' ),
+					'type'     => 'text',
+					'default'  => $availability->get_default_index_backend(),
+					'elements' => $this->get_backend_field_elements( $backends ),
+				)
+			);
+		}
+
+		return $fields;
+	}
+
+	/**
+	 * Sanitizes the backend setting.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $value Raw backend value.
+	 * @return string Sanitized backend.
+	 */
+	public function sanitize_backend( $value ): string {
+		$value        = is_string( $value ) ? $value : '';
+		$availability = $this->create_availability();
+
+		if ( in_array( $value, $availability->get_available_index_backends(), true ) ) {
+			return $value;
+		}
+
+		return $availability->get_default_index_backend();
 	}
 
 	/**
@@ -130,7 +184,7 @@ class RAG_Search extends Abstract_Feature {
 			return;
 		}
 
-		$availability = new Availability();
+		$availability = $this->create_availability();
 		$message      = $availability->get_unavailable_reason();
 
 		if ( '' === $message ) {
@@ -147,5 +201,45 @@ class RAG_Search extends Abstract_Feature {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Creates the availability service.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Availability Availability service.
+	 */
+	protected function create_availability(): Availability {
+		return new Availability();
+	}
+
+	/**
+	 * Returns backend selector elements.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<string> $backends Available backends.
+	 * @return list<array{value: string, label: string}> Backend field elements.
+	 */
+	private function get_backend_field_elements( array $backends ): array {
+		$labels = array(
+			Availability::BACKEND_MARIADB => __( 'MariaDB vector index', 'ai' ),
+			Availability::BACKEND_MEMORY  => __( 'Memory exact scan', 'ai' ),
+		);
+
+		$elements = array();
+		foreach ( $backends as $backend ) {
+			if ( ! isset( $labels[ $backend ] ) ) {
+				continue;
+			}
+
+			$elements[] = array(
+				'value' => $backend,
+				'label' => $labels[ $backend ],
+			);
+		}
+
+		return $elements;
 	}
 }

--- a/includes/RAG/Availability.php
+++ b/includes/RAG/Availability.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Availability checks for MariaDB vector RAG search.
+ * Availability coordinator for RAG search.
  *
  * @package WordPress\AI\RAG
  */
@@ -9,22 +9,14 @@ declare( strict_types=1 );
 
 namespace WordPress\AI\RAG;
 
-use Throwable;
-use function WordPress\AI\has_connector_authentication;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Determines whether native MariaDB vector search can be used.
+ * Determines whether RAG search can run by coordinating backends and embeddings.
  *
  * @since 1.1.0
  */
 class Availability {
-	/**
-	 * OpenAI connector identifier.
-	 */
-	public const OPENAI_CONNECTOR_ID = 'openai';
-
 	/**
 	 * MariaDB vector index backend.
 	 */
@@ -41,14 +33,18 @@ class Availability {
 	public const BACKEND_OPTION = 'wpai_feature_rag-search_field_backend';
 
 	/**
-	 * Required MariaDB version for VECTOR INDEX support.
+	 * Index backends keyed by ID.
+	 *
+	 * @var array<string, \WordPress\AI\RAG\Index_Backend_Interface>
 	 */
-	private const MINIMUM_MARIADB_VERSION = '11.8.0';
+	private array $backends;
 
 	/**
-	 * Required embedding model.
+	 * Embedding client.
+	 *
+	 * @var \WordPress\AI\RAG\OpenAI_Embedding_Client
 	 */
-	private const EMBEDDING_MODEL = 'text-embedding-3-small';
+	private OpenAI_Embedding_Client $embedding_client;
 
 	/**
 	 * Cached availability state.
@@ -65,11 +61,29 @@ class Availability {
 	private string $unavailable_reason = '';
 
 	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<\WordPress\AI\RAG\Index_Backend_Interface>|null $backends         Index backends.
+	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null       $embedding_client Embedding client.
+	 */
+	public function __construct( ?array $backends = null, ?OpenAI_Embedding_Client $embedding_client = null ) {
+		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client();
+		$this->backends         = $this->normalize_backends(
+			$backends ?? array(
+				new MariaDB_Index_Backend(),
+				new Memory_Index_Backend(),
+			)
+		);
+	}
+
+	/**
 	 * Checks whether the feature can run on this site.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return bool True when all runtime requirements are met.
+	 * @return bool True when runtime requirements are met.
 	 */
 	public function is_available(): bool {
 		if ( null !== $this->available ) {
@@ -77,19 +91,13 @@ class Availability {
 		}
 
 		if ( empty( $this->get_available_index_backends() ) ) {
-			$this->unavailable_reason = __( 'MariaDB 11.8 or newer is required when the compact memory fallback is disabled.', 'ai' );
+			$this->unavailable_reason = $this->get_backend_unavailable_reason();
 			$this->available          = false;
 			return false;
 		}
 
-		if ( ! $this->has_openai_connector_authentication() ) {
-			$this->unavailable_reason = __( 'The OpenAI connector must be active and authenticated to generate embeddings.', 'ai' );
-			$this->available          = false;
-			return false;
-		}
-
-		if ( ! $this->supports_openai_embeddings() ) {
-			$this->unavailable_reason = __( 'RAG Search currently supports OpenAI text-embedding-3-small embeddings only.', 'ai' );
+		if ( ! $this->embedding_client->is_available() ) {
+			$this->unavailable_reason = $this->embedding_client->get_unavailable_reason();
 			$this->available          = false;
 			return false;
 		}
@@ -121,9 +129,23 @@ class Availability {
 	 * @return bool True when VECTOR INDEX should be available.
 	 */
 	public function is_mariadb_vector_index_supported(): bool {
-		$version = $this->get_database_version();
+		$backend = $this->backends[ self::BACKEND_MARIADB ] ?? null;
 
-		return $this->is_supported_mariadb_version( $version );
+		return $backend instanceof MariaDB_Index_Backend && $backend->is_mariadb_vector_index_supported();
+	}
+
+	/**
+	 * Checks a raw MariaDB version string.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $version Raw SELECT VERSION() value.
+	 * @return bool True when supported.
+	 */
+	public function is_supported_mariadb_version( string $version ): bool {
+		$backend = $this->backends[ self::BACKEND_MARIADB ] ?? new MariaDB_Index_Backend();
+
+		return $backend instanceof MariaDB_Index_Backend && $backend->is_supported_mariadb_version( $version );
 	}
 
 	/**
@@ -145,6 +167,19 @@ class Availability {
 	}
 
 	/**
+	 * Returns the active backend object.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Index_Backend_Interface Backend.
+	 */
+	public function get_index_backend_instance(): Index_Backend_Interface {
+		$backend_id = $this->get_index_backend();
+
+		return $this->backends[ $backend_id ] ?? $this->backends[ self::BACKEND_MARIADB ];
+	}
+
+	/**
 	 * Returns available concrete index backends.
 	 *
 	 * @since 1.1.0
@@ -152,17 +187,17 @@ class Availability {
 	 * @return list<string> Backend identifiers.
 	 */
 	public function get_available_index_backends(): array {
-		$backends = array();
+		$available = array();
 
-		if ( $this->is_mariadb_vector_index_supported() ) {
-			$backends[] = self::BACKEND_MARIADB;
+		foreach ( $this->backends as $backend ) {
+			if ( ! $backend->is_available() ) {
+				continue;
+			}
+
+			$available[] = $backend->get_id();
 		}
 
-		if ( $this->is_memory_fallback_enabled() ) {
-			$backends[] = self::BACKEND_MEMORY;
-		}
-
-		return $backends;
+		return $available;
 	}
 
 	/**
@@ -190,33 +225,7 @@ class Availability {
 	 * @return string Backend label.
 	 */
 	public function get_index_backend_label(): string {
-		if ( self::BACKEND_MEMORY === $this->get_index_backend() ) {
-			return __( 'Fallback in-memory search backed by PHP', 'ai' );
-		}
-
-		return __( 'Optimal search method backed by MariaDB', 'ai' );
-	}
-
-	/**
-	 * Checks a raw database version string.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param string $version Raw SELECT VERSION() value.
-	 * @return bool True when supported.
-	 */
-	public function is_supported_mariadb_version( string $version ): bool {
-		if ( false === stripos( $version, 'mariadb' ) ) {
-			return false;
-		}
-
-		$version = preg_replace( '/^5\.5\.5-/', '', $version ) ?? $version;
-
-		if ( ! preg_match( '/(\d+\.\d+(?:\.\d+)?)/', $version, $matches ) ) {
-			return false;
-		}
-
-		return version_compare( $matches[1], self::MINIMUM_MARIADB_VERSION, '>=' );
+		return $this->get_index_backend_instance()->get_label();
 	}
 
 	/**
@@ -227,16 +236,7 @@ class Availability {
 	 * @return string Embedding model ID.
 	 */
 	public function get_embedding_model(): string {
-		/**
-		 * Filters the OpenAI embedding model used for MariaDB RAG indexing.
-		 *
-		 * The table schema in this release is fixed to 1536 dimensions.
-		 *
-		 * @since 1.1.0
-		 *
-		 * @param string $model OpenAI embedding model.
-		 */
-		return (string) apply_filters( 'wpai_rag_embedding_model', self::EMBEDDING_MODEL );
+		return $this->embedding_client->get_model();
 	}
 
 	/**
@@ -247,50 +247,74 @@ class Availability {
 	 * @return int Dimension count.
 	 */
 	public function get_embedding_dimensions(): int {
-		return 1536;
+		return $this->embedding_client->get_dimensions();
 	}
 
 	/**
-	 * Reads the database version string.
+	 * Creates the active repository.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return string Version string.
+	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
 	 */
-	protected function get_database_version(): string {
-		global $wpdb;
-
-		$version = $wpdb->get_var( 'SELECT VERSION()' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-
-		return is_string( $version ) ? $version : '';
+	public function create_index_repository(): Index_Repository_Interface {
+		return $this->get_index_backend_instance()->create_repository( $this->get_embedding_dimensions() );
 	}
 
 	/**
-	 * Checks that the OpenAI connector is active and has credentials.
+	 * Ensures active backend storage is ready.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return bool True when OpenAI can be authenticated.
+	 * @return bool True when ready.
 	 */
-	private function has_openai_connector_authentication(): bool {
-		try {
-			return function_exists( 'wp_is_connector_registered' )
-				&& wp_is_connector_registered( self::OPENAI_CONNECTOR_ID )
-				&& has_connector_authentication( self::OPENAI_CONNECTOR_ID );
-		} catch ( Throwable $e ) {
-			return false;
+	public function ensure_index_storage(): bool {
+		return $this->get_index_backend_instance()->ensure_storage();
+	}
+
+	/**
+	 * Checks whether any backend has stored data.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when RAG data exists.
+	 */
+	public function has_index_data(): bool {
+		foreach ( $this->backends as $backend ) {
+			if ( $backend->has_index_data() ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Deletes backend-specific RAG index data.
+	 *
+	 * @since 1.1.0
+	 */
+	public function cleanup_index_backends(): void {
+		foreach ( $this->backends as $backend ) {
+			$backend->cleanup();
 		}
 	}
 
 	/**
-	 * Checks whether the configured OpenAI embedding model matches the fixed schema.
+	 * Returns available backend labels keyed by backend ID.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return bool True when the configured model uses the expected dimensions.
+	 * @return array<string, string> Labels.
 	 */
-	private function supports_openai_embeddings(): bool {
-		return self::EMBEDDING_MODEL === $this->get_embedding_model();
+	public function get_index_backend_labels(): array {
+		$labels = array();
+
+		foreach ( $this->backends as $backend ) {
+			$labels[ $backend->get_id() ] = $backend->get_label();
+		}
+
+		return $labels;
 	}
 
 	/**
@@ -306,7 +330,7 @@ class Availability {
 			return $this->get_default_index_backend();
 		}
 
-		if ( in_array( $preferred, array( self::BACKEND_MARIADB, self::BACKEND_MEMORY ), true ) ) {
+		if ( isset( $this->backends[ $preferred ] ) ) {
 			return $preferred;
 		}
 
@@ -314,20 +338,48 @@ class Availability {
 	}
 
 	/**
-	 * Checks whether the compact memory fallback is enabled.
+	 * Normalizes backend list.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return bool True when enabled.
+	 * @param list<\WordPress\AI\RAG\Index_Backend_Interface> $backends Backends.
+	 * @return array<string, \WordPress\AI\RAG\Index_Backend_Interface>
 	 */
-	private function is_memory_fallback_enabled(): bool {
-		/**
-		 * Filters whether RAG should use compact in-memory exact scan when MariaDB vector indexes are unavailable.
-		 *
-		 * @since 1.1.0
-		 *
-		 * @param bool $enabled Whether the fallback backend is enabled.
-		 */
-		return (bool) apply_filters( 'wpai_rag_memory_fallback_enabled', true );
+	private function normalize_backends( array $backends ): array {
+		$normalized = array();
+
+		foreach ( $backends as $backend ) {
+			$normalized[ $backend->get_id() ] = $backend;
+		}
+
+		if ( ! isset( $normalized[ self::BACKEND_MARIADB ] ) ) {
+			$normalized[ self::BACKEND_MARIADB ] = new MariaDB_Index_Backend();
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Builds an unavailable reason from backend state.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Reason.
+	 */
+	private function get_backend_unavailable_reason(): string {
+		$reasons = array();
+
+		foreach ( $this->backends as $backend ) {
+			$reason = $backend->get_unavailable_reason();
+			if ( '' === $reason ) {
+				continue;
+			}
+
+			$reasons[] = $reason;
+		}
+
+		return empty( $reasons )
+			? __( 'No RAG index backend is available.', 'ai' )
+			: implode( ' ', array_values( array_unique( $reasons ) ) );
 	}
 }

--- a/includes/RAG/Availability.php
+++ b/includes/RAG/Availability.php
@@ -26,6 +26,21 @@ class Availability {
 	public const OPENAI_CONNECTOR_ID = 'openai';
 
 	/**
+	 * MariaDB vector index backend.
+	 */
+	public const BACKEND_MARIADB = 'mariadb';
+
+	/**
+	 * Compact in-memory exact-scan backend.
+	 */
+	public const BACKEND_MEMORY = 'memory';
+
+	/**
+	 * Option key storing the preferred backend.
+	 */
+	public const BACKEND_OPTION = 'wpai_feature_rag-search_field_backend';
+
+	/**
 	 * Required MariaDB version for VECTOR INDEX support.
 	 */
 	private const MINIMUM_MARIADB_VERSION = '11.8.0';
@@ -61,8 +76,8 @@ class Availability {
 			return $this->available;
 		}
 
-		if ( ! $this->is_mariadb_vector_index_supported() ) {
-			$this->unavailable_reason = __( 'MariaDB 11.8 or newer is required for native vector indexes.', 'ai' );
+		if ( empty( $this->get_available_index_backends() ) ) {
+			$this->unavailable_reason = __( 'MariaDB 11.8 or newer is required when the compact memory fallback is disabled.', 'ai' );
 			$this->available          = false;
 			return false;
 		}
@@ -109,6 +124,77 @@ class Availability {
 		$version = $this->get_database_version();
 
 		return $this->is_supported_mariadb_version( $version );
+	}
+
+	/**
+	 * Returns the active index backend.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Backend identifier.
+	 */
+	public function get_index_backend(): string {
+		$available = $this->get_available_index_backends();
+		$preferred = $this->get_preferred_index_backend();
+
+		if ( in_array( $preferred, $available, true ) ) {
+			return $preferred;
+		}
+
+		return $this->get_default_index_backend();
+	}
+
+	/**
+	 * Returns available concrete index backends.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return list<string> Backend identifiers.
+	 */
+	public function get_available_index_backends(): array {
+		$backends = array();
+
+		if ( $this->is_mariadb_vector_index_supported() ) {
+			$backends[] = self::BACKEND_MARIADB;
+		}
+
+		if ( $this->is_memory_fallback_enabled() ) {
+			$backends[] = self::BACKEND_MEMORY;
+		}
+
+		return $backends;
+	}
+
+	/**
+	 * Returns the default concrete index backend for this environment.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Backend identifier.
+	 */
+	public function get_default_index_backend(): string {
+		$available = $this->get_available_index_backends();
+
+		if ( in_array( self::BACKEND_MARIADB, $available, true ) ) {
+			return self::BACKEND_MARIADB;
+		}
+
+		return $available[0] ?? self::BACKEND_MARIADB;
+	}
+
+	/**
+	 * Returns a human-readable backend label.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Backend label.
+	 */
+	public function get_index_backend_label(): string {
+		if ( self::BACKEND_MEMORY === $this->get_index_backend() ) {
+			return __( 'compact in-memory exact scan', 'ai' );
+		}
+
+		return __( 'MariaDB vector index', 'ai' );
 	}
 
 	/**
@@ -205,5 +291,43 @@ class Availability {
 	 */
 	private function supports_openai_embeddings(): bool {
 		return self::EMBEDDING_MODEL === $this->get_embedding_model();
+	}
+
+	/**
+	 * Returns the preferred backend setting.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Preferred backend.
+	 */
+	private function get_preferred_index_backend(): string {
+		$preferred = get_option( self::BACKEND_OPTION, $this->get_default_index_backend() );
+		if ( ! is_string( $preferred ) ) {
+			return $this->get_default_index_backend();
+		}
+
+		if ( in_array( $preferred, array( self::BACKEND_MARIADB, self::BACKEND_MEMORY ), true ) ) {
+			return $preferred;
+		}
+
+		return $this->get_default_index_backend();
+	}
+
+	/**
+	 * Checks whether the compact memory fallback is enabled.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when enabled.
+	 */
+	private function is_memory_fallback_enabled(): bool {
+		/**
+		 * Filters whether RAG should use compact in-memory exact scan when MariaDB vector indexes are unavailable.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param bool $enabled Whether the fallback backend is enabled.
+		 */
+		return (bool) apply_filters( 'wpai_rag_memory_fallback_enabled', true );
 	}
 }

--- a/includes/RAG/Availability.php
+++ b/includes/RAG/Availability.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Availability checks for MariaDB vector RAG search.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use Throwable;
+use function WordPress\AI\has_connector_authentication;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Determines whether native MariaDB vector search can be used.
+ *
+ * @since 1.1.0
+ */
+class Availability {
+	/**
+	 * OpenAI connector identifier.
+	 */
+	public const OPENAI_CONNECTOR_ID = 'openai';
+
+	/**
+	 * Required MariaDB version for VECTOR INDEX support.
+	 */
+	private const MINIMUM_MARIADB_VERSION = '11.8.0';
+
+	/**
+	 * Required embedding model.
+	 */
+	private const EMBEDDING_MODEL = 'text-embedding-3-small';
+
+	/**
+	 * Cached availability state.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $available = null;
+
+	/**
+	 * Cached unavailable reason.
+	 *
+	 * @var string
+	 */
+	private string $unavailable_reason = '';
+
+	/**
+	 * Checks whether the feature can run on this site.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when all runtime requirements are met.
+	 */
+	public function is_available(): bool {
+		if ( null !== $this->available ) {
+			return $this->available;
+		}
+
+		if ( ! $this->is_mariadb_vector_index_supported() ) {
+			$this->unavailable_reason = __( 'MariaDB 11.8 or newer is required for native vector indexes.', 'ai' );
+			$this->available          = false;
+			return false;
+		}
+
+		if ( ! $this->has_openai_connector_authentication() ) {
+			$this->unavailable_reason = __( 'The OpenAI connector must be active and authenticated to generate embeddings.', 'ai' );
+			$this->available          = false;
+			return false;
+		}
+
+		if ( ! $this->supports_openai_embeddings() ) {
+			$this->unavailable_reason = __( 'RAG Search currently supports OpenAI text-embedding-3-small embeddings only.', 'ai' );
+			$this->available          = false;
+			return false;
+		}
+
+		$this->available = true;
+		return true;
+	}
+
+	/**
+	 * Returns the reason the feature is unavailable.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Human-readable reason.
+	 */
+	public function get_unavailable_reason(): string {
+		if ( null === $this->available ) {
+			$this->is_available();
+		}
+
+		return $this->unavailable_reason;
+	}
+
+	/**
+	 * Checks whether the database is MariaDB 11.8+.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when VECTOR INDEX should be available.
+	 */
+	public function is_mariadb_vector_index_supported(): bool {
+		$version = $this->get_database_version();
+
+		return $this->is_supported_mariadb_version( $version );
+	}
+
+	/**
+	 * Checks a raw database version string.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $version Raw SELECT VERSION() value.
+	 * @return bool True when supported.
+	 */
+	public function is_supported_mariadb_version( string $version ): bool {
+		if ( false === stripos( $version, 'mariadb' ) ) {
+			return false;
+		}
+
+		$version = preg_replace( '/^5\.5\.5-/', '', $version ) ?? $version;
+
+		if ( ! preg_match( '/(\d+\.\d+(?:\.\d+)?)/', $version, $matches ) ) {
+			return false;
+		}
+
+		return version_compare( $matches[1], self::MINIMUM_MARIADB_VERSION, '>=' );
+	}
+
+	/**
+	 * Returns the configured embedding model.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Embedding model ID.
+	 */
+	public function get_embedding_model(): string {
+		/**
+		 * Filters the OpenAI embedding model used for MariaDB RAG indexing.
+		 *
+		 * The table schema in this release is fixed to 1536 dimensions.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $model OpenAI embedding model.
+		 */
+		return (string) apply_filters( 'wpai_rag_embedding_model', self::EMBEDDING_MODEL );
+	}
+
+	/**
+	 * Returns the embedding vector dimension count.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int Dimension count.
+	 */
+	public function get_embedding_dimensions(): int {
+		return 1536;
+	}
+
+	/**
+	 * Reads the database version string.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Version string.
+	 */
+	protected function get_database_version(): string {
+		global $wpdb;
+
+		$version = $wpdb->get_var( 'SELECT VERSION()' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return is_string( $version ) ? $version : '';
+	}
+
+	/**
+	 * Checks that the OpenAI connector is active and has credentials.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when OpenAI can be authenticated.
+	 */
+	private function has_openai_connector_authentication(): bool {
+		try {
+			return function_exists( 'wp_is_connector_registered' )
+				&& wp_is_connector_registered( self::OPENAI_CONNECTOR_ID )
+				&& has_connector_authentication( self::OPENAI_CONNECTOR_ID );
+		} catch ( Throwable $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Checks whether the configured OpenAI embedding model matches the fixed schema.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when the configured model uses the expected dimensions.
+	 */
+	private function supports_openai_embeddings(): bool {
+		return self::EMBEDDING_MODEL === $this->get_embedding_model();
+	}
+}

--- a/includes/RAG/Availability.php
+++ b/includes/RAG/Availability.php
@@ -191,10 +191,10 @@ class Availability {
 	 */
 	public function get_index_backend_label(): string {
 		if ( self::BACKEND_MEMORY === $this->get_index_backend() ) {
-			return __( 'compact in-memory exact scan', 'ai' );
+			return __( 'Fallback in-memory search backed by PHP', 'ai' );
 		}
 
-		return __( 'MariaDB vector index', 'ai' );
+		return __( 'Optimal search method backed by MariaDB', 'ai' );
 	}
 
 	/**

--- a/includes/RAG/Index_Backend_Interface.php
+++ b/includes/RAG/Index_Backend_Interface.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Repository backend contract for RAG search.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Describes one concrete RAG index backend.
+ *
+ * @since 1.1.0
+ */
+interface Index_Backend_Interface {
+	/**
+	 * Returns the backend identifier.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Backend identifier.
+	 */
+	public function get_id(): string;
+
+	/**
+	 * Returns the backend label.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Backend label.
+	 */
+	public function get_label(): string;
+
+	/**
+	 * Returns whether the backend can be used in this environment.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when available.
+	 */
+	public function is_available(): bool;
+
+	/**
+	 * Returns a human-readable unavailable reason.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Unavailable reason.
+	 */
+	public function get_unavailable_reason(): string;
+
+	/**
+	 * Creates the repository for this backend.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $dimensions Embedding dimensions.
+	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
+	 */
+	public function create_repository( int $dimensions ): Index_Repository_Interface;
+
+	/**
+	 * Ensures persistent storage exists.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when storage is ready.
+	 */
+	public function ensure_storage(): bool;
+
+	/**
+	 * Checks whether this backend has stored RAG index data.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when data or storage exists.
+	 */
+	public function has_index_data(): bool;
+
+	/**
+	 * Deletes backend-specific RAG index data.
+	 *
+	 * @since 1.1.0
+	 */
+	public function cleanup(): void;
+}

--- a/includes/RAG/Index_Manager.php
+++ b/includes/RAG/Index_Manager.php
@@ -81,9 +81,9 @@ class Index_Manager {
 	/**
 	 * Schema manager.
 	 *
-	 * @var \WordPress\AI\RAG\Index_Schema
+	 * @var \WordPress\AI\RAG\MariaDB_Index_Schema|null
 	 */
-	private Index_Schema $schema;
+	private ?MariaDB_Index_Schema $schema;
 
 	/**
 	 * Repository.
@@ -112,23 +112,23 @@ class Index_Manager {
 	 * @since 1.1.0
 	 *
 	 * @param \WordPress\AI\RAG\Availability|null             $availability     Availability service.
-	 * @param \WordPress\AI\RAG\Index_Schema|null            $schema           Schema manager.
+	 * @param \WordPress\AI\RAG\MariaDB_Index_Schema|null    $schema           Schema manager.
 	 * @param \WordPress\AI\RAG\Index_Repository_Interface|null $repository       Repository.
 	 * @param \WordPress\AI\RAG\Post_Chunker|null            $chunker          Chunker.
 	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null $embedding_client Embedding client.
 	 */
 	public function __construct(
 		?Availability $availability = null,
-		?Index_Schema $schema = null,
+		?MariaDB_Index_Schema $schema = null,
 		?Index_Repository_Interface $repository = null,
 		?Post_Chunker $chunker = null,
 		?OpenAI_Embedding_Client $embedding_client = null
 	) {
 		$this->availability     = $availability ?? new Availability();
-		$this->schema           = $schema ?? new Index_Schema();
+		$this->schema           = $schema;
 		$this->repository       = $repository ?? $this->create_repository();
 		$this->chunker          = $chunker ?? new Post_Chunker();
-		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
+		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client();
 	}
 
 	/**
@@ -155,13 +155,13 @@ class Index_Manager {
 	 * @return bool True when index storage is ready.
 	 */
 	public function ensure_index_storage(): bool {
-		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
-			return true;
+		if ( $this->schema instanceof MariaDB_Index_Schema && Availability::BACKEND_MARIADB === $this->availability->get_index_backend() ) {
+			$this->schema->maybe_upgrade_table();
+
+			return $this->schema->table_exists();
 		}
 
-		$this->schema->maybe_upgrade_table();
-
-		return $this->schema->table_exists();
+		return $this->availability->ensure_index_storage();
 	}
 
 	/**
@@ -172,11 +172,11 @@ class Index_Manager {
 	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
 	 */
 	private function create_repository(): Index_Repository_Interface {
-		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
-			return new Memory_Index_Repository( $this->availability->get_embedding_dimensions() );
+		if ( $this->schema instanceof MariaDB_Index_Schema && Availability::BACKEND_MARIADB === $this->availability->get_index_backend() ) {
+			return new MariaDB_Index_Repository( $this->schema, $this->availability->get_embedding_dimensions() );
 		}
 
-		return new Index_Repository( $this->schema, $this->availability->get_embedding_dimensions() );
+		return $this->availability->create_index_repository();
 	}
 
 	/**
@@ -263,7 +263,7 @@ class Index_Manager {
 			$stats['remaining'] = $this->count_dirty_posts();
 
 			if ( $schedule_tail && $stats['remaining'] > 0 ) {
-				$this->schedule_immediate();
+				$this->schedule_indexing();
 			}
 		} finally {
 			delete_transient( self::LOCK_TRANSIENT );
@@ -280,7 +280,11 @@ class Index_Manager {
 	 * @param int $delay Delay in seconds.
 	 */
 	public function schedule_indexing( int $delay = 1 ): void {
-		$this->schedule_immediate( $delay );
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + max( 1, $delay ), self::CRON_HOOK );
 	}
 
 	/**
@@ -379,6 +383,33 @@ class Index_Manager {
 	}
 
 	/**
+	 * Checks whether RAG index data or scheduled work exists.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when RAG data exists.
+	 */
+	public function has_index_data(): bool {
+		$counts = $this->get_status_counts();
+
+		return $this->availability->has_index_data()
+			|| array_sum( $counts ) > 0
+			|| null !== $this->get_next_scheduled_indexing();
+	}
+
+	/**
+	 * Deletes all RAG index data and scheduled work.
+	 *
+	 * @since 1.1.0
+	 */
+	public function cleanup_index_data(): void {
+		$this->availability->cleanup_index_backends();
+		$this->delete_common_index_meta();
+		wp_clear_scheduled_hook( self::CRON_HOOK );
+		delete_option( Availability::BACKEND_OPTION );
+	}
+
+	/**
 	 * Handles post saves.
 	 *
 	 * @since 1.1.0
@@ -442,7 +473,7 @@ class Index_Manager {
 	 */
 	public function handle_cron(): void {
 		if ( get_transient( self::LOCK_TRANSIENT ) ) {
-			$this->schedule_immediate( 5 * MINUTE_IN_SECONDS );
+			$this->schedule_indexing( 5 * MINUTE_IN_SECONDS );
 			return;
 		}
 
@@ -457,7 +488,7 @@ class Index_Manager {
 			}
 
 			if ( $this->has_dirty_posts() ) {
-				$this->schedule_immediate();
+				$this->schedule_indexing();
 			}
 		} finally {
 			delete_transient( self::LOCK_TRANSIENT );
@@ -550,7 +581,7 @@ class Index_Manager {
 	private function mark_post_dirty( int $post_id ): void {
 		update_post_meta( $post_id, self::META_STATUS, self::STATUS_DIRTY );
 		delete_post_meta( $post_id, self::META_ERROR );
-		$this->schedule_delayed();
+		$this->schedule_indexing( HOUR_IN_SECONDS );
 	}
 
 	/**
@@ -597,7 +628,7 @@ class Index_Manager {
 
 			$texts = array();
 			foreach ( $chunks as $chunk ) {
-				$texts[] = (string) $chunk['content'];
+				$texts[] = isset( $chunk['embedding_text'] ) ? (string) $chunk['embedding_text'] : (string) $chunk['content'];
 			}
 
 			$embeddings = $this->embedding_client->embed( $texts );
@@ -795,34 +826,6 @@ class Index_Manager {
 	}
 
 	/**
-	 * Schedules delayed indexing after content changes.
-	 *
-	 * @since 1.1.0
-	 */
-	private function schedule_delayed(): void {
-		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
-			return;
-		}
-
-		wp_schedule_single_event( time() + HOUR_IN_SECONDS, self::CRON_HOOK );
-	}
-
-	/**
-	 * Schedules the next indexing run.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param int $delay Delay in seconds.
-	 */
-	private function schedule_immediate( int $delay = 1 ): void {
-		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
-			return;
-		}
-
-		wp_schedule_single_event( time() + max( 1, $delay ), self::CRON_HOOK );
-	}
-
-	/**
 	 * Returns batch size.
 	 *
 	 * @since 1.1.0
@@ -850,13 +853,12 @@ class Index_Manager {
 	 */
 	private function build_content_hash( WP_Post $post ): string {
 		$data = array(
-			'post_id'           => (int) $post->ID,
-			'post_title'        => (string) $post->post_title,
-			'post_content'      => (string) $post->post_content,
-			'post_excerpt'      => (string) $post->post_excerpt,
-			'post_modified_gmt' => (string) $post->post_modified_gmt,
-			'model'             => $this->availability->get_embedding_model(),
-			'dimensions'        => $this->availability->get_embedding_dimensions(),
+			'post_id'      => (int) $post->ID,
+			'post_title'   => (string) $post->post_title,
+			'post_content' => (string) $post->post_content,
+			'post_excerpt' => (string) $post->post_excerpt,
+			'model'        => $this->availability->get_embedding_model(),
+			'dimensions'   => $this->availability->get_embedding_dimensions(),
 		);
 
 		return hash( 'sha256', (string) wp_json_encode( $data ) );
@@ -876,5 +878,31 @@ class Index_Manager {
 		}
 
 		return defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE;
+	}
+
+	/**
+	 * Deletes common RAG post meta.
+	 *
+	 * @since 1.1.0
+	 */
+	private function delete_common_index_meta(): void {
+		global $wpdb;
+
+		$meta_keys = array(
+			self::META_STATUS,
+			self::META_ERROR,
+			self::META_INDEXED_AT,
+			self::META_CONTENT_HASH,
+		);
+
+		$placeholders = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Explicit cleanup removes RAG-owned post meta in one query.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->postmeta} WHERE meta_key IN ({$placeholders})", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+				...$meta_keys
+			)
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 	}
 }

--- a/includes/RAG/Index_Manager.php
+++ b/includes/RAG/Index_Manager.php
@@ -88,9 +88,9 @@ class Index_Manager {
 	/**
 	 * Repository.
 	 *
-	 * @var \WordPress\AI\RAG\Index_Repository
+	 * @var \WordPress\AI\RAG\Index_Repository_Interface
 	 */
-	private Index_Repository $repository;
+	private Index_Repository_Interface $repository;
 
 	/**
 	 * Chunker.
@@ -113,20 +113,20 @@ class Index_Manager {
 	 *
 	 * @param \WordPress\AI\RAG\Availability|null             $availability     Availability service.
 	 * @param \WordPress\AI\RAG\Index_Schema|null            $schema           Schema manager.
-	 * @param \WordPress\AI\RAG\Index_Repository|null        $repository       Repository.
+	 * @param \WordPress\AI\RAG\Index_Repository_Interface|null $repository       Repository.
 	 * @param \WordPress\AI\RAG\Post_Chunker|null            $chunker          Chunker.
 	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null $embedding_client Embedding client.
 	 */
 	public function __construct(
 		?Availability $availability = null,
 		?Index_Schema $schema = null,
-		?Index_Repository $repository = null,
+		?Index_Repository_Interface $repository = null,
 		?Post_Chunker $chunker = null,
 		?OpenAI_Embedding_Client $embedding_client = null
 	) {
 		$this->availability     = $availability ?? new Availability();
 		$this->schema           = $schema ?? new Index_Schema();
-		$this->repository       = $repository ?? new Index_Repository( $this->schema, $this->availability->get_embedding_dimensions() );
+		$this->repository       = $repository ?? $this->create_repository();
 		$this->chunker          = $chunker ?? new Post_Chunker();
 		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
 	}
@@ -137,9 +137,7 @@ class Index_Manager {
 	 * @since 1.1.0
 	 */
 	public function init(): void {
-		$this->schema->maybe_upgrade_table();
-
-		if ( ! $this->schema->table_exists() ) {
+		if ( ! $this->ensure_index_storage() ) {
 			return;
 		}
 
@@ -150,16 +148,35 @@ class Index_Manager {
 	}
 
 	/**
-	 * Ensures the RAG index table exists.
+	 * Ensures the RAG index storage exists.
 	 *
 	 * @since 1.1.0
 	 *
-	 * @return bool True when the table exists.
+	 * @return bool True when index storage is ready.
 	 */
-	public function ensure_index_table(): bool {
+	public function ensure_index_storage(): bool {
+		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
+			return true;
+		}
+
 		$this->schema->maybe_upgrade_table();
 
 		return $this->schema->table_exists();
+	}
+
+	/**
+	 * Returns the active repository.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
+	 */
+	private function create_repository(): Index_Repository_Interface {
+		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
+			return new Memory_Index_Repository( $this->availability->get_embedding_dimensions() );
+		}
+
+		return new Index_Repository( $this->schema, $this->availability->get_embedding_dimensions() );
 	}
 
 	/**

--- a/includes/RAG/Index_Manager.php
+++ b/includes/RAG/Index_Manager.php
@@ -1,0 +1,863 @@
+<?php
+/**
+ * RAG indexing lifecycle manager.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Error;
+use WP_Post;
+use WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Coordinates post hooks and cron indexing.
+ *
+ * @since 1.1.0
+ */
+class Index_Manager {
+	/**
+	 * Cron hook.
+	 */
+	public const CRON_HOOK = 'wpai_rag_index_dirty_posts';
+
+	/**
+	 * RAG status post meta key.
+	 */
+	public const META_STATUS = '_ai_rag_status';
+
+	/**
+	 * Last RAG error post meta key.
+	 */
+	public const META_ERROR = '_ai_rag_error';
+
+	/**
+	 * Indexed timestamp post meta key.
+	 */
+	public const META_INDEXED_AT = '_ai_rag_indexed_at';
+
+	/**
+	 * Content hash post meta key.
+	 */
+	public const META_CONTENT_HASH = '_ai_rag_content_hash';
+
+	/**
+	 * Dirty status.
+	 */
+	public const STATUS_DIRTY = 'dirty';
+
+	/**
+	 * Processing status.
+	 */
+	public const STATUS_PROCESSING = 'processing';
+
+	/**
+	 * Clean status.
+	 */
+	public const STATUS_CLEAN = 'clean';
+
+	/**
+	 * Error status.
+	 */
+	public const STATUS_ERROR = 'error';
+
+	/**
+	 * Indexing lock transient.
+	 */
+	private const LOCK_TRANSIENT = 'wpai_rag_indexing_lock';
+
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Schema manager.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Schema
+	 */
+	private Index_Schema $schema;
+
+	/**
+	 * Repository.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Repository
+	 */
+	private Index_Repository $repository;
+
+	/**
+	 * Chunker.
+	 *
+	 * @var \WordPress\AI\RAG\Post_Chunker
+	 */
+	private Post_Chunker $chunker;
+
+	/**
+	 * Embedding client.
+	 *
+	 * @var \WordPress\AI\RAG\OpenAI_Embedding_Client
+	 */
+	private OpenAI_Embedding_Client $embedding_client;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability|null             $availability     Availability service.
+	 * @param \WordPress\AI\RAG\Index_Schema|null            $schema           Schema manager.
+	 * @param \WordPress\AI\RAG\Index_Repository|null        $repository       Repository.
+	 * @param \WordPress\AI\RAG\Post_Chunker|null            $chunker          Chunker.
+	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null $embedding_client Embedding client.
+	 */
+	public function __construct(
+		?Availability $availability = null,
+		?Index_Schema $schema = null,
+		?Index_Repository $repository = null,
+		?Post_Chunker $chunker = null,
+		?OpenAI_Embedding_Client $embedding_client = null
+	) {
+		$this->availability     = $availability ?? new Availability();
+		$this->schema           = $schema ?? new Index_Schema();
+		$this->repository       = $repository ?? new Index_Repository( $this->schema, $this->availability->get_embedding_dimensions() );
+		$this->chunker          = $chunker ?? new Post_Chunker();
+		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
+	}
+
+	/**
+	 * Registers lifecycle hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	public function init(): void {
+		$this->schema->maybe_upgrade_table();
+
+		if ( ! $this->schema->table_exists() ) {
+			return;
+		}
+
+		add_action( 'save_post', array( $this, 'handle_save_post' ), 10, 3 );
+		add_action( 'transition_post_status', array( $this, 'handle_post_status_transition' ), 10, 3 );
+		add_action( 'before_delete_post', array( $this, 'handle_before_delete_post' ) );
+		add_action( self::CRON_HOOK, array( $this, 'handle_cron' ) );
+	}
+
+	/**
+	 * Ensures the RAG index table exists.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when the table exists.
+	 */
+	public function ensure_index_table(): bool {
+		$this->schema->maybe_upgrade_table();
+
+		return $this->schema->table_exists();
+	}
+
+	/**
+	 * Marks eligible posts as dirty for indexing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int> $post_ids Optional explicit post IDs. Empty means all eligible posts.
+	 * @param int       $limit    Maximum posts to mark when no explicit IDs are supplied.
+	 * @return array{marked: int, skipped: int, removed: int} Marking statistics.
+	 */
+	public function mark_posts_dirty_for_indexing( array $post_ids = array(), int $limit = 0 ): array {
+		if ( empty( $post_ids ) ) {
+			$post_ids = $this->get_eligible_post_ids( $limit );
+		}
+
+		$stats = array(
+			'marked'  => 0,
+			'skipped' => 0,
+			'removed' => 0,
+		);
+
+		foreach ( $post_ids as $post_id ) {
+			$post = get_post( $post_id );
+
+			if ( ! $post instanceof WP_Post ) {
+				++$stats['skipped'];
+				continue;
+			}
+
+			if ( $this->should_index_post( $post ) ) {
+				$this->mark_post_dirty( (int) $post->ID );
+				++$stats['marked'];
+				continue;
+			}
+
+			$this->remove_post_from_index( (int) $post->ID );
+			++$stats['removed'];
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Runs one synchronous indexing batch.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int  $limit         Maximum dirty posts to process.
+	 * @param bool $schedule_tail Whether to schedule another run when dirty posts remain.
+	 * @return array{processed: int, clean: int, error: int, removed: int, remaining: int}|\WP_Error Batch statistics or lock error.
+	 */
+	public function run_indexing_batch( int $limit = 0, bool $schedule_tail = true ) {
+		if ( get_transient( self::LOCK_TRANSIENT ) ) {
+			return new WP_Error( 'wpai_rag_indexing_locked', __( 'RAG indexing is already running.', 'ai' ) );
+		}
+
+		set_transient( self::LOCK_TRANSIENT, 1, 10 * MINUTE_IN_SECONDS );
+
+		$stats = array(
+			'processed' => 0,
+			'clean'     => 0,
+			'error'     => 0,
+			'removed'   => 0,
+			'remaining' => 0,
+		);
+
+		try {
+			$post_ids = $this->get_dirty_post_ids( $limit > 0 ? $limit : $this->get_batch_size() );
+
+			foreach ( $post_ids as $post_id ) {
+				$result = $this->process_post( $post_id );
+				++$stats['processed'];
+
+				if ( self::STATUS_CLEAN === $result ) {
+					++$stats['clean'];
+				} elseif ( self::STATUS_ERROR === $result ) {
+					++$stats['error'];
+				} elseif ( 'removed' === $result ) {
+					++$stats['removed'];
+				}
+			}
+
+			$stats['remaining'] = $this->count_dirty_posts();
+
+			if ( $schedule_tail && $stats['remaining'] > 0 ) {
+				$this->schedule_immediate();
+			}
+		} finally {
+			delete_transient( self::LOCK_TRANSIENT );
+		}
+
+		return $stats;
+	}
+
+	/**
+	 * Schedules an indexing run.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $delay Delay in seconds.
+	 */
+	public function schedule_indexing( int $delay = 1 ): void {
+		$this->schedule_immediate( $delay );
+	}
+
+	/**
+	 * Returns status counts for RAG post meta.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, int> Counts keyed by status.
+	 */
+	public function get_status_counts(): array {
+		global $wpdb;
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- CLI/status utility reads a small aggregate over RAG status post meta.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT meta_value AS status, COUNT(*) AS total
+				FROM {$wpdb->postmeta}
+				WHERE meta_key = %s
+				GROUP BY meta_value", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				self::META_STATUS
+			),
+			ARRAY_A
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		$counts = array(
+			self::STATUS_DIRTY      => 0,
+			self::STATUS_PROCESSING => 0,
+			self::STATUS_CLEAN      => 0,
+			self::STATUS_ERROR      => 0,
+		);
+
+		if ( ! $rows ) {
+			return $counts;
+		}
+
+		foreach ( $rows as $row ) {
+			$status = isset( $row['status'] ) ? (string) $row['status'] : '';
+			if ( '' === $status ) {
+				continue;
+			}
+
+			$counts[ $status ] = isset( $row['total'] ) ? (int) $row['total'] : 0;
+		}
+
+		return $counts;
+	}
+
+	/**
+	 * Counts dirty posts in the current indexing scope.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int Dirty post count.
+	 */
+	public function count_dirty_posts(): int {
+		$scope = $this->get_indexing_scope();
+		if ( empty( $scope ) ) {
+			return 0;
+		}
+
+		$query = new WP_Query(
+			array(
+				'fields'                 => 'ids',
+				'post_type'              => array_keys( $scope ),
+				'post_status'            => $this->get_scope_post_statuses( $scope ),
+				'posts_per_page'         => 1,
+				'ignore_sticky_posts'    => true,
+				'no_found_rows'          => false,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- RAG indexing state is intentionally stored as post meta.
+				'meta_query'             => array(
+					array(
+						'key'   => self::META_STATUS,
+						'value' => self::STATUS_DIRTY,
+					),
+				),
+			)
+		);
+
+		return (int) $query->found_posts;
+	}
+
+	/**
+	 * Returns the next scheduled indexing timestamp.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int|null Unix timestamp or null when unscheduled.
+	 */
+	public function get_next_scheduled_indexing(): ?int {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+
+		return $timestamp ? (int) $timestamp : null;
+	}
+
+	/**
+	 * Handles post saves.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object.
+	 * @param bool     $update  Whether this is an update.
+	 */
+	public function handle_save_post( int $post_id, WP_Post $post, bool $update ): void {
+		unset( $update );
+
+		if ( $this->should_skip_post_save( $post_id ) ) {
+			return;
+		}
+
+		if ( $this->should_index_post( $post ) ) {
+			$this->mark_post_dirty( $post_id );
+			return;
+		}
+
+		$this->remove_post_from_index( $post_id );
+	}
+
+	/**
+	 * Handles status transitions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string   $new_status New post status.
+	 * @param string   $old_status Old post status.
+	 * @param \WP_Post $post       Post object.
+	 */
+	public function handle_post_status_transition( string $new_status, string $old_status, WP_Post $post ): void {
+		if ( $new_status === $old_status ) {
+			return;
+		}
+
+		if ( $this->should_index_post( $post ) ) {
+			$this->mark_post_dirty( (int) $post->ID );
+			return;
+		}
+
+		$this->remove_post_from_index( (int) $post->ID );
+	}
+
+	/**
+	 * Removes deleted posts from the index.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function handle_before_delete_post( int $post_id ): void {
+		$this->remove_post_from_index( $post_id );
+	}
+
+	/**
+	 * Processes dirty posts.
+	 *
+	 * @since 1.1.0
+	 */
+	public function handle_cron(): void {
+		if ( get_transient( self::LOCK_TRANSIENT ) ) {
+			$this->schedule_immediate( 5 * MINUTE_IN_SECONDS );
+			return;
+		}
+
+		set_transient( self::LOCK_TRANSIENT, 1, 10 * MINUTE_IN_SECONDS );
+
+		try {
+			$batch_size = $this->get_batch_size();
+			$post_ids   = $this->get_dirty_post_ids( $batch_size );
+
+			foreach ( $post_ids as $post_id ) {
+				$this->process_post( $post_id );
+			}
+
+			if ( $this->has_dirty_posts() ) {
+				$this->schedule_immediate();
+			}
+		} finally {
+			delete_transient( self::LOCK_TRANSIENT );
+		}
+	}
+
+	/**
+	 * Checks whether a post is eligible for indexing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return bool True when the post should be indexed.
+	 */
+	public function should_index_post( WP_Post $post ): bool {
+		$scope = $this->get_indexing_scope();
+
+		$should_index = isset( $scope[ $post->post_type ] )
+			&& in_array( $post->post_status, $scope[ $post->post_type ], true );
+
+		/**
+		 * Filters whether an individual post should be indexed for RAG search.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param bool     $should_index Whether the post should be indexed.
+		 * @param \WP_Post $post         Post object.
+		 */
+		return (bool) apply_filters( 'wpai_rag_should_index_post', $should_index, $post );
+	}
+
+	/**
+	 * Returns the default and filtered indexing scope.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, list<string>> Post type to statuses map.
+	 */
+	public function get_indexing_scope(): array {
+		$scope = array(
+			'post' => array( 'publish' ),
+			'page' => array( 'publish' ),
+		);
+
+		/**
+		 * Filters the post types and statuses indexed for RAG search.
+		 *
+		 * Return an array keyed by post type with a list of statuses for each type.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param array<string, list<string>> $scope Indexing scope.
+		 */
+		$scope = apply_filters( 'wpai_rag_indexing_scope', $scope );
+
+		if ( ! is_array( $scope ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $scope as $post_type => $statuses ) {
+			if ( ! is_string( $post_type ) || ! post_type_exists( $post_type ) || ! is_array( $statuses ) ) {
+				continue;
+			}
+
+			$post_type = sanitize_key( $post_type );
+			$statuses  = array_values(
+				array_filter(
+					array_map( 'sanitize_key', $statuses )
+				)
+			);
+
+			if ( empty( $statuses ) ) {
+				continue;
+			}
+
+			$normalized[ $post_type ] = array_values( array_unique( $statuses ) );
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Marks a post dirty and schedules delayed indexing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function mark_post_dirty( int $post_id ): void {
+		update_post_meta( $post_id, self::META_STATUS, self::STATUS_DIRTY );
+		delete_post_meta( $post_id, self::META_ERROR );
+		$this->schedule_delayed();
+	}
+
+	/**
+	 * Removes all index state for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function remove_post_from_index( int $post_id ): void {
+		$this->repository->delete_post_chunks( $post_id );
+		delete_post_meta( $post_id, self::META_STATUS );
+		delete_post_meta( $post_id, self::META_ERROR );
+		delete_post_meta( $post_id, self::META_INDEXED_AT );
+		delete_post_meta( $post_id, self::META_CONTENT_HASH );
+	}
+
+	/**
+	 * Processes one post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function process_post( int $post_id ): string {
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post || ! $this->should_index_post( $post ) ) {
+			$this->remove_post_from_index( $post_id );
+			return 'removed';
+		}
+
+		update_post_meta( $post_id, self::META_STATUS, self::STATUS_PROCESSING );
+
+		try {
+			$content_hash = $this->build_content_hash( $post );
+			$chunks       = $this->chunker->chunk_post( $post );
+
+			if ( empty( $chunks ) ) {
+				$this->repository->delete_post_chunks( $post_id );
+				$this->mark_post_clean( $post_id, $content_hash );
+				return self::STATUS_CLEAN;
+			}
+
+			$texts = array();
+			foreach ( $chunks as $chunk ) {
+				$texts[] = (string) $chunk['content'];
+			}
+
+			$embeddings = $this->embedding_client->embed( $texts );
+
+			if ( is_wp_error( $embeddings ) ) {
+				$this->mark_post_error( $post_id, $embeddings );
+				return self::STATUS_ERROR;
+			}
+
+			$this->repository->replace_post_chunks(
+				$post,
+				$chunks,
+				$embeddings,
+				$this->availability->get_embedding_model(),
+				$content_hash
+			);
+
+			$this->mark_post_clean( $post_id, $content_hash );
+			return self::STATUS_CLEAN;
+		} catch ( \Throwable $e ) {
+			$this->mark_post_error(
+				$post_id,
+				new WP_Error( 'wpai_rag_indexing_error', $e->getMessage() )
+			);
+		}
+
+		return self::STATUS_ERROR;
+	}
+
+	/**
+	 * Marks a post clean.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int    $post_id      Post ID.
+	 * @param string $content_hash Content hash.
+	 */
+	private function mark_post_clean( int $post_id, string $content_hash ): void {
+		update_post_meta( $post_id, self::META_STATUS, self::STATUS_CLEAN );
+		update_post_meta( $post_id, self::META_CONTENT_HASH, $content_hash );
+		update_post_meta( $post_id, self::META_INDEXED_AT, current_time( 'mysql', true ) );
+		delete_post_meta( $post_id, self::META_ERROR );
+	}
+
+	/**
+	 * Marks a post as failed.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int       $post_id Post ID.
+	 * @param \WP_Error $error   Error.
+	 */
+	private function mark_post_error( int $post_id, WP_Error $error ): void {
+		update_post_meta( $post_id, self::META_STATUS, self::STATUS_ERROR );
+		update_post_meta( $post_id, self::META_ERROR, substr( $error->get_error_message(), 0, 1000 ) );
+	}
+
+	/**
+	 * Gets dirty post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $limit Maximum posts.
+	 * @return list<int> Post IDs.
+	 */
+	private function get_dirty_post_ids( int $limit ): array {
+		$scope = $this->get_indexing_scope();
+		if ( empty( $scope ) ) {
+			return array();
+		}
+
+		$query = new WP_Query(
+			array(
+				'fields'                 => 'ids',
+				'post_type'              => array_keys( $scope ),
+				'post_status'            => $this->get_scope_post_statuses( $scope ),
+				'posts_per_page'         => $limit,
+				'orderby'                => 'modified',
+				'order'                  => 'ASC',
+				'ignore_sticky_posts'    => true,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- RAG indexing state is intentionally stored as post meta.
+				'meta_query'             => array(
+					array(
+						'key'   => self::META_STATUS,
+						'value' => self::STATUS_DIRTY,
+					),
+				),
+			)
+		);
+
+		$post_ids = array();
+		foreach ( $query->posts as $post_id ) {
+			$post_id = $this->normalize_query_post_id( $post_id );
+			if ( $post_id <= 0 ) {
+				continue;
+			}
+
+			$post_ids[] = $post_id;
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Gets eligible post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $limit Maximum posts, or 0 for all.
+	 * @return list<int> Post IDs.
+	 */
+	private function get_eligible_post_ids( int $limit = 0 ): array {
+		$scope = $this->get_indexing_scope();
+		if ( empty( $scope ) ) {
+			return array();
+		}
+
+		$query = new WP_Query(
+			array(
+				'fields'                 => 'ids',
+				'post_type'              => array_keys( $scope ),
+				'post_status'            => $this->get_scope_post_statuses( $scope ),
+				'posts_per_page'         => $limit > 0 ? $limit : -1,
+				'orderby'                => 'modified',
+				'order'                  => 'ASC',
+				'ignore_sticky_posts'    => true,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		$post_ids = array();
+		foreach ( $query->posts as $post_id ) {
+			$post_id = $this->normalize_query_post_id( $post_id );
+			if ( $post_id <= 0 ) {
+				continue;
+			}
+
+			$post_ids[] = $post_id;
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Normalizes a WP_Query post result into a post ID.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $post Query post result.
+	 * @return int Post ID, or 0 when invalid.
+	 */
+	private function normalize_query_post_id( $post ): int {
+		if ( $post instanceof WP_Post ) {
+			return (int) $post->ID;
+		}
+
+		if ( is_numeric( $post ) ) {
+			return (int) $post;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Returns the statuses included in an indexing scope.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, list<string>> $scope Indexing scope.
+	 * @return list<string> Statuses.
+	 */
+	private function get_scope_post_statuses( array $scope ): array {
+		$post_statuses = array();
+		foreach ( $scope as $statuses ) {
+			$post_statuses = array_merge( $post_statuses, $statuses );
+		}
+
+		return array_values( array_unique( $post_statuses ) );
+	}
+
+	/**
+	 * Checks whether dirty posts remain.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when work remains.
+	 */
+	private function has_dirty_posts(): bool {
+		return ! empty( $this->get_dirty_post_ids( 1 ) );
+	}
+
+	/**
+	 * Schedules delayed indexing after content changes.
+	 *
+	 * @since 1.1.0
+	 */
+	private function schedule_delayed(): void {
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + HOUR_IN_SECONDS, self::CRON_HOOK );
+	}
+
+	/**
+	 * Schedules the next indexing run.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $delay Delay in seconds.
+	 */
+	private function schedule_immediate( int $delay = 1 ): void {
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + max( 1, $delay ), self::CRON_HOOK );
+	}
+
+	/**
+	 * Returns batch size.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int Batch size.
+	 */
+	private function get_batch_size(): int {
+		/**
+		 * Filters the number of dirty posts indexed per cron run.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int $batch_size Batch size.
+		 */
+		return max( 1, min( 200, (int) apply_filters( 'wpai_rag_index_batch_size', 50 ) ) );
+	}
+
+	/**
+	 * Builds a content hash for indexing idempotency.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string Hash.
+	 */
+	private function build_content_hash( WP_Post $post ): string {
+		$data = array(
+			'post_id'           => (int) $post->ID,
+			'post_title'        => (string) $post->post_title,
+			'post_content'      => (string) $post->post_content,
+			'post_excerpt'      => (string) $post->post_excerpt,
+			'post_modified_gmt' => (string) $post->post_modified_gmt,
+			'model'             => $this->availability->get_embedding_model(),
+			'dimensions'        => $this->availability->get_embedding_dimensions(),
+		);
+
+		return hash( 'sha256', (string) wp_json_encode( $data ) );
+	}
+
+	/**
+	 * Checks whether to ignore a save_post call.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 * @return bool True to skip.
+	 */
+	private function should_skip_post_save( int $post_id ): bool {
+		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
+			return true;
+		}
+
+		return defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE;
+	}
+}

--- a/includes/RAG/Index_Repository.php
+++ b/includes/RAG/Index_Repository.php
@@ -1,0 +1,280 @@
+<?php
+/**
+ * Repository for MariaDB vector RAG index rows.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use InvalidArgumentException;
+use RuntimeException;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores and queries RAG chunks.
+ *
+ * @since 1.1.0
+ */
+class Index_Repository {
+	// Direct queries are intentional because this repository owns a dedicated vector table.
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	/**
+	 * Schema manager.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Schema
+	 */
+	private Index_Schema $schema;
+
+	/**
+	 * Vector dimensions.
+	 *
+	 * @var int
+	 */
+	private int $dimensions;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Index_Schema $schema     Schema manager.
+	 * @param int                            $dimensions Vector dimensions.
+	 */
+	public function __construct( Index_Schema $schema, int $dimensions = 1536 ) {
+		$this->schema     = $schema;
+		$this->dimensions = $dimensions;
+	}
+
+	/**
+	 * Replaces all chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post       Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
+	 * @param string $model Embedding model.
+	 * @param string $hash Content hash.
+	 * @throws \RuntimeException When a database write fails.
+	 */
+	public function replace_post_chunks( WP_Post $post, array $chunks, array $embeddings, string $model, string $hash ): void {
+		if ( count( $chunks ) !== count( $embeddings ) ) {
+			throw new InvalidArgumentException( 'Chunk and embedding counts must match.' );
+		}
+
+		foreach ( $embeddings as $embedding ) {
+			$this->validate_embedding( $embedding );
+		}
+
+		global $wpdb;
+
+		$wpdb->query( 'START TRANSACTION' );
+
+		try {
+			$this->delete_post_chunks( (int) $post->ID );
+
+			foreach ( $chunks as $index => $chunk ) {
+				$this->insert_chunk( $post, $chunk, $embeddings[ $index ], $model, $hash );
+			}
+
+			$wpdb->query( 'COMMIT' );
+		} catch ( \Throwable $e ) {
+			$wpdb->query( 'ROLLBACK' );
+			// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Previous exception is preserved for internal debugging, not rendered.
+			throw new RuntimeException( 'Failed to replace RAG index chunks.', 0, $e );
+		}
+	}
+
+	/**
+	 * Deletes all indexed chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function delete_post_chunks( int $post_id ): void {
+		global $wpdb;
+
+		$table_name = $this->schema->get_table_name();
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$table_name} WHERE post_id = %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$post_id
+			)
+		);
+	}
+
+	/**
+	 * Searches the nearest chunks.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float> $embedding Query vector.
+	 * @param array{limit?:int, model?:string, post_type?:string|list<string>, post_status?:string|list<string>} $args Search args.
+	 * @return list<array<string, mixed>> Matching rows.
+	 */
+	public function search( array $embedding, array $args = array() ): array {
+		$this->validate_embedding( $embedding );
+
+		global $wpdb;
+
+		$defaults = array(
+			'limit'       => 20,
+			'model'       => 'text-embedding-3-small',
+			'post_type'   => array(),
+			'post_status' => array(),
+		);
+		$args     = wp_parse_args( $args, $defaults );
+		$limit    = max( 1, min( 100, (int) $args['limit'] ) );
+
+		$table_name = $this->schema->get_table_name();
+		$where      = array( 'embedding_model = %s' );
+		$values     = array( (string) $args['model'] );
+
+		$post_types = $this->sanitize_slug_list( (array) $args['post_type'] );
+		if ( ! empty( $post_types ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+			$where[]      = "post_type IN ({$placeholders})";
+			$values       = array_merge( $values, $post_types );
+		}
+
+		$post_statuses = $this->sanitize_slug_list( (array) $args['post_status'] );
+		if ( ! empty( $post_statuses ) ) {
+			$placeholders = implode( ', ', array_fill( 0, count( $post_statuses ), '%s' ) );
+			$where[]      = "post_status IN ({$placeholders})";
+			$values       = array_merge( $values, $post_statuses );
+		}
+
+		$vector_text = wp_json_encode( array_values( $embedding ) );
+		if ( ! is_string( $vector_text ) ) {
+			return array();
+		}
+
+		array_unshift( $values, $vector_text );
+		$values[] = $limit;
+
+		$where_clause = implode( ' AND ', $where );
+
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic clauses are sanitized and target the owned vector index table.
+		$sql = $wpdb->prepare(
+			"SELECT id, post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, anchor, title, permalink, content,
+				VEC_DISTANCE_COSINE(embedding, VEC_FromText(%s)) AS distance
+			FROM {$table_name}
+			WHERE {$where_clause}
+			ORDER BY distance ASC
+			LIMIT %d", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			$values
+		);
+		// phpcs:enable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return $rows ? $rows : array();
+	}
+
+	/**
+	 * Inserts one chunk row.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @param array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string} $chunk Chunk data.
+	 * @param list<int|float> $embedding Embedding vector.
+	 * @param string $model Embedding model.
+	 * @param string $hash Content hash.
+	 * @throws \RuntimeException When insert fails.
+	 */
+	private function insert_chunk( WP_Post $post, array $chunk, array $embedding, string $model, string $hash ): void {
+		global $wpdb;
+
+		$table_name  = $this->schema->get_table_name();
+		$vector_text = wp_json_encode( array_values( $embedding ) );
+		if ( ! is_string( $vector_text ) ) {
+			throw new RuntimeException( 'Failed to encode vector.' );
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic table name targets the owned vector index table.
+		$sql = $wpdb->prepare(
+			"INSERT INTO {$table_name}
+				(post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, anchor, title, permalink, content, content_hash, embedding, embedding_model, embedding_dimensions, indexed_at)
+			VALUES
+				(%d, %s, %s, %s, %d, %d, %s, %s, %s, %s, %s, VEC_FromText(%s), %s, %d, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			(int) $post->ID,
+			(string) $post->post_type,
+			(string) $post->post_status,
+			(string) $chunk['chunk_id'],
+			(int) $chunk['chunk_index'],
+			(int) $chunk['chunk_offset'],
+			isset( $chunk['anchor'] ) ? (string) $chunk['anchor'] : null,
+			(string) $chunk['title'],
+			(string) $chunk['permalink'],
+			(string) $chunk['content'],
+			$hash,
+			$vector_text,
+			$model,
+			$this->dimensions,
+			current_time( 'mysql', true )
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		$result = $wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( false === $result ) {
+			throw new RuntimeException( 'Failed to insert RAG index chunk.' );
+		}
+	}
+
+	/**
+	 * Validates a vector.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $embedding Candidate vector.
+	 */
+	private function validate_embedding( $embedding ): void {
+		if ( ! is_array( $embedding ) || count( $embedding ) !== $this->dimensions ) {
+			throw new InvalidArgumentException( 'Embedding vector has the wrong dimensions.' );
+		}
+
+		foreach ( $embedding as $value ) {
+			if ( ! is_int( $value ) && ! is_float( $value ) ) {
+				throw new InvalidArgumentException( 'Embedding vector contains a non-numeric value.' );
+			}
+		}
+	}
+
+	/**
+	 * Sanitizes a list of slugs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<mixed> $values Raw values.
+	 * @return list<string> Sanitized values.
+	 */
+	private function sanitize_slug_list( array $values ): array {
+		$slugs = array();
+
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$value = sanitize_key( (string) $value );
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$slugs[] = $value;
+		}
+
+		return array_values( array_unique( $slugs ) );
+	}
+
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+}

--- a/includes/RAG/Index_Repository.php
+++ b/includes/RAG/Index_Repository.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * @since 1.1.0
  */
-class Index_Repository {
+class Index_Repository implements Index_Repository_Interface {
 	// Direct queries are intentional because this repository owns a dedicated vector table.
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 

--- a/includes/RAG/Index_Repository_Interface.php
+++ b/includes/RAG/Index_Repository_Interface.php
@@ -24,8 +24,8 @@ interface Index_Repository_Interface {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param \WP_Post $post       Post object.
-	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param \WP_Post $post Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, content:string, embedding_text?:string}> $chunks Chunk data.
 	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
 	 * @param string $model Embedding model.
 	 * @param string $hash Content hash.

--- a/includes/RAG/Index_Repository_Interface.php
+++ b/includes/RAG/Index_Repository_Interface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Repository contract for RAG index backends.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores and queries RAG chunks.
+ *
+ * @since 1.1.0
+ */
+interface Index_Repository_Interface {
+	/**
+	 * Replaces all chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post       Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
+	 * @param string $model Embedding model.
+	 * @param string $hash Content hash.
+	 */
+	public function replace_post_chunks( WP_Post $post, array $chunks, array $embeddings, string $model, string $hash ): void;
+
+	/**
+	 * Deletes all indexed chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function delete_post_chunks( int $post_id ): void;
+
+	/**
+	 * Searches the nearest chunks.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float> $embedding Query vector.
+	 * @param array{limit?:int, model?:string, post_type?:string|list<string>, post_status?:string|list<string>} $args Search args.
+	 * @return list<array<string, mixed>> Matching rows.
+	 */
+	public function search( array $embedding, array $args = array() ): array;
+}

--- a/includes/RAG/Index_Schema.php
+++ b/includes/RAG/Index_Schema.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * MariaDB vector index schema for RAG search.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles database schema management for the RAG index table.
+ *
+ * @since 1.1.0
+ */
+class Index_Schema {
+	// Schema management necessarily uses direct queries against the dedicated RAG table.
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+
+	/**
+	 * Database table name without prefix.
+	 */
+	public const TABLE_NAME = 'wpai_rag_index';
+
+	/**
+	 * Option key storing the schema version.
+	 */
+	private const SCHEMA_VERSION_OPTION = 'wpai_rag_index_schema_version';
+
+	/**
+	 * Current schema version.
+	 */
+	private const SCHEMA_VERSION = '1';
+
+	/**
+	 * Ensures the table exists and has the required indexes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function maybe_upgrade_table(): void {
+		if ( self::SCHEMA_VERSION === get_option( self::SCHEMA_VERSION_OPTION, '' ) && $this->table_exists() ) {
+			return;
+		}
+
+		$this->maybe_create_table();
+
+		if ( ! $this->table_exists() ) {
+			return;
+		}
+
+		update_option( self::SCHEMA_VERSION_OPTION, self::SCHEMA_VERSION, false );
+	}
+
+	/**
+	 * Creates the table if needed and adds missing indexes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function maybe_create_table(): void {
+		if ( ! $this->table_exists() ) {
+			$this->create_table();
+		}
+
+		if ( ! $this->table_exists() ) {
+			return;
+		}
+
+		$this->maybe_add_indexes();
+	}
+
+	/**
+	 * Returns the full table name with prefix.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Prefixed table name.
+	 */
+	public function get_table_name(): string {
+		global $wpdb;
+
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Checks whether the table exists.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when table exists.
+	 */
+	public function table_exists(): bool {
+		global $wpdb;
+
+		$table_name     = $this->get_table_name();
+		$existing_table = $wpdb->get_var(
+			$wpdb->prepare(
+				'SHOW TABLES LIKE %s',
+				$table_name
+			)
+		);
+
+		return $existing_table === $table_name;
+	}
+
+	/**
+	 * Creates the RAG index table.
+	 *
+	 * @since 1.1.0
+	 */
+	private function create_table(): void {
+		global $wpdb;
+
+		$table_name      = $this->get_table_name();
+		$charset_collate = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table_name} (
+			id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			post_id BIGINT UNSIGNED NOT NULL,
+			post_type VARCHAR(64) NOT NULL,
+			post_status VARCHAR(20) NOT NULL,
+			chunk_id CHAR(36) NOT NULL,
+			chunk_index INT UNSIGNED NOT NULL,
+			chunk_offset INT UNSIGNED NOT NULL DEFAULT 0,
+			anchor VARCHAR(191) DEFAULT NULL,
+			title TEXT DEFAULT NULL,
+			permalink TEXT DEFAULT NULL,
+			content MEDIUMTEXT NOT NULL,
+			content_hash CHAR(64) NOT NULL,
+			embedding VECTOR(1536) NOT NULL,
+			embedding_model VARCHAR(64) NOT NULL,
+			embedding_dimensions SMALLINT UNSIGNED NOT NULL DEFAULT 1536,
+			indexed_at DATETIME NOT NULL,
+			UNIQUE KEY uniq_post_chunk (post_id, chunk_id),
+			INDEX idx_post_id (post_id),
+			INDEX idx_post_type_status (post_type, post_status),
+			INDEX idx_embedding_model (embedding_model),
+			INDEX idx_indexed_at (indexed_at)
+		) {$charset_collate};";
+
+		$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Adds missing indexes.
+	 *
+	 * @since 1.1.0
+	 */
+	private function maybe_add_indexes(): void {
+		global $wpdb;
+
+		$table_name       = $this->get_table_name();
+		$existing_indexes = $this->get_existing_indexes();
+
+		$indexes_to_add = array(
+			'idx_post_id'          => "CREATE INDEX idx_post_id ON {$table_name} (post_id)",
+			'idx_post_type_status' => "CREATE INDEX idx_post_type_status ON {$table_name} (post_type, post_status)",
+			'idx_embedding_model'  => "CREATE INDEX idx_embedding_model ON {$table_name} (embedding_model)",
+			'idx_indexed_at'       => "CREATE INDEX idx_indexed_at ON {$table_name} (indexed_at)",
+		);
+
+		foreach ( $indexes_to_add as $index_name => $sql ) {
+			if ( isset( $existing_indexes[ $index_name ] ) ) {
+				continue;
+			}
+
+			$wpdb->query( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		}
+
+		if ( isset( $existing_indexes['idx_embedding'] ) ) {
+			return;
+		}
+
+		$wpdb->suppress_errors( true );
+		$wpdb->query( "CREATE VECTOR INDEX idx_embedding ON {$table_name} (embedding) M=8 DISTANCE=COSINE" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->suppress_errors( false );
+	}
+
+	/**
+	 * Returns existing indexes keyed by name.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, bool> Existing index names.
+	 */
+	private function get_existing_indexes(): array {
+		global $wpdb;
+
+		$table_name       = $this->get_table_name();
+		$existing_indexes = array();
+		$indexes          = $wpdb->get_results( "SHOW INDEX FROM {$table_name}", ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		if ( $indexes ) {
+			foreach ( $indexes as $index ) {
+				if ( ! isset( $index['Key_name'] ) ) {
+					continue;
+				}
+
+				$existing_indexes[ (string) $index['Key_name'] ] = true;
+			}
+		}
+
+		return $existing_indexes;
+	}
+
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
+}

--- a/includes/RAG/MariaDB_Index_Backend.php
+++ b/includes/RAG/MariaDB_Index_Backend.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * MariaDB vector RAG backend.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns MariaDB vector index availability and storage.
+ *
+ * @since 1.1.0
+ */
+class MariaDB_Index_Backend implements Index_Backend_Interface {
+	/**
+	 * Required MariaDB version for VECTOR INDEX support.
+	 */
+	private const MINIMUM_MARIADB_VERSION = '11.8.0';
+
+	/**
+	 * Schema manager.
+	 *
+	 * @var \WordPress\AI\RAG\MariaDB_Index_Schema
+	 */
+	private MariaDB_Index_Schema $schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\MariaDB_Index_Schema|null $schema Schema manager.
+	 */
+	public function __construct( ?MariaDB_Index_Schema $schema = null ) {
+		$this->schema = $schema ?? new MariaDB_Index_Schema();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_id(): string {
+		return Availability::BACKEND_MARIADB;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_label(): string {
+		return __( 'Optimal search method backed by MariaDB', 'ai' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function is_available(): bool {
+		return $this->is_mariadb_vector_index_supported();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_unavailable_reason(): string {
+		return __( 'MariaDB 11.8 or newer is required for native vector indexes.', 'ai' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function create_repository( int $dimensions ): Index_Repository_Interface {
+		return new MariaDB_Index_Repository( $this->schema, $dimensions );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function ensure_storage(): bool {
+		$this->schema->maybe_upgrade_table();
+
+		return $this->schema->table_exists();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function has_index_data(): bool {
+		return $this->schema->has_index_data();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function cleanup(): void {
+		$this->schema->cleanup();
+	}
+
+	/**
+	 * Checks whether the database is MariaDB 11.8+.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when VECTOR INDEX should be available.
+	 */
+	public function is_mariadb_vector_index_supported(): bool {
+		$version = $this->get_database_version();
+
+		return $this->is_supported_mariadb_version( $version );
+	}
+
+	/**
+	 * Checks a raw database version string.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $version Raw SELECT VERSION() value.
+	 * @return bool True when supported.
+	 */
+	public function is_supported_mariadb_version( string $version ): bool {
+		if ( false === stripos( $version, 'mariadb' ) ) {
+			return false;
+		}
+
+		$version = preg_replace( '/^5\.5\.5-/', '', $version ) ?? $version;
+
+		if ( ! preg_match( '/(\d+\.\d+(?:\.\d+)?)/', $version, $matches ) ) {
+			return false;
+		}
+
+		return version_compare( $matches[1], self::MINIMUM_MARIADB_VERSION, '>=' );
+	}
+
+	/**
+	 * Reads the database version string.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Version string.
+	 */
+	protected function get_database_version(): string {
+		global $wpdb;
+
+		$version = $wpdb->get_var( 'SELECT VERSION()' ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+		return is_string( $version ) ? $version : '';
+	}
+}

--- a/includes/RAG/MariaDB_Index_Repository.php
+++ b/includes/RAG/MariaDB_Index_Repository.php
@@ -16,20 +16,20 @@ use WP_Post;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Stores and queries RAG chunks.
+ * Stores and queries RAG chunks in a MariaDB vector table.
  *
  * @since 1.1.0
  */
-class Index_Repository implements Index_Repository_Interface {
+class MariaDB_Index_Repository implements Index_Repository_Interface {
 	// Direct queries are intentional because this repository owns a dedicated vector table.
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 
 	/**
 	 * Schema manager.
 	 *
-	 * @var \WordPress\AI\RAG\Index_Schema
+	 * @var \WordPress\AI\RAG\MariaDB_Index_Schema
 	 */
-	private Index_Schema $schema;
+	private MariaDB_Index_Schema $schema;
 
 	/**
 	 * Vector dimensions.
@@ -43,10 +43,10 @@ class Index_Repository implements Index_Repository_Interface {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param \WordPress\AI\RAG\Index_Schema $schema     Schema manager.
-	 * @param int                            $dimensions Vector dimensions.
+	 * @param \WordPress\AI\RAG\MariaDB_Index_Schema $schema     Schema manager.
+	 * @param int                                    $dimensions Vector dimensions.
 	 */
-	public function __construct( Index_Schema $schema, int $dimensions = 1536 ) {
+	public function __construct( MariaDB_Index_Schema $schema, int $dimensions = 1536 ) {
 		$this->schema     = $schema;
 		$this->dimensions = $dimensions;
 	}
@@ -56,8 +56,8 @@ class Index_Repository implements Index_Repository_Interface {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param \WP_Post $post       Post object.
-	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param \WP_Post $post Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, content:string, embedding_text?:string}> $chunks Chunk data.
 	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
 	 * @param string $model Embedding model.
 	 * @param string $hash Content hash.
@@ -126,7 +126,7 @@ class Index_Repository implements Index_Repository_Interface {
 
 		$defaults = array(
 			'limit'       => 20,
-			'model'       => 'text-embedding-3-small',
+			'model'       => OpenAI_Embedding_Client::DEFAULT_MODEL,
 			'post_type'   => array(),
 			'post_status' => array(),
 		);
@@ -163,7 +163,7 @@ class Index_Repository implements Index_Repository_Interface {
 
 		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic clauses are sanitized and target the owned vector index table.
 		$sql = $wpdb->prepare(
-			"SELECT id, post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, anchor, title, permalink, content,
+			"SELECT id, post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, content,
 				VEC_DISTANCE_COSINE(embedding, VEC_FromText(%s)) AS distance
 			FROM {$table_name}
 			WHERE {$where_clause}
@@ -184,7 +184,7 @@ class Index_Repository implements Index_Repository_Interface {
 	 * @since 1.1.0
 	 *
 	 * @param \WP_Post $post Post object.
-	 * @param array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string} $chunk Chunk data.
+	 * @param array{chunk_id:string, chunk_index:int, chunk_offset:int, content:string, embedding_text?:string} $chunk Chunk data.
 	 * @param list<int|float> $embedding Embedding vector.
 	 * @param string $model Embedding model.
 	 * @param string $hash Content hash.
@@ -202,23 +202,19 @@ class Index_Repository implements Index_Repository_Interface {
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Dynamic table name targets the owned vector index table.
 		$sql = $wpdb->prepare(
 			"INSERT INTO {$table_name}
-				(post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, anchor, title, permalink, content, content_hash, embedding, embedding_model, embedding_dimensions, indexed_at)
+				(post_id, post_type, post_status, chunk_id, chunk_index, chunk_offset, content, content_hash, embedding, embedding_model, indexed_at)
 			VALUES
-				(%d, %s, %s, %s, %d, %d, %s, %s, %s, %s, %s, VEC_FromText(%s), %s, %d, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				(%d, %s, %s, %s, %d, %d, %s, %s, VEC_FromText(%s), %s, %s)", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			(int) $post->ID,
 			(string) $post->post_type,
 			(string) $post->post_status,
 			(string) $chunk['chunk_id'],
 			(int) $chunk['chunk_index'],
 			(int) $chunk['chunk_offset'],
-			isset( $chunk['anchor'] ) ? (string) $chunk['anchor'] : null,
-			(string) $chunk['title'],
-			(string) $chunk['permalink'],
 			(string) $chunk['content'],
 			$hash,
 			$vector_text,
 			$model,
-			$this->dimensions,
 			current_time( 'mysql', true )
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/includes/RAG/MariaDB_Index_Schema.php
+++ b/includes/RAG/MariaDB_Index_Schema.php
@@ -12,11 +12,11 @@ namespace WordPress\AI\RAG;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Handles database schema management for the RAG index table.
+ * Handles database schema management for the MariaDB RAG index table.
  *
  * @since 1.1.0
  */
-class Index_Schema {
+class MariaDB_Index_Schema {
 	// Schema management necessarily uses direct queries against the dedicated RAG table.
 	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange
 
@@ -33,7 +33,7 @@ class Index_Schema {
 	/**
 	 * Current schema version.
 	 */
-	private const SCHEMA_VERSION = '1';
+	private const SCHEMA_VERSION = '2';
 
 	/**
 	 * Ensures the table exists and has the required indexes.
@@ -106,6 +106,41 @@ class Index_Schema {
 	}
 
 	/**
+	 * Checks whether the table has stored rows.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when storage exists.
+	 */
+	public function has_index_data(): bool {
+		$has_schema_option = '' !== get_option( self::SCHEMA_VERSION_OPTION, '' );
+
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+		if ( ! $this->table_exists() ) {
+			return $has_schema_option;
+		}
+
+		$row = $wpdb->get_var( "SELECT id FROM {$table_name} LIMIT 1" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		return null !== $row || $has_schema_option;
+	}
+
+	/**
+	 * Drops the table and schema option.
+	 *
+	 * @since 1.1.0
+	 */
+	public function cleanup(): void {
+		global $wpdb;
+
+		$table_name = $this->get_table_name();
+		$wpdb->query( "DROP TABLE IF EXISTS {$table_name}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		delete_option( self::SCHEMA_VERSION_OPTION );
+	}
+
+	/**
 	 * Creates the RAG index table.
 	 *
 	 * @since 1.1.0
@@ -124,14 +159,10 @@ class Index_Schema {
 			chunk_id CHAR(36) NOT NULL,
 			chunk_index INT UNSIGNED NOT NULL,
 			chunk_offset INT UNSIGNED NOT NULL DEFAULT 0,
-			anchor VARCHAR(191) DEFAULT NULL,
-			title TEXT DEFAULT NULL,
-			permalink TEXT DEFAULT NULL,
 			content MEDIUMTEXT NOT NULL,
 			content_hash CHAR(64) NOT NULL,
 			embedding VECTOR(1536) NOT NULL,
 			embedding_model VARCHAR(64) NOT NULL,
-			embedding_dimensions SMALLINT UNSIGNED NOT NULL DEFAULT 1536,
 			indexed_at DATETIME NOT NULL,
 			UNIQUE KEY uniq_post_chunk (post_id, chunk_id),
 			INDEX idx_post_id (post_id),

--- a/includes/RAG/Memory_Index_Backend.php
+++ b/includes/RAG/Memory_Index_Backend.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Compact in-memory RAG backend.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns compact memory fallback availability and storage.
+ *
+ * @since 1.1.0
+ */
+class Memory_Index_Backend implements Index_Backend_Interface {
+	// Direct queries are used for cleanup/status over the backend-owned meta key.
+	// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_id(): string {
+		return Availability::BACKEND_MEMORY;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_label(): string {
+		return __( 'Fallback in-memory search backed by PHP', 'ai' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function is_available(): bool {
+		/**
+		 * Filters whether RAG should use compact in-memory exact scan when MariaDB vector indexes are unavailable.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param bool $enabled Whether the fallback backend is enabled.
+		 */
+		return (bool) apply_filters( 'wpai_rag_memory_fallback_enabled', true );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_unavailable_reason(): string {
+		return __( 'The compact memory fallback is disabled.', 'ai' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function create_repository( int $dimensions ): Index_Repository_Interface {
+		return new Memory_Index_Repository( $dimensions );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function ensure_storage(): bool {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function has_index_data(): bool {
+		global $wpdb;
+
+		return (bool) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT meta_id FROM {$wpdb->postmeta} WHERE meta_key = %s LIMIT 1", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				Memory_Index_Repository::META_CHUNKS
+			)
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function cleanup(): void {
+		global $wpdb;
+
+		$wpdb->delete(
+			$wpdb->postmeta,
+			array( 'meta_key' => Memory_Index_Repository::META_CHUNKS ),
+			array( '%s' )
+		);
+	}
+
+	// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+}

--- a/includes/RAG/Memory_Index_Repository.php
+++ b/includes/RAG/Memory_Index_Repository.php
@@ -121,7 +121,7 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 	public function search( array $embedding, array $args = array() ): array {
 		$this->validate_embedding( $embedding );
 
-		$defaults = array(
+		$defaults   = array(
 			'limit'       => 20,
 			'model'       => 'text-embedding-3-small',
 			'post_type'   => array(),
@@ -219,19 +219,25 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 					continue;
 				}
 
-				if ( is_numeric( $post ) ) {
-					$post_ids[] = absint( $post );
+				if ( ! is_numeric( $post ) ) {
+					continue;
 				}
+
+				$post_ids[] = absint( $post );
 			}
 
+			$post_ids_count = count( $post_ids );
+
 			foreach ( $post_ids as $post_id ) {
-				if ( $post_id > 0 ) {
-					yield $post_id;
+				if ( $post_id <= 0 ) {
+					continue;
 				}
+
+				yield $post_id;
 			}
 
 			++$page;
-		} while ( count( $post_ids ) === $batch_size );
+		} while ( $post_ids_count === $batch_size );
 	}
 
 	/**
@@ -331,15 +337,19 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 
 		foreach ( $best as $index => $candidate ) {
 			$distance = (float) $candidate['distance'];
-			if ( $distance > $worst_distance ) {
-				$worst_distance = $distance;
-				$worst_index    = (int) $index;
+			if ( $distance <= $worst_distance ) {
+				continue;
 			}
+
+			$worst_distance = $distance;
+			$worst_index    = (int) $index;
 		}
 
-		if ( (float) $row['distance'] < $worst_distance ) {
-			$best[ $worst_index ] = $row;
+		if ( (float) $row['distance'] >= $worst_distance ) {
+			return;
 		}
+
+		$best[ $worst_index ] = $row;
 	}
 
 	/**

--- a/includes/RAG/Memory_Index_Repository.php
+++ b/includes/RAG/Memory_Index_Repository.php
@@ -50,8 +50,8 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param \WP_Post $post       Post object.
-	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param \WP_Post $post Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, content:string, embedding_text?:string}> $chunks Chunk data.
 	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
 	 * @param string $model Embedding model.
 	 * @param string $hash Content hash.
@@ -68,22 +68,18 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 			$this->validate_embedding( $embedding );
 
 			$records[] = array(
-				'post_id'              => (int) $post->ID,
-				'post_type'            => (string) $post->post_type,
-				'post_status'          => (string) $post->post_status,
-				'chunk_id'             => (string) $chunk['chunk_id'],
-				'chunk_index'          => (int) $chunk['chunk_index'],
-				'chunk_offset'         => (int) $chunk['chunk_offset'],
-				'anchor'               => isset( $chunk['anchor'] ) ? (string) $chunk['anchor'] : null,
-				'title'                => (string) $chunk['title'],
-				'permalink'            => (string) $chunk['permalink'],
-				'content'              => (string) $chunk['content'],
-				'content_hash'         => $hash,
-				'embedding'            => base64_encode( $this->pack_embedding( $embedding ) ),
-				'embedding_norm'       => $this->calculate_norm( $embedding ),
-				'embedding_model'      => $model,
-				'embedding_dimensions' => $this->dimensions,
-				'indexed_at'           => current_time( 'mysql', true ),
+				'post_id'         => (int) $post->ID,
+				'post_type'       => (string) $post->post_type,
+				'post_status'     => (string) $post->post_status,
+				'chunk_id'        => (string) $chunk['chunk_id'],
+				'chunk_index'     => (int) $chunk['chunk_index'],
+				'chunk_offset'    => (int) $chunk['chunk_offset'],
+				'content'         => (string) $chunk['content'],
+				'content_hash'    => $hash,
+				'embedding'       => base64_encode( $this->pack_embedding( $embedding ) ),
+				'embedding_norm'  => $this->calculate_norm( $embedding ),
+				'embedding_model' => $model,
+				'indexed_at'      => current_time( 'mysql', true ),
 			);
 		}
 
@@ -123,7 +119,7 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 
 		$defaults   = array(
 			'limit'       => 20,
-			'model'       => 'text-embedding-3-small',
+			'model'       => OpenAI_Embedding_Client::DEFAULT_MODEL,
 			'post_type'   => array(),
 			'post_status' => array(),
 		);
@@ -250,10 +246,9 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 	 * @return bool True when the record can be scanned.
 	 */
 	private function record_matches( array $record, string $model ): bool {
-		return isset( $record['embedding'], $record['embedding_model'], $record['embedding_dimensions'] )
+		return isset( $record['embedding'], $record['embedding_model'] )
 			&& is_string( $record['embedding'] )
-			&& $model === (string) $record['embedding_model']
-			&& $this->dimensions === (int) $record['embedding_dimensions'];
+			&& $model === (string) $record['embedding_model'];
 	}
 
 	/**
@@ -310,9 +305,6 @@ class Memory_Index_Repository implements Index_Repository_Interface {
 			'chunk_id'     => (string) $record['chunk_id'],
 			'chunk_index'  => (int) $record['chunk_index'],
 			'chunk_offset' => (int) $record['chunk_offset'],
-			'anchor'       => isset( $record['anchor'] ) ? (string) $record['anchor'] : null,
-			'title'        => (string) $record['title'],
-			'permalink'    => (string) $record['permalink'],
 			'content'      => (string) $record['content'],
 		);
 	}

--- a/includes/RAG/Memory_Index_Repository.php
+++ b/includes/RAG/Memory_Index_Repository.php
@@ -1,0 +1,429 @@
+<?php
+/**
+ * Compact in-memory exact-scan RAG repository.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use InvalidArgumentException;
+use RuntimeException;
+use WP_Post;
+use WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stores compact vectors in post meta and scans them in memory at query time.
+ *
+ * @since 1.1.0
+ */
+class Memory_Index_Repository implements Index_Repository_Interface {
+	/**
+	 * Post meta key storing compact chunk records.
+	 */
+	public const META_CHUNKS = '_ai_rag_memory_chunks';
+
+	/**
+	 * Vector dimensions.
+	 *
+	 * @var int
+	 */
+	private int $dimensions;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $dimensions Vector dimensions.
+	 */
+	public function __construct( int $dimensions = 1536 ) {
+		$this->dimensions = $dimensions;
+	}
+
+	/**
+	 * Replaces all chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post       Post object.
+	 * @param list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor?:string|null, title:string, permalink:string, content:string}> $chunks Chunk data.
+	 * @param list<list<int|float>> $embeddings Embedding vectors in chunk order.
+	 * @param string $model Embedding model.
+	 * @param string $hash Content hash.
+	 * @throws \RuntimeException When a vector cannot be packed.
+	 */
+	public function replace_post_chunks( WP_Post $post, array $chunks, array $embeddings, string $model, string $hash ): void {
+		if ( count( $chunks ) !== count( $embeddings ) ) {
+			throw new InvalidArgumentException( 'Chunk and embedding counts must match.' );
+		}
+
+		$records = array();
+		foreach ( $chunks as $index => $chunk ) {
+			$embedding = $embeddings[ $index ];
+			$this->validate_embedding( $embedding );
+
+			$records[] = array(
+				'post_id'              => (int) $post->ID,
+				'post_type'            => (string) $post->post_type,
+				'post_status'          => (string) $post->post_status,
+				'chunk_id'             => (string) $chunk['chunk_id'],
+				'chunk_index'          => (int) $chunk['chunk_index'],
+				'chunk_offset'         => (int) $chunk['chunk_offset'],
+				'anchor'               => isset( $chunk['anchor'] ) ? (string) $chunk['anchor'] : null,
+				'title'                => (string) $chunk['title'],
+				'permalink'            => (string) $chunk['permalink'],
+				'content'              => (string) $chunk['content'],
+				'content_hash'         => $hash,
+				'embedding'            => base64_encode( $this->pack_embedding( $embedding ) ),
+				'embedding_norm'       => $this->calculate_norm( $embedding ),
+				'embedding_model'      => $model,
+				'embedding_dimensions' => $this->dimensions,
+				'indexed_at'           => current_time( 'mysql', true ),
+			);
+		}
+
+		if ( empty( $records ) ) {
+			$this->delete_post_chunks( (int) $post->ID );
+			return;
+		}
+
+		$result = update_post_meta( (int) $post->ID, self::META_CHUNKS, $records );
+		if ( false === $result && get_post_meta( (int) $post->ID, self::META_CHUNKS, true ) !== $records ) {
+			throw new RuntimeException( 'Failed to store RAG memory index chunks.' );
+		}
+	}
+
+	/**
+	 * Deletes all indexed chunks for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function delete_post_chunks( int $post_id ): void {
+		delete_post_meta( $post_id, self::META_CHUNKS );
+	}
+
+	/**
+	 * Searches the nearest chunks using an exact in-memory scan.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float> $embedding Query vector.
+	 * @param array{limit?:int, model?:string, post_type?:string|list<string>, post_status?:string|list<string>} $args Search args.
+	 * @return list<array<string, mixed>> Matching rows.
+	 */
+	public function search( array $embedding, array $args = array() ): array {
+		$this->validate_embedding( $embedding );
+
+		$defaults = array(
+			'limit'       => 20,
+			'model'       => 'text-embedding-3-small',
+			'post_type'   => array(),
+			'post_status' => array(),
+		);
+		$args       = wp_parse_args( $args, $defaults );
+		$limit      = max( 1, min( 100, (int) $args['limit'] ) );
+		$model      = (string) $args['model'];
+		$query_norm = $this->calculate_norm( $embedding );
+
+		if ( $query_norm <= 0.0 ) {
+			return array();
+		}
+
+		$best = array();
+
+		foreach ( $this->get_indexed_post_ids( $args ) as $post_id ) {
+			$records = get_post_meta( $post_id, self::META_CHUNKS, true );
+			if ( ! is_array( $records ) ) {
+				continue;
+			}
+
+			foreach ( $records as $record ) {
+				if ( ! is_array( $record ) || ! $this->record_matches( $record, $model ) ) {
+					continue;
+				}
+
+				$distance = $this->distance_from_record( $embedding, $query_norm, $record );
+				if ( null === $distance ) {
+					continue;
+				}
+
+				$row             = $this->record_to_row( $record );
+				$row['distance'] = $distance;
+
+				$this->keep_best_row( $best, $row, $limit );
+			}
+		}
+
+		usort(
+			$best,
+			static fn( array $a, array $b ): int => (float) $a['distance'] <=> (float) $b['distance']
+		);
+
+		return $best;
+	}
+
+	/**
+	 * Returns indexed post IDs matching search args.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $args Search args.
+	 * @return iterable<int>
+	 */
+	private function get_indexed_post_ids( array $args ): iterable {
+		$post_types    = $this->sanitize_slug_list( (array) $args['post_type'] );
+		$post_statuses = $this->sanitize_slug_list( (array) $args['post_status'] );
+		$page          = 1;
+		$batch_size    = max( 50, min( 500, (int) apply_filters( 'wpai_rag_memory_scan_post_batch_size', 200 ) ) );
+
+		do {
+			$query = new WP_Query(
+				array(
+					'fields'                 => 'ids',
+					'post_type'              => empty( $post_types ) ? 'any' : $post_types,
+					'post_status'            => empty( $post_statuses ) ? 'any' : $post_statuses,
+					'posts_per_page'         => $batch_size,
+					'paged'                  => $page,
+					'orderby'                => 'ID',
+					'order'                  => 'ASC',
+					'ignore_sticky_posts'    => true,
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Fallback scans only posts that carry compact RAG metadata.
+					'meta_query'             => array(
+						'relation' => 'AND',
+						array(
+							'key'   => Index_Manager::META_STATUS,
+							'value' => Index_Manager::STATUS_CLEAN,
+						),
+						array(
+							'key'     => self::META_CHUNKS,
+							'compare' => 'EXISTS',
+						),
+					),
+				)
+			);
+
+			$post_ids = array();
+			foreach ( $query->posts as $post ) {
+				if ( $post instanceof WP_Post ) {
+					$post_ids[] = (int) $post->ID;
+					continue;
+				}
+
+				if ( is_numeric( $post ) ) {
+					$post_ids[] = absint( $post );
+				}
+			}
+
+			foreach ( $post_ids as $post_id ) {
+				if ( $post_id > 0 ) {
+					yield $post_id;
+				}
+			}
+
+			++$page;
+		} while ( count( $post_ids ) === $batch_size );
+	}
+
+	/**
+	 * Checks whether a compact chunk record is eligible for a query.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $record Chunk record.
+	 * @param string              $model  Embedding model.
+	 * @return bool True when the record can be scanned.
+	 */
+	private function record_matches( array $record, string $model ): bool {
+		return isset( $record['embedding'], $record['embedding_model'], $record['embedding_dimensions'] )
+			&& is_string( $record['embedding'] )
+			&& $model === (string) $record['embedding_model']
+			&& $this->dimensions === (int) $record['embedding_dimensions'];
+	}
+
+	/**
+	 * Calculates cosine distance for a compact chunk record.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float>      $query      Query vector.
+	 * @param float                $query_norm Query vector norm.
+	 * @param array<string, mixed> $record     Chunk record.
+	 * @return float|null Distance, or null when the record cannot be decoded.
+	 */
+	private function distance_from_record( array $query, float $query_norm, array $record ): ?float {
+		$packed = base64_decode( (string) $record['embedding'], true );
+		if ( ! is_string( $packed ) || strlen( $packed ) !== $this->dimensions * 4 ) {
+			return null;
+		}
+
+		$values = unpack( 'g*', $packed );
+		if ( ! is_array( $values ) || count( $values ) !== $this->dimensions ) {
+			return null;
+		}
+
+		$dot = 0.0;
+		for ( $i = 0; $i < $this->dimensions; ++$i ) {
+			$dot += (float) $query[ $i ] * (float) $values[ $i + 1 ];
+		}
+
+		$record_norm = isset( $record['embedding_norm'] ) ? (float) $record['embedding_norm'] : $this->calculate_norm( array_values( $values ) );
+		if ( $record_norm <= 0.0 ) {
+			return null;
+		}
+
+		$similarity = $dot / ( $query_norm * $record_norm );
+		$similarity = max( -1.0, min( 1.0, $similarity ) );
+
+		return 1.0 - $similarity;
+	}
+
+	/**
+	 * Converts a compact chunk record into the repository row shape.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $record Chunk record.
+	 * @return array<string, mixed> Row.
+	 */
+	private function record_to_row( array $record ): array {
+		return array(
+			'id'           => (string) ( (int) $record['post_id'] ) . ':' . (string) $record['chunk_id'],
+			'post_id'      => (int) $record['post_id'],
+			'post_type'    => (string) $record['post_type'],
+			'post_status'  => (string) $record['post_status'],
+			'chunk_id'     => (string) $record['chunk_id'],
+			'chunk_index'  => (int) $record['chunk_index'],
+			'chunk_offset' => (int) $record['chunk_offset'],
+			'anchor'       => isset( $record['anchor'] ) ? (string) $record['anchor'] : null,
+			'title'        => (string) $record['title'],
+			'permalink'    => (string) $record['permalink'],
+			'content'      => (string) $record['content'],
+		);
+	}
+
+	/**
+	 * Maintains the top rows by distance.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<array<string, mixed>> $best  Current best rows.
+	 * @param array<string, mixed>       $row   Candidate row.
+	 * @param int                        $limit Maximum rows.
+	 */
+	private function keep_best_row( array &$best, array $row, int $limit ): void {
+		if ( count( $best ) < $limit ) {
+			$best[] = $row;
+			return;
+		}
+
+		$worst_index    = 0;
+		$worst_distance = (float) $best[0]['distance'];
+
+		foreach ( $best as $index => $candidate ) {
+			$distance = (float) $candidate['distance'];
+			if ( $distance > $worst_distance ) {
+				$worst_distance = $distance;
+				$worst_index    = (int) $index;
+			}
+		}
+
+		if ( (float) $row['distance'] < $worst_distance ) {
+			$best[ $worst_index ] = $row;
+		}
+	}
+
+	/**
+	 * Packs an embedding into little-endian float32 bytes.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float> $embedding Embedding vector.
+	 * @return string Packed vector.
+	 */
+	private function pack_embedding( array $embedding ): string {
+		$packed = '';
+
+		foreach ( $embedding as $value ) {
+			$packed .= pack( 'g', (float) $value );
+		}
+
+		if ( strlen( $packed ) !== $this->dimensions * 4 ) {
+			throw new RuntimeException( 'Failed to pack embedding vector.' );
+		}
+
+		return $packed;
+	}
+
+	/**
+	 * Calculates vector norm.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<int|float> $embedding Embedding vector.
+	 * @return float Vector norm.
+	 */
+	private function calculate_norm( array $embedding ): float {
+		$sum = 0.0;
+		foreach ( $embedding as $value ) {
+			$sum += (float) $value * (float) $value;
+		}
+
+		return sqrt( $sum );
+	}
+
+	/**
+	 * Validates a vector.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $embedding Candidate vector.
+	 */
+	private function validate_embedding( $embedding ): void {
+		if ( ! is_array( $embedding ) || count( $embedding ) !== $this->dimensions ) {
+			throw new InvalidArgumentException( 'Embedding vector has the wrong dimensions.' );
+		}
+
+		foreach ( $embedding as $value ) {
+			if ( ! is_int( $value ) && ! is_float( $value ) ) {
+				throw new InvalidArgumentException( 'Embedding vector contains a non-numeric value.' );
+			}
+		}
+	}
+
+	/**
+	 * Sanitizes a list of slugs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<mixed> $values Raw values.
+	 * @return list<string> Sanitized values.
+	 */
+	private function sanitize_slug_list( array $values ): array {
+		$slugs = array();
+
+		foreach ( $values as $value ) {
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+
+			$value = sanitize_key( (string) $value );
+			if ( '' === $value ) {
+				continue;
+			}
+
+			$slugs[] = $value;
+		}
+
+		return array_values( array_unique( $slugs ) );
+	}
+}

--- a/includes/RAG/OpenAI_Embedding_Client.php
+++ b/includes/RAG/OpenAI_Embedding_Client.php
@@ -1,0 +1,294 @@
+<?php
+/**
+ * Minimal OpenAI embeddings client for RAG search.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use Throwable;
+use WP_Error;
+use WordPress\AiClient\AiClient;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Calls OpenAI embeddings directly until AI Client exposes embedding execution.
+ *
+ * @since 1.1.0
+ */
+class OpenAI_Embedding_Client {
+	/**
+	 * OpenAI embeddings endpoint.
+	 */
+	private const ENDPOINT = 'https://api.openai.com/v1/embeddings';
+
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability $availability Availability service.
+	 */
+	public function __construct( Availability $availability ) {
+		$this->availability = $availability;
+	}
+
+	/**
+	 * Embeds text inputs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<string> $texts Text inputs.
+	 * @return list<list<float>>|\WP_Error Embedding vectors or error.
+	 */
+	public function embed( array $texts ) {
+		$texts = array_values(
+			array_filter(
+				array_map( 'strval', $texts ),
+				static fn( string $text ): bool => '' !== trim( $text )
+			)
+		);
+
+		if ( empty( $texts ) ) {
+			return array();
+		}
+
+		$api_key = $this->get_api_key();
+		if ( '' === $api_key ) {
+			return new WP_Error( 'wpai_rag_missing_openai_key', __( 'OpenAI API key is not available.', 'ai' ) );
+		}
+
+		$batch_size = max( 1, min( 64, (int) apply_filters( 'wpai_rag_embedding_batch_size', 32 ) ) );
+		$vectors    = array();
+
+		foreach ( array_chunk( $texts, $batch_size ) as $batch ) {
+			$response = $this->request_batch_with_retries( array_values( $batch ), $api_key );
+
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+
+			$vectors = array_merge( $vectors, $response );
+		}
+
+		return $vectors;
+	}
+
+	/**
+	 * Requests one batch with retry for transient failures.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<string> $texts   Text inputs.
+	 * @param string       $api_key API key.
+	 * @return list<list<float>>|\WP_Error Embedding vectors or error.
+	 */
+	private function request_batch_with_retries( array $texts, string $api_key ) {
+		$attempts = max( 1, min( 5, (int) apply_filters( 'wpai_rag_embedding_retry_attempts', 3 ) ) );
+		$last     = null;
+
+		for ( $attempt = 1; $attempt <= $attempts; ++$attempt ) {
+			$result = $this->request_batch( $texts, $api_key );
+
+			if ( ! is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$last        = $result;
+			$status_code = (int) $result->get_error_data( 'status' );
+			$retryable   = 429 === $status_code || $status_code >= 500 || 0 === $status_code;
+
+			if ( ! $retryable || $attempt === $attempts ) {
+				break;
+			}
+
+			$delay = max( 0, (int) apply_filters( 'wpai_rag_embedding_retry_delay', $attempt ) );
+			if ( $delay <= 0 ) {
+				continue;
+			}
+
+			sleep( $delay );
+		}
+
+		return $last instanceof WP_Error ? $last : new WP_Error( 'wpai_rag_embedding_failed', __( 'Embedding request failed.', 'ai' ) );
+	}
+
+	/**
+	 * Requests one OpenAI embeddings batch.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<string> $texts   Text inputs.
+	 * @param string       $api_key API key.
+	 * @return list<list<float>>|\WP_Error Embedding vectors or error.
+	 */
+	private function request_batch( array $texts, string $api_key ) {
+		$body = array(
+			'model' => $this->availability->get_embedding_model(),
+			'input' => $texts,
+		);
+		$json = wp_json_encode( $body );
+
+		if ( ! is_string( $json ) || '' === $json ) {
+			return new WP_Error( 'wpai_rag_embedding_invalid_request', __( 'Failed to encode the embeddings request.', 'ai' ), array( 'status' => 0 ) );
+		}
+
+		$response = wp_remote_post(
+			self::ENDPOINT,
+			array(
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $api_key,
+					'Content-Type'  => 'application/json',
+				),
+				'timeout' => max( 5, (int) apply_filters( 'wpai_rag_embedding_request_timeout', 30 ) ),
+				'body'    => $json,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'wpai_rag_embedding_http_error',
+				$response->get_error_message(),
+				array( 'status' => 0 )
+			);
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$raw_body    = wp_remote_retrieve_body( $response );
+
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			return new WP_Error(
+				'wpai_rag_embedding_http_error',
+				$this->extract_error_message( $raw_body ),
+				array( 'status' => $status_code )
+			);
+		}
+
+		$data = json_decode( $raw_body, true );
+		if ( ! is_array( $data ) || empty( $data['data'] ) || ! is_array( $data['data'] ) ) {
+			return new WP_Error( 'wpai_rag_embedding_invalid_response', __( 'OpenAI returned an invalid embeddings response.', 'ai' ), array( 'status' => $status_code ) );
+		}
+
+		$ordered = array();
+		foreach ( $data['data'] as $item ) {
+			if ( ! is_array( $item ) || ! isset( $item['index'], $item['embedding'] ) || ! is_array( $item['embedding'] ) ) {
+				return new WP_Error( 'wpai_rag_embedding_invalid_response', __( 'OpenAI returned an invalid embedding item.', 'ai' ), array( 'status' => $status_code ) );
+			}
+
+			$embedding = array_values( array_map( 'floatval', $item['embedding'] ) );
+			if ( count( $embedding ) !== $this->availability->get_embedding_dimensions() ) {
+				return new WP_Error( 'wpai_rag_embedding_dimensions_mismatch', __( 'OpenAI returned an embedding with unexpected dimensions.', 'ai' ), array( 'status' => $status_code ) );
+			}
+
+			$ordered[ (int) $item['index'] ] = $embedding;
+		}
+
+		ksort( $ordered );
+
+		return array_values( $ordered );
+	}
+
+	/**
+	 * Resolves the OpenAI API key from the connector.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string API key or empty string.
+	 */
+	private function get_api_key(): string {
+		/**
+		 * Filters the API key used by the RAG OpenAI embeddings client.
+		 *
+		 * Useful for tests and alternate secret storage.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $api_key API key.
+		 */
+		$filtered = apply_filters( 'wpai_rag_openai_embedding_api_key', '' );
+		if ( is_string( $filtered ) && '' !== $filtered ) {
+			return $filtered;
+		}
+
+		if ( class_exists( AiClient::class ) ) {
+			try {
+				$auth = AiClient::defaultRegistry()->getProviderRequestAuthentication( Availability::OPENAI_CONNECTOR_ID );
+				if ( is_object( $auth ) && method_exists( $auth, 'getApiKey' ) ) {
+					$key = $auth->getApiKey();
+					if ( is_string( $key ) && '' !== $key ) {
+						return $key;
+					}
+				}
+			} catch ( Throwable $e ) {
+				unset( $e );
+				// Fall back to connector metadata below.
+			}
+		}
+
+		if ( ! function_exists( 'wp_get_connector' ) ) {
+			return '';
+		}
+
+		$connector = wp_get_connector( Availability::OPENAI_CONNECTOR_ID );
+		if ( ! is_array( $connector ) || empty( $connector['authentication'] ) || ! is_array( $connector['authentication'] ) ) {
+			return '';
+		}
+
+		$auth          = $connector['authentication'];
+		$env_var_name  = isset( $auth['env_var_name'] ) && is_string( $auth['env_var_name'] ) ? $auth['env_var_name'] : '';
+		$constant_name = isset( $auth['constant_name'] ) && is_string( $auth['constant_name'] ) ? $auth['constant_name'] : '';
+		$setting_name  = isset( $auth['setting_name'] ) && is_string( $auth['setting_name'] ) ? $auth['setting_name'] : '';
+
+		if ( '' !== $env_var_name ) {
+			$value = getenv( $env_var_name );
+			if ( false !== $value && '' !== $value ) {
+				return $value;
+			}
+		}
+
+		if ( '' !== $constant_name && defined( $constant_name ) ) {
+			$value = constant( $constant_name );
+			if ( is_string( $value ) && '' !== $value ) {
+				return $value;
+			}
+		}
+
+		if ( '' !== $setting_name ) {
+			$value = get_option( $setting_name, '' );
+			if ( is_string( $value ) && '' !== $value ) {
+				return $value;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Extracts an API error message.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $raw_body Raw response body.
+	 * @return string Error message.
+	 */
+	private function extract_error_message( string $raw_body ): string {
+		$data = json_decode( $raw_body, true );
+
+		if ( is_array( $data ) && isset( $data['error']['message'] ) && is_string( $data['error']['message'] ) ) {
+			return $data['error']['message'];
+		}
+
+		return __( 'OpenAI embeddings request failed.', 'ai' );
+	}
+}

--- a/includes/RAG/OpenAI_Embedding_Client.php
+++ b/includes/RAG/OpenAI_Embedding_Client.php
@@ -12,6 +12,7 @@ namespace WordPress\AI\RAG;
 use Throwable;
 use WP_Error;
 use WordPress\AiClient\AiClient;
+use function WordPress\AI\has_connector_authentication;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -22,27 +23,24 @@ defined( 'ABSPATH' ) || exit;
  */
 class OpenAI_Embedding_Client {
 	/**
+	 * OpenAI connector identifier.
+	 */
+	public const CONNECTOR_ID = 'openai';
+
+	/**
+	 * Default supported embedding model.
+	 */
+	public const DEFAULT_MODEL = 'text-embedding-3-small';
+
+	/**
 	 * OpenAI embeddings endpoint.
 	 */
 	private const ENDPOINT = 'https://api.openai.com/v1/embeddings';
 
 	/**
-	 * Availability service.
-	 *
-	 * @var \WordPress\AI\RAG\Availability
+	 * Embedding dimensions for the supported model.
 	 */
-	private Availability $availability;
-
-	/**
-	 * Constructor.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param \WordPress\AI\RAG\Availability $availability Availability service.
-	 */
-	public function __construct( Availability $availability ) {
-		$this->availability = $availability;
-	}
+	private const DIMENSIONS = 1536;
 
 	/**
 	 * Embeds text inputs.
@@ -83,6 +81,67 @@ class OpenAI_Embedding_Client {
 		}
 
 		return $vectors;
+	}
+
+	/**
+	 * Checks whether OpenAI embeddings can be generated.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when supported and authenticated.
+	 */
+	public function is_available(): bool {
+		return $this->has_connector_authentication() && $this->supports_configured_model();
+	}
+
+	/**
+	 * Returns the unavailable reason.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Reason.
+	 */
+	public function get_unavailable_reason(): string {
+		if ( ! $this->has_connector_authentication() ) {
+			return __( 'The OpenAI connector must be active and authenticated to generate embeddings.', 'ai' );
+		}
+
+		if ( ! $this->supports_configured_model() ) {
+			return __( 'RAG Search currently supports OpenAI text-embedding-3-small embeddings only.', 'ai' );
+		}
+
+		return '';
+	}
+
+	/**
+	 * Returns the configured embedding model.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Embedding model ID.
+	 */
+	public function get_model(): string {
+		/**
+		 * Filters the OpenAI embedding model used for RAG indexing.
+		 *
+		 * The table schema in this release is fixed to 1536 dimensions.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $model OpenAI embedding model.
+		 */
+		return (string) apply_filters( 'wpai_rag_embedding_model', self::DEFAULT_MODEL );
+	}
+
+	/**
+	 * Returns the embedding vector dimension count.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int Dimension count.
+	 */
+	public function get_dimensions(): int {
+		return self::DIMENSIONS;
 	}
 
 	/**
@@ -135,7 +194,7 @@ class OpenAI_Embedding_Client {
 	 */
 	private function request_batch( array $texts, string $api_key ) {
 		$body = array(
-			'model' => $this->availability->get_embedding_model(),
+			'model' => $this->get_model(),
 			'input' => $texts,
 		);
 		$json = wp_json_encode( $body );
@@ -144,6 +203,7 @@ class OpenAI_Embedding_Client {
 			return new WP_Error( 'wpai_rag_embedding_invalid_request', __( 'Failed to encode the embeddings request.', 'ai' ), array( 'status' => 0 ) );
 		}
 
+		// TODO: Replace this direct OpenAI request once AI Client exposes embedding execution.
 		$response = wp_remote_post(
 			self::ENDPOINT,
 			array(
@@ -187,7 +247,7 @@ class OpenAI_Embedding_Client {
 			}
 
 			$embedding = array_values( array_map( 'floatval', $item['embedding'] ) );
-			if ( count( $embedding ) !== $this->availability->get_embedding_dimensions() ) {
+			if ( count( $embedding ) !== $this->get_dimensions() ) {
 				return new WP_Error( 'wpai_rag_embedding_dimensions_mismatch', __( 'OpenAI returned an embedding with unexpected dimensions.', 'ai' ), array( 'status' => $status_code ) );
 			}
 
@@ -223,7 +283,7 @@ class OpenAI_Embedding_Client {
 
 		if ( class_exists( AiClient::class ) ) {
 			try {
-				$auth = AiClient::defaultRegistry()->getProviderRequestAuthentication( Availability::OPENAI_CONNECTOR_ID );
+				$auth = AiClient::defaultRegistry()->getProviderRequestAuthentication( self::CONNECTOR_ID );
 				if ( is_object( $auth ) && method_exists( $auth, 'getApiKey' ) ) {
 					$key = $auth->getApiKey();
 					if ( is_string( $key ) && '' !== $key ) {
@@ -240,7 +300,7 @@ class OpenAI_Embedding_Client {
 			return '';
 		}
 
-		$connector = wp_get_connector( Availability::OPENAI_CONNECTOR_ID );
+		$connector = wp_get_connector( self::CONNECTOR_ID );
 		if ( ! is_array( $connector ) || empty( $connector['authentication'] ) || ! is_array( $connector['authentication'] ) ) {
 			return '';
 		}
@@ -290,5 +350,33 @@ class OpenAI_Embedding_Client {
 		}
 
 		return __( 'OpenAI embeddings request failed.', 'ai' );
+	}
+
+	/**
+	 * Checks that the OpenAI connector is active and has credentials.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when OpenAI can be authenticated.
+	 */
+	private function has_connector_authentication(): bool {
+		try {
+			return function_exists( 'wp_is_connector_registered' )
+				&& wp_is_connector_registered( self::CONNECTOR_ID )
+				&& has_connector_authentication( self::CONNECTOR_ID );
+		} catch ( Throwable $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Checks whether the configured model matches the fixed schema.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when supported.
+	 */
+	private function supports_configured_model(): bool {
+		return self::DEFAULT_MODEL === $this->get_model();
 	}
 }

--- a/includes/RAG/Post_Chunker.php
+++ b/includes/RAG/Post_Chunker.php
@@ -40,10 +40,11 @@ class Post_Chunker {
 	 * @since 1.1.0
 	 *
 	 * @param \WP_Post $post Post object.
-	 * @return list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor:string|null, title:string, permalink:string, content:string}> Chunk records.
+	 * @return list<array{chunk_id:string, chunk_index:int, chunk_offset:int, content:string, embedding_text:string}> Chunk records.
 	 */
 	public function chunk_post( WP_Post $post ): array {
-		$text = $this->get_indexable_text( $post );
+		$text       = $this->get_indexable_text( $post );
+		$post_title = trim( wp_strip_all_tags( get_the_title( $post ) ) );
 
 		if ( '' === $text ) {
 			return array();
@@ -52,13 +53,10 @@ class Post_Chunker {
 		$window = $this->get_window_chars();
 		$step   = $this->get_step_chars( $window );
 
-		$chunks     = array();
-		$text_len   = strlen( $text );
-		$offset     = 0;
-		$chunk_idx  = 0;
-		$permalink  = get_permalink( $post );
-		$permalink  = is_string( $permalink ) ? $permalink : '';
-		$post_title = get_the_title( $post );
+		$chunks    = array();
+		$text_len  = strlen( $text );
+		$offset    = 0;
+		$chunk_idx = 0;
 
 		while ( $offset < $text_len ) {
 			$length  = min( $window, $text_len - $offset );
@@ -71,13 +69,11 @@ class Post_Chunker {
 			$segment = trim( (string) $segment );
 			if ( strlen( $segment ) >= self::MIN_CHUNK_CHARS || 0 === $chunk_idx ) {
 				$chunks[] = array(
-					'chunk_id'     => $this->build_chunk_id( (int) $post->ID, $offset ),
-					'chunk_index'  => $chunk_idx,
-					'chunk_offset' => $offset,
-					'anchor'       => null,
-					'title'        => $post_title,
-					'permalink'    => $permalink,
-					'content'      => $segment,
+					'chunk_id'       => $this->build_chunk_id( (int) $post->ID, $offset ),
+					'chunk_index'    => $chunk_idx,
+					'chunk_offset'   => $offset,
+					'content'        => $segment,
+					'embedding_text' => $this->build_embedding_text( $post_title, $segment ),
 				);
 				++$chunk_idx;
 			}
@@ -112,7 +108,7 @@ class Post_Chunker {
 		$content = $this->html_to_plain_text( (string) $content );
 
 		$title = trim( wp_strip_all_tags( get_the_title( $post ) ) );
-		$text  = trim( $title . "\n\n" . $content );
+		$text  = '' === trim( $content ) ? $title : $content;
 
 		/**
 		 * Filters the normalized post text before RAG chunking.
@@ -125,6 +121,23 @@ class Post_Chunker {
 		$text = (string) apply_filters( 'wpai_rag_indexable_post_text', $text, $post );
 
 		return trim( preg_replace( '/\s+/u', ' ', $text ) ?? $text );
+	}
+
+	/**
+	 * Builds embedding text with post title context.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $title   Post title.
+	 * @param string $content Chunk content.
+	 * @return string Embedding text.
+	 */
+	private function build_embedding_text( string $title, string $content ): string {
+		if ( '' === $title ) {
+			return $content;
+		}
+
+		return trim( $title . "\n\n" . $content );
 	}
 
 	/**

--- a/includes/RAG/Post_Chunker.php
+++ b/includes/RAG/Post_Chunker.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Lean WordPress-native post chunker for RAG indexing.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Converts posts into deterministic text chunks.
+ *
+ * @since 1.1.0
+ */
+class Post_Chunker {
+	/**
+	 * Default chunk window size in characters.
+	 */
+	private const DEFAULT_WINDOW_CHARS = 1500;
+
+	/**
+	 * Default chunk step size in characters.
+	 */
+	private const DEFAULT_STEP_CHARS = 750;
+
+	/**
+	 * Minimum useful chunk size in characters.
+	 */
+	private const MIN_CHUNK_CHARS = 80;
+
+	/**
+	 * Chunks a post for embedding.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return list<array{chunk_id:string, chunk_index:int, chunk_offset:int, anchor:string|null, title:string, permalink:string, content:string}> Chunk records.
+	 */
+	public function chunk_post( WP_Post $post ): array {
+		$text = $this->get_indexable_text( $post );
+
+		if ( '' === $text ) {
+			return array();
+		}
+
+		$window = $this->get_window_chars();
+		$step   = $this->get_step_chars( $window );
+
+		$chunks     = array();
+		$text_len   = strlen( $text );
+		$offset     = 0;
+		$chunk_idx  = 0;
+		$permalink  = get_permalink( $post );
+		$permalink  = is_string( $permalink ) ? $permalink : '';
+		$post_title = get_the_title( $post );
+
+		while ( $offset < $text_len ) {
+			$length  = min( $window, $text_len - $offset );
+			$segment = substr( $text, $offset, $length );
+
+			if ( $offset + $length < $text_len ) {
+				$segment = $this->trim_to_sentence_boundary( $segment );
+			}
+
+			$segment = trim( (string) $segment );
+			if ( strlen( $segment ) >= self::MIN_CHUNK_CHARS || 0 === $chunk_idx ) {
+				$chunks[] = array(
+					'chunk_id'     => $this->build_chunk_id( (int) $post->ID, $offset ),
+					'chunk_index'  => $chunk_idx,
+					'chunk_offset' => $offset,
+					'anchor'       => null,
+					'title'        => $post_title,
+					'permalink'    => $permalink,
+					'content'      => $segment,
+				);
+				++$chunk_idx;
+			}
+
+			if ( $offset + $window >= $text_len ) {
+				break;
+			}
+
+			$offset += $step;
+		}
+
+		return $chunks;
+	}
+
+	/**
+	 * Builds normalized text for embedding.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post object.
+	 * @return string Indexable text.
+	 */
+	public function get_indexable_text( WP_Post $post ): string {
+		$content = (string) $post->post_content;
+
+		if ( function_exists( 'do_blocks' ) ) {
+			$content = do_blocks( $content );
+		}
+
+		$content = strip_shortcodes( $content );
+		$content = apply_filters( 'the_content', $content ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$content = $this->html_to_plain_text( (string) $content );
+
+		$title = trim( wp_strip_all_tags( get_the_title( $post ) ) );
+		$text  = trim( $title . "\n\n" . $content );
+
+		/**
+		 * Filters the normalized post text before RAG chunking.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string   $text Normalized text.
+		 * @param \WP_Post $post Post object.
+		 */
+		$text = (string) apply_filters( 'wpai_rag_indexable_post_text', $text, $post );
+
+		return trim( preg_replace( '/\s+/u', ' ', $text ) ?? $text );
+	}
+
+	/**
+	 * Converts HTML to readable plain text.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $html HTML content.
+	 * @return string Plain text.
+	 */
+	private function html_to_plain_text( string $html ): string {
+		$html = preg_replace( '#<(h[1-6]|p|li|blockquote|pre|br)\b[^>]*>#i', "\n$0", $html ) ?? $html;
+		$html = preg_replace( '#</(h[1-6]|p|li|blockquote|pre)>#i', "$0\n", $html ) ?? $html;
+		$text = html_entity_decode( wp_strip_all_tags( $html ), ENT_QUOTES | ENT_HTML5, get_bloginfo( 'charset' ) );
+
+		return trim( preg_replace( '/[ \t\r\n]+/u', ' ', $text ) ?? $text );
+	}
+
+	/**
+	 * Trims a segment to the last sentence boundary when practical.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $segment Text segment.
+	 * @return string Trimmed segment.
+	 */
+	private function trim_to_sentence_boundary( string $segment ): string {
+		if ( preg_match_all( '/[.!?;:]\s+/u', $segment, $matches, PREG_OFFSET_CAPTURE ) && ! empty( $matches[0] ) ) {
+			$last_match = end( $matches[0] );
+			$boundary   = (int) $last_match[1] + strlen( (string) $last_match[0] );
+
+			if ( $boundary > (int) ( strlen( $segment ) * 0.6 ) ) {
+				return substr( $segment, 0, $boundary );
+			}
+		}
+
+		return $segment;
+	}
+
+	/**
+	 * Builds a deterministic chunk UUID.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $offset  Chunk offset.
+	 * @return string UUID-shaped chunk ID.
+	 */
+	private function build_chunk_id( int $post_id, int $offset ): string {
+		$hash = md5( $post_id . ':' . $offset );
+
+		return sprintf(
+			'%s-%s-%s-%s-%s',
+			substr( $hash, 0, 8 ),
+			substr( $hash, 8, 4 ),
+			substr( $hash, 12, 4 ),
+			substr( $hash, 16, 4 ),
+			substr( $hash, 20, 12 )
+		);
+	}
+
+	/**
+	 * Returns the configured chunk window.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return int Window size.
+	 */
+	private function get_window_chars(): int {
+		/**
+		 * Filters the RAG chunk window size in characters.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int $window_chars Window size.
+		 */
+		return max( 300, (int) apply_filters( 'wpai_rag_chunk_window_chars', self::DEFAULT_WINDOW_CHARS ) );
+	}
+
+	/**
+	 * Returns the configured chunk step.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int $window Window size.
+	 * @return int Step size.
+	 */
+	private function get_step_chars( int $window ): int {
+		/**
+		 * Filters the RAG chunk step size in characters.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int $step_chars Step size.
+		 * @param int $window     Window size.
+		 */
+		$step = (int) apply_filters( 'wpai_rag_chunk_step_chars', self::DEFAULT_STEP_CHARS, $window );
+
+		return max( 100, min( $window, $step ) );
+	}
+}

--- a/includes/RAG/REST/RAG_Maintenance_Controller.php
+++ b/includes/RAG/REST/RAG_Maintenance_Controller.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * REST controller for RAG status and maintenance.
+ *
+ * @package WordPress\AI\RAG\REST
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG\REST;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles RAG maintenance routes.
+ *
+ * @since 1.1.0
+ */
+class RAG_Maintenance_Controller {
+	/**
+	 * API namespace.
+	 */
+	private const API_NAMESPACE = 'ai/v1';
+
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Index manager.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Manager|null
+	 */
+	private ?Index_Manager $index_manager;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability|null  $availability  Availability service.
+	 * @param \WordPress\AI\RAG\Index_Manager|null $index_manager Index manager.
+	 */
+	public function __construct( ?Availability $availability = null, ?Index_Manager $index_manager = null ) {
+		$this->availability  = $availability ?? new Availability();
+		$this->index_manager = $index_manager;
+	}
+
+	/**
+	 * Initializes routes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function init(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers routes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/rag/status',
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/rag/reindex',
+			array(
+				'methods'             => 'POST',
+				'callback'            => array( $this, 'reindex' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/rag/index',
+			array(
+				'methods'             => 'DELETE',
+				'callback'            => array( $this, 'delete_index' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks endpoint permissions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when current user may manage RAG maintenance.
+	 */
+	public function check_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Returns RAG status.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WP_REST_Response Response.
+	 */
+	public function get_status(): WP_REST_Response {
+		return new WP_REST_Response( $this->build_status(), 200 );
+	}
+
+	/**
+	 * Marks eligible posts dirty and schedules indexing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Response or error.
+	 */
+	public function reindex( WP_REST_Request $request ) {
+		unset( $request );
+
+		if ( ! $this->availability->is_available() ) {
+			return new WP_Error(
+				'wpai_rag_unavailable',
+				$this->availability->get_unavailable_reason(),
+				array( 'status' => 503 )
+			);
+		}
+
+		$index_manager = $this->get_index_manager();
+
+		if ( ! $index_manager->ensure_index_storage() ) {
+			return new WP_Error(
+				'wpai_rag_storage_unavailable',
+				__( 'The RAG index storage could not be prepared.', 'ai' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$stats = $index_manager->mark_posts_dirty_for_indexing();
+		$index_manager->schedule_indexing();
+
+		return new WP_REST_Response(
+			array_merge(
+				$this->build_status(),
+				array( 'marking' => $stats )
+			),
+			200
+		);
+	}
+
+	/**
+	 * Deletes RAG index data.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response Response.
+	 */
+	public function delete_index( WP_REST_Request $request ): WP_REST_Response {
+		unset( $request );
+
+		$this->get_index_manager()->cleanup_index_data();
+
+		return new WP_REST_Response( $this->build_status(), 200 );
+	}
+
+	/**
+	 * Builds a status payload.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, mixed> Status.
+	 */
+	private function build_status(): array {
+		$available = $this->availability->is_available();
+		$manager   = $this->get_index_manager();
+
+		return array(
+			'available'            => $available,
+			'unavailable_reason'   => $available ? '' : $this->availability->get_unavailable_reason(),
+			'backend'              => $this->availability->get_index_backend(),
+			'backend_label'        => $this->availability->get_index_backend_label(),
+			'available_backends'   => $this->availability->get_available_index_backends(),
+			'backend_labels'       => $this->availability->get_index_backend_labels(),
+			'storage_ready'        => $available && $manager->ensure_index_storage(),
+			'has_index_data'       => $manager->has_index_data(),
+			'counts'               => $manager->get_status_counts(),
+			'next_scheduled_run'   => $manager->get_next_scheduled_indexing(),
+			'embedding_model'      => $this->availability->get_embedding_model(),
+			'embedding_dimensions' => $this->availability->get_embedding_dimensions(),
+		);
+	}
+
+	/**
+	 * Returns the index manager.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Index_Manager Index manager.
+	 */
+	private function get_index_manager(): Index_Manager {
+		if ( $this->index_manager instanceof Index_Manager ) {
+			return $this->index_manager;
+		}
+
+		$this->index_manager = new Index_Manager( $this->availability );
+
+		return $this->index_manager;
+	}
+}

--- a/includes/RAG/REST/RAG_Search_Controller.php
+++ b/includes/RAG/REST/RAG_Search_Controller.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * REST controller for RAG semantic search.
+ *
+ * @package WordPress\AI\RAG\REST
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG\REST;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Search_Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Handles GET /ai/v1/rag/search.
+ *
+ * @since 1.1.0
+ */
+class RAG_Search_Controller {
+	/**
+	 * API namespace.
+	 */
+	private const API_NAMESPACE = 'ai/v1';
+
+	/**
+	 * API route.
+	 */
+	private const ROUTE = '/rag/search';
+
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Search service.
+	 *
+	 * @var \WordPress\AI\RAG\Search_Service
+	 */
+	private Search_Service $search_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability|null    $availability   Availability service.
+	 * @param \WordPress\AI\RAG\Search_Service|null $search_service Search service.
+	 */
+	public function __construct( ?Availability $availability = null, ?Search_Service $search_service = null ) {
+		$this->availability   = $availability ?? new Availability();
+		$this->search_service = $search_service ?? new Search_Service( $this->availability );
+	}
+
+	/**
+	 * Initializes routes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function init(): void {
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Registers routes.
+	 *
+	 * @since 1.1.0
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			self::API_NAMESPACE,
+			self::ROUTE,
+			array(
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'search' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'q'           => array(
+						'type'              => 'string',
+						'required'          => true,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'per_page'    => array(
+						'type'              => 'integer',
+						'default'           => 10,
+						'minimum'           => 1,
+						'maximum'           => 20,
+						'sanitize_callback' => 'absint',
+					),
+					'post_type'   => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'post_status' => array(
+						'type'              => 'string',
+						'required'          => false,
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks endpoint permissions.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return bool True when current user may search.
+	 */
+	public function check_permission(): bool {
+		/**
+		 * Filters whether the current request may use the RAG search REST endpoint.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param bool $allowed Whether access is allowed.
+		 */
+		return (bool) apply_filters( 'wpai_rag_search_rest_permission', current_user_can( 'read' ) );
+	}
+
+	/**
+	 * Runs semantic search.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error Response or error.
+	 */
+	public function search( WP_REST_Request $request ) {
+		if ( ! $this->availability->is_available() ) {
+			return new WP_Error(
+				'wpai_rag_unavailable',
+				$this->availability->get_unavailable_reason(),
+				array( 'status' => 503 )
+			);
+		}
+
+		$results = $this->search_service->search(
+			(string) $request->get_param( 'q' ),
+			array(
+				'per_page'    => (int) $request->get_param( 'per_page' ),
+				'post_type'   => (string) $request->get_param( 'post_type' ),
+				'post_status' => (string) $request->get_param( 'post_status' ),
+			)
+		);
+
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+
+		return new WP_REST_Response( $results, 200 );
+	}
+}

--- a/includes/RAG/Related_Posts.php
+++ b/includes/RAG/Related_Posts.php
@@ -1,0 +1,721 @@
+<?php
+/**
+ * Semantic related posts for Query Loop blocks.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Block;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Overrides the Related Posts Query Loop variation with semantic RAG results.
+ *
+ * @since 1.1.0
+ */
+class Related_Posts {
+	/**
+	 * Query Loop variation namespace.
+	 */
+	public const QUERY_NAMESPACE = 'ai/related-posts';
+
+	/**
+	 * Default number of related posts to show.
+	 */
+	private const DEFAULT_POST_COUNT = 3;
+
+	/**
+	 * Maximum number of related posts to show.
+	 */
+	private const DEFAULT_MAX_POST_COUNT = 6;
+
+	/**
+	 * Default minimum results required before output is shown.
+	 */
+	private const DEFAULT_MIN_RESULTS = 3;
+
+	/**
+	 * Default search candidate limit.
+	 */
+	private const DEFAULT_CANDIDATE_LIMIT = 12;
+
+	/**
+	 * Default cosine distance threshold for related matches.
+	 */
+	private const DEFAULT_DISTANCE_THRESHOLD = 0.6;
+
+	/**
+	 * Default related posts cache lifetime, matching Jetpack's public cache cadence.
+	 */
+	private const DEFAULT_CACHE_TTL = 43200;
+
+	/**
+	 * Search service.
+	 *
+	 * @var \WordPress\AI\RAG\Search_Service
+	 */
+	private Search_Service $search_service;
+
+	/**
+	 * Related post IDs for the Related Posts Query Loop currently being rendered.
+	 *
+	 * @var list<list<int>>
+	 */
+	private array $active_query_post_ids = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Search_Service|null $search_service Search service.
+	 */
+	public function __construct( ?Search_Service $search_service = null ) {
+		$this->search_service = $search_service ?? new Search_Service();
+	}
+
+	/**
+	 * Registers front-end rendering hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	public function init(): void {
+		add_filter( 'pre_render_block', array( $this, 'prepare_related_query' ), 10, 3 );
+		add_filter( 'query_loop_block_query_vars', array( $this, 'filter_query_vars' ), 10, 3 );
+		add_filter( 'render_block', array( $this, 'reset_related_query' ), 10, 3 );
+	}
+
+	/**
+	 * Prepares semantic IDs for a Related Posts Query Loop before it renders.
+	 *
+	 * Returning an empty string here suppresses the entire Query Loop variation when
+	 * there are not enough good related posts.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string|null     $pre_render   Pre-rendered block content.
+	 * @param array<string,mixed> $parsed_block Parsed block.
+	 * @param \WP_Block|null  $parent_block Parent block.
+	 * @return string|null Pre-rendered block content, or null to continue rendering.
+	 */
+	public function prepare_related_query( ?string $pre_render, array $parsed_block, ?WP_Block $parent_block ) {
+		unset( $parent_block );
+
+		if ( null !== $pre_render || ! $this->is_related_posts_query_block( $parsed_block ) ) {
+			return $pre_render;
+		}
+
+		$source_post = $this->get_source_post();
+		if ( ! $source_post instanceof WP_Post ) {
+			return '';
+		}
+
+		$count    = $this->get_count_from_query_block( $parsed_block, $source_post );
+		$post_ids = $this->get_related_post_ids(
+			$source_post,
+			array(
+				'count'       => $count,
+				'min_results' => min( self::DEFAULT_MIN_RESULTS, $count ),
+				'post_type'   => $this->get_post_type_from_query_block( $parsed_block, $source_post ),
+			)
+		);
+
+		if ( empty( $post_ids ) ) {
+			return '';
+		}
+
+		$this->active_query_post_ids[] = $post_ids;
+
+		return null;
+	}
+
+	/**
+	 * Overrides the active Related Posts Query Loop with semantic related post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string,mixed> $query Query vars.
+	 * @param \WP_Block          $block Query Loop child block.
+	 * @param int                $page  Current page.
+	 * @return array<string,mixed> Query vars.
+	 */
+	public function filter_query_vars( array $query, WP_Block $block, int $page ): array {
+		unset( $block, $page );
+
+		$post_ids = end( $this->active_query_post_ids );
+		if ( empty( $post_ids ) || ! is_array( $post_ids ) ) {
+			return $query;
+		}
+
+		$query['post__in']            = array_values( array_map( 'absint', $post_ids ) );
+		$query['orderby']             = 'post__in';
+		$query['posts_per_page']      = count( $post_ids );
+		$query['ignore_sticky_posts'] = true;
+		$query['no_found_rows']       = true;
+		unset( $query['post__not_in'] );
+
+		return $query;
+	}
+
+	/**
+	 * Clears active semantic IDs after the Related Posts Query Loop renders.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string              $block_content Rendered block content.
+	 * @param array<string,mixed> $parsed_block  Parsed block.
+	 * @param \WP_Block           $block         Block instance.
+	 * @return string Rendered block content.
+	 */
+	public function reset_related_query( string $block_content, array $parsed_block, WP_Block $block ): string {
+		unset( $block );
+
+		if ( $this->is_related_posts_query_block( $parsed_block ) ) {
+			array_pop( $this->active_query_post_ids );
+		}
+
+		return $block_content;
+	}
+
+	/**
+	 * Returns semantic related post IDs for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post             $post Source post.
+	 * @param array<string, mixed> $args Related posts args.
+	 * @return list<int> Related post IDs.
+	 */
+	public function get_related_post_ids( WP_Post $post, array $args = array() ): array {
+		$args = wp_parse_args(
+			$args,
+			array(
+				'count'           => self::DEFAULT_POST_COUNT,
+				'min_results'     => self::DEFAULT_MIN_RESULTS,
+				'candidate_limit' => self::DEFAULT_CANDIDATE_LIMIT,
+				'post_type'       => (string) $post->post_type,
+				'post_status'     => 'publish',
+			)
+		);
+
+		$count           = $this->get_post_count( (int) $args['count'], $post );
+		$min_results     = $this->get_min_results( (int) $args['min_results'], $count, $post );
+		$candidate_limit = $this->get_candidate_limit( (int) $args['candidate_limit'], $count, $post );
+		$threshold       = $this->get_distance_threshold( $post );
+		$cache_key       = $this->get_cache_key( $post, $count, $min_results, $candidate_limit, $threshold, $args );
+		$post_ids        = $this->get_cached_related_post_ids( $cache_key, $args );
+
+		if ( null === $post_ids ) {
+			$post_ids = $this->search_related_post_ids( $post, $count, $candidate_limit, $threshold, $args );
+			$this->set_cached_related_post_ids( $cache_key, $post_ids, $post );
+		}
+
+		/**
+		 * Filters semantic related post IDs before they are applied to the Query Loop.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param list<int>            $post_ids Related post IDs.
+		 * @param \WP_Post            $post     Source post.
+		 * @param array<string,mixed> $args     Related posts args.
+		 */
+		$post_ids = (array) apply_filters( 'wpai_rag_related_posts_results', $post_ids, $post, $args );
+		$post_ids = array_values( array_filter( array_map( 'absint', $post_ids ) ) );
+		$post_ids = array_values( array_diff( array_unique( $post_ids ), array( (int) $post->ID ) ) );
+
+		if ( count( $post_ids ) < $min_results ) {
+			return array();
+		}
+
+		return array_slice( $post_ids, 0, $count );
+	}
+
+	/**
+	 * Searches semantic related post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post             $post            Source post.
+	 * @param int                  $count           Number of posts to return.
+	 * @param int                  $candidate_limit Search candidate limit.
+	 * @param float                $threshold       Distance threshold.
+	 * @param array<string, mixed> $args            Related posts args.
+	 * @return list<int> Related post IDs.
+	 */
+	private function search_related_post_ids( WP_Post $post, int $count, int $candidate_limit, float $threshold, array $args ): array {
+		$results = $this->search_service->search(
+			$this->prepare_query_text( $post ),
+			array(
+				'per_page'                => $candidate_limit,
+				'max_per_page'            => $candidate_limit,
+				'candidate_limit'         => $candidate_limit,
+				'post_type'               => $args['post_type'],
+				'post_status'             => $args['post_status'],
+				'enforce_read_permission' => false,
+			)
+		);
+
+		if ( is_wp_error( $results ) || empty( $results['results'] ) || ! is_array( $results['results'] ) ) {
+			return array();
+		}
+
+		$post_ids = array();
+		$seen_ids = array( (int) $post->ID => true );
+		foreach ( $results['results'] as $result ) {
+			if ( ! is_array( $result ) || empty( $result['post_id'] ) ) {
+				continue;
+			}
+
+			$post_id = absint( $result['post_id'] );
+			if ( $post_id <= 0 || isset( $seen_ids[ $post_id ] ) ) {
+				continue;
+			}
+
+			$seen_ids[ $post_id ] = true;
+
+			if ( isset( $result['distance'] ) && (float) $result['distance'] > $threshold ) {
+				continue;
+			}
+
+			$related_post = get_post( $post_id );
+			if ( ! $related_post instanceof WP_Post || ! $this->post_matches_args( $related_post, $args ) ) {
+				continue;
+			}
+
+			$post_ids[] = $post_id;
+			if ( count( $post_ids ) >= $count ) {
+				break;
+			}
+		}
+
+		return $post_ids;
+	}
+
+	/**
+	 * Checks whether a parsed block is the Related Posts Query Loop variation.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string,mixed> $parsed_block Parsed block.
+	 * @return bool True when this is the related posts variation.
+	 */
+	private function is_related_posts_query_block( array $parsed_block ): bool {
+		if ( 'core/query' !== ( $parsed_block['blockName'] ?? '' ) ) {
+			return false;
+		}
+
+		$attrs = $parsed_block['attrs'] ?? array();
+		if ( ! is_array( $attrs ) ) {
+			return false;
+		}
+
+		return self::QUERY_NAMESPACE === ( $attrs['namespace'] ?? '' );
+	}
+
+	/**
+	 * Returns the source post for the current block render.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WP_Post|null Source post.
+	 */
+	private function get_source_post(): ?WP_Post {
+		$post = get_post();
+		if ( ! $post instanceof WP_Post || 'publish' !== get_post_status( $post ) ) {
+			return null;
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Returns related post count from a Query Loop block.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string,mixed> $parsed_block Parsed block.
+	 * @param \WP_Post           $post         Source post.
+	 * @return int Count.
+	 */
+	private function get_count_from_query_block( array $parsed_block, WP_Post $post ): int {
+		$query = $this->get_query_attrs( $parsed_block );
+		$count = isset( $query['perPage'] ) ? absint( $query['perPage'] ) : self::DEFAULT_POST_COUNT;
+
+		return $this->get_post_count( $count, $post );
+	}
+
+	/**
+	 * Returns post type from a Query Loop block.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string,mixed> $parsed_block Parsed block.
+	 * @param \WP_Post           $post         Source post.
+	 * @return string Post type.
+	 */
+	private function get_post_type_from_query_block( array $parsed_block, WP_Post $post ): string {
+		$query     = $this->get_query_attrs( $parsed_block );
+		$post_type = isset( $query['postType'] ) && is_scalar( $query['postType'] ) ? sanitize_key( (string) $query['postType'] ) : '';
+
+		return '' !== $post_type ? $post_type : (string) $post->post_type;
+	}
+
+	/**
+	 * Returns query attributes from a Query Loop block.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string,mixed> $parsed_block Parsed block.
+	 * @return array<string,mixed> Query attributes.
+	 */
+	private function get_query_attrs( array $parsed_block ): array {
+		$attrs = $parsed_block['attrs'] ?? array();
+		if ( ! is_array( $attrs ) ) {
+			return array();
+		}
+
+		$query = $attrs['query'] ?? array();
+
+		return is_array( $query ) ? $query : array();
+	}
+
+	/**
+	 * Prepares source post text for semantic lookup.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Source post.
+	 * @return string Query text.
+	 */
+	private function prepare_query_text( WP_Post $post ): string {
+		$content = (string) $post->post_content;
+
+		if ( function_exists( 'do_blocks' ) ) {
+			$content = do_blocks( $content );
+		}
+
+		$content = strip_shortcodes( $content );
+		$content = html_entity_decode( wp_strip_all_tags( $content ), ENT_QUOTES | ENT_HTML5, get_bloginfo( 'charset' ) );
+
+		$text = trim(
+			implode(
+				"\n\n",
+				array_filter(
+					array(
+						wp_strip_all_tags( get_the_title( $post ) ),
+						implode( ', ', $this->get_term_names( $post ) ),
+						$content,
+					)
+				)
+			)
+		);
+
+		$text = preg_replace( '/\s+/u', ' ', $text ) ?? $text;
+
+		/**
+		 * Filters the maximum source text length used to find semantic related posts.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int      $max_chars Maximum character length.
+		 * @param \WP_Post $post      Source post.
+		 */
+		$max_chars = max( 500, min( 8000, (int) apply_filters( 'wpai_rag_related_posts_query_max_chars', 4000, $post ) ) );
+
+		if ( strlen( $text ) > $max_chars ) {
+			$text = function_exists( 'mb_substr' ) ? mb_substr( $text, 0, $max_chars ) : substr( $text, 0, $max_chars );
+		}
+
+		/**
+		 * Filters source text used to find semantic related posts.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string   $text Source text.
+		 * @param \WP_Post $post Source post.
+		 */
+		return (string) apply_filters( 'wpai_rag_related_posts_query_text', trim( $text ), $post );
+	}
+
+	/**
+	 * Returns configured related post count.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int      $count Requested count.
+	 * @param \WP_Post $post  Source post.
+	 * @return int Count.
+	 */
+	private function get_post_count( int $count, WP_Post $post ): int {
+		/**
+		 * Filters the number of semantic related posts to display.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int      $count Number of posts.
+		 * @param \WP_Post $post  Source post.
+		 */
+		$count = (int) apply_filters( 'wpai_rag_related_posts_count', $count, $post );
+
+		return max( 1, min( self::DEFAULT_MAX_POST_COUNT, $count ) );
+	}
+
+	/**
+	 * Returns minimum results required for output.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int      $min_results Requested minimum.
+	 * @param int      $count       Display count.
+	 * @param \WP_Post $post        Source post.
+	 * @return int Minimum results.
+	 */
+	private function get_min_results( int $min_results, int $count, WP_Post $post ): int {
+		/**
+		 * Filters the minimum semantic related posts required before output is shown.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int      $min_results Minimum results.
+		 * @param \WP_Post $post        Source post.
+		 */
+		$min_results = (int) apply_filters( 'wpai_rag_related_posts_min_results', $min_results, $post );
+
+		return max( 1, min( $count, $min_results ) );
+	}
+
+	/**
+	 * Returns search candidate limit.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param int      $candidate_limit Requested candidate limit.
+	 * @param int      $count           Display count.
+	 * @param \WP_Post $post            Source post.
+	 * @return int Candidate limit.
+	 */
+	private function get_candidate_limit( int $candidate_limit, int $count, WP_Post $post ): int {
+		/**
+		 * Filters the semantic related posts search candidate limit.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int      $candidate_limit Candidate limit.
+		 * @param \WP_Post $post            Source post.
+		 */
+		$candidate_limit = (int) apply_filters( 'wpai_rag_related_posts_candidate_limit', $candidate_limit, $post );
+
+		return max( $count + 1, min( 100, $candidate_limit ) );
+	}
+
+	/**
+	 * Returns maximum distance for related matches.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Source post.
+	 * @return float Distance threshold.
+	 */
+	private function get_distance_threshold( WP_Post $post ): float {
+		/**
+		 * Filters the cosine distance threshold for semantic related posts.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param float    $threshold Distance threshold.
+		 * @param \WP_Post $post      Source post.
+		 */
+		$threshold = (float) apply_filters( 'wpai_rag_related_posts_distance_threshold', self::DEFAULT_DISTANCE_THRESHOLD, $post );
+
+		return max( 0.0, min( 2.0, $threshold ) );
+	}
+
+	/**
+	 * Gets cached related post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string               $cache_key Cache key.
+	 * @param array<string, mixed> $args      Related posts args.
+	 * @return list<int>|null Cached related post IDs, or null when uncached.
+	 */
+	private function get_cached_related_post_ids( string $cache_key, array $args ): ?array {
+		$cached = get_transient( $cache_key );
+		if ( ! is_array( $cached ) ) {
+			return null;
+		}
+
+		$post_ids = array_values( array_filter( array_map( 'absint', $cached ) ) );
+		if ( empty( $post_ids ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$post_ids,
+				function ( int $post_id ) use ( $args ): bool {
+					$post = get_post( $post_id );
+
+					return $post instanceof WP_Post && $this->post_matches_args( $post, $args );
+				}
+			)
+		);
+	}
+
+	/**
+	 * Sets cached related post IDs.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string    $cache_key Cache key.
+	 * @param list<int> $post_ids  Related post IDs.
+	 * @param \WP_Post  $post      Source post.
+	 */
+	private function set_cached_related_post_ids( string $cache_key, array $post_ids, WP_Post $post ): void {
+		/**
+		 * Filters the semantic related posts cache lifetime in seconds.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param int      $ttl  Cache lifetime in seconds.
+		 * @param \WP_Post $post Source post.
+		 */
+		$ttl = max( 0, (int) apply_filters( 'wpai_rag_related_posts_cache_ttl', self::DEFAULT_CACHE_TTL, $post ) );
+		if ( 0 === $ttl ) {
+			return;
+		}
+
+		set_transient( $cache_key, array_values( array_filter( array_map( 'absint', $post_ids ) ) ), $ttl );
+	}
+
+	/**
+	 * Returns a related posts cache key.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post             $post            Source post.
+	 * @param int                  $count           Count.
+	 * @param int                  $min_results     Minimum results.
+	 * @param int                  $candidate_limit Candidate limit.
+	 * @param float                $threshold       Distance threshold.
+	 * @param array<string, mixed> $args            Related posts args.
+	 * @return string Cache key.
+	 */
+	private function get_cache_key( WP_Post $post, int $count, int $min_results, int $candidate_limit, float $threshold, array $args ): string {
+		$encoded = wp_json_encode(
+			array(
+				'modified'        => $post->post_modified_gmt,
+				'content'         => $post->post_content,
+				'count'           => $count,
+				'min_results'     => $min_results,
+				'candidate_limit' => $candidate_limit,
+				'post_type'       => $args['post_type'],
+				'post_status'     => $args['post_status'],
+				'threshold'       => $threshold,
+			)
+		);
+
+		return 'wpai_rag_rel_' . (int) $post->ID . '_' . substr( md5( is_string( $encoded ) ? $encoded : '' ), 0, 12 );
+	}
+
+	/**
+	 * Checks whether a post matches related posts args.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post             $post Post to check.
+	 * @param array<string, mixed> $args Related posts args.
+	 * @return bool True when the post matches.
+	 */
+	private function post_matches_args( WP_Post $post, array $args ): bool {
+		$post_types    = $this->sanitize_list_arg( $args['post_type'] );
+		$post_statuses = $this->sanitize_list_arg( $args['post_status'] );
+
+		return ( empty( $post_types ) || in_array( (string) $post->post_type, $post_types, true ) )
+			&& ( empty( $post_statuses ) || in_array( (string) $post->post_status, $post_statuses, true ) );
+	}
+
+	/**
+	 * Returns term names for related-post matching.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return list<string> Term names.
+	 */
+	private function get_term_names( WP_Post $post ): array {
+		$names = array();
+		foreach ( $this->get_terms( $post ) as $term ) {
+			$names[] = $term->name;
+		}
+
+		return array_values( array_unique( $names ) );
+	}
+
+	/**
+	 * Returns public category and tag terms for a post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post Post.
+	 * @return list<\WP_Term> Terms.
+	 */
+	private function get_terms( WP_Post $post ): array {
+		$taxonomies = array_values( array_intersect( array( 'category', 'post_tag' ), get_object_taxonomies( (string) $post->post_type ) ) );
+		if ( empty( $taxonomies ) ) {
+			return array();
+		}
+
+		$terms = wp_get_post_terms( (int) $post->ID, $taxonomies );
+		if ( is_wp_error( $terms ) ) {
+			return array();
+		}
+
+		return array_values(
+			array_filter(
+				$terms,
+				static fn( $term ): bool => $term instanceof \WP_Term
+			)
+		);
+	}
+
+	/**
+	 * Sanitizes comma-separated or array list arguments.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $value Raw value.
+	 * @return list<string> Sanitized list.
+	 */
+	private function sanitize_list_arg( $value ): array {
+		if ( is_string( $value ) ) {
+			$value = explode( ',', $value );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				continue;
+			}
+
+			$item = sanitize_key( (string) $item );
+			if ( '' === $item ) {
+				continue;
+			}
+
+			$items[] = $item;
+		}
+
+		return array_values( array_unique( $items ) );
+	}
+}

--- a/includes/RAG/Search_Augmenter.php
+++ b/includes/RAG/Search_Augmenter.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Augments WordPress search with semantic RAG candidates.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Query;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Merges semantic candidates into the main search query.
+ *
+ * @since 1.1.0
+ */
+class Search_Augmenter {
+	/**
+	 * Default cosine distance threshold for promoted semantic matches.
+	 */
+	private const DEFAULT_STRONG_DISTANCE_THRESHOLD = 0.6;
+
+	/**
+	 * Query var containing semantic IDs.
+	 */
+	private const QUERY_VAR_IDS = '_wpai_rag_post_ids';
+
+	/**
+	 * Query var containing strong semantic IDs.
+	 */
+	private const QUERY_VAR_STRONG_IDS = '_wpai_rag_strong_post_ids';
+
+	/**
+	 * Search service.
+	 *
+	 * @var \WordPress\AI\RAG\Search_Service
+	 */
+	private Search_Service $search_service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Search_Service|null $search_service Search service.
+	 */
+	public function __construct( ?Search_Service $search_service = null ) {
+		$this->search_service = $search_service ?? new Search_Service();
+	}
+
+	/**
+	 * Registers hooks.
+	 *
+	 * @since 1.1.0
+	 */
+	public function init(): void {
+		add_action( 'pre_get_posts', array( $this, 'prepare_semantic_candidates' ) );
+		add_filter( 'posts_search', array( $this, 'merge_semantic_search_clause' ), 10, 2 );
+		add_filter( 'posts_orderby', array( $this, 'promote_semantic_results' ), 10, 2 );
+	}
+
+	/**
+	 * Finds semantic candidates for the main search query.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Query $query Query object.
+	 */
+	public function prepare_semantic_candidates( WP_Query $query ): void {
+		if ( ! $this->should_augment_query( $query ) ) {
+			return;
+		}
+
+		$search = (string) $query->get( 's' );
+		$limit  = max( 1, min( 100, (int) apply_filters( 'wpai_rag_search_candidate_limit', 50 ) ) );
+
+		$results = $this->search_service->search(
+			$search,
+			array(
+				'per_page'                => $limit,
+				'max_per_page'            => $limit,
+				'candidate_limit'         => $limit,
+				'enforce_read_permission' => false,
+			)
+		);
+
+		if ( is_wp_error( $results ) || empty( $results['results'] ) || ! is_array( $results['results'] ) ) {
+			return;
+		}
+
+		$threshold  = (float) apply_filters( 'wpai_rag_search_distance_threshold', self::DEFAULT_STRONG_DISTANCE_THRESHOLD );
+		$post_ids   = array();
+		$strong_ids = array();
+
+		foreach ( $results['results'] as $result ) {
+			if ( ! is_array( $result ) || empty( $result['post_id'] ) ) {
+				continue;
+			}
+
+			$post_id    = (int) $result['post_id'];
+			$post_ids[] = $post_id;
+
+			if ( ! isset( $result['distance'] ) || (float) $result['distance'] > $threshold ) {
+				continue;
+			}
+
+			$strong_ids[] = $post_id;
+		}
+
+		if ( empty( $post_ids ) ) {
+			return;
+		}
+
+		// phpcs:disable WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts -- should_augment_query() verifies this is the main search query before these mutations.
+		$query->set( self::QUERY_VAR_IDS, array_values( array_unique( $post_ids ) ) );
+		$query->set( self::QUERY_VAR_STRONG_IDS, array_values( array_unique( $strong_ids ) ) );
+		// phpcs:enable WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
+	}
+
+	/**
+	 * Adds semantic IDs to the search condition.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string    $search Search SQL.
+	 * @param \WP_Query $query  Query object.
+	 * @return string Search SQL.
+	 */
+	public function merge_semantic_search_clause( string $search, WP_Query $query ): string {
+		$post_ids = $this->get_query_ids( $query, self::QUERY_VAR_IDS );
+		if ( empty( $post_ids ) || '' === trim( $search ) ) {
+			return $search;
+		}
+
+		global $wpdb;
+
+		$body = preg_replace( '/^\s*AND\s*/i', '', $search );
+		$ids  = implode( ',', $post_ids );
+
+		return " AND ( {$body} OR {$wpdb->posts}.ID IN ({$ids}) )";
+	}
+
+	/**
+	 * Promotes strong semantic matches while retaining normal ordering.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string    $orderby Order by SQL.
+	 * @param \WP_Query $query   Query object.
+	 * @return string Order by SQL.
+	 */
+	public function promote_semantic_results( string $orderby, WP_Query $query ): string {
+		$strong_ids = $this->get_query_ids( $query, self::QUERY_VAR_STRONG_IDS );
+		if ( empty( $strong_ids ) ) {
+			return $orderby;
+		}
+
+		global $wpdb;
+
+		$ids       = implode( ',', $strong_ids );
+		$promotion = "CASE WHEN {$wpdb->posts}.ID IN ({$ids}) THEN 0 ELSE 1 END ASC, FIELD({$wpdb->posts}.ID, {$ids}) ASC";
+
+		if ( '' === trim( $orderby ) ) {
+			return $promotion;
+		}
+
+		return $promotion . ', ' . $orderby;
+	}
+
+	/**
+	 * Checks whether a query should be augmented.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Query $query Query object.
+	 * @return bool True when query should be augmented.
+	 */
+	private function should_augment_query( WP_Query $query ): bool {
+		if ( is_admin() || ! $query->is_main_query() || ! $query->is_search() || '' === trim( (string) $query->get( 's' ) ) ) {
+			return false;
+		}
+
+		if ( $query->is_feed() ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether the current search query should be augmented with RAG results.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param bool      $augment Whether to augment.
+		 * @param \WP_Query $query   Query object.
+		 */
+		return (bool) apply_filters( 'wpai_rag_search_augment_enabled', true, $query );
+	}
+
+	/**
+	 * Gets integer IDs from a query var.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Query $query Query object.
+	 * @param string    $key   Query var key.
+	 * @return list<int> IDs.
+	 */
+	private function get_query_ids( WP_Query $query, string $key ): array {
+		$value = $query->get( $key );
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$ids = array_filter( array_map( 'absint', $value ) );
+
+		return array_values( array_unique( $ids ) );
+	}
+}

--- a/includes/RAG/Search_Service.php
+++ b/includes/RAG/Search_Service.php
@@ -30,9 +30,9 @@ class Search_Service {
 	/**
 	 * Repository.
 	 *
-	 * @var \WordPress\AI\RAG\Index_Repository
+	 * @var \WordPress\AI\RAG\Index_Repository_Interface
 	 */
-	private Index_Repository $repository;
+	private Index_Repository_Interface $repository;
 
 	/**
 	 * Embedding client.
@@ -47,17 +47,17 @@ class Search_Service {
 	 * @since 1.1.0
 	 *
 	 * @param \WordPress\AI\RAG\Availability|null             $availability     Availability service.
-	 * @param \WordPress\AI\RAG\Index_Repository|null        $repository       Repository.
+	 * @param \WordPress\AI\RAG\Index_Repository_Interface|null $repository       Repository.
 	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null $embedding_client Embedding client.
 	 */
 	public function __construct(
 		?Availability $availability = null,
-		?Index_Repository $repository = null,
+		?Index_Repository_Interface $repository = null,
 		?OpenAI_Embedding_Client $embedding_client = null
 	) {
 		$this->availability     = $availability ?? new Availability();
 		$schema                 = new Index_Schema();
-		$this->repository       = $repository ?? new Index_Repository( $schema, $this->availability->get_embedding_dimensions() );
+		$this->repository       = $repository ?? $this->create_repository( $schema );
 		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
 	}
 
@@ -216,6 +216,22 @@ class Search_Service {
 		$prefix = (string) apply_filters( 'wpai_rag_query_embedding_input_prefix', '' );
 
 		return $prefix . $query;
+	}
+
+	/**
+	 * Creates the active repository.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Index_Schema $schema Schema manager.
+	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
+	 */
+	private function create_repository( Index_Schema $schema ): Index_Repository_Interface {
+		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
+			return new Memory_Index_Repository( $this->availability->get_embedding_dimensions() );
+		}
+
+		return new Index_Repository( $schema, $this->availability->get_embedding_dimensions() );
 	}
 
 	/**

--- a/includes/RAG/Search_Service.php
+++ b/includes/RAG/Search_Service.php
@@ -56,9 +56,8 @@ class Search_Service {
 		?OpenAI_Embedding_Client $embedding_client = null
 	) {
 		$this->availability     = $availability ?? new Availability();
-		$schema                 = new Index_Schema();
-		$this->repository       = $repository ?? $this->create_repository( $schema );
-		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
+		$this->repository       = $repository ?? $this->availability->create_index_repository();
+		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client();
 	}
 
 	/**
@@ -183,8 +182,8 @@ class Search_Service {
 					'chunk_id'    => (string) $row['chunk_id'],
 					'chunk_index' => (int) $row['chunk_index'],
 					'excerpt'     => wp_html_excerpt( (string) $row['content'], 280, '...' ),
-					'anchor'      => isset( $row['anchor'] ) ? (string) $row['anchor'] : '',
-					'permalink'   => (string) $row['permalink'],
+					'anchor'      => '',
+					'permalink'   => (string) $grouped[ $post_id ]['permalink'],
 					'distance'    => $distance,
 				);
 			}
@@ -216,22 +215,6 @@ class Search_Service {
 		$prefix = (string) apply_filters( 'wpai_rag_query_embedding_input_prefix', '' );
 
 		return $prefix . $query;
-	}
-
-	/**
-	 * Creates the active repository.
-	 *
-	 * @since 1.1.0
-	 *
-	 * @param \WordPress\AI\RAG\Index_Schema $schema Schema manager.
-	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
-	 */
-	private function create_repository( Index_Schema $schema ): Index_Repository_Interface {
-		if ( Availability::BACKEND_MEMORY === $this->availability->get_index_backend() ) {
-			return new Memory_Index_Repository( $this->availability->get_embedding_dimensions() );
-		}
-
-		return new Index_Repository( $schema, $this->availability->get_embedding_dimensions() );
 	}
 
 	/**

--- a/includes/RAG/Search_Service.php
+++ b/includes/RAG/Search_Service.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Semantic RAG search service.
+ *
+ * @package WordPress\AI\RAG
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\RAG;
+
+use WP_Error;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Runs semantic search against indexed chunks.
+ *
+ * @since 1.1.0
+ */
+class Search_Service {
+	/**
+	 * Availability service.
+	 *
+	 * @var \WordPress\AI\RAG\Availability
+	 */
+	private Availability $availability;
+
+	/**
+	 * Repository.
+	 *
+	 * @var \WordPress\AI\RAG\Index_Repository
+	 */
+	private Index_Repository $repository;
+
+	/**
+	 * Embedding client.
+	 *
+	 * @var \WordPress\AI\RAG\OpenAI_Embedding_Client
+	 */
+	private OpenAI_Embedding_Client $embedding_client;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Availability|null             $availability     Availability service.
+	 * @param \WordPress\AI\RAG\Index_Repository|null        $repository       Repository.
+	 * @param \WordPress\AI\RAG\OpenAI_Embedding_Client|null $embedding_client Embedding client.
+	 */
+	public function __construct(
+		?Availability $availability = null,
+		?Index_Repository $repository = null,
+		?OpenAI_Embedding_Client $embedding_client = null
+	) {
+		$this->availability     = $availability ?? new Availability();
+		$schema                 = new Index_Schema();
+		$this->repository       = $repository ?? new Index_Repository( $schema, $this->availability->get_embedding_dimensions() );
+		$this->embedding_client = $embedding_client ?? new OpenAI_Embedding_Client( $this->availability );
+	}
+
+	/**
+	 * Searches posts semantically.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $query Search query.
+	 * @param array{per_page?:int, max_per_page?:int, candidate_limit?:int, post_type?:string|list<string>, post_status?:string|list<string>, enforce_read_permission?:bool} $args Search args.
+	 * @return array<string, mixed>|\WP_Error Search results or error.
+	 */
+	public function search( string $query, array $args = array() ) {
+		$query = trim( $query );
+		if ( '' === $query ) {
+			return new WP_Error( 'wpai_rag_empty_query', __( 'Search query cannot be empty.', 'ai' ), array( 'status' => 400 ) );
+		}
+
+		$defaults = array(
+			'per_page'                => 10,
+			'max_per_page'            => 20,
+			'candidate_limit'         => (int) apply_filters( 'wpai_rag_search_candidate_limit', 50 ),
+			'post_type'               => array(),
+			'post_status'             => array(),
+			'enforce_read_permission' => true,
+		);
+		$args     = wp_parse_args( $args, $defaults );
+		$per_page = max( 1, min( max( 1, (int) $args['max_per_page'] ), (int) $args['per_page'] ) );
+		$limit    = max( $per_page, min( 100, (int) $args['candidate_limit'] ) );
+
+		$embedding = $this->embedding_client->embed( array( $this->prepare_query_text( $query ) ) );
+		if ( is_wp_error( $embedding ) ) {
+			return $embedding;
+		}
+
+		if ( empty( $embedding[0] ) || ! is_array( $embedding[0] ) ) {
+			return new WP_Error( 'wpai_rag_query_embedding_failed', __( 'Failed to generate a query embedding.', 'ai' ), array( 'status' => 500 ) );
+		}
+
+		$query_embedding = array_values( $embedding[0] );
+
+		$rows = $this->repository->search(
+			$query_embedding,
+			array(
+				'limit'       => $limit,
+				'model'       => $this->availability->get_embedding_model(),
+				'post_type'   => $this->sanitize_list_arg( $args['post_type'] ),
+				'post_status' => $this->sanitize_list_arg( $args['post_status'] ),
+			)
+		);
+
+		$results = $this->group_rows_by_post( $rows, $per_page, (bool) $args['enforce_read_permission'] );
+
+		/**
+		 * Filters semantic RAG search results.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param list<array<string, mixed>> $results Results.
+		 * @param string                     $query   Search query.
+		 * @param array<string, mixed>       $args    Search args.
+		 */
+		$results = (array) apply_filters( 'wpai_rag_search_results', $results, $query, $args );
+
+		return array(
+			'query'   => $query,
+			'model'   => $this->availability->get_embedding_model(),
+			'results' => array_values( $results ),
+		);
+	}
+
+	/**
+	 * Groups chunk rows by post.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<array<string, mixed>> $rows                    Chunk rows.
+	 * @param int                        $per_page                Number of posts to return.
+	 * @param bool                       $enforce_read_permission Whether to enforce read_post.
+	 * @return list<array<string, mixed>> Results.
+	 */
+	private function group_rows_by_post( array $rows, int $per_page, bool $enforce_read_permission ): array {
+		$grouped = array();
+
+		foreach ( $rows as $row ) {
+			$post_id = isset( $row['post_id'] ) ? (int) $row['post_id'] : 0;
+			if ( $post_id <= 0 ) {
+				continue;
+			}
+
+			if ( $enforce_read_permission && ! current_user_can( 'read_post', $post_id ) ) {
+				continue;
+			}
+
+			$post = get_post( $post_id );
+			if ( ! $post instanceof WP_Post ) {
+				continue;
+			}
+
+			$distance = isset( $row['distance'] ) ? (float) $row['distance'] : 1.0;
+
+			if ( ! isset( $grouped[ $post_id ] ) ) {
+				$permalink           = get_permalink( $post );
+				$grouped[ $post_id ] = array(
+					'post_id'     => $post_id,
+					'post_type'   => (string) $post->post_type,
+					'post_status' => (string) $post->post_status,
+					'title'       => get_the_title( $post ),
+					'permalink'   => is_string( $permalink ) ? $permalink : '',
+					'score'       => max( 0.0, 1.0 - $distance ),
+					'distance'    => $distance,
+					'chunks'      => array(),
+				);
+			}
+
+			if ( $distance < (float) $grouped[ $post_id ]['distance'] ) {
+				$grouped[ $post_id ]['distance'] = $distance;
+				$grouped[ $post_id ]['score']    = max( 0.0, 1.0 - $distance );
+			}
+
+			if ( count( $grouped[ $post_id ]['chunks'] ) < 3 ) {
+				$grouped[ $post_id ]['chunks'][] = array(
+					'chunk_id'    => (string) $row['chunk_id'],
+					'chunk_index' => (int) $row['chunk_index'],
+					'excerpt'     => wp_html_excerpt( (string) $row['content'], 280, '...' ),
+					'anchor'      => isset( $row['anchor'] ) ? (string) $row['anchor'] : '',
+					'permalink'   => (string) $row['permalink'],
+					'distance'    => $distance,
+				);
+			}
+
+			if ( count( $grouped ) >= $per_page ) {
+				break;
+			}
+		}
+
+		return array_values( $grouped );
+	}
+
+	/**
+	 * Prepares query text for embedding.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $query Raw query.
+	 * @return string Query text.
+	 */
+	private function prepare_query_text( string $query ): string {
+		/**
+		 * Filters the prefix applied to semantic query embedding inputs.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string $prefix Query prefix.
+		 */
+		$prefix = (string) apply_filters( 'wpai_rag_query_embedding_input_prefix', '' );
+
+		return $prefix . $query;
+	}
+
+	/**
+	 * Sanitizes comma-separated or array list arguments.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $value Raw value.
+	 * @return list<string> Sanitized list.
+	 */
+	private function sanitize_list_arg( $value ): array {
+		if ( is_string( $value ) ) {
+			$value = explode( ',', $value );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$items = array();
+		foreach ( $value as $item ) {
+			if ( ! is_scalar( $item ) ) {
+				continue;
+			}
+
+			$item = sanitize_key( (string) $item );
+			if ( '' === $item ) {
+				continue;
+			}
+
+			$items[] = $item;
+		}
+
+		return array_values( array_unique( $items ) );
+	}
+}

--- a/includes/REST/Models_Controller.php
+++ b/includes/REST/Models_Controller.php
@@ -55,7 +55,7 @@ final class Models_Controller {
 	 *
 	 * @var list<string>
 	 */
-	private const VALID_CAPABILITIES = array( 'text_generation', 'image_generation', 'vision' ); // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is a single array constant.
+	private const VALID_CAPABILITIES = array( 'text_generation', 'image_generation', 'vision', 'embedding_generation' ); // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is a single array constant.
 
 	/**
 	 * Initializes the REST routes.
@@ -176,6 +176,12 @@ final class Models_Controller {
 							array( ModalityEnum::text(), ModalityEnum::image() )
 						),
 					)
+				);
+
+			case 'embedding_generation':
+				return new ModelRequirements(
+					array( CapabilityEnum::embeddingGeneration() ),
+					array()
 				);
 
 			default:

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Page } from '@wordpress/admin-ui';
+import apiFetch from '@wordpress/api-fetch';
 import {
 	Button,
 	Card,
@@ -23,7 +24,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	check as checkIcon,
@@ -84,7 +85,27 @@ interface PageData {
 
 const FEATURE_SETTING_PATTERN = /^wpai_feature_(.+)_enabled$/;
 const GLOBAL_FIELD_ID = 'wpai_features_enabled';
+const RAG_FEATURE_ID = 'rag-search';
 const noop = () => {};
+
+interface RagStatusCounts {
+	dirty: number;
+	processing: number;
+	clean: number;
+	error: number;
+}
+
+interface RagStatus {
+	available: boolean;
+	unavailable_reason: string;
+	backend_label: string;
+	storage_ready: boolean;
+	has_index_data: boolean;
+	counts: RagStatusCounts;
+	next_scheduled_run: number | null;
+	embedding_model: string;
+	embedding_dimensions: number;
+}
 
 function isRecord( value: unknown ): value is Record< string, unknown > {
 	return typeof value === 'object' && value !== null;
@@ -253,6 +274,50 @@ const STABLE_FEATURE_DEFINITIONS: FeatureData[] = ( () => {
 	}
 	return unique;
 } )();
+
+function toNumberValue( value: unknown ): number {
+	return typeof value === 'number' && Number.isFinite( value ) ? value : 0;
+}
+
+function normalizeRagStatus( value: unknown ): RagStatus | null {
+	if ( ! isRecord( value ) ) {
+		return null;
+	}
+
+	const status = value as Partial< RagStatus >;
+	const counts: Partial< RagStatusCounts > = isRecord( status.counts )
+		? ( status.counts as Partial< RagStatusCounts > )
+		: {};
+	const nextScheduledRun =
+		typeof status.next_scheduled_run === 'number'
+			? status.next_scheduled_run
+			: null;
+
+	return {
+		available: Boolean( status.available ),
+		unavailable_reason: toStringValue( status.unavailable_reason ),
+		backend_label: toStringValue( status.backend_label ),
+		storage_ready: Boolean( status.storage_ready ),
+		has_index_data: Boolean( status.has_index_data ),
+		counts: {
+			dirty: toNumberValue( counts.dirty ),
+			processing: toNumberValue( counts.processing ),
+			clean: toNumberValue( counts.clean ),
+			error: toNumberValue( counts.error ),
+		},
+		next_scheduled_run: nextScheduledRun,
+		embedding_model: toStringValue( status.embedding_model ),
+		embedding_dimensions: toNumberValue( status.embedding_dimensions ),
+	};
+}
+
+function formatScheduledRun( timestamp: number | null ): string {
+	if ( ! timestamp ) {
+		return __( 'None', 'ai' );
+	}
+
+	return new Date( timestamp * 1000 ).toLocaleString();
+}
 
 interface InfoTipProps {
 	content: string;
@@ -454,6 +519,196 @@ function SectionActions( {
 	);
 }
 
+function RagStatusPanel( { enabled }: { enabled: boolean } ) {
+	const [ status, setStatus ] = useState< RagStatus | null >( null );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ mutatingAction, setMutatingAction ] = useState<
+		'reindex' | 'delete' | null
+	>( null );
+	const { createSuccessNotice, createErrorNotice } =
+		useDispatch( noticesStore );
+
+	const refreshStatus = useCallback( async () => {
+		setIsLoading( true );
+		try {
+			const response = await apiFetch( {
+				path: '/ai/v1/rag/status',
+			} );
+			setStatus( normalizeRagStatus( response ) );
+		} catch {
+			setStatus( null );
+		} finally {
+			setIsLoading( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		void refreshStatus();
+	}, [ refreshStatus ] );
+
+	const handleReindex = useCallback( async () => {
+		setMutatingAction( 'reindex' );
+		try {
+			const response = await apiFetch( {
+				path: '/ai/v1/rag/reindex',
+				method: 'POST',
+			} );
+			setStatus( normalizeRagStatus( response ) );
+			createSuccessNotice( __( 'RAG indexing scheduled.', 'ai' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice( __( 'Failed to schedule RAG indexing.', 'ai' ), {
+				type: 'snackbar',
+			} );
+		} finally {
+			setMutatingAction( null );
+		}
+	}, [ createErrorNotice, createSuccessNotice ] );
+
+	const handleDelete = useCallback( async () => {
+		// eslint-disable-next-line no-alert -- A destructive cleanup needs explicit confirmation.
+		const confirmed = window.confirm(
+			__(
+				'Delete all RAG index data? This removes stored vectors, indexing status, and scheduled RAG indexing work.',
+				'ai'
+			)
+		);
+
+		if ( ! confirmed ) {
+			return;
+		}
+
+		setMutatingAction( 'delete' );
+		try {
+			const response = await apiFetch( {
+				path: '/ai/v1/rag/index',
+				method: 'DELETE',
+			} );
+			setStatus( normalizeRagStatus( response ) );
+			createSuccessNotice( __( 'RAG index data deleted.', 'ai' ), {
+				type: 'snackbar',
+			} );
+		} catch {
+			createErrorNotice( __( 'Failed to delete RAG index data.', 'ai' ), {
+				type: 'snackbar',
+			} );
+		} finally {
+			setMutatingAction( null );
+		}
+	}, [ createErrorNotice, createSuccessNotice ] );
+
+	if ( ! enabled && isLoading ) {
+		return null;
+	}
+
+	if ( ! enabled && ! status?.has_index_data ) {
+		return null;
+	}
+
+	if ( ! enabled ) {
+		return (
+			<div className="ai-rag-status ai-rag-status--cleanup">
+				<span>{ __( 'RAG index data exists.', 'ai' ) }</span>
+				<Button
+					variant="outline"
+					size="compact"
+					className="ai-rag-status__danger-button"
+					onClick={ handleDelete }
+					disabled={ mutatingAction !== null }
+					loading={ mutatingAction === 'delete' }
+				>
+					{ __( 'Delete index data', 'ai' ) }
+				</Button>
+			</div>
+		);
+	}
+
+	if ( isLoading || ! status ) {
+		return (
+			<div className="ai-rag-status ai-rag-status--loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<Stack direction="column" gap="sm" className="ai-rag-status">
+			{ ! status.available && status.unavailable_reason && (
+				<Notice.Root intent="warning">
+					<Notice.Description>
+						{ status.unavailable_reason }
+					</Notice.Description>
+				</Notice.Root>
+			) }
+			<div className="ai-rag-status__grid">
+				<span>{ __( 'Backend', 'ai' ) }</span>
+				<strong>{ status.backend_label }</strong>
+				<span>{ __( 'Storage', 'ai' ) }</span>
+				<strong>
+					{ status.storage_ready
+						? __( 'Ready', 'ai' )
+						: __( 'Not ready', 'ai' ) }
+				</strong>
+				<span>{ __( 'Embedding model', 'ai' ) }</span>
+				<strong>
+					{ status.embedding_model || __( 'Unknown', 'ai' ) }
+				</strong>
+				<span>{ __( 'Next run', 'ai' ) }</span>
+				<strong>
+					{ formatScheduledRun( status.next_scheduled_run ) }
+				</strong>
+			</div>
+			<div className="ai-rag-status__counts">
+				<span>
+					{ sprintf(
+						// translators: %d: Dirty post count.
+						__( '%d dirty', 'ai' ),
+						status.counts.dirty
+					) }
+				</span>
+				<span>
+					{ sprintf(
+						// translators: %d: Clean post count.
+						__( '%d clean', 'ai' ),
+						status.counts.clean
+					) }
+				</span>
+				<span>
+					{ sprintf(
+						// translators: %d: Error post count.
+						__( '%d error', 'ai' ),
+						status.counts.error
+					) }
+				</span>
+			</div>
+			<Stack direction="row" gap="sm" className="ai-rag-status__actions">
+				<Button
+					variant="outline"
+					size="compact"
+					onClick={ handleReindex }
+					disabled={ ! status.available || mutatingAction !== null }
+					loading={ mutatingAction === 'reindex' }
+				>
+					{ __( 'Reindex', 'ai' ) }
+				</Button>
+				<Button
+					variant="outline"
+					size="compact"
+					className="ai-rag-status__danger-button"
+					onClick={ handleDelete }
+					disabled={
+						! status.has_index_data || mutatingAction !== null
+					}
+					loading={ mutatingAction === 'delete' }
+				>
+					{ __( 'Delete index data', 'ai' ) }
+				</Button>
+			</Stack>
+		</Stack>
+	);
+}
+
 function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 	const fieldIds = useMemo(
 		() => feature.settingsFields.map( ( f ) => f.id ),
@@ -610,6 +865,45 @@ function FeatureToggleWithSettings( {
 				<InlineFeatureSettings feature={ feature } />
 			) }
 			{ checked && isDeveloperMode && feature && (
+				<DeveloperSettings
+					featureId={ feature.id }
+					capability={ feature.capability }
+				/>
+			) }
+		</div>
+	);
+}
+
+interface RagFeatureToggleProps extends DataFormControlProps< AISettings > {
+	feature: FeatureData;
+	globalEnabled: boolean;
+}
+
+function RagFeatureToggle( {
+	field,
+	data,
+	onChange,
+	feature,
+	globalEnabled,
+}: RagFeatureToggleProps ) {
+	const checked = !! field.getValue( { item: data } );
+	const isDeveloperMode = useDeveloperModeContext();
+	const enabled = checked && globalEnabled;
+
+	return (
+		<div className="ai-feature-toggle-with-settings">
+			<ToggleControl
+				label={ field.label }
+				help={ field.description }
+				checked={ checked }
+				onChange={ ( value ) => {
+					onChange( { [ field.id ]: value } );
+				} }
+				disabled={ ! globalEnabled }
+			/>
+			{ enabled && <InlineFeatureSettings feature={ feature } /> }
+			<RagStatusPanel enabled={ enabled } />
+			{ enabled && isDeveloperMode && (
 				<DeveloperSettings
 					featureId={ feature.id }
 					capability={ feature.capability }
@@ -840,7 +1134,15 @@ function AISettingsPage() {
 				type: 'boolean' as const,
 			};
 
-			if ( VISUAL_CARD_FEATURES.has( feature.settingName ) ) {
+			if ( feature.id === RAG_FEATURE_ID ) {
+				baseField.Edit = ( props ) => (
+					<RagFeatureToggle
+						{ ...props }
+						feature={ feature }
+						globalEnabled={ globalEnabled }
+					/>
+				);
+			} else if ( VISUAL_CARD_FEATURES.has( feature.settingName ) ) {
 				baseField.Edit = VisualCardToggle;
 			} else if ( ! globalEnabled ) {
 				baseField.Edit = DisabledToggle;

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -51,6 +51,58 @@
 	max-width: 480px;
 }
 
+.ai-rag-status {
+	margin-top: var(--wpds-dimension-padding-xs);
+	margin-inline-start: 40px;
+	max-width: 480px;
+	padding: var(--wpds-dimension-padding-sm);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-sm);
+}
+
+.ai-rag-status--cleanup {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+.ai-rag-status--loading {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 36px;
+}
+
+.ai-rag-status__grid {
+	display: grid;
+	grid-template-columns: max-content minmax(0, 1fr);
+	gap: 6px 12px;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.ai-rag-status__grid strong {
+	font-weight: 500;
+	overflow-wrap: anywhere;
+}
+
+.ai-rag-status__counts {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+	font-size: 12px;
+}
+
+.ai-rag-status__actions {
+	flex-wrap: wrap;
+}
+
+.ai-rag-status__danger-button {
+	color: #b32d2e;
+	border-color: #b32d2e;
+}
+
 .ai-section-actions {
 	border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 	margin-top: var(--wpds-dimension-padding-md);

--- a/src/experiments/rag-search/index.ts
+++ b/src/experiments/rag-search/index.ts
@@ -1,0 +1,76 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockVariation } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+
+const RELATED_POSTS_NAMESPACE = 'ai/related-posts';
+
+registerBlockVariation( 'core/query', {
+	name: 'ai-related-posts',
+	title: __( 'Related Posts', 'ai' ),
+	description: __(
+		'Display semantically related posts for the current post.',
+		'ai'
+	),
+	scope: [ 'inserter' ],
+	attributes: {
+		namespace: RELATED_POSTS_NAMESPACE,
+		query: {
+			perPage: 3,
+			pages: 0,
+			offset: 0,
+			postType: 'post',
+			order: 'desc',
+			orderBy: 'date',
+			author: '',
+			search: '',
+			exclude: [],
+			sticky: '',
+			inherit: false,
+			taxQuery: null,
+			parents: [],
+		},
+		displayLayout: {
+			type: 'flex',
+			columns: 3,
+		},
+	},
+	innerBlocks: [
+		[
+			'core/heading',
+			{
+				level: 3,
+				content: __( 'Related posts', 'ai' ),
+			},
+		],
+		[
+			'core/post-template',
+			{
+				layout: {
+					type: 'grid',
+					columnCount: 3,
+				},
+			},
+			[
+				[
+					'core/post-featured-image',
+					{
+						isLink: true,
+					},
+				],
+				[
+					'core/post-title',
+					{
+						isLink: true,
+						level: 4,
+					},
+				],
+				[ 'core/post-excerpt', { moreText: '' } ],
+			],
+		],
+	],
+	isActive: ( blockAttributes ) =>
+		// eslint-disable-next-line dot-notation -- Gutenberg block attributes are typed with an index signature.
+		blockAttributes[ 'namespace' ] === RELATED_POSTS_NAMESPACE,
+} );

--- a/tests/Integration/Includes/CLI/RAG_CommandTest.php
+++ b/tests/Integration/Includes/CLI/RAG_CommandTest.php
@@ -78,7 +78,7 @@ class RAG_CommandTest extends WP_UnitTestCase {
 		$messages = implode( "\n", $this->get_cli_messages() );
 
 		$this->assertStringContainsString( 'Available: yes', $messages );
-		$this->assertStringContainsString( 'Backend: MariaDB vector index', $messages );
+		$this->assertStringContainsString( 'Backend: Optimal search method backed by MariaDB', $messages );
 		$this->assertStringContainsString( 'Index storage: ready', $messages );
 		$this->assertStringContainsString( 'Dirty: 2', $messages );
 		$this->assertStringContainsString( 'Clean: 5', $messages );
@@ -225,7 +225,7 @@ class RAG_CommandTest extends WP_UnitTestCase {
 			 * {@inheritDoc}
 			 */
 			public function get_index_backend_label(): string {
-				return 'MariaDB vector index';
+				return 'Optimal search method backed by MariaDB';
 			}
 		};
 	}

--- a/tests/Integration/Includes/CLI/RAG_CommandTest.php
+++ b/tests/Integration/Includes/CLI/RAG_CommandTest.php
@@ -78,7 +78,8 @@ class RAG_CommandTest extends WP_UnitTestCase {
 		$messages = implode( "\n", $this->get_cli_messages() );
 
 		$this->assertStringContainsString( 'Available: yes', $messages );
-		$this->assertStringContainsString( 'Index table: present', $messages );
+		$this->assertStringContainsString( 'Backend: MariaDB vector index', $messages );
+		$this->assertStringContainsString( 'Index storage: ready', $messages );
 		$this->assertStringContainsString( 'Dirty: 2', $messages );
 		$this->assertStringContainsString( 'Clean: 5', $messages );
 		$this->assertStringContainsString( 'Error: 1', $messages );
@@ -212,6 +213,20 @@ class RAG_CommandTest extends WP_UnitTestCase {
 			public function get_unavailable_reason(): string {
 				return 'Unavailable for tests.';
 			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend(): string {
+				return Availability::BACKEND_MARIADB;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend_label(): string {
+				return 'MariaDB vector index';
+			}
 		};
 	}
 
@@ -270,7 +285,7 @@ class RAG_CommandTest extends WP_UnitTestCase {
 			/**
 			 * {@inheritDoc}
 			 */
-			public function ensure_index_table(): bool {
+			public function ensure_index_storage(): bool {
 				return true;
 			}
 

--- a/tests/Integration/Includes/CLI/RAG_CommandTest.php
+++ b/tests/Integration/Includes/CLI/RAG_CommandTest.php
@@ -177,6 +177,21 @@ class RAG_CommandTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests cleanup command.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_cleanup_deletes_index_data_with_yes_flag(): void {
+		$manager = $this->create_manager();
+		$command = new RAG_Command( $this->create_availability( true ), $manager );
+
+		$command->cleanup( array(), array( 'yes' => true ) );
+
+		$this->assertTrue( $manager->cleaned_up );
+		$this->assertStringContainsString( 'Deleted RAG index data.', implode( "\n", $this->get_cli_messages( 'success' ) ) );
+	}
+
+	/**
 	 * Creates a fake availability service.
 	 *
 	 * @param bool $available Whether RAG is available.
@@ -267,6 +282,13 @@ class RAG_CommandTest extends WP_UnitTestCase {
 			public array $schedule_tail_values = array();
 
 			/**
+			 * Whether cleanup was called.
+			 *
+			 * @var bool
+			 */
+			public bool $cleaned_up = false;
+
+			/**
 			 * Fake behavior config.
 			 *
 			 * @var array<string, mixed>
@@ -352,6 +374,13 @@ class RAG_CommandTest extends WP_UnitTestCase {
 			 */
 			public function schedule_indexing( int $delay = 1 ): void {
 				$this->scheduled_delay = $delay;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function cleanup_index_data(): void {
+				$this->cleaned_up = true;
 			}
 		};
 	}

--- a/tests/Integration/Includes/CLI/RAG_CommandTest.php
+++ b/tests/Integration/Includes/CLI/RAG_CommandTest.php
@@ -1,0 +1,343 @@
+<?php
+/**
+ * Integration tests for the RAG_Command WP-CLI class.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\CLI
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\CLI;
+
+use WP_UnitTestCase;
+use WordPress\AI\CLI\RAG_Command;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+
+require_once __DIR__ . '/wp-cli-stubs.php';
+
+/**
+ * RAG_Command test case.
+ *
+ * @covers \WordPress\AI\CLI\RAG_Command
+ *
+ * @since 1.1.0
+ */
+class RAG_CommandTest extends WP_UnitTestCase {
+	/**
+	 * Set up test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( '\WP_CLI' ) || ! method_exists( '\WP_CLI', 'reset' ) ) {
+			return;
+		}
+
+		\WP_CLI::reset();
+	}
+
+	/**
+	 * Gets captured WP_CLI messages at a given level.
+	 *
+	 * @param string|null $level The level to filter by, or null for all.
+	 * @return array<int, string> Captured messages.
+	 */
+	private function get_cli_messages( ?string $level = null ): array {
+		$messages = array();
+		foreach ( \WP_CLI::$messages as $entry ) {
+			if ( null !== $level && $entry['level'] !== $level ) {
+				continue;
+			}
+
+			$messages[] = $entry['message'];
+		}
+		return $messages;
+	}
+
+	/**
+	 * Tests status output.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_status_outputs_index_counts(): void {
+		$command = new RAG_Command(
+			$this->create_availability( true ),
+			$this->create_manager(
+				array(
+					'status_counts' => array(
+						Index_Manager::STATUS_DIRTY => 2,
+						Index_Manager::STATUS_CLEAN => 5,
+						Index_Manager::STATUS_ERROR => 1,
+					),
+					'scheduled'     => 1234567890,
+				)
+			)
+		);
+
+		$command->status( array(), array() );
+
+		$messages = implode( "\n", $this->get_cli_messages() );
+
+		$this->assertStringContainsString( 'Available: yes', $messages );
+		$this->assertStringContainsString( 'Index table: present', $messages );
+		$this->assertStringContainsString( 'Dirty: 2', $messages );
+		$this->assertStringContainsString( 'Clean: 5', $messages );
+		$this->assertStringContainsString( 'Error: 1', $messages );
+	}
+
+	/**
+	 * Tests mark-dirty command.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_mark_dirty_marks_ids(): void {
+		$manager = $this->create_manager();
+		$command = new RAG_Command( $this->create_availability( true ), $manager );
+
+		$command->mark_dirty( array(), array( 'ids' => '10,11' ) );
+
+		$this->assertSame( array( 10, 11 ), $manager->marked_ids );
+		$this->assertStringContainsString( 'Marked 2 post(s) dirty', implode( "\n", $this->get_cli_messages( 'success' ) ) );
+	}
+
+	/**
+	 * Tests indexing runs until complete when --all is supplied.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_index_all_runs_batches_until_no_dirty_posts_remain(): void {
+		$manager = $this->create_manager(
+			array(
+				'batches' => array(
+					array(
+						'processed' => 50,
+						'clean'     => 50,
+						'error'     => 0,
+						'removed'   => 0,
+						'remaining' => 1,
+					),
+					array(
+						'processed' => 1,
+						'clean'     => 1,
+						'error'     => 0,
+						'removed'   => 0,
+						'remaining' => 0,
+					),
+				),
+			)
+		);
+		$command = new RAG_Command( $this->create_availability( true ), $manager );
+
+		$command->index( array(), array( 'all' => true ) );
+
+		$this->assertSame( 2, $manager->index_runs );
+		$this->assertStringContainsString( 'RAG indexing complete for 51 post(s)', implode( "\n", $this->get_cli_messages( 'success' ) ) );
+	}
+
+	/**
+	 * Tests that tail scheduling can be disabled for a single batch.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_index_can_disable_tail_scheduling(): void {
+		$manager = $this->create_manager(
+			array(
+				'batches' => array(
+					array(
+						'processed' => 1,
+						'clean'     => 1,
+						'error'     => 0,
+						'removed'   => 0,
+						'remaining' => 2,
+					),
+				),
+			)
+		);
+		$command = new RAG_Command( $this->create_availability( true ), $manager );
+
+		$command->index( array(), array( 'schedule' => false ) );
+
+		$this->assertSame( array( false ), $manager->schedule_tail_values );
+		$this->assertStringContainsString( '2 dirty post(s) remain', implode( "\n", $this->get_cli_messages() ) );
+	}
+
+	/**
+	 * Tests schedule command.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_schedule_schedules_indexing(): void {
+		$manager = $this->create_manager();
+		$command = new RAG_Command( $this->create_availability( true ), $manager );
+
+		$command->schedule( array(), array( 'delay' => 30 ) );
+
+		$this->assertSame( 30, $manager->scheduled_delay );
+		$this->assertStringContainsString( 'Scheduled RAG indexing in 30 second(s).', implode( "\n", $this->get_cli_messages( 'success' ) ) );
+	}
+
+	/**
+	 * Creates a fake availability service.
+	 *
+	 * @param bool $available Whether RAG is available.
+	 * @return \WordPress\AI\RAG\Availability Fake availability service.
+	 */
+	private function create_availability( bool $available ): Availability {
+		return new class( $available ) extends Availability {
+			/**
+			 * Whether RAG is available.
+			 *
+			 * @var bool
+			 */
+			private bool $available;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param bool $available Whether RAG is available.
+			 */
+			public function __construct( bool $available ) {
+				$this->available = $available;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function is_available(): bool {
+				return $this->available;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_unavailable_reason(): string {
+				return 'Unavailable for tests.';
+			}
+		};
+	}
+
+	/**
+	 * Creates a fake index manager.
+	 *
+	 * @param array<string, mixed> $config Fake behavior config.
+	 * @return \WordPress\AI\RAG\Index_Manager Fake manager.
+	 */
+	private function create_manager( array $config = array() ): Index_Manager {
+		return new class( $config ) extends Index_Manager {
+			/**
+			 * IDs passed to mark dirty.
+			 *
+			 * @var list<int>
+			 */
+			public array $marked_ids = array();
+
+			/**
+			 * Scheduled delay.
+			 *
+			 * @var int|null
+			 */
+			public ?int $scheduled_delay = null;
+
+			/**
+			 * Number of indexing runs.
+			 *
+			 * @var int
+			 */
+			public int $index_runs = 0;
+
+			/**
+			 * Schedule-tail values passed to run_indexing_batch().
+			 *
+			 * @var list<bool>
+			 */
+			public array $schedule_tail_values = array();
+
+			/**
+			 * Fake behavior config.
+			 *
+			 * @var array<string, mixed>
+			 */
+			private array $config;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array<string, mixed> $config Fake behavior config.
+			 */
+			public function __construct( array $config ) {
+				$this->config = $config;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function ensure_index_table(): bool {
+				return true;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_status_counts(): array {
+				return wp_parse_args(
+					$this->config['status_counts'] ?? array(),
+					array(
+						Index_Manager::STATUS_DIRTY      => 0,
+						Index_Manager::STATUS_PROCESSING => 0,
+						Index_Manager::STATUS_CLEAN      => 0,
+						Index_Manager::STATUS_ERROR      => 0,
+					)
+				);
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_next_scheduled_indexing(): ?int {
+				return isset( $this->config['scheduled'] ) ? (int) $this->config['scheduled'] : null;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function mark_posts_dirty_for_indexing( array $post_ids = array(), int $limit = 0 ): array {
+				unset( $limit );
+				$this->marked_ids = $post_ids;
+
+				return array(
+					'marked'  => count( $post_ids ),
+					'skipped' => 0,
+					'removed' => 0,
+				);
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function run_indexing_batch( int $limit = 0, bool $schedule_tail = true ) {
+				unset( $limit );
+
+				$this->schedule_tail_values[] = $schedule_tail;
+
+				$batches = $this->config['batches'] ?? array();
+				$stats   = $batches[ $this->index_runs ] ?? array(
+					'processed' => 0,
+					'clean'     => 0,
+					'error'     => 0,
+					'removed'   => 0,
+					'remaining' => 0,
+				);
+
+				++$this->index_runs;
+
+				return $stats;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function schedule_indexing( int $delay = 1 ): void {
+				$this->scheduled_delay = $delay;
+			}
+		};
+	}
+}

--- a/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
+++ b/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
@@ -77,6 +77,7 @@ class RAG_SearchTest extends WP_UnitTestCase {
 		$this->assertSame( 'Optimal search method backed by MariaDB', $fields[0]['elements'][0]['label'] );
 		$this->assertSame( Availability::BACKEND_MEMORY, $fields[0]['elements'][1]['value'] );
 		$this->assertSame( 'Fallback in-memory search backed by PHP', $fields[0]['elements'][1]['label'] );
+		$this->assertSame( 'wpai_feature_rag-search_field_augment_search', $fields[1]['id'] );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
+++ b/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
@@ -198,6 +198,16 @@ class RAG_SearchTest extends WP_UnitTestCase {
 					public function get_default_index_backend(): string {
 						return $this->default_backend;
 					}
+
+					/**
+					 * {@inheritDoc}
+					 */
+					public function get_index_backend_labels(): array {
+						return array(
+							Availability::BACKEND_MARIADB => 'Optimal search method backed by MariaDB',
+							Availability::BACKEND_MEMORY  => 'Fallback in-memory search backed by PHP',
+						);
+					}
 				};
 			}
 		};

--- a/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
+++ b/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
@@ -74,7 +74,9 @@ class RAG_SearchTest extends WP_UnitTestCase {
 		$this->assertSame( 'text', $fields[0]['type'] );
 		$this->assertSame( Availability::BACKEND_MARIADB, $fields[0]['default'] );
 		$this->assertSame( Availability::BACKEND_MARIADB, $fields[0]['elements'][0]['value'] );
+		$this->assertSame( 'Optimal search method backed by MariaDB', $fields[0]['elements'][0]['label'] );
 		$this->assertSame( Availability::BACKEND_MEMORY, $fields[0]['elements'][1]['value'] );
+		$this->assertSame( 'Fallback in-memory search backed by PHP', $fields[0]['elements'][1]['label'] );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
+++ b/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Integration tests for the RAG Search experiment.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Experiments\RAG_Search
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Experiments\RAG_Search;
+
+use WP_UnitTestCase;
+use WordPress\AI\Experiments\Experiment_Category;
+use WordPress\AI\Experiments\RAG_Search\RAG_Search;
+
+/**
+ * RAG Search experiment test case.
+ *
+ * @since 1.1.0
+ */
+class RAG_SearchTest extends WP_UnitTestCase {
+	/**
+	 * Cleans up options.
+	 */
+	public function tearDown(): void {
+		delete_option( 'wpai_feature_rag-search_field_augment_search' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests feature metadata.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_metadata(): void {
+		$experiment = new RAG_Search();
+
+		$this->assertSame( 'rag-search', $experiment::get_id() );
+		$this->assertSame( Experiment_Category::ADMIN, $experiment->get_category() );
+		$this->assertSame( 'embedding_generation', $experiment->get_capability() );
+	}
+
+	/**
+	 * Tests settings fields.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_settings_fields_returns_augment_search_field(): void {
+		$experiment = new RAG_Search();
+		$fields     = $experiment->get_settings_fields_metadata();
+
+		$this->assertCount( 1, $fields );
+		$this->assertSame( 'wpai_feature_rag-search_field_augment_search', $fields[0]['id'] );
+		$this->assertSame( 'boolean', $fields[0]['type'] );
+		$this->assertFalse( $fields[0]['default'] );
+	}
+
+	/**
+	 * Tests setting lookup.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_is_search_augmentation_enabled_reads_option(): void {
+		$experiment = new RAG_Search();
+
+		$this->assertFalse( $experiment->is_search_augmentation_enabled() );
+
+		update_option( 'wpai_feature_rag-search_field_augment_search', true );
+
+		$this->assertTrue( $experiment->is_search_augmentation_enabled() );
+	}
+}

--- a/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
+++ b/tests/Integration/Includes/Experiments/RAG_Search/RAG_SearchTest.php
@@ -10,6 +10,7 @@ namespace WordPress\AI\Tests\Integration\Includes\Experiments\RAG_Search;
 use WP_UnitTestCase;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\Experiments\RAG_Search\RAG_Search;
+use WordPress\AI\RAG\Availability;
 
 /**
  * RAG Search experiment test case.
@@ -21,6 +22,7 @@ class RAG_SearchTest extends WP_UnitTestCase {
 	 * Cleans up options.
 	 */
 	public function tearDown(): void {
+		delete_option( Availability::BACKEND_OPTION );
 		delete_option( 'wpai_feature_rag-search_field_augment_search' );
 
 		parent::tearDown();
@@ -47,11 +49,67 @@ class RAG_SearchTest extends WP_UnitTestCase {
 	public function test_get_settings_fields_returns_augment_search_field(): void {
 		$experiment = new RAG_Search();
 		$fields     = $experiment->get_settings_fields_metadata();
+		$field_ids  = array_column( $fields, 'id' );
+		$index      = array_search( 'wpai_feature_rag-search_field_augment_search', $field_ids, true );
 
-		$this->assertCount( 1, $fields );
-		$this->assertSame( 'wpai_feature_rag-search_field_augment_search', $fields[0]['id'] );
-		$this->assertSame( 'boolean', $fields[0]['type'] );
-		$this->assertFalse( $fields[0]['default'] );
+		$this->assertNotFalse( $index );
+		$this->assertSame( 'boolean', $fields[ $index ]['type'] );
+		$this->assertFalse( $fields[ $index ]['default'] );
+	}
+
+	/**
+	 * Tests that backend settings are shown when multiple backends are available.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_settings_fields_includes_backend_when_multiple_backends_are_available(): void {
+		$experiment = $this->create_experiment_with_backends(
+			array( Availability::BACKEND_MARIADB, Availability::BACKEND_MEMORY ),
+			Availability::BACKEND_MARIADB
+		);
+		$fields     = $experiment->get_settings_fields_metadata();
+
+		$this->assertCount( 2, $fields );
+		$this->assertSame( Availability::BACKEND_OPTION, $fields[0]['id'] );
+		$this->assertSame( 'text', $fields[0]['type'] );
+		$this->assertSame( Availability::BACKEND_MARIADB, $fields[0]['default'] );
+		$this->assertSame( Availability::BACKEND_MARIADB, $fields[0]['elements'][0]['value'] );
+		$this->assertSame( Availability::BACKEND_MEMORY, $fields[0]['elements'][1]['value'] );
+	}
+
+	/**
+	 * Tests backend setting sanitization.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_sanitize_backend_only_accepts_available_backends(): void {
+		$experiment = $this->create_experiment_with_backends(
+			array( Availability::BACKEND_MEMORY ),
+			Availability::BACKEND_MEMORY
+		);
+
+		$this->assertSame( Availability::BACKEND_MEMORY, $experiment->sanitize_backend( Availability::BACKEND_MEMORY ) );
+		$this->assertSame( Availability::BACKEND_MEMORY, $experiment->sanitize_backend( Availability::BACKEND_MARIADB ) );
+		$this->assertSame( Availability::BACKEND_MEMORY, $experiment->sanitize_backend( 'wat' ) );
+	}
+
+	/**
+	 * Tests setting registration.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_register_settings_registers_backend_setting(): void {
+		$experiment = $this->create_experiment_with_backends(
+			array( Availability::BACKEND_MARIADB, Availability::BACKEND_MEMORY ),
+			Availability::BACKEND_MARIADB
+		);
+
+		$experiment->register_settings();
+
+		$registered = get_registered_settings();
+
+		$this->assertArrayHasKey( Availability::BACKEND_OPTION, $registered );
+		$this->assertNotEmpty( $registered[ Availability::BACKEND_OPTION ]['show_in_rest'] );
 	}
 
 	/**
@@ -67,5 +125,83 @@ class RAG_SearchTest extends WP_UnitTestCase {
 		update_option( 'wpai_feature_rag-search_field_augment_search', true );
 
 		$this->assertTrue( $experiment->is_search_augmentation_enabled() );
+	}
+
+	/**
+	 * Creates a RAG Search experiment with fixed backend availability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<string> $backends        Available backends.
+	 * @param string       $default_backend Default backend.
+	 * @return \WordPress\AI\Experiments\RAG_Search\RAG_Search Experiment.
+	 */
+	private function create_experiment_with_backends( array $backends, string $default_backend ): RAG_Search {
+		$experiment = new class() extends RAG_Search {
+			/**
+			 * Available backends.
+			 *
+			 * @var list<string>
+			 */
+			public array $backends = array();
+
+			/**
+			 * Default backend.
+			 *
+			 * @var string
+			 */
+			public string $default_backend = Availability::BACKEND_MEMORY;
+
+			/**
+			 * {@inheritDoc}
+			 */
+			protected function create_availability(): Availability {
+				return new class( $this->backends, $this->default_backend ) extends Availability {
+					/**
+					 * Available backends.
+					 *
+					 * @var list<string>
+					 */
+					private array $backends;
+
+					/**
+					 * Default backend.
+					 *
+					 * @var string
+					 */
+					private string $default_backend;
+
+					/**
+					 * Constructor.
+					 *
+					 * @param list<string> $backends        Available backends.
+					 * @param string       $default_backend Default backend.
+					 */
+					public function __construct( array $backends, string $default_backend ) {
+						$this->backends        = $backends;
+						$this->default_backend = $default_backend;
+					}
+
+					/**
+					 * {@inheritDoc}
+					 */
+					public function get_available_index_backends(): array {
+						return $this->backends;
+					}
+
+					/**
+					 * {@inheritDoc}
+					 */
+					public function get_default_index_backend(): string {
+						return $this->default_backend;
+					}
+				};
+			}
+		};
+
+		$experiment->backends        = $backends;
+		$experiment->default_backend = $default_backend;
+
+		return $experiment;
 	}
 }

--- a/tests/Integration/Includes/RAG/AvailabilityTest.php
+++ b/tests/Integration/Includes/RAG/AvailabilityTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Integration tests for RAG availability checks.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Availability;
+
+/**
+ * Availability test case.
+ *
+ * @since 1.1.0
+ */
+class AvailabilityTest extends WP_UnitTestCase {
+	/**
+	 * Tests MariaDB vector index version support detection.
+	 *
+	 * @dataProvider data_mariadb_versions
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $version  Raw DB version.
+	 * @param bool   $expected Expected support.
+	 */
+	public function test_is_supported_mariadb_version( string $version, bool $expected ): void {
+		$availability = new Availability();
+
+		$this->assertSame( $expected, $availability->is_supported_mariadb_version( $version ) );
+	}
+
+	/**
+	 * Data provider for version checks.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, array{string, bool}>
+	 */
+	public function data_mariadb_versions(): array {
+		return array(
+			'mariadb 11.8'     => array( '11.8.0-MariaDB', true ),
+			'mariadb 11.8.2'   => array( '11.8.2-MariaDB-ubu2404', true ),
+			'mariadb 11.7'     => array( '11.7.2-MariaDB', false ),
+			'prefixed mariadb' => array( '5.5.5-11.8.1-MariaDB', true ),
+			'mysql 8'          => array( '8.0.36', false ),
+			'empty'            => array( '', false ),
+		);
+	}
+}

--- a/tests/Integration/Includes/RAG/AvailabilityTest.php
+++ b/tests/Integration/Includes/RAG/AvailabilityTest.php
@@ -9,6 +9,12 @@ namespace WordPress\AI\Tests\Integration\Includes\RAG;
 
 use WP_UnitTestCase;
 use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Backend_Interface;
+use WordPress\AI\RAG\Index_Repository_Interface;
+use WordPress\AI\RAG\MariaDB_Index_Backend;
+use WordPress\AI\RAG\Memory_Index_Backend;
+use WordPress\AI\RAG\Memory_Index_Repository;
+use WordPress\AI\RAG\OpenAI_Embedding_Client;
 
 /**
  * Availability test case.
@@ -122,6 +128,61 @@ class AvailabilityTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests availability delegates backend checks.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_is_available_delegates_to_registered_backends(): void {
+		$availability = new Availability(
+			array(
+				$this->create_backend( Availability::BACKEND_MARIADB, false, 'MariaDB unavailable.' ),
+				$this->create_backend( Availability::BACKEND_MEMORY, true, 'Memory unavailable.' ),
+			),
+			$this->create_embedding_client( true )
+		);
+
+		$this->assertTrue( $availability->is_available() );
+		$this->assertSame( Availability::BACKEND_MEMORY, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Tests unavailable backend reasons are reported when no backend can run.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_is_available_reports_backend_reason_when_no_backend_is_available(): void {
+		$availability = new Availability(
+			array(
+				$this->create_backend( Availability::BACKEND_MARIADB, false, 'MariaDB unavailable.' ),
+				$this->create_backend( Availability::BACKEND_MEMORY, false, 'Memory unavailable.' ),
+			),
+			$this->create_embedding_client( true )
+		);
+
+		$this->assertFalse( $availability->is_available() );
+		$this->assertStringContainsString( 'MariaDB unavailable.', $availability->get_unavailable_reason() );
+		$this->assertStringContainsString( 'Memory unavailable.', $availability->get_unavailable_reason() );
+	}
+
+	/**
+	 * Tests embedding client availability is part of RAG availability.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_is_available_reports_embedding_client_reason(): void {
+		$availability = new Availability(
+			array(
+				$this->create_backend( Availability::BACKEND_MARIADB, false, 'MariaDB unavailable.' ),
+				$this->create_backend( Availability::BACKEND_MEMORY, true, 'Memory unavailable.' ),
+			),
+			$this->create_embedding_client( false, 'Embedding unavailable.' )
+		);
+
+		$this->assertFalse( $availability->is_available() );
+		$this->assertSame( 'Embedding unavailable.', $availability->get_unavailable_reason() );
+	}
+
+	/**
 	 * Creates an availability service with a fixed database version.
 	 *
 	 * @since 1.1.0
@@ -130,28 +191,190 @@ class AvailabilityTest extends WP_UnitTestCase {
 	 * @return \WordPress\AI\RAG\Availability Availability service.
 	 */
 	private function create_availability_for_database_version( string $version ): Availability {
-		return new class( $version ) extends Availability {
+		return new Availability(
+			array(
+				new class( $version ) extends MariaDB_Index_Backend {
+					/**
+					 * Database version.
+					 *
+					 * @var string
+					 */
+					private string $version;
+
+					/**
+					 * Constructor.
+					 *
+					 * @param string $version Database version.
+					 */
+					public function __construct( string $version ) {
+						parent::__construct();
+
+						$this->version = $version;
+					}
+
+					/**
+					 * {@inheritDoc}
+					 */
+					protected function get_database_version(): string {
+						return $this->version;
+					}
+				},
+				new Memory_Index_Backend(),
+			),
+			$this->create_embedding_client( true )
+		);
+	}
+
+	/**
+	 * Creates a test backend.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $id        Backend ID.
+	 * @param bool   $available Whether the backend is available.
+	 * @param string $reason    Unavailable reason.
+	 * @return \WordPress\AI\RAG\Index_Backend_Interface Backend.
+	 */
+	private function create_backend( string $id, bool $available, string $reason ): Index_Backend_Interface {
+		return new class( $id, $available, $reason ) implements Index_Backend_Interface {
 			/**
-			 * Database version.
+			 * Backend ID.
 			 *
 			 * @var string
 			 */
-			private string $version;
+			private string $id;
+
+			/**
+			 * Availability.
+			 *
+			 * @var bool
+			 */
+			private bool $available;
+
+			/**
+			 * Unavailable reason.
+			 *
+			 * @var string
+			 */
+			private string $reason;
 
 			/**
 			 * Constructor.
 			 *
-			 * @param string $version Database version.
+			 * @param string $id        Backend ID.
+			 * @param bool   $available Whether the backend is available.
+			 * @param string $reason    Unavailable reason.
 			 */
-			public function __construct( string $version ) {
-				$this->version = $version;
+			public function __construct( string $id, bool $available, string $reason ) {
+				$this->id        = $id;
+				$this->available = $available;
+				$this->reason    = $reason;
 			}
 
 			/**
 			 * {@inheritDoc}
 			 */
-			protected function get_database_version(): string {
-				return $this->version;
+			public function get_id(): string {
+				return $this->id;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_label(): string {
+				return $this->id;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function is_available(): bool {
+				return $this->available;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_unavailable_reason(): string {
+				return $this->reason;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function create_repository( int $dimensions ): Index_Repository_Interface {
+				return new Memory_Index_Repository( $dimensions );
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function ensure_storage(): bool {
+				return $this->available;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function has_index_data(): bool {
+				return false;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function cleanup(): void {}
+		};
+	}
+
+	/**
+	 * Creates a test embedding client.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param bool   $available Whether embeddings are available.
+	 * @param string $reason    Unavailable reason.
+	 * @return \WordPress\AI\RAG\OpenAI_Embedding_Client Embedding client.
+	 */
+	private function create_embedding_client( bool $available, string $reason = '' ): OpenAI_Embedding_Client {
+		return new class( $available, $reason ) extends OpenAI_Embedding_Client {
+			/**
+			 * Availability.
+			 *
+			 * @var bool
+			 */
+			private bool $available;
+
+			/**
+			 * Unavailable reason.
+			 *
+			 * @var string
+			 */
+			private string $reason;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param bool   $available Whether embeddings are available.
+			 * @param string $reason    Unavailable reason.
+			 */
+			public function __construct( bool $available, string $reason ) {
+				$this->available = $available;
+				$this->reason    = $reason;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function is_available(): bool {
+				return $this->available;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_unavailable_reason(): string {
+				return $this->reason;
 			}
 		};
 	}

--- a/tests/Integration/Includes/RAG/AvailabilityTest.php
+++ b/tests/Integration/Includes/RAG/AvailabilityTest.php
@@ -17,6 +17,16 @@ use WordPress\AI\RAG\Availability;
  */
 class AvailabilityTest extends WP_UnitTestCase {
 	/**
+	 * Cleans up filters.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'wpai_rag_memory_fallback_enabled' );
+		delete_option( Availability::BACKEND_OPTION );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * Tests MariaDB vector index version support detection.
 	 *
 	 * @dataProvider data_mariadb_versions
@@ -48,5 +58,101 @@ class AvailabilityTest extends WP_UnitTestCase {
 			'mysql 8'          => array( '8.0.36', false ),
 			'empty'            => array( '', false ),
 		);
+	}
+
+	/**
+	 * Tests backend selection for supported MariaDB.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_index_backend_prefers_mariadb_when_supported(): void {
+		$availability = $this->create_availability_for_database_version( '11.8.2-MariaDB' );
+
+		$this->assertSame( Availability::BACKEND_MARIADB, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Tests explicit backend selection.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_index_backend_honors_backend_setting_when_available(): void {
+		update_option( Availability::BACKEND_OPTION, Availability::BACKEND_MEMORY );
+
+		$availability = $this->create_availability_for_database_version( '11.8.2-MariaDB' );
+
+		$this->assertSame( Availability::BACKEND_MEMORY, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Tests fallback when the selected backend is unavailable.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_index_backend_uses_default_when_setting_is_unavailable(): void {
+		update_option( Availability::BACKEND_OPTION, Availability::BACKEND_MARIADB );
+
+		$availability = $this->create_availability_for_database_version( '8.0.36' );
+
+		$this->assertSame( Availability::BACKEND_MEMORY, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Tests backend selection for the compact fallback.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_index_backend_uses_memory_fallback_without_mariadb(): void {
+		$availability = $this->create_availability_for_database_version( '8.0.36' );
+
+		$this->assertSame( Availability::BACKEND_MEMORY, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Tests backend selection when the fallback is disabled.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_index_backend_returns_mariadb_when_memory_fallback_is_disabled(): void {
+		add_filter( 'wpai_rag_memory_fallback_enabled', '__return_false' );
+
+		$availability = $this->create_availability_for_database_version( '8.0.36' );
+
+		$this->assertSame( Availability::BACKEND_MARIADB, $availability->get_index_backend() );
+	}
+
+	/**
+	 * Creates an availability service with a fixed database version.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $version Database version.
+	 * @return \WordPress\AI\RAG\Availability Availability service.
+	 */
+	private function create_availability_for_database_version( string $version ): Availability {
+		return new class( $version ) extends Availability {
+			/**
+			 * Database version.
+			 *
+			 * @var string
+			 */
+			private string $version;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $version Database version.
+			 */
+			public function __construct( string $version ) {
+				$this->version = $version;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			protected function get_database_version(): string {
+				return $this->version;
+			}
+		};
 	}
 }

--- a/tests/Integration/Includes/RAG/Backend_SearchTest.php
+++ b/tests/Integration/Includes/RAG/Backend_SearchTest.php
@@ -10,7 +10,6 @@ namespace WordPress\AI\Tests\Integration\Includes\RAG;
 use WP_UnitTestCase;
 use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
-use WordPress\AI\RAG\Index_Repository_Interface;
 use WordPress\AI\RAG\MariaDB_Index_Repository;
 use WordPress\AI\RAG\MariaDB_Index_Schema;
 use WordPress\AI\RAG\Memory_Index_Repository;
@@ -215,10 +214,11 @@ class Backend_SearchTest extends WP_UnitTestCase {
 	 * @param int    $dimensions Vector dimensions.
 	 */
 	public function test_seed_many_posts_and_search_across_backends( string $backend, int $dimensions ): void {
-		$repository   = $this->create_repository( $backend, $dimensions );
+		$context      = $this->create_backend_context( $backend, $dimensions );
+		$repository   = $context['repository'];
 		$availability = new Backend_Search_Test_Availability( $backend, $dimensions, self::MODEL );
 		$client       = new Backend_Search_Test_Embedding_Client( $dimensions );
-		$manager      = new Index_Manager( $availability, null, $repository, null, $client );
+		$manager      = new Index_Manager( $availability, $context['schema'], $repository, null, $client );
 
 		$this->assertTrue( $manager->ensure_index_storage() );
 
@@ -270,17 +270,20 @@ class Backend_SearchTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Creates the repository under test.
+	 * Creates the backend context under test.
 	 *
 	 * @since 1.1.0
 	 *
 	 * @param string $backend    Backend identifier.
 	 * @param int    $dimensions Vector dimensions.
-	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
+	 * @return array{repository: \WordPress\AI\RAG\Index_Repository_Interface, schema: \WordPress\AI\RAG\MariaDB_Index_Schema|null} Backend context.
 	 */
-	private function create_repository( string $backend, int $dimensions ): Index_Repository_Interface {
+	private function create_backend_context( string $backend, int $dimensions ): array {
 		if ( Availability::BACKEND_MEMORY === $backend ) {
-			return new Memory_Index_Repository( $dimensions );
+			return array(
+				'repository' => new Memory_Index_Repository( $dimensions ),
+				'schema'     => null,
+			);
 		}
 
 		$availability = new Availability();
@@ -288,7 +291,12 @@ class Backend_SearchTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'MariaDB VECTOR indexes are not available in this test environment.' );
 		}
 
-		return new MariaDB_Index_Repository( new MariaDB_Index_Schema(), $dimensions );
+		$schema = new MariaDB_Index_Schema();
+
+		return array(
+			'repository' => new MariaDB_Index_Repository( $schema, $dimensions ),
+			'schema'     => $schema,
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/RAG/Backend_SearchTest.php
+++ b/tests/Integration/Includes/RAG/Backend_SearchTest.php
@@ -10,9 +10,9 @@ namespace WordPress\AI\Tests\Integration\Includes\RAG;
 use WP_UnitTestCase;
 use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
-use WordPress\AI\RAG\Index_Repository;
 use WordPress\AI\RAG\Index_Repository_Interface;
-use WordPress\AI\RAG\Index_Schema;
+use WordPress\AI\RAG\MariaDB_Index_Repository;
+use WordPress\AI\RAG\MariaDB_Index_Schema;
 use WordPress\AI\RAG\Memory_Index_Repository;
 use WordPress\AI\RAG\OpenAI_Embedding_Client;
 use WordPress\AI\RAG\Search_Service;
@@ -150,6 +150,13 @@ class Backend_Search_Test_Availability extends Availability {
 	public function get_embedding_dimensions(): int {
 		return $this->dimensions;
 	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function ensure_index_storage(): bool {
+		return true;
+	}
 }
 
 /**
@@ -281,7 +288,7 @@ class Backend_SearchTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'MariaDB VECTOR indexes are not available in this test environment.' );
 		}
 
-		return new Index_Repository( new Index_Schema(), $dimensions );
+		return new MariaDB_Index_Repository( new MariaDB_Index_Schema(), $dimensions );
 	}
 
 	/**

--- a/tests/Integration/Includes/RAG/Backend_SearchTest.php
+++ b/tests/Integration/Includes/RAG/Backend_SearchTest.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Integration tests for RAG search across index backends.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\Index_Repository;
+use WordPress\AI\RAG\Index_Repository_Interface;
+use WordPress\AI\RAG\Index_Schema;
+use WordPress\AI\RAG\Memory_Index_Repository;
+use WordPress\AI\RAG\OpenAI_Embedding_Client;
+use WordPress\AI\RAG\Search_Service;
+
+/**
+ * Deterministic embedding client for backend corpus tests.
+ *
+ * @since 1.1.0
+ */
+class Backend_Search_Test_Embedding_Client extends OpenAI_Embedding_Client {
+	/**
+	 * Vector dimensions.
+	 *
+	 * @var int
+	 */
+	private int $dimensions;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param int $dimensions Vector dimensions.
+	 */
+	public function __construct( int $dimensions ) {
+		$this->dimensions = $dimensions;
+	}
+
+	/**
+	 * Embeds text inputs.
+	 *
+	 * @param list<string> $texts Text inputs.
+	 * @return list<list<float>> Embedding vectors.
+	 */
+	public function embed( array $texts ) {
+		return array_map(
+			function ( string $text ): array {
+				return $this->vector_for_text( $text );
+			},
+			$texts
+		);
+	}
+
+	/**
+	 * Returns a deterministic vector for text.
+	 *
+	 * @param string $text Text.
+	 * @return list<float> Embedding vector.
+	 */
+	private function vector_for_text( string $text ): array {
+		$tokens = array(
+			Backend_SearchTest::TARGET_TOKEN,
+			'decoy-alpha',
+			'decoy-beta',
+			'decoy-gamma',
+			'decoy-delta',
+		);
+		$text   = strtolower( $text );
+		$vector = array_fill( 0, $this->dimensions, 0.0 );
+
+		foreach ( $tokens as $index => $token ) {
+			if ( false !== strpos( $text, $token ) ) {
+				$vector[ $index ] = 1.0;
+				return $vector;
+			}
+		}
+
+		$vector[ count( $tokens ) ] = 1.0;
+		return $vector;
+	}
+}
+
+/**
+ * Fixed backend availability service for backend corpus tests.
+ *
+ * @since 1.1.0
+ */
+class Backend_Search_Test_Availability extends Availability {
+	/**
+	 * Backend.
+	 *
+	 * @var string
+	 */
+	private string $backend;
+
+	/**
+	 * Vector dimensions.
+	 *
+	 * @var int
+	 */
+	private int $dimensions;
+
+	/**
+	 * Embedding model.
+	 *
+	 * @var string
+	 */
+	private string $model;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $backend    Backend identifier.
+	 * @param int    $dimensions Vector dimensions.
+	 * @param string $model      Embedding model.
+	 */
+	public function __construct( string $backend, int $dimensions, string $model ) {
+		$this->backend    = $backend;
+		$this->dimensions = $dimensions;
+		$this->model      = $model;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function is_available(): bool {
+		return true;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_index_backend(): string {
+		return $this->backend;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_embedding_model(): string {
+		return $this->model;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_embedding_dimensions(): int {
+		return $this->dimensions;
+	}
+}
+
+/**
+ * Backend search test case.
+ *
+ * @since 1.1.0
+ */
+class Backend_SearchTest extends WP_UnitTestCase {
+	/**
+	 * Token that should dominate semantic search results.
+	 */
+	public const TARGET_TOKEN = 'needle-rag-topic';
+
+	/**
+	 * Test embedding model.
+	 */
+	private const MODEL = 'test-embedding-backend-corpus';
+
+	/**
+	 * Total seeded posts.
+	 */
+	private const POST_COUNT = 80;
+
+	/**
+	 * Target post count.
+	 */
+	private const TARGET_COUNT = 7;
+
+	/**
+	 * Set up test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_transient( 'wpai_rag_indexing_lock' );
+	}
+
+	/**
+	 * Cleans up scheduled RAG events.
+	 */
+	public function tearDown(): void {
+		delete_transient( 'wpai_rag_indexing_lock' );
+		wp_clear_scheduled_hook( Index_Manager::CRON_HOOK );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests indexing and semantic search over a larger corpus.
+	 *
+	 * @dataProvider data_backends
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $backend    Backend identifier.
+	 * @param int    $dimensions Vector dimensions.
+	 */
+	public function test_seed_many_posts_and_search_across_backends( string $backend, int $dimensions ): void {
+		$repository   = $this->create_repository( $backend, $dimensions );
+		$availability = new Backend_Search_Test_Availability( $backend, $dimensions, self::MODEL );
+		$client       = new Backend_Search_Test_Embedding_Client( $dimensions );
+		$manager      = new Index_Manager( $availability, null, $repository, null, $client );
+
+		$this->assertTrue( $manager->ensure_index_storage() );
+
+		$target_ids = $this->seed_posts_and_mark_dirty( $manager );
+		$stats      = $manager->run_indexing_batch( self::POST_COUNT, false );
+
+		$this->assertSame( self::POST_COUNT, $stats['processed'] );
+		$this->assertSame( self::POST_COUNT, $stats['clean'] );
+		$this->assertSame( 0, $stats['error'] );
+
+		$search  = new Search_Service( $availability, $repository, $client );
+		$results = $search->search(
+			'Find the ' . self::TARGET_TOKEN . ' posts',
+			array(
+				'per_page'                => 5,
+				'candidate_limit'         => 20,
+				'enforce_read_permission' => false,
+			)
+		);
+
+		$this->assertFalse( is_wp_error( $results ) );
+		$this->assertIsArray( $results );
+		$this->assertCount( 5, $results['results'] );
+
+		$result_ids = array_map(
+			static function ( array $result ): int {
+				return (int) $result['post_id'];
+			},
+			$results['results']
+		);
+
+		foreach ( $result_ids as $post_id ) {
+			$this->assertContains( $post_id, $target_ids );
+		}
+	}
+
+	/**
+	 * Backend data provider.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, array{string, int}>
+	 */
+	public function data_backends(): array {
+		return array(
+			'memory'  => array( Availability::BACKEND_MEMORY, 16 ),
+			'mariadb' => array( Availability::BACKEND_MARIADB, 1536 ),
+		);
+	}
+
+	/**
+	 * Creates the repository under test.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $backend    Backend identifier.
+	 * @param int    $dimensions Vector dimensions.
+	 * @return \WordPress\AI\RAG\Index_Repository_Interface Repository.
+	 */
+	private function create_repository( string $backend, int $dimensions ): Index_Repository_Interface {
+		if ( Availability::BACKEND_MEMORY === $backend ) {
+			return new Memory_Index_Repository( $dimensions );
+		}
+
+		$availability = new Availability();
+		if ( ! $availability->is_mariadb_vector_index_supported() ) {
+			$this->markTestSkipped( 'MariaDB VECTOR indexes are not available in this test environment.' );
+		}
+
+		return new Index_Repository( new Index_Schema(), $dimensions );
+	}
+
+	/**
+	 * Seeds posts and marks them dirty for indexing.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WordPress\AI\RAG\Index_Manager $manager Index manager.
+	 * @return list<int> Target post IDs.
+	 */
+	private function seed_posts_and_mark_dirty( Index_Manager $manager ): array {
+		$target_ids = array();
+		$decoys     = array( 'decoy-alpha', 'decoy-beta', 'decoy-gamma', 'decoy-delta' );
+
+		for ( $i = 0; $i < self::POST_COUNT; ++$i ) {
+			$is_target = $i > 0 && 0 === $i % 11 && count( $target_ids ) < self::TARGET_COUNT;
+			$token     = $is_target ? self::TARGET_TOKEN : $decoys[ $i % count( $decoys ) ];
+			$post_id   = self::factory()->post->create(
+				array(
+					'post_title'   => sprintf( 'Backend corpus article %02d', $i ),
+					'post_content' => sprintf( '<p>Seeded backend corpus content %02d about %s.</p>', $i, $token ),
+					'post_status'  => 'publish',
+				)
+			);
+
+			if ( $is_target ) {
+				$target_ids[] = $post_id;
+			}
+
+			$manager->handle_save_post( $post_id, get_post( $post_id ), true );
+		}
+
+		$this->assertCount( self::TARGET_COUNT, $target_ids );
+
+		return $target_ids;
+	}
+}

--- a/tests/Integration/Includes/RAG/Index_ManagerTest.php
+++ b/tests/Integration/Includes/RAG/Index_ManagerTest.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Integration tests for the RAG index manager.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Index_Manager;
+
+/**
+ * Index manager test case.
+ *
+ * @since 1.1.0
+ */
+class Index_ManagerTest extends WP_UnitTestCase {
+	/**
+	 * Cleans up filters and post types.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'wpai_rag_indexing_scope' );
+
+		if ( post_type_exists( 'book' ) ) {
+			unregister_post_type( 'book' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests default indexing scope.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_indexing_scope_defaults_to_published_posts_and_pages(): void {
+		$manager = new Index_Manager();
+
+		$this->assertSame(
+			array(
+				'post' => array( 'publish' ),
+				'page' => array( 'publish' ),
+			),
+			$manager->get_indexing_scope()
+		);
+	}
+
+	/**
+	 * Tests scope filter.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_indexing_scope_can_include_custom_post_types_and_statuses(): void {
+		register_post_type( 'book', array( 'public' => true ) );
+
+		add_filter(
+			'wpai_rag_indexing_scope',
+			static function () {
+				return array(
+					'book' => array( 'draft', 'publish' ),
+				);
+			}
+		);
+
+		$manager = new Index_Manager();
+
+		$this->assertSame(
+			array(
+				'book' => array( 'draft', 'publish' ),
+			),
+			$manager->get_indexing_scope()
+		);
+	}
+
+	/**
+	 * Tests post eligibility.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_should_index_post_uses_scope(): void {
+		$manager = new Index_Manager();
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$draft   = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		$this->assertTrue( $manager->should_index_post( get_post( $post_id ) ) );
+		$this->assertFalse( $manager->should_index_post( get_post( $draft ) ) );
+	}
+}

--- a/tests/Integration/Includes/RAG/Index_ManagerTest.php
+++ b/tests/Integration/Includes/RAG/Index_ManagerTest.php
@@ -10,6 +10,7 @@ namespace WordPress\AI\Tests\Integration\Includes\RAG;
 use WP_UnitTestCase;
 use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\Memory_Index_Backend;
 use WordPress\AI\RAG\Memory_Index_Repository;
 use WordPress\AI\RAG\OpenAI_Embedding_Client;
 
@@ -34,6 +35,7 @@ class Index_ManagerTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_all_filters( 'wpai_rag_indexing_scope' );
 		delete_transient( 'wpai_rag_indexing_lock' );
+		delete_option( Availability::BACKEND_OPTION );
 		wp_clear_scheduled_hook( Index_Manager::CRON_HOOK );
 
 		if ( post_type_exists( 'book' ) ) {
@@ -163,6 +165,111 @@ class Index_ManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests save hooks schedule delayed indexing.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_handle_save_post_schedules_delayed_indexing(): void {
+		$manager = new Index_Manager(
+			$this->create_memory_availability(),
+			null,
+			new Memory_Index_Repository( 3 )
+		);
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Content that should be indexed later.',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$manager->handle_save_post( $post_id, get_post( $post_id ), true );
+
+		$scheduled = wp_next_scheduled( Index_Manager::CRON_HOOK );
+
+		$this->assertIsInt( $scheduled );
+		$this->assertGreaterThanOrEqual( time() + HOUR_IN_SECONDS - 5, $scheduled );
+	}
+
+	/**
+	 * Tests content hashes ignore modified timestamps.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_content_hash_ignores_post_modified_timestamp(): void {
+		$manager = new Index_Manager(
+			$this->create_memory_availability(),
+			null,
+			new Memory_Index_Repository( 3 )
+		);
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Stable hash',
+				'post_content' => 'Hashable content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post    = get_post( $post_id );
+		$method  = new \ReflectionMethod( Index_Manager::class, 'build_content_hash' );
+		$method->setAccessible( true );
+
+		$first = $method->invoke( $manager, $post );
+
+		$post->post_modified_gmt = '2099-01-01 00:00:00';
+		$second                  = $method->invoke( $manager, $post );
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * Tests explicit cleanup removes memory data, status meta, options, and cron.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_cleanup_index_data_removes_memory_index_state(): void {
+		$repository = new Memory_Index_Repository( 3 );
+		$manager    = new Index_Manager(
+			$this->create_memory_availability(),
+			null,
+			$repository
+		);
+		$post_id    = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$repository->replace_post_chunks(
+			get_post( $post_id ),
+			array(
+				array(
+					'chunk_id'       => 'chunk',
+					'chunk_index'    => 0,
+					'chunk_offset'   => 0,
+					'content'        => 'Stored content',
+					'embedding_text' => 'Stored title Stored content',
+				),
+			),
+			array( array( 1.0, 0.0, 0.0 ) ),
+			'test-embedding',
+			'hash'
+		);
+		update_post_meta( $post_id, Index_Manager::META_STATUS, Index_Manager::STATUS_CLEAN );
+		update_post_meta( $post_id, Index_Manager::META_ERROR, 'error' );
+		update_post_meta( $post_id, Index_Manager::META_INDEXED_AT, 'now' );
+		update_post_meta( $post_id, Index_Manager::META_CONTENT_HASH, 'hash' );
+		update_option( Availability::BACKEND_OPTION, Availability::BACKEND_MEMORY );
+		$manager->schedule_indexing( 30 );
+
+		$this->assertTrue( $manager->has_index_data() );
+
+		$manager->cleanup_index_data();
+
+		$this->assertSame( '', get_post_meta( $post_id, Memory_Index_Repository::META_CHUNKS, true ) );
+		$this->assertSame( '', get_post_meta( $post_id, Index_Manager::META_STATUS, true ) );
+		$this->assertSame( '', get_post_meta( $post_id, Index_Manager::META_ERROR, true ) );
+		$this->assertSame( '', get_post_meta( $post_id, Index_Manager::META_INDEXED_AT, true ) );
+		$this->assertSame( '', get_post_meta( $post_id, Index_Manager::META_CONTENT_HASH, true ) );
+		$this->assertFalse( wp_next_scheduled( Index_Manager::CRON_HOOK ) );
+		$this->assertSame( '', get_option( Availability::BACKEND_OPTION, '' ) );
+	}
+
+	/**
 	 * Creates a memory-backend availability service.
 	 *
 	 * @since 1.1.0
@@ -171,6 +278,20 @@ class Index_ManagerTest extends WP_UnitTestCase {
 	 */
 	private function create_memory_availability(): Availability {
 		return new class() extends Availability {
+			/**
+			 * Memory backend.
+			 *
+			 * @var \WordPress\AI\RAG\Memory_Index_Backend
+			 */
+			private Memory_Index_Backend $backend;
+
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {
+				$this->backend = new Memory_Index_Backend();
+			}
+
 			/**
 			 * {@inheritDoc}
 			 */
@@ -197,6 +318,27 @@ class Index_ManagerTest extends WP_UnitTestCase {
 			 */
 			public function get_embedding_dimensions(): int {
 				return 3;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function ensure_index_storage(): bool {
+				return true;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function has_index_data(): bool {
+				return $this->backend->has_index_data();
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function cleanup_index_backends(): void {
+				$this->backend->cleanup();
 			}
 		};
 	}

--- a/tests/Integration/Includes/RAG/Index_ManagerTest.php
+++ b/tests/Integration/Includes/RAG/Index_ManagerTest.php
@@ -8,7 +8,10 @@
 namespace WordPress\AI\Tests\Integration\Includes\RAG;
 
 use WP_UnitTestCase;
+use WordPress\AI\RAG\Availability;
 use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\Memory_Index_Repository;
+use WordPress\AI\RAG\OpenAI_Embedding_Client;
 
 /**
  * Index manager test case.
@@ -17,10 +20,21 @@ use WordPress\AI\RAG\Index_Manager;
  */
 class Index_ManagerTest extends WP_UnitTestCase {
 	/**
+	 * Set up test case.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_transient( 'wpai_rag_indexing_lock' );
+	}
+
+	/**
 	 * Cleans up filters and post types.
 	 */
 	public function tearDown(): void {
 		remove_all_filters( 'wpai_rag_indexing_scope' );
+		delete_transient( 'wpai_rag_indexing_lock' );
+		wp_clear_scheduled_hook( Index_Manager::CRON_HOOK );
 
 		if ( post_type_exists( 'book' ) ) {
 			unregister_post_type( 'book' );
@@ -85,5 +99,105 @@ class Index_ManagerTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $manager->should_index_post( get_post( $post_id ) ) );
 		$this->assertFalse( $manager->should_index_post( get_post( $draft ) ) );
+	}
+
+	/**
+	 * Tests indexing through the compact memory repository.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_run_indexing_batch_can_use_memory_repository(): void {
+		$repository = new Memory_Index_Repository( 3 );
+		$manager    = new Index_Manager(
+			$this->create_memory_availability(),
+			null,
+			$repository,
+			null,
+			new class() extends OpenAI_Embedding_Client {
+				/**
+				 * Constructor.
+				 */
+				public function __construct() {}
+
+				/**
+				 * {@inheritDoc}
+				 */
+				public function embed( array $texts ) {
+					return array_map(
+						static function ( string $text ) {
+							unset( $text );
+
+							return array( 1.0, 0.0, 0.0 );
+						},
+						$texts
+					);
+				}
+			}
+		);
+		$post_id    = self::factory()->post->create(
+			array(
+				'post_title'   => 'Memory Search',
+				'post_content' => '<p>This post should be indexed with compact memory vectors.</p>',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$manager->handle_save_post( $post_id, get_post( $post_id ), true );
+		$stats = $manager->run_indexing_batch( 1, false );
+
+		$this->assertSame( 1, $stats['processed'] );
+		$this->assertSame( 1, $stats['clean'] );
+		$this->assertSame( Index_Manager::STATUS_CLEAN, get_post_meta( $post_id, Index_Manager::META_STATUS, true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, Memory_Index_Repository::META_CHUNKS, true ) );
+
+		$rows = $repository->search(
+			array( 1.0, 0.0, 0.0 ),
+			array(
+				'limit' => 1,
+				'model' => 'test-embedding',
+			)
+		);
+
+		$this->assertCount( 1, $rows );
+		$this->assertSame( $post_id, (int) $rows[0]['post_id'] );
+	}
+
+	/**
+	 * Creates a memory-backend availability service.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Availability Availability service.
+	 */
+	private function create_memory_availability(): Availability {
+		return new class() extends Availability {
+			/**
+			 * {@inheritDoc}
+			 */
+			public function is_available(): bool {
+				return true;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend(): string {
+				return Availability::BACKEND_MEMORY;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_embedding_model(): string {
+				return 'test-embedding';
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_embedding_dimensions(): int {
+				return 3;
+			}
+		};
 	}
 }

--- a/tests/Integration/Includes/RAG/Memory_Index_RepositoryTest.php
+++ b/tests/Integration/Includes/RAG/Memory_Index_RepositoryTest.php
@@ -59,6 +59,10 @@ class Memory_Index_RepositoryTest extends WP_UnitTestCase {
 		$stored = get_post_meta( $post_one, Memory_Index_Repository::META_CHUNKS, true );
 
 		$this->assertIsArray( $stored );
+		$this->assertArrayNotHasKey( 'title', $stored[0] );
+		$this->assertArrayNotHasKey( 'permalink', $stored[0] );
+		$this->assertArrayNotHasKey( 'anchor', $stored[0] );
+		$this->assertArrayNotHasKey( 'embedding_dimensions', $stored[0] );
 		$this->assertSame( 16, strlen( $stored[0]['embedding'] ) );
 		$this->assertSame( 12, strlen( base64_decode( $stored[0]['embedding'], true ) ) );
 
@@ -142,13 +146,11 @@ class Memory_Index_RepositoryTest extends WP_UnitTestCase {
 	 */
 	private function create_chunk( string $id, string $content ): array {
 		return array(
-			'chunk_id'     => $id,
-			'chunk_index'  => 0,
-			'chunk_offset' => 0,
-			'anchor'       => null,
-			'title'        => 'Test title',
-			'permalink'    => 'https://example.com/test',
-			'content'      => $content,
+			'chunk_id'       => $id,
+			'chunk_index'    => 0,
+			'chunk_offset'   => 0,
+			'content'        => $content,
+			'embedding_text' => 'Test title ' . $content,
 		);
 	}
 }

--- a/tests/Integration/Includes/RAG/Memory_Index_RepositoryTest.php
+++ b/tests/Integration/Includes/RAG/Memory_Index_RepositoryTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Integration tests for the compact memory RAG index repository.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\Memory_Index_Repository;
+
+/**
+ * Memory index repository test case.
+ *
+ * @since 1.1.0
+ */
+class Memory_Index_RepositoryTest extends WP_UnitTestCase {
+	/**
+	 * Tests storing compact vectors and exact search.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_replace_post_chunks_stores_packed_vectors_and_searches_exact_matches(): void {
+		$repo     = new Memory_Index_Repository( 3 );
+		$post_one = self::factory()->post->create(
+			array(
+				'post_title'   => 'Alpha',
+				'post_content' => 'Alpha content',
+				'post_status'  => 'publish',
+			)
+		);
+		$post_two = self::factory()->post->create(
+			array(
+				'post_title'   => 'Beta',
+				'post_content' => 'Beta content',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$repo->replace_post_chunks(
+			get_post( $post_one ),
+			array( $this->create_chunk( 'alpha', 'Alpha content' ) ),
+			array( array( 1.0, 0.0, 0.0 ) ),
+			'test-embedding',
+			'hash-one'
+		);
+		$repo->replace_post_chunks(
+			get_post( $post_two ),
+			array( $this->create_chunk( 'beta', 'Beta content' ) ),
+			array( array( 0.0, 1.0, 0.0 ) ),
+			'test-embedding',
+			'hash-two'
+		);
+		update_post_meta( $post_one, Index_Manager::META_STATUS, Index_Manager::STATUS_CLEAN );
+		update_post_meta( $post_two, Index_Manager::META_STATUS, Index_Manager::STATUS_CLEAN );
+
+		$stored = get_post_meta( $post_one, Memory_Index_Repository::META_CHUNKS, true );
+
+		$this->assertIsArray( $stored );
+		$this->assertSame( 16, strlen( $stored[0]['embedding'] ) );
+		$this->assertSame( 12, strlen( base64_decode( $stored[0]['embedding'], true ) ) );
+
+		$rows = $repo->search(
+			array( 1.0, 0.0, 0.0 ),
+			array(
+				'limit' => 2,
+				'model' => 'test-embedding',
+			)
+		);
+
+		$this->assertCount( 2, $rows );
+		$this->assertSame( $post_one, (int) $rows[0]['post_id'] );
+		$this->assertSame( 'alpha', $rows[0]['chunk_id'] );
+		$this->assertSame( 0.0, (float) $rows[0]['distance'] );
+		$this->assertSame( $post_two, (int) $rows[1]['post_id'] );
+		$this->assertGreaterThan( 0.9, (float) $rows[1]['distance'] );
+	}
+
+	/**
+	 * Tests that model filters are applied.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_search_filters_by_model(): void {
+		$repo    = new Memory_Index_Repository( 3 );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$repo->replace_post_chunks(
+			get_post( $post_id ),
+			array( $this->create_chunk( 'chunk', 'Stored content' ) ),
+			array( array( 1.0, 0.0, 0.0 ) ),
+			'expected-model',
+			'hash'
+		);
+		update_post_meta( $post_id, Index_Manager::META_STATUS, Index_Manager::STATUS_CLEAN );
+
+		$rows = $repo->search(
+			array( 1.0, 0.0, 0.0 ),
+			array(
+				'limit' => 1,
+				'model' => 'other-model',
+			)
+		);
+
+		$this->assertSame( array(), $rows );
+	}
+
+	/**
+	 * Tests deleting compact chunk records.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_delete_post_chunks_removes_memory_index_meta(): void {
+		$repo    = new Memory_Index_Repository( 3 );
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$repo->replace_post_chunks(
+			get_post( $post_id ),
+			array( $this->create_chunk( 'chunk', 'Stored content' ) ),
+			array( array( 1.0, 0.0, 0.0 ) ),
+			'test-embedding',
+			'hash'
+		);
+
+		$this->assertNotEmpty( get_post_meta( $post_id, Memory_Index_Repository::META_CHUNKS, true ) );
+
+		$repo->delete_post_chunks( $post_id );
+
+		$this->assertSame( '', get_post_meta( $post_id, Memory_Index_Repository::META_CHUNKS, true ) );
+	}
+
+	/**
+	 * Creates a chunk record.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $id      Chunk ID.
+	 * @param string $content Chunk content.
+	 * @return array<string, mixed> Chunk.
+	 */
+	private function create_chunk( string $id, string $content ): array {
+		return array(
+			'chunk_id'     => $id,
+			'chunk_index'  => 0,
+			'chunk_offset' => 0,
+			'anchor'       => null,
+			'title'        => 'Test title',
+			'permalink'    => 'https://example.com/test',
+			'content'      => $content,
+		);
+	}
+}

--- a/tests/Integration/Includes/RAG/Post_ChunkerTest.php
+++ b/tests/Integration/Includes/RAG/Post_ChunkerTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Integration tests for the RAG post chunker.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Post_Chunker;
+
+/**
+ * Post chunker test case.
+ *
+ * @since 1.1.0
+ */
+class Post_ChunkerTest extends WP_UnitTestCase {
+	/**
+	 * Tests chunk generation.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_chunk_post_returns_deterministic_chunks(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Semantic Search',
+				'post_content' => '<p>This is the first paragraph. This is the second paragraph.</p>',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$post    = get_post( $post_id );
+		$chunker = new Post_Chunker();
+
+		$first  = $chunker->chunk_post( $post );
+		$second = $chunker->chunk_post( $post );
+
+		$this->assertNotEmpty( $first );
+		$this->assertSame( $first, $second );
+		$this->assertSame( 0, $first[0]['chunk_index'] );
+		$this->assertSame( 0, $first[0]['chunk_offset'] );
+		$this->assertStringContainsString( 'Semantic Search', $first[0]['content'] );
+		$this->assertStringContainsString( 'first paragraph', $first[0]['content'] );
+	}
+
+	/**
+	 * Tests empty content handling.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_chunk_post_handles_empty_content(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => '',
+				'post_content' => '',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$chunker = new Post_Chunker();
+
+		$this->assertSame( array(), $chunker->chunk_post( get_post( $post_id ) ) );
+	}
+}

--- a/tests/Integration/Includes/RAG/Post_ChunkerTest.php
+++ b/tests/Integration/Includes/RAG/Post_ChunkerTest.php
@@ -40,7 +40,8 @@ class Post_ChunkerTest extends WP_UnitTestCase {
 		$this->assertSame( $first, $second );
 		$this->assertSame( 0, $first[0]['chunk_index'] );
 		$this->assertSame( 0, $first[0]['chunk_offset'] );
-		$this->assertStringContainsString( 'Semantic Search', $first[0]['content'] );
+		$this->assertStringNotContainsString( 'Semantic Search', $first[0]['content'] );
+		$this->assertStringContainsString( 'Semantic Search', $first[0]['embedding_text'] );
 		$this->assertStringContainsString( 'first paragraph', $first[0]['content'] );
 	}
 

--- a/tests/Integration/Includes/RAG/REST/RAG_Maintenance_ControllerTest.php
+++ b/tests/Integration/Includes/RAG/REST/RAG_Maintenance_ControllerTest.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Integration tests for the RAG maintenance REST controller.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG\REST
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG\REST;
+
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Availability;
+use WordPress\AI\RAG\Index_Manager;
+use WordPress\AI\RAG\REST\RAG_Maintenance_Controller;
+
+/**
+ * RAG maintenance controller test case.
+ *
+ * @since 1.1.0
+ */
+class RAG_Maintenance_ControllerTest extends WP_UnitTestCase {
+	/**
+	 * Tests status can report cleanup availability when RAG is unavailable.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_status_reports_index_data_when_unavailable(): void {
+		$controller = new RAG_Maintenance_Controller(
+			$this->create_unavailable_availability(),
+			$this->create_manager_with_data()
+		);
+
+		$response = $controller->get_status();
+		$data     = $response->get_data();
+
+		$this->assertFalse( $data['available'] );
+		$this->assertSame( 'Unavailable for tests.', $data['unavailable_reason'] );
+		$this->assertTrue( $data['has_index_data'] );
+		$this->assertFalse( $data['storage_ready'] );
+	}
+
+	/**
+	 * Creates unavailable availability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Availability Availability.
+	 */
+	private function create_unavailable_availability(): Availability {
+		return new class() extends Availability {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function is_available(): bool {
+				return false;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_unavailable_reason(): string {
+				return 'Unavailable for tests.';
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend(): string {
+				return Availability::BACKEND_MEMORY;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend_label(): string {
+				return 'Fallback in-memory search backed by PHP';
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_available_index_backends(): array {
+				return array();
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_index_backend_labels(): array {
+				return array(
+					Availability::BACKEND_MEMORY => 'Fallback in-memory search backed by PHP',
+				);
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_embedding_model(): string {
+				return 'test-embedding';
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_embedding_dimensions(): int {
+				return 3;
+			}
+		};
+	}
+
+	/**
+	 * Creates a manager reporting existing data.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WordPress\AI\RAG\Index_Manager Manager.
+	 */
+	private function create_manager_with_data(): Index_Manager {
+		return new class() extends Index_Manager {
+			/**
+			 * Constructor.
+			 */
+			public function __construct() {}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function ensure_index_storage(): bool {
+				return false;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function has_index_data(): bool {
+				return true;
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_status_counts(): array {
+				return array(
+					Index_Manager::STATUS_DIRTY      => 1,
+					Index_Manager::STATUS_PROCESSING => 0,
+					Index_Manager::STATUS_CLEAN      => 2,
+					Index_Manager::STATUS_ERROR      => 0,
+				);
+			}
+
+			/**
+			 * {@inheritDoc}
+			 */
+			public function get_next_scheduled_indexing(): ?int {
+				return null;
+			}
+		};
+	}
+}

--- a/tests/Integration/Includes/RAG/Related_PostsTest.php
+++ b/tests/Integration/Includes/RAG/Related_PostsTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Integration tests for semantic related posts Query Loop variation.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_Query;
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Related_Posts;
+use WordPress\AI\RAG\Search_Service;
+
+/**
+ * Fake RAG search service for related posts tests.
+ *
+ * @since 1.1.0
+ */
+class Related_Posts_Test_Search_Service extends Search_Service {
+	/**
+	 * Search results to return.
+	 *
+	 * @var list<array<string, mixed>>
+	 */
+	private array $results;
+
+	/**
+	 * Search calls.
+	 *
+	 * @var list<array{query: string, args: array<string, mixed>}>
+	 */
+	public array $calls = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<array<string, mixed>> $results Search results.
+	 */
+	public function __construct( array $results ) {
+		$this->results = $results;
+	}
+
+	/**
+	 * Returns configured search results.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $query Search query.
+	 * @param array  $args  Search args.
+	 * @return array<string, mixed> Search results.
+	 */
+	public function search( string $query, array $args = array() ) {
+		$this->calls[] = array(
+			'query' => $query,
+			'args'  => $args,
+		);
+
+		return array(
+			'query'   => $query,
+			'model'   => 'text-embedding-3-small',
+			'results' => $this->results,
+		);
+	}
+}
+
+/**
+ * Related posts Query Loop variation test case.
+ *
+ * @since 1.1.0
+ */
+class Related_PostsTest extends WP_UnitTestCase {
+	/**
+	 * Renderer under test.
+	 *
+	 * @var \WordPress\AI\RAG\Related_Posts|null
+	 */
+	private ?Related_Posts $renderer = null;
+
+	/**
+	 * Restores filters and post globals.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'wpai_rag_related_posts_cache_ttl' );
+		remove_all_filters( 'wpai_rag_related_posts_distance_threshold' );
+		remove_all_filters( 'wpai_rag_related_posts_count' );
+		remove_all_filters( 'wpai_rag_related_posts_min_results' );
+		remove_all_filters( 'wpai_rag_related_posts_candidate_limit' );
+		remove_all_filters( 'wpai_rag_related_posts_query_text' );
+		remove_all_filters( 'wpai_rag_related_posts_results' );
+
+		if ( $this->renderer instanceof Related_Posts ) {
+			remove_filter( 'pre_render_block', array( $this->renderer, 'prepare_related_query' ), 10 );
+			remove_filter( 'query_loop_block_query_vars', array( $this->renderer, 'filter_query_vars' ), 10 );
+			remove_filter( 'render_block', array( $this->renderer, 'reset_related_query' ), 10 );
+		}
+
+		wp_reset_postdata();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests related Query Loop renders semantic posts in semantic order.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_related_query_loop_renders_semantic_posts_in_order(): void {
+		$this->disable_cache();
+
+		$category_id = $this->factory->category->create( array( 'name' => 'Shared Topic' ) );
+		$source_id   = $this->create_post( 'Source Article', 'Source content about semantic discovery.', array( $category_id ) );
+		$related_ids = array(
+			$this->create_post( 'Related One', 'More semantic discovery notes.', array( $category_id ) ),
+			$this->create_post( 'Related Two', 'Another semantic discovery article.', array( $category_id ) ),
+			$this->create_post( 'Related Three', 'A third semantic discovery article.', array( $category_id ) ),
+		);
+		$service     = new Related_Posts_Test_Search_Service(
+			array_merge(
+				array(
+					array(
+						'post_id'  => $source_id,
+						'distance' => 0.01,
+					),
+				),
+				$this->create_results( $related_ids )
+			)
+		);
+
+		$this->renderer = new Related_Posts( $service );
+		$this->renderer->init();
+		$this->go_to_post( $source_id );
+
+		$markup = do_blocks( $this->get_related_query_block_markup( 3 ) );
+
+		$this->assertStringContainsString( 'Related One', $markup );
+		$this->assertStringContainsString( 'Related Two', $markup );
+		$this->assertStringContainsString( 'Related Three', $markup );
+		$this->assertStringNotContainsString( 'Source Article', $markup );
+		$this->assertLessThan( strpos( $markup, 'Related Two' ), strpos( $markup, 'Related One' ) );
+		$this->assertLessThan( strpos( $markup, 'Related Three' ), strpos( $markup, 'Related Two' ) );
+		$this->assertStringContainsString( 'Shared Topic', $service->calls[0]['query'] );
+		$this->assertSame( 'post', $service->calls[0]['args']['post_type'] );
+		$this->assertSame( 'publish', $service->calls[0]['args']['post_status'] );
+	}
+
+	/**
+	 * Tests related Query Loop suppresses itself when there are too few matches.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_related_query_loop_renders_nothing_when_not_enough_matches(): void {
+		$this->disable_cache();
+
+		$source_id   = $this->create_post( 'Source Article', 'Source content.' );
+		$related_ids = array(
+			$this->create_post( 'Related One', 'Related content one.' ),
+			$this->create_post( 'Related Two', 'Related content two.' ),
+		);
+
+		$this->renderer = new Related_Posts( new Related_Posts_Test_Search_Service( $this->create_results( $related_ids ) ) );
+		$this->renderer->init();
+		$this->go_to_post( $source_id );
+
+		$this->assertSame( '', do_blocks( $this->get_related_query_block_markup( 3 ) ) );
+	}
+
+	/**
+	 * Tests related Query Loop skips distant semantic matches.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_related_query_loop_skips_results_above_distance_threshold(): void {
+		$this->disable_cache();
+
+		$source_id = $this->create_post( 'Source Article', 'Source content.' );
+		$near_ids  = array(
+			$this->create_post( 'Near One', 'Near content one.' ),
+			$this->create_post( 'Near Two', 'Near content two.' ),
+			$this->create_post( 'Near Three', 'Near content three.' ),
+		);
+		$far_id    = $this->create_post( 'Far Result', 'Far content.' );
+		$results   = array(
+			array(
+				'post_id'  => $near_ids[0],
+				'distance' => 0.2,
+			),
+			array(
+				'post_id'  => $far_id,
+				'distance' => 0.9,
+			),
+			array(
+				'post_id'  => $near_ids[1],
+				'distance' => 0.3,
+			),
+			array(
+				'post_id'  => $near_ids[2],
+				'distance' => 0.4,
+			),
+		);
+
+		$this->renderer = new Related_Posts( new Related_Posts_Test_Search_Service( $results ) );
+		$this->renderer->init();
+		$this->go_to_post( $source_id );
+
+		$markup = do_blocks( $this->get_related_query_block_markup( 3 ) );
+
+		$this->assertStringContainsString( 'Near One', $markup );
+		$this->assertStringContainsString( 'Near Two', $markup );
+		$this->assertStringContainsString( 'Near Three', $markup );
+		$this->assertStringNotContainsString( 'Far Result', $markup );
+	}
+
+	/**
+	 * Tests normal Query Loops are not intercepted.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_plain_query_loop_is_not_suppressed(): void {
+		$this->disable_cache();
+
+		$source_id = $this->create_post( 'Source Article', 'Source content.' );
+		$this->create_post( 'Ordinary Query Result', 'Ordinary query content.' );
+
+		$this->renderer = new Related_Posts( new Related_Posts_Test_Search_Service( array() ) );
+		$this->renderer->init();
+		$this->go_to_post( $source_id );
+
+		$markup = do_blocks(
+			'<!-- wp:query {"query":{"perPage":1,"postType":"post","inherit":false}} -->' .
+			'<div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --></div>' .
+			'<!-- /wp:query -->'
+		);
+
+		$this->assertStringContainsString( 'Ordinary Query Result', $markup );
+	}
+
+	/**
+	 * Disables transient caching for a deterministic test.
+	 */
+	private function disable_cache(): void {
+		add_filter(
+			'wpai_rag_related_posts_cache_ttl',
+			static function (): int {
+				return 0;
+			}
+		);
+	}
+
+	/**
+	 * Creates a published post.
+	 *
+	 * @param string    $title        Post title.
+	 * @param string    $content      Post content.
+	 * @param list<int> $category_ids Category IDs.
+	 * @return int Post ID.
+	 */
+	private function create_post( string $title, string $content, array $category_ids = array() ): int {
+		return $this->factory->post->create(
+			array(
+				'post_title'    => $title,
+				'post_content'  => $content,
+				'post_status'   => 'publish',
+				'post_category' => $category_ids,
+			)
+		);
+	}
+
+	/**
+	 * Sets the main query to a single post.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	private function go_to_post( int $post_id ): void {
+		$this->go_to( get_permalink( $post_id ) );
+
+		global $wp_query;
+		$this->assertInstanceOf( WP_Query::class, $wp_query );
+		$wp_query->the_post();
+	}
+
+	/**
+	 * Returns a serialized Related Posts Query Loop block.
+	 *
+	 * @param int $per_page Posts per page.
+	 * @return string Serialized block markup.
+	 */
+	private function get_related_query_block_markup( int $per_page ): string {
+		return sprintf(
+			'<!-- wp:query {"namespace":"%1$s","query":{"perPage":%2$d,"postType":"post","inherit":false}} -->' .
+			'<div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title /--><!-- /wp:post-template --></div>' .
+			'<!-- /wp:query -->',
+			Related_Posts::QUERY_NAMESPACE,
+			$per_page
+		);
+	}
+
+	/**
+	 * Creates fake search result rows.
+	 *
+	 * @param list<int> $post_ids Post IDs.
+	 * @return list<array{post_id: int, distance: float}> Results.
+	 */
+	private function create_results( array $post_ids ): array {
+		return array_map(
+			static function ( int $post_id ): array {
+				return array(
+					'post_id'  => $post_id,
+					'distance' => 0.2,
+				);
+			},
+			$post_ids
+		);
+	}
+}

--- a/tests/Integration/Includes/RAG/Search_AugmenterTest.php
+++ b/tests/Integration/Includes/RAG/Search_AugmenterTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Integration tests for search page RAG augmentation.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\RAG
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\RAG;
+
+use WP_Query;
+use WP_UnitTestCase;
+use WordPress\AI\RAG\Search_Augmenter;
+use WordPress\AI\RAG\Search_Service;
+
+/**
+ * Fake RAG search service for augmentation tests.
+ *
+ * @since 1.1.0
+ */
+class Search_Augmenter_Test_Search_Service extends Search_Service {
+	/**
+	 * Search results to return.
+	 *
+	 * @var list<array<string, mixed>>
+	 */
+	private array $results;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param list<array<string, mixed>> $results Search results.
+	 */
+	public function __construct( array $results ) {
+		$this->results = $results;
+	}
+
+	/**
+	 * Returns configured search results.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string $query Search query.
+	 * @param array  $args  Search args.
+	 * @return array<string, mixed> Search results.
+	 */
+	public function search( string $query, array $args = array() ) {
+		unset( $args );
+
+		return array(
+			'query'   => $query,
+			'model'   => 'text-embedding-3-small',
+			'results' => $this->results,
+		);
+	}
+}
+
+/**
+ * Search augmenter test case.
+ *
+ * @since 1.1.0
+ */
+class Search_AugmenterTest extends WP_UnitTestCase {
+	/**
+	 * Restores global query and filters.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'wpai_rag_search_distance_threshold' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests default promotion threshold against a real-world OpenAI distance.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_default_threshold_promotes_clear_semantic_match(): void {
+		global $wpdb, $wp_query;
+
+		$this->go_to( '/?s=how+do+I+stop+furniture+from+shaking' );
+		$this->assertInstanceOf( WP_Query::class, $wp_query );
+
+		$wp_query->set( 's', 'how do I stop furniture from shaking' );
+		$wp_query->is_search = true;
+		$wp_query->is_feed   = false;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Required to exercise main-query-only augmentation.
+		$GLOBALS['wp_the_query'] = $wp_query;
+
+		$this->assertTrue( $wp_query->is_main_query() );
+		$this->assertTrue( $wp_query->is_search() );
+
+		$augmenter = new Search_Augmenter(
+			new Search_Augmenter_Test_Search_Service(
+				array(
+					array(
+						'post_id'  => 123,
+						'distance' => 0.53003317313708,
+					),
+					array(
+						'post_id'  => 456,
+						'distance' => 0.67827118224785,
+					),
+				)
+			)
+		);
+
+		$augmenter->prepare_semantic_candidates( $wp_query );
+		$orderby = $augmenter->promote_semantic_results( "{$wpdb->posts}.post_date DESC", $wp_query );
+
+		$this->assertStringContainsString( "CASE WHEN {$wpdb->posts}.ID IN (123)", $orderby );
+		$this->assertStringContainsString( "FIELD({$wpdb->posts}.ID, 123)", $orderby );
+		$this->assertStringNotContainsString( "FIELD({$wpdb->posts}.ID, 123,456)", $orderby );
+	}
+}

--- a/tests/Integration/Includes/REST/Models_ControllerTest.php
+++ b/tests/Integration/Includes/REST/Models_ControllerTest.php
@@ -51,7 +51,7 @@ class Models_ControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'string', $capability_argument['type'] );
 		$this->assertTrue( $capability_argument['required'] );
 		$this->assertSame(
-			array( 'text_generation', 'image_generation', 'vision' ),
+			array( 'text_generation', 'image_generation', 'vision', 'embedding_generation' ),
 			$capability_argument['enum']
 		);
 		$this->assertSame( 'sanitize_key', $capability_argument['sanitize_callback'] );
@@ -178,6 +178,7 @@ class Models_ControllerTest extends WP_UnitTestCase {
 			'text generation'  => array( 'text_generation' ),
 			'image generation' => array( 'image_generation' ),
 			'vision'           => array( 'vision' ),
+			'embedding'        => array( 'embedding_generation' ),
 		);
 	}
 

--- a/tests/e2e-request-mocking/e2e-request-mocking.php
+++ b/tests/e2e-request-mocking/e2e-request-mocking.php
@@ -168,6 +168,11 @@ function ai_e2e_test_request_mocking( $preempt, $parsed_args, $url ) {
 		$response = file_get_contents( __DIR__ . '/responses/OpenAI/image.json' );
 	}
 
+	// Mock the OpenAI embeddings API response.
+	if ( str_contains( $url, 'https://api.openai.com/v1/embeddings' ) ) {
+		$response = ai_e2e_openai_embeddings_response( $parsed_args['body'] ?? '' );
+	}
+
 	if ( ! empty( $response ) ) {
 		return array(
 			'headers'     => array(),
@@ -185,4 +190,43 @@ function ai_e2e_test_request_mocking( $preempt, $parsed_args, $url ) {
 
 	// Return the original response if the URL is not a known request.
 	return $preempt;
+}
+
+/**
+ * Builds a deterministic OpenAI embeddings response.
+ *
+ * @param string $body Request body.
+ * @return string JSON response.
+ */
+function ai_e2e_openai_embeddings_response( $body ) {
+	$payload = json_decode( is_string( $body ) ? $body : '', true );
+	$inputs  = isset( $payload['input'] ) && is_array( $payload['input'] ) ? $payload['input'] : array( '' );
+	$data    = array();
+
+	foreach ( array_values( $inputs ) as $index => $input ) {
+		$seed      = abs( crc32( (string) $input ) );
+		$embedding = array();
+
+		for ( $i = 0; $i < 1536; ++$i ) {
+			$embedding[] = ( ( ( $seed + $i ) % 2000 ) - 1000 ) / 1000;
+		}
+
+		$data[] = array(
+			'object'    => 'embedding',
+			'index'     => $index,
+			'embedding' => $embedding,
+		);
+	}
+
+	return wp_json_encode(
+		array(
+			'object' => 'list',
+			'data'   => $data,
+			'model'  => 'text-embedding-3-small',
+			'usage'  => array(
+				'prompt_tokens' => 1,
+				'total_tokens'  => 1,
+			),
+		)
+	);
 }

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -255,7 +255,9 @@ test.describe( 'Plugin settings', () => {
 		await enableExperiment( admin, page, 'RAG Search' );
 
 		await expect(
-			page.getByText( 'Fallback in-memory search backed by PHP' )
+			page
+				.locator( '.ai-rag-status' )
+				.getByText( 'Fallback in-memory search backed by PHP' )
 		).toBeVisible();
 		await expect( page.getByText( '1 dirty' ) ).toBeVisible();
 		await expect( page.getByText( '2 clean' ) ).toBeVisible();

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -26,6 +26,74 @@ const EXPERIMENT_GROUPS = {
 	editor: 'Editor Experiments',
 	admin: 'Admin Experiments',
 };
+const RAG_STATUS_ROUTE = /\/wp-json\/ai\/v1\/rag\/status(?:\?.*)?$/;
+const RAG_REINDEX_ROUTE = /\/wp-json\/ai\/v1\/rag\/reindex(?:\?.*)?$/;
+const RAG_DELETE_ROUTE = /\/wp-json\/ai\/v1\/rag\/index(?:\?.*)?$/;
+
+const createRagStatus = ( overrides = {} ) => ( {
+	available: true,
+	unavailable_reason: '',
+	backend: 'memory',
+	backend_label: 'Fallback in-memory search backed by PHP',
+	available_backends: [ 'memory' ],
+	backend_labels: {
+		memory: 'Fallback in-memory search backed by PHP',
+	},
+	storage_ready: true,
+	has_index_data: true,
+	counts: {
+		dirty: 1,
+		processing: 0,
+		clean: 2,
+		error: 0,
+	},
+	next_scheduled_run: null,
+	embedding_model: 'text-embedding-3-small',
+	embedding_dimensions: 1536,
+	...overrides,
+} );
+
+const mockRagMaintenanceRoutes = async ( page, initialStatus ) => {
+	let status = initialStatus;
+
+	await page.route( RAG_STATUS_ROUTE, async ( route ) => {
+		await route.fulfill( {
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify( status ),
+		} );
+	} );
+	await page.route( RAG_REINDEX_ROUTE, async ( route ) => {
+		status = {
+			...status,
+			counts: {
+				...status.counts,
+				dirty: 3,
+			},
+		};
+		await route.fulfill( {
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify( status ),
+		} );
+	} );
+	await page.route( RAG_DELETE_ROUTE, async ( route ) => {
+		status = createRagStatus( {
+			has_index_data: false,
+			counts: {
+				dirty: 0,
+				processing: 0,
+				clean: 0,
+				error: 0,
+			},
+		} );
+		await route.fulfill( {
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify( status ),
+		} );
+	} );
+};
 
 test.describe( 'Plugin settings', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
@@ -176,6 +244,82 @@ test.describe( 'Plugin settings', () => {
 		// Assert: inline settings must still show the pending edit (not reset).
 		await expect( strategySelect ).toHaveValue( newValue );
 		await expect( saveButton ).toBeVisible();
+	} );
+
+	test( 'RAG settings show status and schedule reindexing', async ( {
+		admin,
+		page,
+	} ) => {
+		await mockRagMaintenanceRoutes( page, createRagStatus() );
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'RAG Search' );
+
+		await expect(
+			page.getByText( 'Fallback in-memory search backed by PHP' )
+		).toBeVisible();
+		await expect( page.getByText( '1 dirty' ) ).toBeVisible();
+		await expect( page.getByText( '2 clean' ) ).toBeVisible();
+
+		await page.getByRole( 'button', { name: 'Reindex' } ).click();
+
+		await expect(
+			page.locator( '.components-snackbar__content', {
+				hasText: 'RAG indexing scheduled.',
+			} )
+		).toBeVisible();
+		await expect( page.getByText( '3 dirty' ) ).toBeVisible();
+	} );
+
+	test( 'RAG cleanup remains available when disabled and data exists', async ( {
+		admin,
+		page,
+	} ) => {
+		await mockRagMaintenanceRoutes( page, createRagStatus() );
+		await enableExperiments( admin, page );
+		await disableExperiment( admin, page, 'RAG Search' );
+
+		await expect(
+			page.getByText( 'RAG index data exists.' )
+		).toBeVisible();
+
+		page.once( 'dialog', async ( dialog ) => {
+			expect( dialog.message() ).toContain( 'Delete all RAG index data' );
+			await dialog.accept();
+		} );
+		await page.getByRole( 'button', { name: 'Delete index data' } ).click();
+
+		await expect(
+			page.locator( '.components-snackbar__content', {
+				hasText: 'RAG index data deleted.',
+			} )
+		).toBeVisible();
+		await expect(
+			page.getByText( 'RAG index data exists.' )
+		).not.toBeVisible();
+	} );
+
+	test( 'RAG cleanup is hidden when disabled and no data exists', async ( {
+		admin,
+		page,
+	} ) => {
+		await mockRagMaintenanceRoutes(
+			page,
+			createRagStatus( {
+				has_index_data: false,
+				counts: {
+					dirty: 0,
+					processing: 0,
+					clean: 0,
+					error: 0,
+				},
+			} )
+		);
+		await enableExperiments( admin, page );
+		await disableExperiment( admin, page, 'RAG Search' );
+
+		await expect(
+			page.getByText( 'RAG index data exists.' )
+		).not.toBeVisible();
 	} );
 
 	test( 'Can turn on all experiments in a group', async ( {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -100,6 +100,11 @@ module.exports = {
 			'src/experiments/comment-moderation',
 			'index.tsx'
 		),
+		'experiments/rag-search': path.resolve(
+			process.cwd(),
+			'src/experiments/rag-search',
+			'index.ts'
+		),
 		'experiments/alt-text-generation': path.resolve(
 			process.cwd(),
 			'src/experiments/alt-text-generation',


### PR DESCRIPTION
## Summary

This introduces native RAG search for hosts that can support it:

**New Infrastructure:**

- [x] Add an opt-in `rag-search` experiment backed by MariaDB native `VECTOR(1536)` storage and a cosine `VECTOR INDEX`. Gates activation on MariaDB 11.8+ and an authenticated OpenAI connector, using `text-embedding-3-small` embeddings.
- [x] Add fallback which stores embeddings in post meta and searches them in-memory. This should be performant enough for smaller sites
- [x] Add indexing lifecycle hooks, one-hour dirty-post cron scheduling, short batch indexing, transactional replace-by-post behavior where possible, cleanup hooks, and `wp ai rag` WP-CLI utilities.
- [ ] Move to embeddings supplied by WP AI CLient once that is available

<img width="700" height="223" alt="Zrzut ekranu 2026-06-8 o 20 04 37" src="https://github.com/user-attachments/assets/9a643c88-d982-4e33-8c72-fc9b9eebae31" />




**User facing features**:

- [x] Augment the public search page to integrate the RAG results into the result
- [x] Introduce the "related posts" functionality just like in Jetpack - for SEO


<img width="1015" height="980" alt="Zrzut ekranu 2026-06-8 o 20 01 13" src="https://github.com/user-attachments/assets/80075160-961c-4843-b052-d9fbb3286142" />


## Rationale
MariaDB 11.8 LTS ships a community-available vector index implementation, so WordPress can offer a lean RAG search experiment without introducing another runtime service or PHP dependency.

Unfortunately MySQL 9 does not have vector search capabilities, despite having vector store.

The feature is intentionally gated for supporting hosts: it only becomes operational when the site has both a supported MariaDB version and an authenticated OpenAI connector capable of producing the fixed 1536-dimensional embedding shape used by the first schema.

## Testing

Manual default `wp-env` smoke test:

```bash
source ~/.nvm/nvm.sh
nvm use 22.21.1
npm run wp-env -- start
npm run wp-env -- run cli wp ai rag status
```

Environment observed:

```text
WordPress: http://localhost:8888
MariaDB: 12.3.2-MariaDB-ubu2404
RAG available: yes
Index table: present
```

- Connect OpenAI key in the default wp-env site connectors screen
- Create few posts semantically similar to a specific topic but **not containing the keywords**. For example posts about tables being broken, but NOT having "furniture shaking" words.

Then ran the procesing manually since chunking happens every hour. So you can chunk them initially with wp-cli:

```bash
npm run wp-env -- run cli wp ai rag index --all --batch-size=50
npm run wp-env -- run cli wp ai rag status
```

Result:

```text
Processed 8 post(s): 8 clean, 0 error, 0 removed. 0 dirty post(s) remain.
RAG index rows: 8
Indexed posts: 8
```

Semantic search smoke test:


```text
http://localhost:8888/?s=how+do+I+stop+furniture+from+shaking
First result: RAG fixture ... cafe table leveling
```

A raw keyword lookup for `furniture` / `shaking` should return no matching posts, while the semantic search API returned the cafe-table post first.


<img width="1301" height="730" alt="Zrzut ekranu 2026-06-8 o 12 17 00" src="https://github.com/user-attachments/assets/279d66a0-4b75-4210-9c46-03aede2ba349" />

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-683-d2615bd620fd2bc6b8514132399f7c4afbc346e1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->