### PR TITLE
Fix[Excerpt]: Preserve Focus During Generate and Regenerate Actions

### DIFF
--- a/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptInlineButton.tsx
@@ -47,6 +47,7 @@ export default function ExcerptInlineButton(): React.JSX.Element | null {
 			isBusy={ isGenerating }
 			className="ai-excerpt-inline-button"
 			label={ buttonLabel }
+			accessibleWhenDisabled
 			showTooltip
 		/>
 	);


### PR DESCRIPTION
Closes: #697

## What?

This PR fixes an accessibility issue where keyboard focus is lost when generating or regenerating an excerpt.

This change adds `accessibleWhenDisabled` to the generate and regenerate excerpt action buttons, allowing focus to be retained while the buttons are temporarily disabled.

## Why?

Preserving focus during asynchronous actions provides a more accessible and predictable experience for keyboard and assistive technology users.

Before this change:
- Focus was lost after generating or regenerating an excerpt.

After this change:
- Focus remains on the action button.

## Testing Instructions
1. Create or open a post.
2. Open the Post sidebar.
3. Navigate to the excerpt section.
4. Use the keyboard to activate the "Generate excerpt" button.
5. Verify that focus remains on the button while the excerpt is being generated and after the action completes.
6. Activate the "Regenerate excerpt" button.
7. Verify that focus remains on the button while the excerpt is being generated and after the action completes.

## Screenshots

#### Before
https://github.com/user-attachments/assets/0b78b692-4e04-44b5-afe2-d8894de4ab80

#### After
https://github.com/user-attachments/assets/2090846e-400b-4994-bb26-1fb7fc37c56f

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-698-7605123949178ce4f462fdbf50b6bbff12698df0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->