### PR TITLE
Update output schema for get-post-terms ability and sanitize image_url in Alt_Text_Generation

### DIFF
--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -67,9 +67,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 					'description'       => esc_html__( 'The attachment ID of the image to generate alt text for.', 'ai' ),
 				),
 				'image_url'     => array(
-					'type'              => 'string',
-					'sanitize_callback' => array( $this, 'sanitize_image_reference_input' ),
-					'description'       => esc_html__( 'URL or data URI of the image to generate alt text for. Used if attachment_id is not provided.', 'ai' ),
+					'type'        => 'string',
+					'description' => esc_html__( 'URL or data URI of the image to generate alt text for. Used if attachment_id is not provided.', 'ai' ),
 				),
 				'context'       => array(
 					'type'              => 'string',
@@ -121,6 +120,8 @@ class Alt_Text_Generation extends Abstract_Ability {
 				'image_meta'    => '',
 			),
 		);
+
+		$args['image_url'] = $this->sanitize_image_reference_input( $args['image_url'] );
 
 		// Get the image reference.
 		$image_reference = $this->get_image_reference( $args );

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -121,7 +121,9 @@ class Alt_Text_Generation extends Abstract_Ability {
 			),
 		);
 
-		$args['image_url'] = $this->sanitize_image_reference_input( $args['image_url'] );
+		if ( isset( $args['image_url'] ) ) {
+			$args['image_url'] = $this->sanitize_image_reference_input( $args['image_url'] );
+		}
 
 		// Get the image reference.
 		$image_reference = $this->get_image_reference( $args );

--- a/includes/Abilities/Utilities/Posts.php
+++ b/includes/Abilities/Utilities/Posts.php
@@ -206,53 +206,50 @@ class Posts {
 					'required'   => array( 'post_id' ),
 				),
 				'output_schema'       => array(
-					'type'        => 'object',
+					'type'        => 'array',
 					'description' => esc_html__( 'An array of WP_Term objects assigned to the post.', 'ai' ),
-					'properties'  => array(
-						'type'  => 'array',
-						'items' => array(
-							'type'  => 'array',
-							'items' => array(
-								'term_id'          => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The ID of the term.', 'ai' ),
-								),
-								'name'             => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The name of the term.', 'ai' ),
-								),
-								'slug'             => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The slug of the term.', 'ai' ),
-								),
-								'term_group'       => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The group ID of the term.', 'ai' ),
-								),
-								'term_taxonomy_id' => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The taxonomy ID of the term.', 'ai' ),
-								),
-								'taxonomy'         => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The taxonomy name of the term.', 'ai' ),
-								),
-								'description'      => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'The description of the term.', 'ai' ),
-								),
-								'parent'           => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'The parent ID of the term.', 'ai' ),
-								),
-								'count'            => array(
-									'type'        => 'integer',
-									'description' => esc_html__( 'How many times the term is used.', 'ai' ),
-								),
-								'filter'           => array(
-									'type'        => 'string',
-									'description' => esc_html__( 'How the term should be filtered.', 'ai' ),
-								),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'term_id'          => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The ID of the term.', 'ai' ),
+							),
+							'name'             => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The name of the term.', 'ai' ),
+							),
+							'slug'             => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The slug of the term.', 'ai' ),
+							),
+							'term_group'       => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The group ID of the term.', 'ai' ),
+							),
+							'term_taxonomy_id' => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The taxonomy ID of the term.', 'ai' ),
+							),
+							'taxonomy'         => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The taxonomy name of the term.', 'ai' ),
+							),
+							'description'      => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'The description of the term.', 'ai' ),
+							),
+							'parent'           => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'The parent ID of the term.', 'ai' ),
+							),
+							'count'            => array(
+								'type'        => 'integer',
+								'description' => esc_html__( 'How many times the term is used.', 'ai' ),
+							),
+							'filter'           => array(
+								'type'        => 'string',
+								'description' => esc_html__( 'How the term should be filtered.', 'ai' ),
 							),
 						),
 					),
