### PR TITLE
Update the Plugin Check Action to 1.1.7

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -58,7 +58,7 @@ jobs:
         run: npm run build
 
       - name: Run plugin check
-        uses: wordpress/plugin-check-action@18573eb38f13543484a1f095672dae3849a4fbb0 # v1.1.6
+        uses: wordpress/plugin-check-action@98a1788320d0add90df2d8183934ecccbc4e05d2 # v1.1.7
         with:
           wp-version: 'latest'
           # Exclude file_type because of the dev files present in the repository.

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
+      pull-requests: write
     timeout-minutes: 20
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What?

Our Plugin Check action has been failing for a number of weeks due to an upstream issue with the action we use. v1.1.7 of that was just released to address that problem and so this PR bumps to that version.

## Why?

Fixes our Plugin Check action

## How?

- Bump from v1.1.6 to v1.1.7 of `wordpress/plugin-check-action`
- Add the `pull-requests: write` permission to that workflow so Plugin Check can leave PR comments

### Use of AI Tools

none

## Testing Instructions

Ensure the Plugin Check workflow is running and passing on this PR

## Changelog Entry

> Developer - Bump `wordpress/plugin-check-action` from v1.1.6 to v1.1.7

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-726-e8e2f98605277b35344e71e8627466cea36d3408.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->