### PR TITLE
Fix Persian/RTL characters display in Ability Explorer schemas

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -209,7 +209,7 @@ class Admin_Page {
 					<h3><?php esc_html_e( 'Input Schema', 'ai' ); ?></h3>
 					<div class="ability-schema-wrapper">
 						<button type="button" class="button button-small ability-copy-btn" data-copy="input-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-						<pre class="ability-schema-display" id="input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+						<pre class="ability-schema-display" id="input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ); ?></pre>
 					</div>
 				</div>
 			<?php endif; ?>
@@ -219,7 +219,7 @@ class Admin_Page {
 					<h3><?php esc_html_e( 'Output Schema', 'ai' ); ?></h3>
 					<div class="ability-schema-wrapper">
 						<button type="button" class="button button-small ability-copy-btn" data-copy="output-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-						<pre class="ability-schema-display" id="output-schema"><?php echo esc_html( (string) wp_json_encode( $ability['output_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+						<pre class="ability-schema-display" id="output-schema"><?php echo esc_html( (string) wp_json_encode( $ability['output_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ); ?></pre>
 					</div>
 				</div>
 			<?php endif; ?>
@@ -228,7 +228,7 @@ class Admin_Page {
 				<h3><?php esc_html_e( 'Raw Data', 'ai' ); ?></h3>
 				<div class="ability-schema-wrapper">
 					<button type="button" class="button button-small ability-copy-btn" data-copy="raw-data"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-					<pre class="ability-schema-display" id="raw-data"><?php echo esc_html( (string) wp_json_encode( $ability['raw_data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+					<pre class="ability-schema-display" id="raw-data"><?php echo esc_html( (string) wp_json_encode( $ability['raw_data'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ); ?></pre>
 				</div>
 			</div>
 		</div>
@@ -311,7 +311,7 @@ class Admin_Page {
 				<?php endif; ?>
 
 				<label for="ability-test-payload" class="screen-reader-text"><?php esc_html_e( 'Ability test input (JSON)', 'ai' ); ?></label>
-				<textarea id="ability-test-payload" rows="12"><?php echo esc_textarea( (string) wp_json_encode( $example_input, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></textarea>
+				<textarea id="ability-test-payload" rows="12"><?php echo esc_textarea( (string) wp_json_encode( $example_input, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ); ?></textarea>
 
 				<div class="ability-test-actions">
 					<button type="button" id="ability-test-invoke" class="button button-primary" data-ability="<?php echo esc_attr( $ability_slug ); ?>">
@@ -338,14 +338,14 @@ class Admin_Page {
 					<h3><?php esc_html_e( 'Input Schema Reference', 'ai' ); ?></h3>
 					<div class="ability-schema-wrapper">
 						<button type="button" class="button button-small ability-copy-btn" data-copy="test-input-schema"><?php esc_html_e( 'Copy', 'ai' ); ?></button>
-						<pre class="ability-schema-display" id="test-input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) ); ?></pre>
+						<pre class="ability-schema-display" id="test-input-schema"><?php echo esc_html( (string) wp_json_encode( $ability['input_schema'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) ); ?></pre>
 					</div>
 				</div>
 			<?php endif; ?>
 		</div>
 
 		<script type="application/json" id="ability-input-schema">
-			<?php echo wp_json_encode( $ability['input_schema'] ); ?>
+			<?php echo wp_json_encode( $ability['input_schema'], JSON_UNESCAPED_UNICODE ); ?>
 		</script>
 		<?php
 	}

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -345,7 +345,7 @@ class Admin_Page {
 		</div>
 
 		<script type="application/json" id="ability-input-schema">
-			<?php echo wp_json_encode( $ability['input_schema'], JSON_UNESCAPED_UNICODE ); ?>
+			<?php echo wp_json_encode( $ability['input_schema'], JSON_HEX_TAG | JSON_UNESCAPED_UNICODE ); ?>
 		</script>
 		<?php
 	}


### PR DESCRIPTION
## What?
Fixes the display of non‑ASCII characters (e.g., Persian, Arabic, Urdu) in the Ability Explorer schema viewer. Previously these characters were rendered as escaped unicode sequences such as \u0645\u062d\u062a\u0648\u0627.

## Why?
When abilities include localized descriptions or examples in languages using non‑ASCII characters, the schema viewer becomes difficult to read because the JSON output escapes all Unicode characters. This reduces usability for multilingual environments and RTL languages.

## How?
Adds the `JSON_UNESCAPED_UNICODE` flag to `wp_json_encode()` calls in:

includes/Experiments/Abilities_Explorer/Admin_Page.php

This ensures that schema data is rendered in a human‑readable format while preserving valid JSON output. Existing escaping (`esc_html`, `esc_textarea`) remains unchanged to maintain output safety.

### Use of AI Tools
AI assistance: Yes  
Tool(s): ChatGPT  
Model(s): GPT‑5  
Used for: Code review suggestion and preparation of the pull request description. Final changes were reviewed and implemented manually.

## Testing Instructions
1. Enable the AI plugin locally.
2. Open **Tools → AI → Abilities Explorer**.
3. Register or test an ability containing Persian or other non‑ASCII text in its schema.
4. Verify that characters are displayed directly instead of escaped unicode sequences.

## Screenshots or screencast

| Before | After |
|------|------|
| Persian text displayed as `\u0645\u062d\u062a\u0648\u0627` | Persian text displayed correctly |

## Changelog Entry
Fixed - Improve readability of Ability Explorer schema output by preventing unicode escaping for non‑ASCII characters.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-740-169089f83f30a3fa0889ceddb63070a08f3ef3e1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->