### PR TITLE
Fix content classification minimum content check for CJK languages

### DIFF
--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -37,7 +37,7 @@ const MAX_SUGGESTIONS = 10;
  * Used to detect content that uses character-based rather than word-based
  * counting (Japanese, Chinese, Korean).
  */
-const CJK_REGEX = /[　-鿿가-퟿！-｠]/;
+const CJK_REGEX = /[\u3000-\u9FFF\uAC00-\uD7FF\uFF01-\uFF60]/;
 
 const normalizeMaxSuggestions = ( value: unknown ): number => {
 	const parsedValue = Number.parseInt(

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -32,6 +32,13 @@ const DEFAULT_MAX_SUGGESTIONS = 5;
 const MIN_SUGGESTIONS = 1;
 const MAX_SUGGESTIONS = 10;
 
+/**
+ * Matches CJK Unified Ideographs, Hangul, and fullwidth punctuation.
+ * Used to detect content that uses character-based rather than word-based
+ * counting (Japanese, Chinese, Korean).
+ */
+const CJK_REGEX = /[　-鿿가-퟿！-｠]/;
+
 const normalizeMaxSuggestions = ( value: unknown ): number => {
 	const parsedValue = Number.parseInt(
 		String( value ?? DEFAULT_MAX_SUGGESTIONS ),
@@ -152,9 +159,15 @@ export function useContentClassification( taxonomy: string ): {
 	const [ suggestions, setSuggestions ] = useState< TagSuggestion[] >( [] );
 	const { removeNotice, createErrorNotice } = dispatch( noticesStore ) as any;
 
-	// Check if content has enough words.
+	// Check if content has enough words (or characters for CJK languages).
+	const text = content || '';
+	const hasCJKContent = CJK_REGEX.test( text );
+	const countType = hasCJKContent ? 'characters_excluding_spaces' : 'words';
 	const hasEnoughContent =
-		wordCount( content || '', 'words' ) >= MINIMUM_WORD_COUNT;
+		wordCount(
+			text,
+			countType as 'words' | 'characters_excluding_spaces'
+		) >= MINIMUM_WORD_COUNT;
 
 	const handleGenerate = useCallback( async () => {
 		if ( ! ensureProvider( NOTICE_ID ) ) {


### PR DESCRIPTION
## Problem

Fixes #571

Japanese, Chinese, and Korean don't separate words with spaces. `count( text, 'words' )` returns near-zero for CJK content, so `hasEnoughContent` was always `false` for CJK users — the classification panel was permanently disabled even with long articles.

## Solution

Detect CJK content via a Unicode range regex and switch to `'characters_excluding_spaces'` counting. The same `MINIMUM_WORD_COUNT = 150` threshold is reused, which is meaningful in CJK context (≈ a short paragraph of ~150 characters).

Non-CJK content continues to use word-based counting as before.

## Changes

- `src/experiments/content-classification/components/useContentClassification.ts`
  - Add `CJK_REGEX` constant
  - `hasEnoughContent`: detect CJK and use character count instead of word count

## Testing

1. Create a post with 150+ Japanese/Chinese/Korean characters
2. Open the Content Classification panel — the **Generate** button should be enabled
3. Verify English posts still require 150+ words before the button enables

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-716-28e3ac2f9ea6bce2394c58cc25afba9778d18e74.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->