### PR TITLE
Fix[Meta Description]: Improve Copy and Focus Behavior

### DIFF
--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -34,18 +34,30 @@ function CopyButton( {
 	text: string;
 	disabled: boolean;
 } ): JSX.Element {
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
+	const [ copiedText, setCopiedText ] = useState< string | null >( null );
+	const showCopyConfirmation = copiedText === text && text.length > 0;
+
 	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > >();
-	const ref = useCopyToClipboard< HTMLButtonElement >( text, () => {
-		speak( __( 'Meta description copied to clipboard.', 'ai' ) );
-		setShowCopyConfirmation( true );
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
+	const pendingCopyTextRef = useRef< string | null >( null );
+
+	const ref = useCopyToClipboard< HTMLButtonElement >(
+		() => {
+			pendingCopyTextRef.current = text;
+			return text;
+		},
+		() => {
+			speak( __( 'Meta description copied to clipboard.', 'ai' ) );
+			setCopiedText( pendingCopyTextRef.current );
+
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+
+			timeoutIdRef.current = setTimeout( () => {
+				setCopiedText( null );
+			}, 4000 );
 		}
-		timeoutIdRef.current = setTimeout( () => {
-			setShowCopyConfirmation( false );
-		}, 4000 );
-	} );
+	);
 
 	useEffect( () => {
 		return () => {
@@ -57,9 +69,9 @@ function CopyButton( {
 
 	return (
 		<Button
-			ref={ ref }
+			ref={ disabled ? undefined : ref }
 			variant="tertiary"
-			disabled={ disabled }
+			disabled={ disabled || showCopyConfirmation }
 			accessibleWhenDisabled
 		>
 			{ showCopyConfirmation
@@ -111,6 +123,7 @@ export default function MetaDescriptionModal( {
 			onRequestClose={ onClose }
 			className="ai-meta-description-modal"
 			size="medium"
+			focusOnMount="firstContentElement"
 		>
 			<div className="ai-meta-description-modal__content">
 				{ /* Editable textarea */ }
@@ -125,6 +138,7 @@ export default function MetaDescriptionModal( {
 							'Aim for 140–160 characters for optimal display in search results.',
 							'ai'
 						) }
+						disabled={ isGenerating }
 					/>
 					<CharacterCount count={ editableText.length } />
 				</div>
@@ -153,9 +167,16 @@ export default function MetaDescriptionModal( {
 					</Button>
 					<CopyButton
 						text={ editableText }
-						disabled={ editableText.trim().length === 0 }
+						disabled={
+							editableText.trim().length === 0 || isGenerating
+						}
 					/>
-					<Button variant="tertiary" onClick={ onClose }>
+					<Button
+						variant="tertiary"
+						isDestructive
+						onClick={ onClose }
+						className="ai-meta-description-modal__cancel"
+					>
 						{ __( 'Cancel', 'ai' ) }
 					</Button>
 				</div>

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -53,7 +53,6 @@ function CopyButton( {
 			if ( timeoutIdRef.current ) {
 				clearTimeout( timeoutIdRef.current );
 			}
-
 			timeoutIdRef.current = setTimeout( () => {
 				setCopiedText( null );
 			}, 4000 );

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -36,6 +36,7 @@ function CopyButton( {
 } ): JSX.Element {
 	const [ copiedText, setCopiedText ] = useState< string | null >( null );
 	const showCopyConfirmation = copiedText === text && text.length > 0;
+	const isCopyDisabled = disabled || showCopyConfirmation;
 
 	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > >();
 	const pendingCopyTextRef = useRef< string | null >( null );
@@ -69,9 +70,9 @@ function CopyButton( {
 
 	return (
 		<Button
-			ref={ disabled ? undefined : ref }
+			ref={ isCopyDisabled ? undefined : ref }
 			variant="tertiary"
-			disabled={ disabled || showCopyConfirmation }
+			disabled={ isCopyDisabled }
 			accessibleWhenDisabled
 		>
 			{ showCopyConfirmation

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -39,25 +39,18 @@ function CopyButton( {
 	const isCopyDisabled = disabled || showCopyConfirmation;
 
 	const timeoutIdRef = useRef< ReturnType< typeof setTimeout > >();
-	const pendingCopyTextRef = useRef< string | null >( null );
 
-	const ref = useCopyToClipboard< HTMLButtonElement >(
-		() => {
-			pendingCopyTextRef.current = text;
-			return text;
-		},
-		() => {
-			speak( __( 'Meta description copied to clipboard.', 'ai' ) );
-			setCopiedText( pendingCopyTextRef.current );
+	const ref = useCopyToClipboard< HTMLButtonElement >( text, () => {
+		speak( __( 'Meta description copied to clipboard.', 'ai' ) );
+		setCopiedText( text );
 
-			if ( timeoutIdRef.current ) {
-				clearTimeout( timeoutIdRef.current );
-			}
-			timeoutIdRef.current = setTimeout( () => {
-				setCopiedText( null );
-			}, 4000 );
+		if ( timeoutIdRef.current ) {
+			clearTimeout( timeoutIdRef.current );
 		}
-	);
+		timeoutIdRef.current = setTimeout( () => {
+			setCopiedText( null );
+		}, 4000 );
+	} );
 
 	useEffect( () => {
 		return () => {

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -153,7 +153,9 @@ export default function MetaDescriptionModal( {
 							onClose();
 						} }
 						accessibleWhenDisabled
-						disabled={ editableText.trim().length === 0 }
+						disabled={
+							isGenerating || editableText.trim().length === 0
+						}
 					>
 						{ __( 'Apply', 'ai' ) }
 					</Button>
@@ -169,7 +171,7 @@ export default function MetaDescriptionModal( {
 					<CopyButton
 						text={ editableText }
 						disabled={
-							editableText.trim().length === 0 || isGenerating
+							isGenerating || editableText.trim().length === 0
 						}
 					/>
 					<Button

--- a/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
@@ -5,7 +5,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { update } from '@wordpress/icons';
@@ -37,6 +37,15 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ editableText, setEditableText ] = useState( '' );
 
+	const shouldFocusEditButton = useRef( false );
+
+	const focusEditButtonOnFirstMount = ( node: HTMLButtonElement | null ) => {
+		if ( shouldFocusEditButton.current && node ) {
+			node.focus();
+			shouldFocusEditButton.current = false;
+		}
+	};
+
 	const hasDescription =
 		currentDescription && currentDescription.trim().length > 0;
 
@@ -50,6 +59,8 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 			}
 			setIsModalOpen( true );
 			await generateDescription();
+
+			shouldFocusEditButton.current = true;
 			return;
 		}
 
@@ -82,8 +93,9 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 					<div className="ai-meta-description-panel__actions">
 						<Button
 							variant="link"
-							onClick={ handleOpenEditModal }
 							size="compact"
+							onClick={ handleOpenEditModal }
+							ref={ focusEditButtonOnFirstMount }
 						>
 							{ __( 'Edit description', 'ai' ) }
 						</Button>

--- a/src/experiments/meta-description/index.scss
+++ b/src/experiments/meta-description/index.scss
@@ -62,4 +62,8 @@
 		padding-top: 8px;
 		border-top: 1px solid var(--wp-admin-border-color-lighter, #dcdcde);
 	}
+
+	&__cancel {
+		margin-left: auto;
+	}
 }


### PR DESCRIPTION
## What, Why, and How?

Related to https://github.com/WordPress/ai/issues/589

This PR addresses the following issues:

1. Disables the Accept button in the Meta Description modal while generation is in progress to prevent users from accidentally closing the modal and losing the ongoing generation state.
2. Fixes focus loss after accepting the first generated description. Since the modal initiator, the Generate button, disappears after the first generation, focus is moved to the Edit description button. Subsequent focus handling is managed by the modal as expected.
3. Visually separates the Cancel button and moves it to the right to emphasize that it can be a destructive action, as closing the modal discards the ongoing generation state.
4. Disables the text area while generation is in progress, since any edits made during generation would be overwritten by the generated content once it completes.
5. Fixes the disabled Copy button remaining clickable when `useCopyToClipboard` is used with accessibleWhenDisabled, by only applying the hook’s returned ref when the button is enabled.
6. Updates the copy feedback when the description changes. Previously, the Copied message remained visible for a fixed `4000ms` even after the text was edited. It now immediately resets to Copy to clipboard, giving users accurate feedback.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Initial code skeleton; final implementation was reviewed and edited by me.

## Testing Instructions
1. Open the Meta Description experiment in the editor.
2. Generate a meta description.
3. Verify the modal opens with generated text.
4. Verify focus is handled correctly.
5. Close the modal.
6. Verify focus is not lost.
7. Verify disabled copy does nothing.
8. Edit or regenerate the description.
9. Verify copy, apply, and cancel states.

## Screencast

https://github.com/user-attachments/assets/b8bfaaa9-49d3-45eb-8484-da56dc05e692

## Changelog Entry

> Fixed - Prevent accidental interactions and stale feedback in the Meta Description generation modal and improve focus handling.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-696-ffdbb3261d6c70301fbefa1522c9a5e35ffbd9fa.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->