### PR TITLE
fix: rename unforwarded `MaskCanvas` to `InnerMaskCanvas` to avoid duplicate declarations.

### DIFF
--- a/src/features/image-generation/components/MaskCanvas.tsx
+++ b/src/features/image-generation/components/MaskCanvas.tsx
@@ -39,7 +39,7 @@ const MAX_UNDO_STACK = 20;
  * @param {Object} ref   Imperative handle ref.
  */
 export const MaskCanvas = forwardRef< MaskCanvasHandle, Props >(
-	function MaskCanvas( { imageSrc, brushSize, onMaskChange }, ref ) {
+	function InnerMaskCanvas( { imageSrc, brushSize, onMaskChange }, ref ) {
 		const canvasRef = useRef< HTMLCanvasElement >( null );
 		const ctxRef = useRef< CanvasRenderingContext2D | null >( null );
 		const wrapperRef = useRef< HTMLDivElement >( null );
@@ -306,3 +306,5 @@ export const MaskCanvas = forwardRef< MaskCanvasHandle, Props >(
 		);
 	}
 );
+
+MaskCanvas.displayName = 'MaskCanvas';


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes <!-- #ISSUE-NUMBER or URL -->

<!-- In a few words, what is the PR actually doing? -->

This PR renames the internal `MaskCanvas` component function to `InnerMaskCanvas` and sets an explicit `displayName` for the forwarded `const MaskCanvas` that wraps it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

After updating our dependencies in #712 , Eslint warns about
```
 42:11  error  'MaskCanvas' is already declared in the upper scope on line 41 column 14  @typescript-eslint/no-shadow
```
 
 The explicit `displayName` helps debuggers and React Dev Tools not get cofused by the forwardedRef noise now that the components aren't identically named.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See diff.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

I asked GitHub Copilot Chat to check the repo is there was a previous naming convention used for this sorts of forwardRef wrappers. When the results came back negative, I asked it to check more broadly whether `Unforwarded<ComponentName>` or `Inner<ComponentName>` was the more common ecosystem pattern.

Naming things is 🤷


## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed -  Rename unforwarded `MaskCanvas` component function to `InnerMaskCanvas` to avoid duplicate declarations.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-713-bcd801ca265e32190b656f7f8d7a5acf56a5cb63.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->