### PR TITLE
Skip Comment Moderation Analysis if marked as spam/trash

### DIFF
--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -301,6 +301,11 @@ class Comment_Moderation extends Abstract_Feature {
 			return;
 		}
 
+		// Skip moderation if the comment is already marked as spam or trash.
+		if ( in_array( $comment->comment_approved, array( 'spam', 'trash' ), true ) ) {
+			return;
+		}
+
 		$analysis = $this->get_comment_analysis_ability()->analyze_comment_by_id( (int) $comment_id );
 		if ( is_wp_error( $analysis ) ) {
 			return;

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -310,6 +310,7 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 			'comment_post_ID'      => $post_id,
 			'comment_author'       => 'Test Spammer',
 			'comment_author_email' => 'spammer@example.com',
+			'comment_author_url'   => '',
 			'comment_content'      => 'spam-comment-test',
 			'comment_approved'     => '1',
 		);

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -307,9 +307,11 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create();
 
 		$comment_data = array(
-			'comment_post_ID'  => $post_id,
-			'comment_content'  => 'spam-comment-test',
-			'comment_approved' => '1',
+			'comment_post_ID'      => $post_id,
+			'comment_author'       => 'Test Spammer',
+			'comment_author_email' => 'spammer@example.com',
+			'comment_content'      => 'spam-comment-test',
+			'comment_approved'     => '1',
 		);
 
 		$comment_id = wp_new_comment( $comment_data );

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -290,6 +290,43 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test moderate_comment() skips comments flagged as spam in pre_comment_approved.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_moderate_comment_skips_spam_comments() {
+		// Simulate a spam filter.
+		$filter = static function ( $approved, $commentdata ) {
+			if ( 'spam-comment-test' === $commentdata['comment_content'] ) {
+				return 'spam';
+			}
+			return $approved;
+		};
+		add_filter( 'pre_comment_approved', $filter, 10, 2 );
+
+		$post_id = self::factory()->post->create();
+
+		$comment_data = array(
+			'comment_post_ID'  => $post_id,
+			'comment_content'  => 'spam-comment-test',
+			'comment_approved' => '1',
+		);
+
+		$comment_id = wp_new_comment( $comment_data );
+		remove_filter( 'pre_comment_approved', $filter, 10 );
+
+		$this->assertNotFalse( $comment_id, 'Comment should be inserted.' );
+		$comment = get_comment( $comment_id );
+		$this->assertSame( 'spam', $comment->comment_approved, 'Comment approved status should be spam.' );
+
+		$this->assertSame(
+			'',
+			get_comment_meta( $comment_id, Comment_Moderation::META_ANALYSIS_STATUS, true ),
+			'Spam comment should not be analyzed by AI.'
+		);
+	}
+
+	/**
 	 * Filters the analysis result for tests.
 	 *
 	 * @since 0.9.0


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Follow up to https://github.com/WordPress/ai/pull/516#issuecomment-4393854369

<!-- In a few words, what is the PR actually doing? -->
This PR enables skipping of comment moderation AI analysis when comment is flagged as spam/trash by WordPress moderation/external plugins.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We should avoid token usage and sentiment analysis when a comment has been flagged to be spam by auto moderation beforehand.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a check in `moderate_comment()` function to validate `comment_approved` status.
Skips comment analysis when comment approval status is `spam`/`trash`

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

AI assistance: Yes
Tool(s): Antigravity IDE
Model(s): Gemini 3.5 Flash (Low)
Used for: Creating the boilerplate of the integration test. Reviewed and modified by me to function properly.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Enable Comment Moderation experiment.

For spam testing:
- Install Akismet Anti-spam: Spam protection plugin.
- Enter valid API key to enable the plugin.
- Comment on a post with `akismet-guaranteed-spam`
- Go to comments list in admin, verify that it is flagged as spam and check sentiment, toxicity analysis to be empty.

<img width="2098" height="1026" alt="image" src="https://github.com/user-attachments/assets/4784a97c-b5cc-4fe9-a787-cc731196a35a" />


For trash testing:
- Go to WordPress settings -> Discussion
- Scroll down to **Disallowed Comment Keys** and add `trash` as a keyword.
- Save settings.
- Comment a post with `trash` word.
- Go to comments list in admin, verify that it is flagged as trash and check sentiment, toxicity analysis to be empty.

<img width="2090" height="622" alt="image" src="https://github.com/user-attachments/assets/a8db2ee8-3fcd-495e-909f-0c743818e11f" />


## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->
Visible empty sentiment, toxicity analysis.
<img width="2476" height="1388" alt="image" src="https://github.com/user-attachments/assets/5f118001-9553-474a-ac7f-4ddb1c28025c" />
<img width="2476" height="1388" alt="image" src="https://github.com/user-attachments/assets/a5011447-8344-45d9-a917-d6ff3a74d73a" />


## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Changed - `moderate_comment()` function to skip comment analysis and moderation when comment is flagged as spam/trash.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-743-380eff540f39fd102d8f38fa0b0f8133810dfac1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->