@@ -319,7 +316,16 @@ class Posts {
 					 */
 					$terms = apply_filters( 'wpai_get_post_terms', $terms, $post_id, $allowed_taxonomies );
 
-					return $terms;
+					return array_map(
+						static function ( $term ): array {
+							if ( $term instanceof \WP_Term ) {
+								return $term->to_array();
+							}
+
+							return (array) $term;
+						},
+						$terms
+					);
 				},
 				'permission_callback' => array( $this, 'permission_callback' ),
 				'meta'                => array(

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -146,7 +146,14 @@ function get_post_context( int $post_id ): array {
 			$grouped_terms = array();
 
 			foreach ( $terms as $term ) {
-				$grouped_terms[ $term->taxonomy ][] = $term->name;
+				$taxonomy = $term['taxonomy'] ?? '';
+				$name     = $term['name'] ?? '';
+
+				if ( '' === $taxonomy || '' === $name ) {
+					continue;
+				}
+
+				$grouped_terms[ $taxonomy ][] = $name;
 			}
 
 			$context = array_merge(

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -63,6 +63,13 @@ class Testable_Alt_Text_Generation extends Alt_Text_Generation {
 	private string $generated_alt_text;
 
 	/**
+	 * Last image reference arguments.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $last_image_reference_args = array();
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $generated_alt_text Mock generated alt text.
@@ -86,6 +93,8 @@ class Testable_Alt_Text_Generation extends Alt_Text_Generation {
 	 * @return array{reference: string} Mock image reference.
 	 */
 	protected function get_image_reference( array $args ) {
+		$this->last_image_reference_args = $args;
+
 		return array( 'reference' => 'data:image/png;base64,dGVzdA==' );
 	}
 
@@ -99,6 +108,15 @@ class Testable_Alt_Text_Generation extends Alt_Text_Generation {
 	 */
 	protected function generate_alt_text( array $image_reference, string $context = '', string $image_meta = '' ) {
 		return $this->generated_alt_text;
+	}
+
+	/**
+	 * Gets the last image reference arguments.
+	 *
+	 * @return array<string, mixed> Last image reference arguments.
+	 */
+	public function get_last_image_reference_args(): array {
+		return $this->last_image_reference_args;
 	}
 }
 
@@ -206,7 +224,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		$this->assertEquals( 'absint', $schema['properties']['attachment_id']['sanitize_callback'], 'attachment_id should use absint' );
 
 		$this->assertEquals( 'string', $schema['properties']['image_url']['type'], 'image_url should be string type' );
-		$this->assertIsArray( $schema['properties']['image_url']['sanitize_callback'], 'image_url should use callback array' );
+		$this->assertArrayNotHasKey( 'sanitize_callback', $schema['properties']['image_url'], 'image_url should not expose an object-bound sanitize callback.' );
 
 		$this->assertEquals( 'string', $schema['properties']['context']['type'], 'context should be string type' );
 		$this->assertEquals( 'sanitize_textarea_field', $schema['properties']['context']['sanitize_callback'], 'context should use sanitize_textarea_field' );
@@ -340,6 +358,29 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 		$this->assertSame( 'A person writing in a notebook', $result['alt_text'], 'Alt text should be returned.' );
 		$this->assertArrayHasKey( 'is_decorative', $result, 'Result should include is_decorative.' );
 		$this->assertFalse( $result['is_decorative'], 'Non-decorative generated alt text should return is_decorative as false.' );
+	}
+
+	/**
+	 * Test that execute_callback() sanitizes image_url before resolving the image reference.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_sanitizes_image_url_before_resolving_reference(): void {
+		$ability    = new Testable_Alt_Text_Generation( 'A person writing in a notebook' );
+		$reflection = new \ReflectionClass( $ability );
+		$method     = $reflection->getMethod( 'execute_callback' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$ability,
+			array(
+				'image_url' => ' data:image/png;base64,dGVzdA== ',
+			)
+		);
+
+		$args = $ability->get_last_image_reference_args();
+
+		$this->assertSame( 'data:image/png;base64,dGVzdA==', $args['image_url'], 'image_url should be sanitized before image resolution.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -371,6 +371,26 @@ class HelpersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the get-post-terms ability exposes a valid output schema.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_post_terms_output_schema_is_valid_json_schema() {
+		$ability = wp_get_ability( 'ai/get-post-terms' );
+		$this->assertNotNull( $ability, 'get-post-terms ability should be registered' );
+
+		$output_schema = $ability->get_output_schema();
+
+		$this->assertSame( 'array', $output_schema['type'], 'Output schema should describe the list of term objects returned by the ability.' );
+		$this->assertArrayNotHasKey( 'properties', $output_schema, 'Output schema should not nest array keywords under properties.' );
+		$this->assertSame( 'object', $output_schema['items']['type'], 'Output schema items should describe term objects.' );
+		$this->assertSame( 'integer', $output_schema['items']['properties']['term_id']['type'], 'Term schema should include term_id.' );
+		$this->assertSame( 'string', $output_schema['items']['properties']['name']['type'], 'Term schema should include name.' );
+		$this->assertSame( 'string', $output_schema['items']['properties']['taxonomy']['type'], 'Term schema should include taxonomy.' );
+		$this->assertNotFalse( wp_json_encode( $output_schema ), 'Output schema should be JSON-encodable.' );
+	}
+
+	/**
 	 * Test that the wpai_get_post_details filter modifies the ability output.
 	 *
 	 * @since 0.7.0
@@ -478,8 +498,12 @@ class HelpersTest extends WP_UnitTestCase {
 		$post_id     = $this->factory->post->create();
 		wp_set_post_categories( $post_id, array( $category_id ) );
 
-		$filter_callback = static function ( $terms, $filter_post_id, $filter_taxonomies ) {
-			$terms['category'] = sprintf( 'post:%d|taxonomies:%s', $filter_post_id, implode( ',', $filter_taxonomies ) );
+		$received_post_id    = null;
+		$received_taxonomies = array();
+
+		$filter_callback = static function ( $terms, $filter_post_id, $filter_taxonomies ) use ( &$received_post_id, &$received_taxonomies ) {
+			$received_post_id    = $filter_post_id;
+			$received_taxonomies = $filter_taxonomies;
 			return $terms;
 		};
 
@@ -491,12 +515,8 @@ class HelpersTest extends WP_UnitTestCase {
 		remove_filter( 'wpai_get_post_terms', $filter_callback, 10 );
 
 		$this->assertIsArray( $result, 'Result should be an array' );
-		$this->assertArrayHasKey( 'category', $result, 'Result should include category key' );
-		$this->assertSame(
-			sprintf( 'post:%d|taxonomies:category,post_tag', $post_id ),
-			$result['category'],
-			'Filter output should encode the received post ID and taxonomies'
-		);
+		$this->assertSame( $post_id, $received_post_id, 'Filter should receive the post ID.' );
+		$this->assertSame( array( 'category', 'post_tag' ), $received_taxonomies, 'Filter should receive the allowed taxonomy names.' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
Closes #668

Fixes invalid JSON Schema definitions for AI abilities exposed through the Abilities API, REST, and MCP adapters.

## Why?

Two ability schemas were not clean JSON Schema:

- `ai/alt-text-generation` exposed an object-bound PHP callable in `image_url.sanitize_callback`, which can cause strict schema consumers to recurse through a live PHP object graph.
- `ai/get-post-terms` had a malformed `output_schema`, with array schema keywords incorrectly nested under `properties`.

Strict consumers such as `wordpress/mcp-adapter` validate and traverse these schemas, so malformed or non-serializable schema values prevent these abilities from being exposed as MCP tools.

## How?

- Removed the object-bound `sanitize_callback` from the exported `image_url` input schema.
- Preserved `image_url` sanitization by running it inside the alt text ability execution path before resolving the image reference.
- Reworked `ai/get-post-terms` output schema into a valid array-of-objects schema.
- Converted returned `WP_Term` objects into associative arrays after the `wpai_get_post_terms` filter runs, so the ability output matches its JSON Schema.
- Updated `get_post_context()` to consume the new array-shaped term output.
- Added/updated integration tests for the clean term output schema, alt text sanitization behavior, and filter argument handling.

### Use of AI Tools

AI assistance: Yes  
Tool(s): Codex / ChatGPT  
Model(s): GPT-5.5  
Used for: Investigating the schema failures, drafting the implementation, and updating tests. Final changes were reviewed and adjusted by me.


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
Ensure AI ability schemas and outputs are valid JSON Schema for strict REST and MCP consumers.


> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
> Developer - Development related updates.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-688-c97b6d3a962033ade952ff3fa78093a4d87a3483.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->