### PR TITLE
Add refresh button to AI Request Logs table header

### DIFF
--- a/src/admin/ai-request-logs/components/LogsTable.tsx
+++ b/src/admin/ai-request-logs/components/LogsTable.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Popover } from '@wordpress/components';
+import { Button, Popover } from '@wordpress/components';
 import {
 	DataViews,
 	type View,
@@ -12,6 +12,7 @@ import {
 import { dateI18n, getSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from '@wordpress/element';
+import { rotateRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -31,6 +32,7 @@ interface LogsTableProps {
 	setQuery: React.Dispatch< React.SetStateAction< LogsQuery > >;
 	providerMetadata: Record< string, ProviderMetadata >;
 	connectorsUrl: string;
+	onRefresh: () => void;
 }
 
 /**
@@ -400,6 +402,7 @@ const LogsTable: React.FC< LogsTableProps > = ( {
 	setQuery,
 	providerMetadata,
 	connectorsUrl,
+	onRefresh,
 } ) => {
 	const [ viewConfig, setViewConfig ] = useState< ViewConfig >( () => ( {
 		filters: buildFiltersFromQuery( query ),
@@ -688,6 +691,17 @@ const LogsTable: React.FC< LogsTableProps > = ( {
 				view={ view }
 				onChangeView={ onChangeView }
 				actions={ actions }
+				header={
+					<Button
+						className="ai-request-logs__refresh-button"
+						icon={ rotateRight }
+						label={ __( 'Refresh', 'ai' ) }
+						showTooltip
+						size="compact"
+						onClick={ onRefresh }
+						disabled={ loading }
+					/>
+				}
 				paginationInfo={ paginationInfo }
 				getItemId={ ( item: LogEntry ) => item.id }
 				isLoading={ loading }

--- a/src/admin/ai-request-logs/index.scss
+++ b/src/admin/ai-request-logs/index.scss
@@ -85,6 +85,10 @@
 	border-radius: 4px;
 	background: #fff;
 	overflow: hidden;
+
+	.ai-request-logs__refresh-button.components-button {
+		order: -1;
+	}
 }
 
 .ai-request-logs__cell--time {

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -348,7 +348,10 @@ const App: React.FC = () => {
 						setQuery={ setLogsQuery }
 						providerMetadata={ providerMetadata }
 						connectorsUrl={ connectorsUrl }
-						onRefresh={ fetchLogs }
+						onRefresh={ () => {
+							fetchLogs();
+							fetchSummary( summaryPeriod );
+						} }
 					/>
 
 					<SettingsPanel

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -348,6 +348,7 @@ const App: React.FC = () => {
 						setQuery={ setLogsQuery }
 						providerMetadata={ providerMetadata }
 						connectorsUrl={ connectorsUrl }
+						onRefresh={ fetchLogs }
 					/>
 
 					<SettingsPanel


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes #684
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The logs table had no way to reload data without a full page refresh. A refresh button in the table header gives users a quick way to fetch the latest logs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added an onRefresh prop to LogsTable wired to fetchLogs in the parent component.
- Rendered a Button in the DataViews header slot.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Go to Tools → AI Request Logs.
2. Confirm a refresh (rotate) icon appears in the table toolbar, to the left of the settings icon.
3. Click the refresh button — the table should reload with the latest logs.
4. Confirm the button is disabled while the table is loading.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/400f4a4e-484f-45f0-986c-5109bdcfd03d


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Added - Manual refresh button to the AI Request Logs table header.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-687-837d15110b451701856e28fd52cc2e7ed491752e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->