### PR TITLE
Use a neutral icon for disabled features and experiments in the AI Status widget

### DIFF
--- a/includes/Admin/Dashboard/AI_Status_Widget.php
+++ b/includes/Admin/Dashboard/AI_Status_Widget.php
@@ -160,9 +160,11 @@ class AI_Status_Widget {
 						<?php foreach ( $stable_features as $feature ) : ?>
 							<li class="ai-dashboard-status__list-item">
 								<?php if ( $feature->is_enabled() ) : ?>
-									<span class="dashicons dashicons-yes-alt ai-dashboard-status__icon--success"></span>
+									<span class="dashicons dashicons-yes-alt ai-dashboard-status__icon--success" aria-hidden="true"></span>
+									<span class="screen-reader-text"><?php esc_html_e( 'Enabled:', 'ai' ); ?></span>
 								<?php else : ?>
-									<span class="dashicons dashicons-no ai-dashboard-status__icon--error"></span>
+									<span class="dashicons dashicons-marker ai-dashboard-status__icon--neutral" aria-hidden="true"></span>
+									<span class="screen-reader-text"><?php esc_html_e( 'Disabled:', 'ai' ); ?></span>
 								<?php endif; ?>
 								<?php echo esc_html( $feature->get_label() ); ?>
 							</li>
@@ -179,9 +181,11 @@ class AI_Status_Widget {
 						<?php foreach ( $experimental_features as $feature ) : ?>
 							<li class="ai-dashboard-status__list-item">
 								<?php if ( $feature->is_enabled() ) : ?>
-									<span class="dashicons dashicons-yes-alt ai-dashboard-status__icon--success"></span>
+									<span class="dashicons dashicons-yes-alt ai-dashboard-status__icon--success" aria-hidden="true"></span>
+									<span class="screen-reader-text"><?php esc_html_e( 'Enabled:', 'ai' ); ?></span>
 								<?php else : ?>
-									<span class="dashicons dashicons-no ai-dashboard-status__icon--error"></span>
+									<span class="dashicons dashicons-marker ai-dashboard-status__icon--neutral" aria-hidden="true"></span>
+									<span class="screen-reader-text"><?php esc_html_e( 'Disabled:', 'ai' ); ?></span>
 								<?php endif; ?>
 								<?php echo esc_html( $feature->get_label() ); ?>
 							</li>

--- a/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
+++ b/tests/Integration/Includes/Dashboard/AI_Status_WidgetTest.php
@@ -90,6 +90,7 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 		delete_option( 'wpai_feature_test-feature-a_enabled' );
 		delete_option( 'wpai_feature_test-feature-b_enabled' );
 		remove_all_filters( 'wpai_feature_test-feature-a_enabled' );
+		remove_all_filters( 'wpai_has_ai_credentials' );
 		parent::tearDown();
 	}
 
@@ -298,6 +299,117 @@ class AI_Status_WidgetTest extends WP_UnitTestCase {
 			'ai-dashboard-status',
 			$output,
 			'Should render without errors with multiple features'
+		);
+	}
+
+	/**
+	 * Renders the widget in full status mode.
+	 *
+	 * Enables credentials (via filter), the global toggle, and the
+	 * individual setting for feature A, leaving feature B disabled.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string The rendered widget output.
+	 */
+	private function render_status_view(): string {
+		add_filter( 'wpai_has_ai_credentials', '__return_true' );
+		update_option( Settings_Registration::GLOBAL_OPTION, true );
+		update_option( 'wpai_feature_test-feature-a_enabled', true );
+		update_option( 'wpai_feature_test-feature-b_enabled', false );
+
+		$registry = new Registry();
+		$registry->register_feature( new Status_Test_Feature_A() );
+		$registry->register_feature( new Status_Test_Feature_B() );
+
+		$widget = new AI_Status_Widget( $registry );
+
+		ob_start();
+		$widget->render();
+
+		return ob_get_clean();
+	}
+
+	/**
+	 * Tests that the status view renders the three-column layout.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_status_view_renders_columns() {
+		$output = $this->render_status_view();
+
+		$this->assertStringContainsString(
+			'ai-dashboard-status__columns',
+			$output,
+			'Should render the status view when setup is complete'
+		);
+	}
+
+	/**
+	 * Tests that an enabled experiment shows a success icon.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_status_view_shows_success_icon_for_enabled_experiment() {
+		$output = $this->render_status_view();
+
+		$this->assertMatchesRegularExpression(
+			'/dashicons-yes-alt.*First Feature/s',
+			$output,
+			'Enabled experiments should show a success icon'
+		);
+	}
+
+	/**
+	 * Tests that a disabled experiment shows a neutral icon, not an error icon.
+	 *
+	 * Disabled experiments are an expected state, not a problem, so they
+	 * should not be rendered with the red error cross.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_status_view_shows_neutral_icon_for_disabled_experiment() {
+		$output = $this->render_status_view();
+
+		$this->assertMatchesRegularExpression(
+			'/ai-dashboard-status__icon--neutral.*Second Feature/s',
+			$output,
+			'Disabled experiments should show a neutral icon'
+		);
+
+		// The Experiments column is rendered last, so everything after the
+		// section title belongs to it. Disabled experiments must not use
+		// the error icon there.
+		$experiments_section = substr( $output, (int) strpos( $output, 'Experiments' ) );
+		$this->assertStringNotContainsString(
+			'ai-dashboard-status__icon--error',
+			$experiments_section,
+			'Disabled experiments should not show the error icon'
+		);
+		$this->assertStringNotContainsString(
+			'dashicons-no',
+			$experiments_section,
+			'Disabled experiments should not use the dashicons-no icon'
+		);
+	}
+
+	/**
+	 * Tests that feature state is exposed to screen readers in the status view.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_status_view_exposes_state_to_screen_readers() {
+		$output = $this->render_status_view();
+
+		$this->assertMatchesRegularExpression(
+			'/screen-reader-text">[^<]*Enabled:/s',
+			$output,
+			'Enabled state should be announced to screen readers'
+		);
+		$this->assertMatchesRegularExpression(
+			'/screen-reader-text">[^<]*Disabled:/s',
+			$output,
+			'Disabled state should be announced to screen readers'
 		);
 	}
 


### PR DESCRIPTION
## Motivation for the change, related issues

Fixes #718.

The AI Status dashboard widget renders disabled features and experiments with a red cross (`dashicons-no` + the error icon style). A red cross reads as an error, failure, or missing configuration — but a disabled experiment is an expected, healthy state the user chose. A dashboard full of red crosses right after login suggests something is wrong when nothing is.

## Implementation details

`includes/Admin/Dashboard/AI_Status_Widget.php` — in the Features and Experiments columns of the status view:

- Disabled items now render `dashicons-marker` with the existing `ai-dashboard-status__icon--neutral` style (gray, already defined in `src/admin/dashboard/index.scss` but previously unused) instead of `dashicons-no` + `ai-dashboard-status__icon--error`.
- Enabled items keep the green `dashicons-yes-alt`.
- Added `screen-reader-text` "Enabled:"/"Disabled:" labels and `aria-hidden="true"` on the decorative icons — the state was previously conveyed by color/glyph alone.

Deliberately unchanged, since both still warrant attention:
- The Connectors column (an unconfigured connector keeps the red icon).
- The getting-started checklist (incomplete setup steps keep `dashicons-dismiss`).

This matches the proposal mockup in #718: green check = enabled, neutral gray = disabled, red reserved for actual problems.

## Testing Instructions (or ideally a Blueprint)

1. Configure a connector, enable AI features globally, and enable at least one feature/experiment (so the widget shows the status view rather than the checklist).
2. Leave at least one experiment disabled.
3. Visit the WP dashboard: enabled items show a green check, disabled items show a gray neutral marker, and nothing renders the red cross.
4. `npm run test:php -- --filter AI_Status_WidgetTest` — includes 4 new tests covering the status view: column rendering, success icon for enabled experiments, neutral (never error) icon for disabled experiments, and the screen-reader state labels.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-720-7d7ff943428b253155cd7aecec2bdd7b328603f6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->