### PR TITLE
Fix[Meta Description]: Allow clearing meta description

### DIFF
--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -146,7 +146,9 @@ export default function MetaDescriptionModal( {
 						} }
 						accessibleWhenDisabled
 						disabled={
-							isGenerating || editableText.trim().length === 0
+							isGenerating ||
+							( !! editableText &&
+								editableText.trim().length === 0 )
 						}
 					>
 						{ __( 'Apply', 'ai' ) }

--- a/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionPanel.tsx
@@ -38,6 +38,10 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 	const [ editableText, setEditableText ] = useState( '' );
 
 	const shouldFocusEditButton = useRef( false );
+	const shouldFocusGenerateButton = useRef( false );
+
+	const hasDescription =
+		currentDescription && currentDescription.trim().length > 0;
 
 	const focusEditButtonOnFirstMount = ( node: HTMLButtonElement | null ) => {
 		if ( shouldFocusEditButton.current && node ) {
@@ -46,8 +50,14 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 		}
 	};
 
-	const hasDescription =
-		currentDescription && currentDescription.trim().length > 0;
+	const focusGenerateButtonOnEmptyState = (
+		node: HTMLButtonElement | null
+	) => {
+		if ( ! hasDescription && shouldFocusGenerateButton.current && node ) {
+			node.focus();
+			shouldFocusGenerateButton.current = false;
+		}
+	};
 
 	const handleOpenModal = async () => {
 		setEditableText( currentDescription );
@@ -115,6 +125,7 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 					onClick={ handleOpenModal }
 					disabled={ isGenerating }
 					isBusy={ isGenerating }
+					ref={ focusGenerateButtonOnEmptyState }
 					accessibleWhenDisabled
 				>
 					{ isGenerating
@@ -130,7 +141,15 @@ export default function MetaDescriptionPanel(): React.JSX.Element {
 					editableText={ editableText }
 					onEditableTextChange={ setEditableText }
 					onGenerate={ generateDescription }
-					onApply={ applyDescription }
+					onApply={ ( text ) => {
+						applyDescription( text );
+
+						// Restore focus to the generate button when applying an empty description.
+						if ( text.trim().length === 0 ) {
+							shouldFocusEditButton.current = false;
+							shouldFocusGenerateButton.current = true;
+						}
+					} }
 					onClose={ () => {
 						clearSuggestion();
 						setIsModalOpen( false );


### PR DESCRIPTION
## What, Why, and How?

Follow-up to https://github.com/WordPress/ai/pull/696

This PR updates the meta description flow so users can clear a previously applied meta description when they decide it is not needed. Previously, the modal disabled the Apply button for an empty textarea, which prevented users from returning the post to its default “no meta description” state through the UI. 

The change allows a truly empty value to be applied, while still blocking whitespace-only input because saving only spaces has no practical value. After clearing the description, the panel returns to the empty state and restores focus to the Generate Meta Description button.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review

## Testing Instructions

1. Create or open a post.
2. Generate a meta description.
3. Apply the generated description and confirm it appears in the panel.
4. Edit the description, remove all text, and click Apply.
5. Confirm the description is cleared and the Generate Meta Description button is shown and focused.
6. Try entering only spaces in the modal and confirm Apply remains disabled.
7. Save/update the post and confirm the empty meta description is not output on the front end.

## Screencast

https://github.com/user-attachments/assets/944c013f-166f-4230-a7e0-00342d98db95

## Changelog Entry

> Fixed - Allow users to clear an applied meta description while preventing whitespace-only descriptions.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-706-b477baec1113b1326f05fec3fcef496749357f15.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->