### PR TITLE
Logging: replace "Purge All Logs" with age-based delete control

### DIFF
--- a/includes/Logging/AI_Request_Log_Manager.php
+++ b/includes/Logging/AI_Request_Log_Manager.php
@@ -283,6 +283,31 @@ class AI_Request_Log_Manager {
 	}
 
 	/**
+	 * Deletes logs older than a given number of days.
+	 *
+	 * When $days is 0, all logs are purged. Otherwise only logs with a
+	 * timestamp older than $days days ago are removed, in batches.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param int $days Number of days to retain. 0 means purge everything.
+	 * @return int Number of logs deleted.
+	 */
+	public function delete_logs_older_than( int $days ): int {
+		if ( $days <= 0 ) {
+			return $this->purge_all_logs();
+		}
+
+		$deleted = $this->repository->cleanup_by_retention( $days );
+
+		if ( $deleted > 0 ) {
+			$this->repository->invalidate_caches();
+		}
+
+		return $deleted;
+	}
+
+	/**
 	 * Purges all logs from the database.
 	 *
 	 * @since 1.0.0

--- a/includes/Logging/REST/AI_Request_Log_Controller.php
+++ b/includes/Logging/REST/AI_Request_Log_Controller.php
@@ -61,6 +61,14 @@ class AI_Request_Log_Controller extends WP_REST_Controller {
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'purge_logs' ),
 					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'before_days' => array(
+							'description' => __( 'Delete logs older than this many days. 0 deletes all logs.', 'ai' ),
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'default'     => 0,
+						),
+					),
 				),
 			)
 		);
@@ -215,13 +223,17 @@ class AI_Request_Log_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Purges all logs.
+	 * Deletes logs, optionally limiting to entries older than a given number of days.
+	 *
+	 * When before_days is 0 (the default), all logs are purged. When before_days
+	 * is a positive integer, only logs older than that many days are removed.
 	 *
 	 * @param \WP_REST_Request $request Request.
 	 * @return \WP_REST_Response
 	 */
 	public function purge_logs( WP_REST_Request $request ): WP_REST_Response {
-		$deleted = $this->manager->purge_all_logs();
+		$before_days = (int) $request->get_param( 'before_days' );
+		$deleted     = $this->manager->delete_logs_older_than( $before_days );
 
 		return rest_ensure_response(
 			array(
@@ -229,7 +241,7 @@ class AI_Request_Log_Controller extends WP_REST_Controller {
 				'deleted' => $deleted,
 				'message' => sprintf(
 					/* translators: %d: Number of deleted logs. */
-					__( 'Successfully purged %d log entries.', 'ai' ),
+					__( 'Successfully deleted %d log entries.', 'ai' ),
 					$deleted
 				),
 			)

--- a/src/admin/ai-request-logs/components/SettingsPanel.tsx
+++ b/src/admin/ai-request-logs/components/SettingsPanel.tsx
@@ -1,29 +1,37 @@
 /**
  * WordPress dependencies
  */
-import { Button, Card, CardBody, CardHeader } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Button, Card, CardBody, CardHeader, SelectControl } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { useRef, useState } from '@wordpress/element';
+
+const DELETE_OPTIONS = [
+	{ value: '30', label: __( 'Older than 30 days', 'ai' ) },
+	{ value: '90', label: __( 'Older than 90 days', 'ai' ) },
+	{ value: '365', label: __( 'Older than 1 year', 'ai' ) },
+	{ value: '0', label: __( 'All logs', 'ai' ) },
+];
 
 interface SettingsPanelProps {
 	hasLogs: boolean;
-	onPurgeLogs: () => void;
+	onDeleteLogs: ( days: number ) => void;
 	purging: boolean;
 }
 
 const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 	hasLogs,
-	onPurgeLogs,
+	onDeleteLogs,
 	purging,
 } ) => {
-	const [ showPurgeConfirm, setShowPurgeConfirm ] = useState( false );
-	const focusPurgeButtonRef = useRef< boolean >( false );
+	const [ showConfirm, setShowConfirm ] = useState( false );
+	const [ selectedDays, setSelectedDays ] = useState( '30' );
+	const focusDeleteButtonRef = useRef< boolean >( false );
 	const focusCancelButtonRef = useRef< boolean >( false );
 
-	function focusPurgeButtonOnMount( node: HTMLButtonElement | null ) {
-		if ( focusPurgeButtonRef.current && node ) {
+	function focusDeleteButtonOnMount( node: HTMLButtonElement | null ) {
+		if ( focusDeleteButtonRef.current && node ) {
 			node.focus();
-			focusPurgeButtonRef.current = false;
+			focusDeleteButtonRef.current = false;
 		}
 	}
 
@@ -34,14 +42,27 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 		}
 	}
 
-	const handlePurge = () => {
-		if ( showPurgeConfirm ) {
-			onPurgeLogs();
-			setShowPurgeConfirm( false );
-			focusPurgeButtonRef.current = true;
+	const getConfirmMessage = () => {
+		const days = parseInt( selectedDays, 10 );
+		if ( days === 0 ) {
+			return __( 'Permanently delete all logs? This action cannot be undone.', 'ai' );
+		}
+		const option = DELETE_OPTIONS.find( ( o ) => o.value === selectedDays );
+		return sprintf(
+			/* translators: %s: human-readable age threshold, e.g. "older than 30 days". */
+			__( 'Permanently delete logs %s? This action cannot be undone.', 'ai' ),
+			option?.label.toLowerCase() ?? ''
+		);
+	};
+
+	const handleDelete = () => {
+		if ( showConfirm ) {
+			onDeleteLogs( parseInt( selectedDays, 10 ) );
+			setShowConfirm( false );
+			focusDeleteButtonRef.current = true;
 		} else {
 			focusCancelButtonRef.current = true;
-			setShowPurgeConfirm( true );
+			setShowConfirm( true );
 		}
 	};
 
@@ -55,32 +76,46 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 					<h3>{ __( 'Danger Zone', 'ai' ) }</h3>
 					<p className="description">
 						{ __(
-							'Permanently delete all logged requests. This action cannot be undone.',
+							'Delete log entries by age. This action cannot be undone.',
 							'ai'
 						) }
 					</p>
-					{ showPurgeConfirm ? (
+					<SelectControl
+						label={ __( 'Delete logs', 'ai' ) }
+						value={ selectedDays }
+						options={ DELETE_OPTIONS }
+						onChange={ ( value ) => {
+							setSelectedDays( value );
+							setShowConfirm( false );
+						} }
+						disabled={ purging || ! hasLogs }
+						__nextHasNoMarginBottom
+					/>
+					<div style={ { marginTop: '8px' } }>
+					{ showConfirm ? (
 						<div className="ai-request-logs__purge-confirm">
-							<span>{ __( 'Are you sure?', 'ai' ) }</span>
+							<span>{ getConfirmMessage() }</span>
 							<Button
 								variant="primary"
 								isDestructive
-								onClick={ handlePurge }
+								onClick={ handleDelete }
 								disabled={ purging }
 								isBusy={ purging }
 								accessibleWhenDisabled
+								__next40pxDefaultSize
 							>
-								{ __( 'Yes, Purge All', 'ai' ) }
+								{ __( 'Yes, Delete', 'ai' ) }
 							</Button>
 							<Button
 								variant="secondary"
 								ref={ focusCancelButtonOnMount }
 								onClick={ () => {
-									setShowPurgeConfirm( false );
-									focusPurgeButtonRef.current = true;
+									setShowConfirm( false );
+									focusDeleteButtonRef.current = true;
 								} }
 								disabled={ purging }
 								accessibleWhenDisabled
+								__next40pxDefaultSize
 							>
 								{ __( 'Cancel', 'ai' ) }
 							</Button>
@@ -89,14 +124,16 @@ const SettingsPanel: React.FC< SettingsPanelProps > = ( {
 						<Button
 							variant="secondary"
 							isDestructive
-							ref={ focusPurgeButtonOnMount }
-							onClick={ handlePurge }
+							ref={ focusDeleteButtonOnMount }
+							onClick={ handleDelete }
 							disabled={ purging || ! hasLogs }
 							accessibleWhenDisabled
+							__next40pxDefaultSize
 						>
-							{ __( 'Purge All Logs', 'ai' ) }
+							{ __( 'Delete', 'ai' ) }
 						</Button>
 					) }
+					</div>
 				</div>
 			</CardBody>
 		</Card>

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -293,20 +293,13 @@ const App: React.FC = () => {
 				data: { before_days: days },
 			} );
 
-			setLogs( [] );
-			setTotal( 0 );
-			setTotalPages( 1 );
-			setLogsQuery( ( previous ) => ( {
-				...previous,
-				page: 1,
-			} ) );
-
 			showNotice(
 				'success',
 				days > 0
 					? __( 'Logs have been deleted.', 'ai' )
 					: __( 'All logs have been purged.', 'ai' )
 			);
+			fetchLogs();
 			fetchSummary( summaryPeriod );
 			fetchFilters();
 		} catch ( apiError ) {

--- a/src/admin/ai-request-logs/index.tsx
+++ b/src/admin/ai-request-logs/index.tsx
@@ -283,13 +283,14 @@ const App: React.FC = () => {
 		setLogsQuery( ( previous ) => ( { ...previous, page: 1 } ) );
 	};
 
-	const handlePurge = async () => {
+	const handleDeleteLogs = async ( days: number ) => {
 		setPurging( true );
 
 		try {
 			await apiFetch( {
 				path: settings.rest.routes.logs,
 				method: 'DELETE',
+				data: { before_days: days },
 			} );
 
 			setLogs( [] );
@@ -300,7 +301,12 @@ const App: React.FC = () => {
 				page: 1,
 			} ) );
 
-			showNotice( 'success', __( 'All logs have been purged.', 'ai' ) );
+			showNotice(
+				'success',
+				days > 0
+					? __( 'Logs have been deleted.', 'ai' )
+					: __( 'All logs have been purged.', 'ai' )
+			);
 			fetchSummary( summaryPeriod );
 			fetchFilters();
 		} catch ( apiError ) {
@@ -356,7 +362,7 @@ const App: React.FC = () => {
 
 					<SettingsPanel
 						hasLogs={ total > 0 }
-						onPurgeLogs={ handlePurge }
+						onDeleteLogs={ handleDeleteLogs }
 						purging={ purging }
 					/>
 				</div>

--- a/tests/Integration/Includes/Logging/AI_Request_Log_ControllerTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_ControllerTest.php
@@ -243,7 +243,7 @@ class AI_Request_Log_ControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that purge_logs returns a success response structure.
+	 * Tests that purge_logs with before_days=0 deletes all logs.
 	 *
 	 * This test uses TRUNCATE internally via purge_all(), so it must
 	 * run last in the class to avoid breaking the transaction.
@@ -265,6 +265,64 @@ class AI_Request_Log_ControllerTest extends WP_UnitTestCase {
 		$this->assertTrue( $data['success'] );
 		$this->assertArrayHasKey( 'deleted', $data );
 		$this->assertArrayHasKey( 'message', $data );
+	}
+
+	/**
+	 * Tests that purge_logs with before_days only removes old entries.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_purge_logs_with_before_days_removes_only_old_entries(): void {
+		global $wpdb;
+
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$table = $wpdb->prefix . \WordPress\AI\Logging\AI_Request_Log_Schema::TABLE_NAME;
+
+		// Insert a log and backdate it to 60 days ago.
+		$old_id = $this->insert_log();
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			array( 'timestamp' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ) ),
+			array( 'log_id' => $old_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		// Insert a recent log.
+		$this->insert_log();
+
+		$request = new WP_REST_Request( 'DELETE', '/ai/v1/logs' );
+		$request->set_param( 'before_days', 30 );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertSame( 1, $data['deleted'] );
+
+		// The recent log must still be present.
+		$get_request  = new WP_REST_Request( 'GET', '/ai/v1/logs' );
+		$get_response = rest_get_server()->dispatch( $get_request );
+		$this->assertSame( '1', $get_response->get_headers()['X-WP-Total'] );
+	}
+
+	/**
+	 * Tests that a negative before_days value is rejected.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_purge_logs_rejects_negative_before_days(): void {
+		$admin_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$request = new WP_REST_Request( 'DELETE', '/ai/v1/logs' );
+		$request->set_param( 'before_days', -1 );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
 	}
 
 	/**

--- a/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
@@ -256,6 +256,76 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that delete_logs_older_than with a positive value only removes old entries.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_delete_logs_older_than_removes_only_old_entries(): void {
+		global $wpdb;
+
+		$table = $wpdb->prefix . \WordPress\AI\Logging\AI_Request_Log_Schema::TABLE_NAME;
+
+		// Insert a log and backdate it to 60 days ago.
+		$old_id = $this->manager->log(
+			array(
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			)
+		);
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			array( 'timestamp' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ) ),
+			array( 'log_id' => $old_id ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		// Insert a recent log.
+		$this->manager->log(
+			array(
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			)
+		);
+
+		$deleted = $this->manager->delete_logs_older_than( 30 );
+
+		$this->assertSame( 1, $deleted );
+		$this->assertSame( 1, $this->manager->get_logs()['total'] );
+	}
+
+	/**
+	 * Tests that delete_logs_older_than with 0 purges all logs.
+	 *
+	 * This test uses TRUNCATE internally, so it must run last in the class.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_delete_logs_older_than_zero_purges_all(): void {
+		$this->manager->log(
+			array(
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			)
+		);
+		$this->manager->log(
+			array(
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			)
+		);
+
+		$deleted = $this->manager->delete_logs_older_than( 0 );
+
+		$this->assertIsInt( $deleted );
+		$this->assertGreaterThanOrEqual( 2, $deleted );
+	}
+
+	/**
 	 * Tests that purge_all_logs returns the deleted row count.
 	 *
 	 * This test uses TRUNCATE internally, so it must run last


### PR DESCRIPTION
## What?
Closes #689

Replaces the single "Purge All Logs" button in the **Manage Logs** panel with an age-based delete control: a dropdown (Older than 30 days / 90 days / 1 year / All logs) followed by a "Delete" button.

## Why?
The existing "Purge All Logs" button is too blunt — it forces users to delete their entire log history even when they only want to remove old entries. This change gives users meaningful control over how much history to keep, while still allowing a full purge via the "All logs" option.

## How?

**PHP:**
- Added `AI_Request_Log_Manager::delete_logs_older_than(int $days): int` — delegates to the existing `AI_Request_Log_Repository::cleanup_by_retention()` for the batched SQL delete, or falls back to `purge_all_logs()` when `$days === 0`.
- Extended the `DELETE /ai/v1/logs` REST endpoint with an optional `before_days` integer param (minimum: 0). When omitted or 0, all logs are purged (backwards-compatible). Negative values are rejected with a 400.

**React:**
- Rewrote `SettingsPanel` to use a `SelectControl` (30 / 90 / 365 / 0 days) and a "Delete" button with a contextual confirmation message.
- Updated `handleDeleteLogs` in `index.tsx` to accept `days: number`, pass it as `before_days` in the DELETE request, and call `fetchLogs()` after deletion so the table immediately reflects actual remaining entries.

**Tests:**
- `AI_Request_Log_ManagerTest`: `test_delete_logs_older_than_removes_only_old_entries`, `test_delete_logs_older_than_zero_purges_all`
- `AI_Request_Log_ControllerTest`: `test_purge_logs_with_before_days_removes_only_old_entries`, `test_purge_logs_rejects_negative_before_days`

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Code scaffolding and test suggestions; all implementation details, logic, and tests were reviewed, tested locally, and edited by me.

## Testing Instructions

1. Enable the **AI Request Logging** experiment under **AI → Settings → Experiments**.
2. Navigate to **Tools → AI Request Logs**.
3. Insert logs at different ages (or use the REST API / WP-CLI to backdate entries).
4. In the **Manage Logs → Danger Zone** panel, select an age threshold from the dropdown.
5. Click **Delete** → confirm → verify only logs older than the selected threshold are removed and the table immediately updates without a page refresh.
6. Select **All logs** and confirm → all entries are removed.
7. Verify the **Delete** button is disabled when there are no logs.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| <img width="700" alt="Before - single Purge All Logs button" src="https://github.com/user-attachments/assets/2389934e-849c-4cb3-8655-0fe1b4ac882c" /> | <img width="700" alt="After - age-based delete dropdown" src="https://github.com/user-attachments/assets/271bc984-da11-4a89-b25d-b9f041ea9dc3" /> |

## Changelog Entry

> Changed - Replace "Purge All Logs" button with an age-based delete control (30 days / 90 days / 1 year / All) in the Manage Logs panel.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-735-a2320649cd00c4bbce46cf2fa5efde4e298edcd6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->