### PR TITLE
Fix content resizing "Shorten" action for CJK languages

### DIFF
--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -46,7 +46,7 @@ const NOTICE_ID = 'ai_content_resizing_error';
  * Used to detect content that uses character-based rather than word-based
  * counting (Japanese, Chinese, Korean).
  */
-const CJK_REGEX = /[　-鿿가-퟿！-｠]/;
+const CJK_REGEX = /[\u3000-\u9FFF\uAC00-\uD7FF\uFF01-\uFF60]/;
 
 /**
  * Content resizing toolbar component.

--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -38,7 +38,15 @@ import { ensureProvider } from '../../../utils/provider-status';
 import AIIcon from '../../../../routes/ai-home/ai-icon';
 
 const SHORTEN_MIN_WORDS = 5;
+const SHORTEN_MIN_CHARS = 10;
 const NOTICE_ID = 'ai_content_resizing_error';
+
+/**
+ * Matches CJK Unified Ideographs, Hangul, and fullwidth punctuation.
+ * Used to detect content that uses character-based rather than word-based
+ * counting (Japanese, Chinese, Korean).
+ */
+const CJK_REGEX = /[　-鿿가-퟿！-｠]/;
 
 /**
  * Content resizing toolbar component.
@@ -100,9 +108,19 @@ export default function ContentResizingToolbar( {
 			}
 
 			if ( action === 'shorten' ) {
-				const wordCount = count( blockContent, 'words', {} );
-				// We need at least 5 words to shorten the content.
-				if ( wordCount < SHORTEN_MIN_WORDS ) {
+				const hasCJKContent = CJK_REGEX.test( blockContent );
+				const countType = hasCJKContent
+					? 'characters_excluding_spaces'
+					: 'words';
+				const effectiveCount = count(
+					blockContent,
+					countType as 'words' | 'characters_excluding_spaces',
+					{}
+				);
+				const minimumCount = hasCJKContent
+					? SHORTEN_MIN_CHARS
+					: SHORTEN_MIN_WORDS;
+				if ( effectiveCount < minimumCount ) {
 					noticesDispatch.createErrorNotice(
 						__( 'Text is too short to shorten further.', 'ai' ),
 						{
@@ -172,15 +190,30 @@ export default function ContentResizingToolbar( {
 		}
 	}, [ handleAction, isLoading, lastAction ] );
 
-	// Calculate the word difference between the original and suggested content.
+	// Calculate the word/character difference between the original and suggested content.
 	const wordDiff = useMemo( () => {
 		if ( suggestedContent === null ) {
 			return null;
 		}
 
+		const hasCJKContent =
+			CJK_REGEX.test( blockContent ) ||
+			CJK_REGEX.test( suggestedContent );
+		const countType = hasCJKContent
+			? 'characters_excluding_spaces'
+			: 'words';
+
 		const delta =
-			count( suggestedContent, 'words', {} ) -
-			count( blockContent, 'words', {} );
+			count(
+				suggestedContent,
+				countType as 'words' | 'characters_excluding_spaces',
+				{}
+			) -
+			count(
+				blockContent,
+				countType as 'words' | 'characters_excluding_spaces',
+				{}
+			);
 
 		if ( delta === 0 ) {
 			return {


### PR DESCRIPTION
## Problem

Fixes #578

Japanese, Chinese, and Korean text doesn't use spaces as word separators. `@wordpress/wordcount`'s `count( text, 'words', {} )` returns near-zero for CJK content, so the "Shorten" action always showed the error _"Text is too short to shorten further."_ even for long paragraphs.

## Solution

Detect CJK content via a Unicode range regex and switch to `'characters_excluding_spaces'` counting with a character-based minimum threshold (`SHORTEN_MIN_CHARS = 10`). The same locale-aware counting is applied to the word-diff display so the +/− indicator remains meaningful for CJK text.

Non-CJK content is unaffected — the existing `SHORTEN_MIN_WORDS = 5` path runs as before.

## Changes

- `src/experiments/content-resizing/components/ContentResizingToolbar.tsx`
  - Add `CJK_REGEX` and `SHORTEN_MIN_CHARS` constants
  - `handleAction('shorten')`: use `characters_excluding_spaces` count for CJK content
  - `wordDiff` memo: use locale-aware count for accurate +/− display

## Testing

1. Create a post with Japanese/Chinese/Korean paragraph text (e.g. `これはテストです。日本語のコンテンツをテストしています。`)
2. Select a text block and open the AI resize menu
3. Click **Shorten** — it should proceed without the "too short" error
4. Verify the word-diff badge shows a reasonable character delta
5. With English text, verify the existing behaviour is unchanged

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-715-b1c30e8528deb96cb69f1bf65b15123e37a7a4fc.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->