### PR TITLE
Show "Generate" instead of "Regenerate" when post body is empty

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -80,12 +80,13 @@ interface TitleToolbarProps {
 export default function TitleToolbar( {
 	isStandalone = false,
 }: TitleToolbarProps ): React.JSX.Element | null {
-	const { postId, title } = useSelect( ( selectFn ) => {
+	const { postId, title, content } = useSelect( ( selectFn ) => {
 		const editor = selectFn( editorStore );
 
 		return {
 			postId: editor.getCurrentPostId(),
 			title: editor.getEditedPostAttribute( 'title' ) as string,
+			content: editor.getEditedPostContent(),
 		};
 	}, [] );
 
@@ -136,12 +137,13 @@ export default function TitleToolbar( {
 	};
 
 	const hasTitle = title.trim().length > 0;
+	const hasContent = ( content || '' ).trim().length > 0;
 
 	let buttonLabel: string = __( 'Generate', 'ai' );
 
 	if ( isGenerating || isRegenerating ) {
 		buttonLabel = __( 'Generating…', 'ai' );
-	} else if ( hasTitle ) {
+	} else if ( hasTitle && hasContent ) {
 		buttonLabel = __( 'Regenerate', 'ai' );
 	}
 
@@ -157,12 +159,12 @@ export default function TitleToolbar( {
 			return;
 		}
 
-		const content = select( editorStore ).getEditedPostContent();
+		const postContent = select( editorStore ).getEditedPostContent();
 		setIsGenerating( true );
 		( dispatch( noticesStore ) as any ).removeNotice( NOTICE_ID );
 
 		try {
-			const result = await generateTitle( postId as number, content );
+			const result = await generateTitle( postId as number, postContent );
 			setGeneratedTitle( result );
 			openModal();
 		} catch ( error: any ) {
@@ -184,12 +186,12 @@ export default function TitleToolbar( {
 	 * Fetches a new suggestion without closing the modal.
 	 */
 	const handleRegenerate = async () => {
-		const content = select( editorStore ).getEditedPostContent();
+		const postContent = select( editorStore ).getEditedPostContent();
 		setIsRegenerating( true );
 		( dispatch( noticesStore ) as any ).removeNotice( NOTICE_ID );
 
 		try {
-			const result = await generateTitle( postId as number, content );
+			const result = await generateTitle( postId as number, postContent );
 			setGeneratedTitle( result );
 		} catch ( error: any ) {
 			const message =


### PR DESCRIPTION
## Problem

Fixes #391

The toolbar button was labelled **Regenerate** whenever the post had a title, even when the post body was empty. With no content the AI has nothing to work from, so "Regenerate" was misleading — it implied a previous generation existed and would be replaced.

## Solution

Read `getEditedPostContent()` in the `useSelect` call and only label the button "Regenerate" when the post has **both** a title **and** body content. When the body is empty the button always reads **Generate**, making the prerequisite clear to users.

## Changes

- `src/experiments/title-generation/components/TitleToolbar.tsx`
  - Add `content` to `useSelect` return value
  - Derive `hasContent` from the post body
  - Use `hasTitle && hasContent` instead of `hasTitle` to decide the "Regenerate" label
  - Rename `content` variable inside `handleGenerate` / `handleRegenerate` to `postContent` to avoid shadowing the new reactive state

## Testing

1. Create a new post — leave the body empty, add only a title
   - Button should read **Generate**
2. Add body content
   - Button should switch to **Regenerate**
3. Clear body content again
   - Button should return to **Generate**
4. Generate a title with content present — modal Regenerate button should work as before

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-717-282152ac8532ae411f91f2fe793fb9bc5ba80b5c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->