### PR TITLE
Abilities Explorer: Add a filter to customize the Ability Table class and expose ability meta

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -98,6 +98,7 @@ class Ability_Handler {
 			'category'      => self::get_ability_category( $ability ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
+			'meta'          => $meta,
 			'raw_data'      => array(
 				'name'          => $name,
 				'label'         => $ability->get_label(),

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -133,7 +133,24 @@ class Admin_Page {
 	 * @since 0.2.0
 	 */
 	private function render_list_view(): void {
-		$table = new Ability_Table();
+		/**
+		 * Filters the class used to render the Abilities Explorer list table.
+		 *
+		 * Allows plugins to extend the Ability_Table class, e.g. to add custom
+		 * columns. The filtered class must be a subclass of Ability_Table
+		 * (or Ability_Table itself); anything else is ignored.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $table_class Fully qualified class name of the list table.
+		 */
+		$table_class = apply_filters( 'wpai_abilities_explorer_table_class', Ability_Table::class );
+
+		if ( ! is_string( $table_class ) || ! is_a( $table_class, Ability_Table::class, true ) ) {
+			$table_class = Ability_Table::class;
+		}
+
+		$table = new $table_class();
 		$table->prepare_items();
 
 		?>

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
@@ -64,6 +64,94 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test formatted abilities expose meta at the top level.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_ability_includes_meta_at_top_level() {
+		$this->register_fake_ability();
+
+		try {
+			$ability = Ability_Handler::get_ability( 'ai/fake-meta-ability' );
+
+			$this->assertIsArray( $ability );
+			$this->assertArrayHasKey( 'meta', $ability );
+			$this->assertIsArray( $ability['meta'] );
+			$this->assertTrue( $ability['meta']['supports_mcp'] );
+			// The meta key inside raw_data is kept for backwards compatibility.
+			$this->assertSame( $ability['raw_data']['meta'], $ability['meta'] );
+		} finally {
+			$this->unregister_fake_ability();
+		}
+	}
+
+	/**
+	 * Registers a fake ability with meta for testing.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_fake_ability(): void {
+		global $wp_current_filter;
+
+		// Ensure the registry singleton is initialized so its own init action
+		// fires before we fake the filter state.
+		$registry = \WP_Abilities_Registry::get_instance();
+
+		if ( null !== $registry && $registry->is_registered( 'ai/fake-meta-ability' ) ) {
+			wp_unregister_ability( 'ai/fake-meta-ability' );
+		}
+
+		$previous_filter     = $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			wp_register_ability(
+				'ai/fake-meta-ability',
+				array(
+					'label'               => 'Fake Meta Ability',
+					'description'         => 'Fake ability for testing meta output.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'value' => array( 'type' => 'string' ),
+						),
+					),
+					'output_schema'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'value' => array( 'type' => 'string' ),
+						),
+					),
+					'meta'                => array(
+						'supports_mcp' => true,
+					),
+					'execute_callback'    => '__return_empty_array',
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			$wp_current_filter = $previous_filter;
+		}
+	}
+
+	/**
+	 * Unregisters the fake ability.
+	 *
+	 * @since x.x.x
+	 */
+	private function unregister_fake_ability(): void {
+		if ( ! function_exists( 'wp_unregister_ability' ) ) {
+			return;
+		}
+
+		$registry = \WP_Abilities_Registry::get_instance();
+		if ( null !== $registry && $registry->is_registered( 'ai/fake-meta-ability' ) ) {
+			wp_unregister_ability( 'ai/fake-meta-ability' );
+		}
+	}
+
+	/**
 	 * Test validate_input returns valid for empty schema.
 	 *
 	 * @since 0.2.0


### PR DESCRIPTION
## What?

Closes #203

Adds an extensibility hook so plugins can provide their own `Ability_Table` subclass for the Abilities Explorer list table, and exposes each ability's `meta` at the top level of the formatted ability data so custom columns can render metadata.

## Why?

There is currently no way for third-party plugins to add custom columns to the Abilities Explorer table without modifying plugin files. The motivating use case from the issue: displaying which abilities support MCP directly in the table view.

## How?

- Adds a `wpai_abilities_explorer_table_class` filter in `Admin_Page::render_list_view()`. The issue proposed `ai_abilities_explorer_table_class`, but this PR follows the plugin's existing `wpai_` filter prefix convention (`wpai_settings_feature_metadata`, `wpai_ability_category`, …). The filtered value is validated with `is_a( $table_class, Ability_Table::class, true )` and silently falls back to the default class, so a bad filter return can't fatal the admin page.
- `Ability_Handler::format_single_ability()` now includes `'meta' => $meta` at the top level. The copy nested in `raw_data` is kept for backwards compatibility.
- Adds an integration test registering an ability with `meta` and asserting it is exposed at the top level.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Implementation and test drafting under my direction; I reviewed the changes and take responsibility for them.

## Testing Instructions

1. Activate the AI plugin and enable the Abilities Explorer experiment.
2. Add a small mu-plugin that subclasses `Ability_Table`, adds a column reading `$item['meta']`, and returns the subclass name from the `wpai_abilities_explorer_table_class` filter.
3. Visit Tools → Abilities Explorer and confirm the custom column renders.
4. Return a non-existent class name from the filter and confirm the page still renders with the default table (graceful fallback).
5. Run `npm run test:php -- --filter Ability_HandlerTest` and confirm the new `test_get_ability_includes_meta_at_top_level` test passes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-714-9d134f7c95f6c01856f8cba46993cbd0ad680f2c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->