### PR TITLE
[in progress] Add a core/content ability

### DIFF
--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -6,6 +6,7 @@
 	"plugins": [
 		".",
 		"./tests/e2e-request-mocking",
+		"./tests/e2e-sample-content",
 		"https://downloads.wordpress.org/plugin/ai-provider-for-google.zip",
 		"https://downloads.wordpress.org/plugin/ai-provider-for-openai.zip"
 	],

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -1,0 +1,711 @@
+<?php
+/**
+ * The `core/content` WordPress Ability.
+ *
+ * @package WordPress\AI
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Abilities\Content;
+
+use WP_Error;
+use WP_Post;
+use WP_Query;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class - Content
+ *
+ * Registers the read-only `core/content` ability, which retrieves one or more posts of a
+ * post type exposed to abilities via `show_in_abilities`. Supports fetching a single post
+ * by ID or by slug, or querying multiple posts filtered by post type, status, author, or
+ * parent, returning a basic, support-aware set of fields per post.
+ *
+ * This class is kept almost identical to the WordPress core class `WP_Content_Abilities`
+ * so the two implementations stay in sync. Differences from the core class are marked with
+ * `// Plugin:` comments. Additionally, all user-facing strings use esc_html__() with the
+ * 'ai' text domain rather than core's __().
+ *
+ * @internal This class should not be used outside the plugin and there is no guarantee of backwards compatibility.
+ *
+ * @since 1.1.0
+ */
+class Content {
+
+	/**
+	 * The ability category used for content abilities.
+	 *
+	 * @since 1.1.0
+	 * @var string
+	 */
+	public const CATEGORY = 'content';
+
+	/**
+	 * The fields a post object may expose, in output order.
+	 *
+	 * @since 1.1.0
+	 * @var string[]
+	 */
+	private static array $fields = array(
+		'id',
+		'type',
+		'status',
+		'date',
+		'modified',
+		'slug',
+		'link',
+		'title',
+		'excerpt',
+		'raw_content',
+		'author',
+		'parent',
+	);
+
+	/**
+	 * Default number of posts returned per page in query mode.
+	 *
+	 * @since 1.1.0
+	 * @var int
+	 */
+	public const DEFAULT_PER_PAGE = 10;
+
+	/**
+	 * Maximum number of posts returned per page in query mode.
+	 *
+	 * @since 1.1.0
+	 * @var int
+	 */
+	public const MAX_PER_PAGE = 100;
+
+	/**
+	 * Hooks the ability into the Abilities API.
+	 *
+	 * Plugin: this method has no equivalent in the core class. In core, register() is
+	 * invoked directly from wp_register_core_abilities() (already on the
+	 * `wp_abilities_api_init` hook). The plugin instead hooks register() slightly later
+	 * (priority 11) so it can override any core-provided copy, and registers the category
+	 * as a fallback in case core has not.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function init(): void {
+		add_action( 'wp_abilities_api_categories_init', array( self::class, 'register_category' ), 11 );
+		add_action( 'wp_abilities_api_init', array( self::class, 'register' ), 11 );
+	}
+
+	/**
+	 * Registers the `content` ability category if it is not already registered.
+	 *
+	 * Plugin: this method has no equivalent in the core class; core relies on
+	 * wp_register_core_ability_categories() to register the `content` category.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function register_category(): void {
+		if ( wp_has_ability_category( self::CATEGORY ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			self::CATEGORY,
+			array(
+				'label'       => esc_html__( 'Content', 'ai' ),
+				'description' => esc_html__( 'Abilities that retrieve or manage posts and other content.', 'ai' ),
+			)
+		);
+	}
+
+	/**
+	 * Registers all content abilities.
+	 *
+	 * Must run on the `wp_abilities_api_init` hook.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function register(): void {
+		self::register_get_content();
+
+		/*
+		 * A future write-oriented ability can be registered here, reusing the shared
+		 * helpers below (get_exposed_post_types(), format_post(), check_permission()):
+		 *
+		 *     self::register_manage_content();
+		 */
+	}
+
+	/**
+	 * Registers the read-only `core/content` ability.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function register_get_content(): void {
+		// Plugin: unregister any core-provided copy first so the plugin's version wins.
+		if ( wp_has_ability( 'core/content' ) ) {
+			wp_unregister_ability( 'core/content' );
+		}
+
+		$post_types = array_keys( self::get_exposed_post_types() );
+		$statuses   = self::get_available_statuses();
+
+		wp_register_ability(
+			'core/content',
+			array(
+				'label'               => esc_html__( 'Get Content', 'ai' ),
+				'description'         => esc_html__( 'Retrieves one or more posts of a post type exposed to abilities. Fetch a single post by ID or by slug, or query multiple posts filtered by post type, status, author, or parent. Returns a basic, support-aware set of fields per post.', 'ai' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => self::get_content_input_schema( $post_types, $statuses ),
+				'output_schema'       => self::get_content_output_schema(),
+				'execute_callback'    => array( self::class, 'execute_get_content' ),
+				'permission_callback' => array( self::class, 'check_permission' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					// Opt into REST-level pagination: query mode accepts `page`/`per_page`
+					// and returns `total`/`total_pages`, which the run controller turns into
+					// the standard X-WP-Total / X-WP-TotalPages response headers.
+					'pagination'   => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback for the `core/content` ability.
+	 *
+	 * Implements defense in depth: this gate decides whether the request may proceed at
+	 * all (coarse, by post type capabilities and requested statuses), while the per-post
+	 * `read_post` meta capability check in {@see self::execute_get_content()} is the
+	 * authoritative, row-level enforcement of author-scoped visibility.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return bool True if the request may proceed, false otherwise.
+	 */
+	public static function check_permission( $input = array() ): bool {
+		$input   = is_array( $input ) ? $input : array();
+		$exposed = self::get_exposed_post_types();
+
+		// Single-post mode (by ID).
+		if ( ! empty( $input['id'] ) ) {
+			$post = get_post( (int) $input['id'] );
+
+			if ( ! $post
+				|| ! isset( $exposed[ $post->post_type ] )
+				|| ( ! empty( $input['post_type'] ) && $post->post_type !== $input['post_type'] )
+			) {
+				return current_user_can( 'read' );
+			}
+
+			return current_user_can( 'read_post', $post->ID );
+		}
+
+		// Query / slug mode requires an exposed post type.
+		$post_type = isset( $input['post_type'] ) ? (string) $input['post_type'] : '';
+		if ( '' === $post_type || ! isset( $exposed[ $post_type ] ) ) {
+			return false;
+		}
+
+		$post_type_object = $exposed[ $post_type ];
+
+		if ( ! current_user_can( $post_type_object->cap->read ?? 'read' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+			return false;
+		}
+
+		$statuses = self::normalize_statuses( $input );
+
+		if ( array( 'publish' ) === $statuses ) {
+			return true;
+		}
+
+		if ( current_user_can( $post_type_object->cap->edit_posts ?? 'edit_posts' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+			return true;
+		}
+
+		if ( current_user_can( $post_type_object->cap->read_private_posts ?? 'read_private_posts' ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+			foreach ( $statuses as $status ) {
+				if ( 'private' !== $status && 'publish' !== $status ) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Executes the `core/content` ability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return array<string, mixed>|\WP_Error A map with a `posts` list, or a WP_Error on failure.
+	 */
+	public static function execute_get_content( $input = array() ) {
+		$input   = is_array( $input ) ? $input : array();
+		$exposed = self::get_exposed_post_types();
+		$fields  = self::normalize_fields( $input );
+
+		// Single-post mode (by ID).
+		if ( ! empty( $input['id'] ) ) {
+			$post = get_post( (int) $input['id'] );
+
+			if ( ! $post
+				|| ! isset( $exposed[ $post->post_type ] )
+				|| ( ! empty( $input['post_type'] ) && $post->post_type !== $input['post_type'] )
+				|| ! current_user_can( 'read_post', $post->ID )
+			) {
+				return self::not_found_error();
+			}
+
+			return array(
+				'posts'       => array( self::format_post( $post, $fields ) ),
+				'total'       => 1,
+				'total_pages' => 1,
+			);
+		}
+
+		// Query / slug mode.
+		$post_type = isset( $input['post_type'] ) ? (string) $input['post_type'] : '';
+		if ( '' === $post_type || ! isset( $exposed[ $post_type ] ) ) {
+			return self::not_found_error();
+		}
+
+		$per_page = self::normalize_per_page( $input );
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+
+		$query_args = array(
+			'post_type'           => $post_type,
+			'post_status'         => self::normalize_statuses( $input ),
+			'posts_per_page'      => $per_page,
+			'paged'               => $page,
+			'ignore_sticky_posts' => true,
+		);
+
+		if ( ! empty( $input['slug'] ) ) {
+			$query_args['name'] = sanitize_title( (string) $input['slug'] );
+		}
+
+		if ( ! empty( $input['author'] ) ) {
+			$query_args['author'] = (int) $input['author'];
+		}
+
+		if ( isset( $input['parent'] ) ) {
+			$query_args['post_parent'] = (int) $input['parent'];
+		}
+
+		$query = new WP_Query( $query_args );
+
+		$posts = array();
+		foreach ( $query->posts as $post ) {
+			if ( ! current_user_can( 'read_post', $post->ID ) ) {
+				continue;
+			}
+			$posts[] = self::format_post( $post, $fields );
+		}
+
+		return array(
+			'posts'       => $posts,
+			'total'       => (int) $query->found_posts,
+			'total_pages' => (int) $query->max_num_pages,
+		);
+	}
+
+	/**
+	 * Normalizes the requested per-page value to the supported bounds.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return int The clamped per-page value.
+	 */
+	protected static function normalize_per_page( array $input ): int {
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : self::DEFAULT_PER_PAGE;
+
+		return max( 1, min( self::MAX_PER_PAGE, $per_page ) );
+	}
+
+	/**
+	 * Returns the post types exposed through the Abilities API, keyed by name.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, \WP_Post_Type> Exposed post type objects keyed by name.
+	 */
+	protected static function get_exposed_post_types(): array {
+		$exposed = array();
+
+		foreach ( get_post_types( array(), 'objects' ) as $post_type_object ) {
+			if ( empty( $post_type_object->show_in_abilities ) ) {
+				continue;
+			}
+			$exposed[ $post_type_object->name ] = $post_type_object;
+		}
+
+		return $exposed;
+	}
+
+	/**
+	 * Returns the post statuses that may be requested through the ability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string[] List of public, non-internal post status slugs.
+	 */
+	protected static function get_available_statuses(): array {
+		return array_values( get_post_stati( array( 'internal' => false ) ) );
+	}
+
+	/**
+	 * Normalizes the requested statuses to a non-empty, sanitized list defaulting to publish.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return string[] Normalized list of post status slugs.
+	 */
+	protected static function normalize_statuses( array $input ): array {
+		$statuses = $input['status'] ?? array( 'publish' );
+		if ( ! is_array( $statuses ) || array() === $statuses ) {
+			return array( 'publish' );
+		}
+
+		return array_map( 'sanitize_key', $statuses );
+	}
+
+	/**
+	 * Normalizes the requested fields to the supported set, defaulting to all fields.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return string[] List of requested field names.
+	 */
+	protected static function normalize_fields( array $input ): array {
+		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
+			return self::$fields;
+		}
+
+		$fields = array_intersect( self::$fields, array_map( 'strval', $input['fields'] ) );
+
+		return array() === $fields ? self::$fields : array_values( $fields );
+	}
+
+	/**
+	 * Builds the input schema for the `core/content` ability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param string[] $post_types Exposed post type names.
+	 * @param string[] $statuses   Requestable post status slugs.
+	 * @return array<string, mixed> The input JSON Schema.
+	 */
+	protected static function get_content_input_schema( array $post_types, array $statuses ): array {
+		return array(
+			'type'                 => 'object',
+			'default'              => array(),
+			// `post_type` is required unless a single post is requested by `id`.
+			'anyOf'                => array(
+				array( 'required' => array( 'id' ) ),
+				array( 'required' => array( 'post_type' ) ),
+			),
+			'properties'           => array(
+				'post_type' => array(
+					'type'        => 'string',
+					'enum'        => $post_types,
+					'description' => esc_html__( 'Post type to retrieve. Required unless `id` is provided.', 'ai' ),
+				),
+				'id'        => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'description' => esc_html__( 'Retrieve a single post by ID. When provided, `post_type` is optional.', 'ai' ),
+				),
+				'slug'      => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'Retrieve posts by slug. Requires `post_type`, as slugs are not unique across post types.', 'ai' ),
+				),
+				'status'    => array(
+					'type'        => 'array',
+					'uniqueItems' => true,
+					'default'     => array( 'publish' ),
+					'items'       => array(
+						'type' => 'string',
+						'enum' => $statuses,
+					),
+					'description' => esc_html__( 'Filter by one or more post statuses. Defaults to publish. Non-published statuses require the appropriate capabilities.', 'ai' ),
+				),
+				'author'    => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'description' => esc_html__( 'Filter by author user ID.', 'ai' ),
+				),
+				'parent'    => array(
+					'type'        => 'integer',
+					'minimum'     => 0,
+					'description' => esc_html__( 'Filter by parent post ID, for hierarchical post types. Use 0 for top-level posts.', 'ai' ),
+				),
+				'fields'    => array(
+					'type'        => 'array',
+					'uniqueItems' => true,
+					'items'       => array(
+						'type' => 'string',
+						'enum' => self::$fields,
+					),
+					'description' => esc_html__( 'Limit each returned post to these fields. If omitted, all supported fields are returned.', 'ai' ),
+				),
+				'page'      => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'default'     => 1,
+					'description' => esc_html__( 'Page of results to return in query mode. Ignored when retrieving a single post by ID.', 'ai' ),
+				),
+				'per_page'  => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'maximum'     => self::MAX_PER_PAGE,
+					'default'     => self::DEFAULT_PER_PAGE,
+					'description' => esc_html__( 'Maximum number of posts to return per page in query mode.', 'ai' ),
+				),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Builds the output schema for the `core/content` ability.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, mixed> The output JSON Schema.
+	 */
+	protected static function get_content_output_schema(): array {
+		$post_schema = array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'id'          => array(
+					'type'        => 'integer',
+					'description' => esc_html__( 'The post ID.', 'ai' ),
+				),
+				'type'        => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The post type.', 'ai' ),
+				),
+				'status'      => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The post status.', 'ai' ),
+				),
+				'date'        => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The publication date, in ISO 8601 format (GMT).', 'ai' ),
+				),
+				'modified'    => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The last modified date, in ISO 8601 format (GMT).', 'ai' ),
+				),
+				'slug'        => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The post slug.', 'ai' ),
+				),
+				'link'        => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The permalink URL.', 'ai' ),
+				),
+				'title'       => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The post title. Present when the post type supports titles.', 'ai' ),
+				),
+				'excerpt'     => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The post excerpt. Present when the post type supports excerpts. Empty when withheld for a password-protected post.', 'ai' ),
+				),
+				'raw_content' => array(
+					'type'        => 'string',
+					'description' => esc_html__( 'The raw, unfiltered post content (block markup). Present when the post type supports the editor. Empty when withheld for a password-protected post.', 'ai' ),
+				),
+				'author'      => array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'properties'           => array(
+						'id'           => array(
+							'type'        => 'integer',
+							'description' => esc_html__( 'The author user ID.', 'ai' ),
+						),
+						'display_name' => array(
+							'type'        => 'string',
+							'description' => esc_html__( 'The author display name.', 'ai' ),
+						),
+					),
+					'description'          => esc_html__( 'The post author. Present when the post type supports authors.', 'ai' ),
+				),
+				'parent'      => array(
+					'type'        => 'integer',
+					'description' => esc_html__( 'The parent post ID. Present for hierarchical post types.', 'ai' ),
+				),
+			),
+		);
+
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => array(
+				'posts'       => array(
+					'type'        => 'array',
+					'description' => esc_html__( 'The posts matching the request. A single-element list when requested by ID.', 'ai' ),
+					'items'       => $post_schema,
+				),
+				'total'       => array(
+					'type'        => 'integer',
+					'description' => esc_html__( 'Total number of posts matching the query, across all pages. Surfaced over REST as the X-WP-Total header.', 'ai' ),
+				),
+				'total_pages' => array(
+					'type'        => 'integer',
+					'description' => esc_html__( 'Total number of pages available. Surfaced over REST as the X-WP-TotalPages header.', 'ai' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Formats a post into the ability output shape.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post   The post object.
+	 * @param string[] $fields The requested field names.
+	 * @return array<string, mixed> The formatted post data.
+	 */
+	protected static function format_post( WP_Post $post, array $fields ): array {
+		$type      = $post->post_type;
+		$wants     = static function ( string $field ) use ( $fields ): bool {
+			return in_array( $field, $fields, true );
+		};
+		$protected = post_password_required( $post ) && ! current_user_can( 'edit_post', $post->ID );
+
+		$data = array();
+
+		if ( $wants( 'id' ) ) {
+			$data['id'] = (int) $post->ID;
+		}
+		if ( $wants( 'type' ) ) {
+			$data['type'] = $type;
+		}
+		if ( $wants( 'status' ) ) {
+			$data['status'] = $post->post_status;
+		}
+		if ( $wants( 'date' ) ) {
+			$data['date'] = self::format_gmt_date( $post, 'date' );
+		}
+		if ( $wants( 'modified' ) ) {
+			$data['modified'] = self::format_gmt_date( $post, 'modified' );
+		}
+		if ( $wants( 'slug' ) ) {
+			$data['slug'] = $post->post_name;
+		}
+		if ( $wants( 'link' ) ) {
+			$data['link'] = (string) get_permalink( $post );
+		}
+
+		if ( $wants( 'title' ) && post_type_supports( $type, 'title' ) ) {
+			$data['title'] = self::get_title( $post );
+		}
+
+		if ( $wants( 'excerpt' ) && post_type_supports( $type, 'excerpt' ) ) {
+			$data['excerpt'] = $protected ? '' : (string) get_the_excerpt( $post );
+		}
+
+		if ( $wants( 'raw_content' ) && post_type_supports( $type, 'editor' ) ) {
+			$data['raw_content'] = $protected ? '' : (string) $post->post_content;
+		}
+
+		if ( $wants( 'author' ) && post_type_supports( $type, 'author' ) ) {
+			$author         = get_userdata( (int) $post->post_author );
+			$data['author'] = array(
+				'id'           => (int) $post->post_author,
+				'display_name' => $author ? $author->display_name : '',
+			);
+		}
+
+		if ( $wants( 'parent' ) && is_post_type_hierarchical( $type ) ) {
+			$data['parent'] = (int) $post->post_parent;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns the post title with the protected/private prefixes stripped.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post The post object.
+	 * @return string The post title.
+	 */
+	protected static function get_title( WP_Post $post ): string {
+		$strip = array( self::class, 'return_raw_title_format' );
+		add_filter( 'protected_title_format', $strip );
+		add_filter( 'private_title_format', $strip );
+		$title = get_the_title( $post );
+		remove_filter( 'protected_title_format', $strip );
+		remove_filter( 'private_title_format', $strip );
+
+		return $title;
+	}
+
+	/**
+	 * Returns the raw title format, used to strip protected/private title prefixes.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string The unprefixed title format.
+	 */
+	public static function return_raw_title_format(): string {
+		return '%s';
+	}
+
+	/**
+	 * Formats a post date field as an ISO 8601 string in GMT.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param \WP_Post $post  The post object.
+	 * @param string   $field Either 'date' or 'modified'.
+	 * @return string The ISO 8601 date, or an empty string if unavailable.
+	 */
+	protected static function format_gmt_date( WP_Post $post, string $field ): string {
+		$datetime = get_post_datetime( $post, $field, 'gmt' );
+		if ( $datetime ) {
+			return $datetime->format( 'c' );
+		}
+
+		$local     = 'modified' === $field ? $post->post_modified : $post->post_date;
+		$timestamp = mysql2date( 'U', $local, false );
+
+		return $timestamp ? gmdate( 'c', (int) $timestamp ) : '';
+	}
+
+	/**
+	 * Builds the uniform not-found error.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return \WP_Error The not-found error.
+	 */
+	protected static function not_found_error(): WP_Error {
+		return new WP_Error(
+			'content_not_found',
+			esc_html__( 'The requested content was not found.', 'ai' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/includes/Abilities/Show_In_Abilities.php
+++ b/includes/Abilities/Show_In_Abilities.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Polyfills the core `show_in_abilities` flag onto curated core objects.
+ *
+ * @package WordPress\AI
+ *
+ * @since 1.1.0
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Abilities;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class - Show_In_Abilities
+ *
+ * WordPress core does not yet ship the `show_in_abilities` flag consumed by the
+ * `core/content` ability (and, in the future, settings and meta abilities). This
+ * component polyfills that flag onto a curated set of core objects so the abilities
+ * return data on a stock site, before/without the equivalent core change.
+ *
+ * It is intentionally object-type-agnostic: today it marks post types; settings and
+ * meta can be marked here the same way as those abilities land.
+ *
+ * @internal This class should not be used outside the plugin and there is no guarantee of backwards compatibility.
+ *
+ * @since 1.1.0
+ */
+class Show_In_Abilities {
+
+	/**
+	 * Registers the hooks that mark core objects as exposed to abilities.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function register(): void {
+		add_filter( 'register_post_type_args', array( self::class, 'mark_post_type' ), 10, 2 );
+
+		/*
+		 * Core post types (post, page) are registered very early — during bootstrap and on
+		 * `init` priority 0 — which is typically before this component runs, so the filter
+		 * above would miss them. Mark any already-registered curated post types directly.
+		 */
+		self::mark_registered_post_types();
+	}
+
+	/**
+	 * Adds the `show_in_abilities` flag to curated core post types as they are registered.
+	 *
+	 * Respects an explicit `show_in_abilities` value already present on the post type (for
+	 * example once core ships it natively), only filling it in when absent.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @param array<string, mixed> $args      The post type registration arguments.
+	 * @param string               $post_type The post type key.
+	 * @return array<string, mixed> The (possibly amended) registration arguments.
+	 */
+	public static function mark_post_type( array $args, string $post_type ): array {
+		$post_types = self::post_types_map();
+
+		if ( isset( $post_types[ $post_type ] ) && empty( $args['show_in_abilities'] ) ) {
+			$args['show_in_abilities'] = $post_types[ $post_type ];
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Marks already-registered curated post types as exposed to abilities.
+	 *
+	 * The `register_post_type_args` filter only affects post types registered after it is
+	 * added, but core post types are registered during bootstrap. This patches the existing
+	 * post type objects directly so the polyfill works regardless of when it runs.
+	 * {@see WP_Post_Type} allows dynamic properties, so this is safe on stock WordPress.
+	 *
+	 * @since 1.1.0
+	 */
+	public static function mark_registered_post_types(): void {
+		foreach ( self::post_types_map() as $post_type => $show ) {
+			$object = get_post_type_object( $post_type );
+			if ( ! ( $object instanceof \WP_Post_Type ) || ! empty( $object->show_in_abilities ) ) {
+				continue;
+			}
+
+			$object->show_in_abilities = $show;
+		}
+	}
+
+	/**
+	 * Returns the curated core post types to expose, keyed by post type key.
+	 *
+	 * The value is whatever `show_in_abilities` should contain: `true`, or an array
+	 * reserved for enabling specific operations in the future. This matches the set
+	 * marked natively by the core `core/content` implementation (`post` and `page`).
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return array<string, bool|array<string, mixed>> Post types map keyed by post type key.
+	 */
+	public static function post_types_map(): array {
+		return array(
+			'post' => true,
+			'page' => true,
+		);
+	}
+}

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -11,6 +11,8 @@ declare( strict_types=1 );
 
 namespace WordPress\AI;
 
+use WordPress\AI\Abilities\Content\Content as Content_Ability;
+use WordPress\AI\Abilities\Show_In_Abilities;
 use WordPress\AI\Abilities\Utilities\Posts;
 use WordPress\AI\Admin\Activation;
 use WordPress\AI\Admin\Dashboard\Dashboard_Widgets;
@@ -129,6 +131,11 @@ final class Main {
 
 			// Register our post-related WordPress Abilities.
 			( new Posts() )->register();
+
+			// Expose curated core post types to the Abilities API, then register the
+			// `core/content` ability (overriding any core-provided copy).
+			Show_In_Abilities::register();
+			Content_Ability::init();
 		} catch ( \Throwable $e ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/tests/Integration/Includes/Abilities/Content/ContentTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentTest.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Integration tests for the core/content Ability provided by the plugin.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
+
+use WP_UnitTestCase;
+use WordPress\AI\Abilities\Content\Content;
+use WordPress\AI\Abilities\Show_In_Abilities;
+
+/**
+ * Content ability test case.
+ *
+ * @since 1.1.0
+ */
+class ContentTest extends WP_UnitTestCase {
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since 1.1.0
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mark the curated core post types (post, page) as exposed to abilities.
+		Show_In_Abilities::register();
+
+		$this->ensure_content_category();
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since 1.1.0
+	 */
+	public function tearDown(): void {
+		if ( wp_has_ability( 'core/content' ) ) {
+			wp_unregister_ability( 'core/content' );
+		}
+
+		remove_filter( 'register_post_type_args', array( Show_In_Abilities::class, 'mark_post_type' ), 10 );
+
+		// Restore the curated post types to their unmarked state to avoid leaking into other tests.
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			$object = get_post_type_object( $post_type );
+			if ( ! $object ) {
+				continue;
+			}
+
+			unset( $object->show_in_abilities );
+		}
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensures the `content` ability category exists for the ability to attach to.
+	 *
+	 * @since 1.1.0
+	 */
+	private function ensure_content_category(): void {
+		if ( wp_has_ability_category( 'content' ) ) {
+			return;
+		}
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability_category(
+				'content',
+				array(
+					'label'       => 'Content',
+					'description' => 'Content.',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Registers the plugin's core/content ability inside a faked init action.
+	 *
+	 * @since 1.1.0
+	 */
+	private function register_ability(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			Content::register();
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Logs in as a user with the given role and returns the user ID.
+	 *
+	 * @param string $role The role to create the user with.
+	 * @return int The new user ID.
+	 */
+	private function login_as( string $role ): int {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * The ability is registered in the `content` category and flagged read-only.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_registers_core_content_ability(): void {
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/content' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'core/content', $ability->get_name() );
+		$this->assertSame( 'content', $ability->get_category() );
+
+		$annotations = $ability->get_meta_item( 'annotations', array() );
+		$this->assertTrue( $annotations['readonly'] );
+	}
+
+	/**
+	 * When core already provides core/content, the plugin's version replaces it.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_override_replaces_existing_core_content(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability(
+				'core/content',
+				array(
+					'label'               => 'Core Provided',
+					'description'         => 'Core provided content ability.',
+					'category'            => 'content',
+					'execute_callback'    => static function (): array {
+						return array( 'posts' => array() );
+					},
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->assertSame( 'Core Provided', wp_get_ability( 'core/content' )->get_label() );
+
+		$this->register_ability();
+
+		$this->assertSame( 'Get Content', wp_get_ability( 'core/content' )->get_label() );
+	}
+
+	/**
+	 * The input schema requires either `id` or `post_type` and exposes only marked types.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_input_schema_requires_id_or_post_type(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/content' )->get_input_schema();
+
+		$this->assertSame(
+			array(
+				array( 'required' => array( 'id' ) ),
+				array( 'required' => array( 'post_type' ) ),
+			),
+			$schema['anyOf']
+		);
+
+		$enum = $schema['properties']['post_type']['enum'];
+		$this->assertContains( 'post', $enum );
+		$this->assertContains( 'page', $enum );
+	}
+
+	/**
+	 * A published post can be fetched by ID.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_get_single_published_post_by_id(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_title'   => 'Hello Content',
+				'post_content' => 'Body here.',
+				'post_status'  => 'publish',
+			)
+		);
+
+		$result = wp_get_ability( 'core/content' )->execute( array( 'id' => $post_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result['posts'] );
+		$this->assertSame( $post_id, $result['posts'][0]['id'] );
+		$this->assertSame( 'Hello Content', $result['posts'][0]['title'] );
+		$this->assertSame( 'Body here.', $result['posts'][0]['raw_content'] );
+	}
+
+	/**
+	 * Query mode returns only published posts by default.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_query_returns_only_published_by_default(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$published = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$draft     = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		$result = wp_get_ability( 'core/content' )->execute( array( 'post_type' => 'post' ) );
+		$ids    = wp_list_pluck( $result['posts'], 'id' );
+
+		$this->assertContains( $published, $ids );
+		$this->assertNotContains( $draft, $ids );
+	}
+
+	/**
+	 * Querying by slug without a post type is rejected by the input schema.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_query_by_slug_requires_post_type(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/content' )->execute( array( 'slug' => 'whatever' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code() );
+	}
+
+	/**
+	 * The `fields` filter limits the returned keys.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_fields_filter_limits_returned_keys(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$result = wp_get_ability( 'core/content' )->execute(
+			array(
+				'id'     => $post_id,
+				'fields' => array( 'id', 'title' ),
+			)
+		);
+
+		$this->assertSame( array( 'id', 'title' ), array_keys( $result['posts'][0] ) );
+	}
+
+	/**
+	 * Logged-out users cannot run the ability.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_logged_out_user_is_denied(): void {
+		wp_set_current_user( 0 );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/content' )->execute( array( 'post_type' => 'post' ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+
+	/**
+	 * Subscribers cannot request draft posts.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_subscriber_cannot_request_draft_status(): void {
+		$this->login_as( 'subscriber' );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/content' )->execute(
+			array(
+				'post_type' => 'post',
+				'status'    => array( 'draft' ),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+
+	/**
+	 * An author can pass the draft gate but only sees their own drafts.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_author_cannot_see_other_authors_drafts(): void {
+		$author_a = self::factory()->user->create( array( 'role' => 'author' ) );
+		$author_b = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		$draft_a = self::factory()->post->create(
+			array(
+				'post_author' => $author_a,
+				'post_status' => 'draft',
+			)
+		);
+		$draft_b = self::factory()->post->create(
+			array(
+				'post_author' => $author_b,
+				'post_status' => 'draft',
+			)
+		);
+
+		wp_set_current_user( $author_b );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/content' )->execute(
+			array(
+				'post_type' => 'post',
+				'status'    => array( 'draft' ),
+			)
+		);
+		$ids    = wp_list_pluck( $result['posts'], 'id' );
+
+		$this->assertContains( $draft_b, $ids );
+		$this->assertNotContains( $draft_a, $ids );
+	}
+
+	/**
+	 * Password-protected content is withheld from users who cannot edit the post.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_password_protected_content_withheld_from_non_editor(): void {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_status'   => 'publish',
+				'post_password' => 'secret',
+				'post_content'  => 'Top secret body.',
+			)
+		);
+
+		$this->login_as( 'subscriber' );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/content' )->execute(
+			array(
+				'id'     => $post_id,
+				'fields' => array( 'id', 'raw_content' ),
+			)
+		);
+
+		$this->assertSame( '', $result['posts'][0]['raw_content'] );
+	}
+
+	/**
+	 * Query mode paginates with `page`/`per_page` and reports totals.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_query_paginates_and_reports_totals(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+
+		$page1 = wp_get_ability( 'core/content' )->execute(
+			array(
+				'post_type' => 'post',
+				'per_page'  => 2,
+				'page'      => 1,
+			)
+		);
+
+		$this->assertCount( 2, $page1['posts'] );
+		$this->assertGreaterThanOrEqual( 3, $page1['total'] );
+		$this->assertSame( (int) ceil( $page1['total'] / 2 ), $page1['total_pages'] );
+
+		$page2 = wp_get_ability( 'core/content' )->execute(
+			array(
+				'post_type' => 'post',
+				'per_page'  => 2,
+				'page'      => 2,
+			)
+		);
+
+		$this->assertNotEmpty( $page2['posts'] );
+		$this->assertSame( $page1['total'], $page2['total'] );
+	}
+
+	/**
+	 * A single post fetched by ID still reports pagination totals of one.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_single_post_reports_totals(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$result = wp_get_ability( 'core/content' )->execute( array( 'id' => $post_id ) );
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( 1, $result['total_pages'] );
+	}
+}

--- a/tests/Integration/Includes/Abilities/Show_In_AbilitiesTest.php
+++ b/tests/Integration/Includes/Abilities/Show_In_AbilitiesTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Integration tests for the Show_In_Abilities exposure component.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities;
+
+use WP_UnitTestCase;
+use WordPress\AI\Abilities\Show_In_Abilities;
+
+/**
+ * Show_In_Abilities test case.
+ *
+ * @since 1.1.0
+ */
+class Show_In_AbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since 1.1.0
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		Show_In_Abilities::register();
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since 1.1.0
+	 */
+	public function tearDown(): void {
+		remove_filter( 'register_post_type_args', array( Show_In_Abilities::class, 'mark_post_type' ), 10 );
+
+		// Restore the curated post types to their unmarked state.
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			$object = get_post_type_object( $post_type );
+			if ( ! $object ) {
+				continue;
+			}
+
+			unset( $object->show_in_abilities );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Curated core post types are marked directly, since they register before the filter.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_marks_curated_registered_post_types(): void {
+		// Show_In_Abilities::register() ran in setUp and patches existing post types.
+		$this->assertNotEmpty( get_post_type_object( 'post' )->show_in_abilities );
+		$this->assertNotEmpty( get_post_type_object( 'page' )->show_in_abilities );
+	}
+
+	/**
+	 * The post type args filter marks a curated post type when it is registered.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_filter_marks_curated_post_type(): void {
+		$args = Show_In_Abilities::mark_post_type( array(), 'page' );
+
+		$this->assertTrue( $args['show_in_abilities'] );
+	}
+
+	/**
+	 * The post type args filter leaves uncurated post types untouched.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_filter_skips_uncurated_post_type(): void {
+		$args = Show_In_Abilities::mark_post_type( array(), 'wpai_not_curated_cpt' );
+
+		$this->assertTrue( empty( $args['show_in_abilities'] ) );
+	}
+
+	/**
+	 * An explicit `show_in_abilities` value already on the post type is preserved.
+	 *
+	 * @since 1.1.0
+	 */
+	public function test_filter_respects_existing_post_type_value(): void {
+		$args = Show_In_Abilities::mark_post_type(
+			array( 'show_in_abilities' => array( 'custom' => true ) ),
+			'post'
+		);
+
+		$this->assertSame( array( 'custom' => true ), $args['show_in_abilities'] );
+	}
+}

--- a/tests/e2e-sample-content/e2e-sample-content.php
+++ b/tests/e2e-sample-content/e2e-sample-content.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Plugin name: AI E2E Sample Content
+ * Description: Registers a post type flagged with `show_in_abilities` and seeds a sample post, used by E2E tests to verify the `core/content` ability exposes content registered by other active plugins.
+ * Version: 0.1.0
+ * Author: WordPress.org Contributors
+ * Author URI: https://make.wordpress.org/ai/
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+add_action(
+	'init',
+	static function (): void {
+		register_post_type(
+			'ai_e2e_sample',
+			array(
+				'label'             => 'AI E2E Sample',
+				'public'            => true,
+				'show_in_rest'      => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title', 'editor', 'excerpt', 'author' ),
+			)
+		);
+	},
+	5
+);
+
+// Seed a published sample post once, after the post type is registered.
+add_action(
+	'init',
+	static function (): void {
+		if ( get_page_by_path( 'ai-e2e-sample-content', OBJECT, 'ai_e2e_sample' ) ) {
+			return;
+		}
+
+		wp_insert_post(
+			array(
+				'post_type'    => 'ai_e2e_sample',
+				'post_name'    => 'ai-e2e-sample-content',
+				'post_title'   => 'AI E2E Sample Content',
+				'post_content' => 'Sample content body for end-to-end testing.',
+				'post_status'  => 'publish',
+			)
+		);
+	},
+	20
+);

--- a/tests/e2e/specs/abilities/core-content.spec.js
+++ b/tests/e2e/specs/abilities/core-content.spec.js
@@ -1,0 +1,126 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	enableExperiment,
+	enableExperiments,
+} = require( '../../utils/helpers' );
+
+/**
+ * Runs the `core/content` ability through the client-side Abilities API, exactly
+ * as a consumer would in the browser.
+ *
+ * Mirrors the plugin's own sequence in `src/utils/run-ability.ts`: importing
+ * `@wordpress/core-abilities` initializes the client store (WordPress core's build
+ * runs `initialize()` on load and exports the resulting `ready` promise), so we
+ * await `ready` before calling `executeAbility` from `@wordpress/abilities`.
+ *
+ * The client modules are only present in the page's import map once an AI experiment
+ * is enabled in the block editor (it declares them as `module_dependencies`), which is
+ * set up in `beforeEach`.
+ *
+ * @param {import('@playwright/test').Page} page  The Playwright page.
+ * @param {Object}                          input The ability input.
+ * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
+ */
+async function runCoreContent( page, input ) {
+	return page.evaluate( async ( abilityInput ) => {
+		const { ready } = await import( '@wordpress/core-abilities' );
+		if ( ready ) {
+			await ready;
+		}
+
+		const { executeAbility } = await import( '@wordpress/abilities' );
+
+		try {
+			const result = await executeAbility( 'core/content', abilityInput );
+			return { ok: true, result };
+		} catch ( e ) {
+			return { ok: false, code: e && e.code ? e.code : null };
+		}
+	}, input );
+}
+
+test.describe( 'core/content ability (client-side Abilities API)', () => {
+	test.beforeEach( async ( { admin, page } ) => {
+		// Enabling an experiment loads its block-editor script, which declares the
+		// `@wordpress/abilities` + `@wordpress/core-abilities` modules as dependencies
+		// and so adds them to the editor's import map.
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'Excerpt Generation' );
+
+		// Run from the block editor, where the abilities client modules are available.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'core/content ability test',
+		} );
+	} );
+
+	test( 'returns a posts list of the requested post type', async ( {
+		page,
+	} ) => {
+		const outcome = await runCoreContent( page, { post_type: 'post' } );
+
+		expect( outcome.ok ).toBe( true );
+		expect( Array.isArray( outcome.result.posts ) ).toBe( true );
+		// Pagination totals travel in the body (and as X-WP-Total headers when core supports it).
+		expect( typeof outcome.result.total ).toBe( 'number' );
+		expect( typeof outcome.result.total_pages ).toBe( 'number' );
+		for ( const post of outcome.result.posts ) {
+			expect( post.type ).toBe( 'post' );
+			expect( post.status ).toBe( 'publish' );
+		}
+	} );
+
+	test( 'paginates with page and per_page', async ( { page } ) => {
+		const outcome = await runCoreContent( page, {
+			post_type: 'post',
+			per_page: 1,
+			page: 1,
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.posts.length ).toBeLessThanOrEqual( 1 );
+	} );
+
+	test( 'limits each post to the requested fields', async ( { page } ) => {
+		const outcome = await runCoreContent( page, {
+			post_type: 'post',
+			fields: [ 'id', 'title' ],
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.posts.length ).toBeGreaterThan( 0 );
+		for ( const post of outcome.result.posts ) {
+			expect( Object.keys( post ).sort() ).toEqual( [ 'id', 'title' ] );
+		}
+	} );
+
+	test( 'rejects a slug query without a post type', async ( { page } ) => {
+		const outcome = await runCoreContent( page, { slug: 'whatever' } );
+
+		expect( outcome.ok ).toBe( false );
+		expect( outcome.code ).toBe( 'ability_invalid_input' );
+	} );
+
+	test( 'exposes a post type registered by another active plugin', async ( {
+		page,
+	} ) => {
+		// The `e2e-sample-content` plugin (mapped in .wp-env.test.json) registers the
+		// `ai_e2e_sample` post type with `show_in_abilities` and seeds a published post.
+		const outcome = await runCoreContent( page, {
+			post_type: 'ai_e2e_sample',
+			slug: 'ai-e2e-sample-content',
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.posts ).toHaveLength( 1 );
+		expect( outcome.result.posts[ 0 ].title ).toBe( 'AI E2E Sample Content' );
+		expect( outcome.result.posts[ 0 ].slug ).toBe( 'ai-e2e-sample-content' );
+	} );
+} );


### PR DESCRIPTION
## Summary

Adds the read-only `core/content` ability to the plugin, mirroring the WordPress core `WP_Content_Abilities` implementation (see the companion core PR) so the two stay in sync. It overrides any core-provided copy.

Retrieves one or more posts of a post type exposed to abilities: fetch a single post by `id` or `slug`, or query multiple posts filtered by `post_type`, `status`, `author`, `parent`, with a `fields` selector and `page`/`per_page` pagination. Output is `{ posts, total, total_pages }`.

## Security

Defense in depth: a coarse status/capability gate plus an authoritative per-post `read_post` check on every row; default status `publish`; password-protected content withheld from non-editors; uniform not-found responses to avoid leaking post existence.

## Show_In_Abilities

WordPress core does not yet ship the `show_in_abilities` flag this ability reads, so a self-contained `Show_In_Abilities` component polyfills it onto curated core post types (`post`, `page`). It is structured exactly like the settings polyfill from the `core/settings` PR (#691), so the two merge cleanly.

This PR is independent of #691 and can be reviewed/merged on its own.

## Tests

PHPUnit integration tests for the ability and the polyfill, plus an e2e spec (`tests/e2e/specs/abilities/core-content.spec.js`) backed by a sample-content plugin that registers an ability-exposed post type.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-738-b901ec0c5d97c1255615bf28bcb69aa1b0ffe4c6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->