### PR TITLE
AI Request Logs: use a fixed 30-day window for the "Last 30 Days" summary period

### DIFF
--- a/includes/Logging/AI_Request_Log_Repository.php
+++ b/includes/Logging/AI_Request_Log_Repository.php
@@ -731,7 +731,7 @@ class AI_Request_Log_Repository {
 			case 'week':
 				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 WEEK)';
 			case 'month':
-				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 MONTH)';
+				return 'AND timestamp >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 30 DAY)';
 			default:
 				return '';
 		}

--- a/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
@@ -559,6 +559,51 @@ class AI_Request_Log_RepositoryTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the 'month' summary period spans a fixed 30-day window.
+	 *
+	 * The dashboard labels this period "Last 30 Days" and the logs table filters
+	 * it as a fixed 30-day window, so the summary cutoff must also be 30 days.
+	 * A calendar INTERVAL 1 MONTH spans 28–31 days depending on the month, which
+	 * makes the summary cards disagree with the table for the same selection.
+	 *
+	 * @since 1.0.3
+	 */
+	public function test_get_summary_month_period_uses_30_day_window(): void {
+		global $wpdb;
+		$table = $wpdb->prefix . AI_Request_Log_Schema::TABLE_NAME;
+
+		// Just inside the 30-day window (29 days, 23 hours old).
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$table,
+			array(
+				'log_id'    => wp_generate_uuid4(),
+				'timestamp' => gmdate( 'Y-m-d H:i:s', strtotime( '-29 days -23 hours' ) ),
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			),
+			array( '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		// Just outside the 30-day window (30 days, 1 hour old).
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$table,
+			array(
+				'log_id'    => wp_generate_uuid4(),
+				'timestamp' => gmdate( 'Y-m-d H:i:s', strtotime( '-30 days -1 hour' ) ),
+				'type'      => 'ai_client',
+				'operation' => 'openai:completions',
+				'status'    => 'success',
+			),
+			array( '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		$summary = $this->repository->get_summary( 'month', true );
+
+		$this->assertSame( 1, $summary['total_requests'] );
+	}
+
+	/**
 	 * Tests that get_filter_options returns distinct values from logs.
 	 *
 	 * @since 1.0.0

--- a/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_RepositoryTest.php
@@ -566,7 +566,7 @@ class AI_Request_Log_RepositoryTest extends WP_UnitTestCase {
 	 * A calendar INTERVAL 1 MONTH spans 28–31 days depending on the month, which
 	 * makes the summary cards disagree with the table for the same selection.
 	 *
-	 * @since 1.0.3
+	 * @since x.x.x
 	 */
 	public function test_get_summary_month_period_uses_30_day_window(): void {
 		global $wpdb;


### PR DESCRIPTION
## What?

Closes #752

Make the **"Last 30 Days"** summary period (`period=month`) use a fixed **30-day** window instead of a calendar `INTERVAL 1 MONTH`, so the summary cards and the logs table cover the same span for that selection.

## Why?

On the AI Request Logs screen the header dropdown labels this period **"Last 30 Days"**, and the logs table already filters it as a fixed 30 days (computed in the browser). The summary cards, however, build their cutoff server-side with `DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 MONTH)`, which spans 28–31 days depending on the date.

Because both views are driven by the same dropdown selection, they should cover the same window. With a calendar month they don't: in a 31-day look-back the summary card counts an extra day the table omits; in a February look-back it counts fewer. The fix aligns the summary with the "Last 30 Days" label and the table's window. The other periods already use matching fixed offsets on both sides and are unaffected.

This is the same `get_date_condition()` method recently corrected for a UTC mismatch in #671.

## How?

In `AI_Request_Log_Repository::get_date_condition()`, change the `month` case from `INTERVAL 1 MONTH` to `INTERVAL 30 DAY`. One line; no change to the front end, which already uses 30 days.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8 / Sonnet 4.6
Used for: Locating the discrepancy across the PHP/JS boundary and drafting the regression test. I reviewed, ran, and take responsibility for the final change.

## Testing Instructions

Automated:

```
npm run test:php -- --filter test_get_summary_month_period_uses_30_day_window
```

The new test inserts two logs — one 29 days 23 hours old (inside 30 days) and one 30 days 1 hour old (outside) — and asserts `get_summary( 'month' )` counts exactly one. It passes with the fix; with the previous `INTERVAL 1 MONTH` it fails on months whose calendar look-back is not exactly 30 days.

Manual:

1. Enable AI request logging and accumulate logs spanning the last ~31 days.
2. Open **AI Request Logs** and select **"Last 30 Days"**.
3. Confirm the **Total Requests** summary card matches the table total (`X-WP-Total`) — both now cover the last 30 days.

## Changelog Entry

> Fixed - AI Request Logs: the "Last 30 Days" summary period now uses a fixed 30-day window so the summary cards and logs table cover the same span.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-753-c370dd1ed0550008452e749ea471edae89cecc50.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->