### PR TITLE
Build/Test Tools: Remove ready_for_review trigger from workflows

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -10,7 +10,6 @@ on:
     types:
       - opened
       - synchronize
-      - ready_for_review
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ on:
     types:
       - opened
       - synchronize
-      - ready_for_review
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:


### PR DESCRIPTION
Ref: https://wordpress.slack.com/archives/C08TJ8BPULS/p1781199277502779

## What?
Removes the `ready_for_review` pull request event from the Test and Plugin Check GitHub Actions workflows.
- Remove `ready_for_review` from `.github/workflows/test.yml`.
- Remove `ready_for_review` from `.github/workflows/plugin-check.yml`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-703-307054be6270da51b332e9bdf4977f330bb188dd.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->