### PR TITLE
Fix: Title Generation: toolbar button disappears after toggling "Show template" off (normal editing mode), until reload

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
+++ b/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
@@ -196,6 +196,36 @@ function TitleToolbarWrapper(): React.JSX.Element {
 			}
 		};
 
+		// Tear down any state left over from a previous attachment so the
+		// toolbar can be re-attached to a freshly rendered title input. This
+		// happens when the editor recreates the title DOM, e.g. after toggling
+		// "Show template" on and then off.
+		const resetAttachmentState = () => {
+			if ( removeTitleListeners ) {
+				removeTitleListeners();
+				removeTitleListeners = null;
+			}
+
+			if ( removeToolbarListeners ) {
+				removeToolbarListeners();
+				removeToolbarListeners = null;
+			}
+
+			if ( root ) {
+				root.unmount();
+				root = null;
+			}
+
+			if ( wrapperContainer ) {
+				wrapperContainer.remove();
+				wrapperContainer = null;
+			}
+
+			toolbarContainer = null;
+			titleInput = null;
+			isAttached = false;
+		};
+
 		// Wait for the editor to be ready
 		const findAndAttachToolbar = () => {
 			// Don't try if already attached
@@ -329,20 +359,27 @@ function TitleToolbarWrapper(): React.JSX.Element {
 			findAndAttachToolbar();
 		}, 100 );
 
-		// Also listen for DOM changes in the editor iframe
-		// But only check if we haven't attached yet
+		// Also listen for DOM changes in the editor iframe.
+		// The observer stays connected for the editor's lifetime so the toolbar
+		// can be re-attached if the editor recreates the title input (e.g. when
+		// toggling "Show template" on and then off).
 		const setupObserver = () => {
 			const editorDoc = getEditorDocument();
 			if ( editorDoc && ! observer ) {
-				observer = new MutationObserver( ( _mutations, obs ) => {
-					if (
-						! isAttached &&
-						! editorDoc.querySelector( '.ai-title-toolbar-wrapper' )
-					) {
+				observer = new MutationObserver( () => {
+					const wrapperExists = !! editorDoc.querySelector(
+						'.ai-title-toolbar-wrapper'
+					);
+
+					// Our injected toolbar was removed from the DOM, but we
+					// still think it is attached. Reset so we can re-attach to
+					// the new title input.
+					if ( isAttached && ! wrapperExists ) {
+						resetAttachmentState();
+					}
+
+					if ( ! isAttached && ! wrapperExists ) {
 						findAndAttachToolbar();
-					} else if ( isAttached ) {
-						// Disconnect observer once toolbar is attached
-						obs.disconnect();
 					}
 				} );
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/693

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR reattaches the button to the title element.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Currently observable element was not observing after the element is attached. Updated to observe, reset and again add the element.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
- Yes, Claude Code, Opus 4.8.
- Used for RCA and implementation for the same.
- Implementation was tested and reviwed.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable the **Title Generation** experiment (and a connector).
2. Open an existing post in the **post editor** (normal editing mode, not the site/template editor).
3. Click into the post title — confirm the "Generate"/"Regenerate" button appears above the title.
4. Open the editor "view" menu (the display options dropdown) and choose **Show template**.
5. Open the same menu again and toggle **Show template** back off (return to normal editing mode).
6. Click into the post title again and look for the title generation button.
7. You would see the button now.

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

https://github.com/user-attachments/assets/326cf2e2-a3c9-460d-aa60-5fda092a738e


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->


> Fixed - Title generation button disappears after toggling "Show template" off (normal editing mode).


--- 

# AI Summary

## Root cause

The Title Generation experiment attaches its "Generate"/"Regenerate" toolbar in normal editing mode via DOM injection in `TitleToolbarWrapper.tsx` (a `registerPlugin` render that manipulates the editor DOM directly, rather than rendering React into the editor tree).

Two pieces of logic made the attachment a **one-time, irreversible** operation:

1. **The `MutationObserver` permanently disconnected after the first attach.** Once `isAttached` became `true`, the observer callback called `obs.disconnect()` and stopped watching the editor DOM entirely.
2. **`findAndAttachToolbar()` early-returns while `isAttached` is `true`.** Even if something re-triggered it, the guard at the top would bail out.

When the user toggles **Show template** on, the editor swaps the post title region — the normal-mode `.editor-post-title__input` is replaced by the `core/post-title` block view. Toggling it back off recreates a fresh `.editor-post-title__input`, and React discards the old subtree, taking our injected `.ai-title-toolbar-wrapper` with it.

At that point the toolbar is gone from the DOM, but:

- `isAttached` is still `true`, and
- the observer has already been disconnected,

so nothing re-injects the toolbar onto the new title input. The component never unmounts during the toggle, so the effect's cleanup/re-run path never fires either. Only a full editor reload re-runs the `useEffect` and re-attaches — which is why a refresh "fixes" it.

## What we fixed

In `src/experiments/title-generation/components/TitleToolbarWrapper.tsx`:

1. **Keep the `MutationObserver` connected for the editor's lifetime.** Removed the `obs.disconnect()` branch so the observer keeps watching after the first attach. (It still disconnects in the effect's cleanup on real unmount.)
2. **Detect when our toolbar was torn down and re-attach.** The observer now checks whether `.ai-title-toolbar-wrapper` still exists in the editor document. If we believe we're attached but the wrapper is gone, we reset our state and re-attach to the newly rendered title input.
3. **Added a `resetAttachmentState()` helper** that cleanly tears down the stale attachment before re-attaching — unmounts the React root, removes the title/toolbar focus-blur listeners, removes the orphaned wrapper node, and clears the `isAttached`/reference state. This prevents leaked React roots and dangling event listeners across re-attachments.

The re-attach is safe from infinite loops: inserting the wrapper triggers the observer again, but on that fire both `isAttached` and `wrapperExists` are `true`, so neither the reset nor the attach branch runs. The existing retry logic in `findAndAttachToolbar()` handles the brief window where the new title input hasn't rendered yet.

**Result:** toggling "Show template" off (or any editor interaction that recreates the title input) now re-injects the toolbar immediately, without requiring a page refresh.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-694-e5cc8523770119fea160f896b7fa84a4a6b67861.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->