### PR TITLE
fix(logging): capture generations that bypass the SDK HTTP transporter

### DIFF
--- a/includes/Logging/Logging_Event_Listener.php
+++ b/includes/Logging/Logging_Event_Listener.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Provider-agnostic logging fallback driven by SDK generation events.
+ *
+ * @package WordPress\AI\Logging
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Logging;
+
+use WordPress\AiClient\Events\AfterGenerateResultEvent;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Logs successful generations that do not flow through the SDK HTTP transporter.
+ *
+ * The {@see Logging_Http_Transporter} only sees requests routed through the SDK's
+ * HTTP transporter. Providers with a custom transport (for example one that proxies
+ * to a localhost sidecar) never reach it and would otherwise be absent from the log.
+ *
+ * This listener taps the core generation lifecycle hooks, which fire for every
+ * provider regardless of transport:
+ *
+ * - `wp_ai_client_before_generate_result`
+ * - `wp_ai_client_after_generate_result`
+ *
+ * These are bridged from the SDK's `BeforeGenerateResultEvent` / `AfterGenerateResultEvent`
+ * by the dispatcher registered in WordPress core (`wp-settings.php`).
+ *
+ * To avoid double-logging transporter-based providers (which fire the event *and*
+ * pass through the decorator), a per-generation flag is reset on the before-event and
+ * set by {@see Logging_Http_Transporter::send()}; the after-event only writes a row
+ * when the transporter did not already log the current generation.
+ *
+ * Known limitation: the SDK's after-event fires on success only (there is no error
+ * event), so failed custom-transport generations are not captured here.
+ *
+ * @since 1.0.0
+ */
+class Logging_Event_Listener {
+
+	/**
+	 * Whether the transporter logged the current generation.
+	 *
+	 * @var bool
+	 */
+	private static bool $transporter_logged = false;
+
+	/**
+	 * The log manager instance.
+	 *
+	 * @var \WordPress\AI\Logging\AI_Request_Log_Manager
+	 */
+	private AI_Request_Log_Manager $log_manager;
+
+	/**
+	 * Timer for the in-progress generation.
+	 *
+	 * @var array{start: int}|null
+	 */
+	private ?array $timer = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param \WordPress\AI\Logging\AI_Request_Log_Manager $log_manager The log manager.
+	 */
+	public function __construct( AI_Request_Log_Manager $log_manager ) {
+		$this->log_manager = $log_manager;
+	}
+
+	/**
+	 * Registers the generation lifecycle listeners.
+	 *
+	 * @since 1.0.0
+	 */
+	public function register(): void {
+		add_action( 'wp_ai_client_before_generate_result', array( $this, 'handle_before_generate' ) );
+		add_action( 'wp_ai_client_after_generate_result', array( $this, 'handle_after_generate' ) );
+	}
+
+	/**
+	 * Marks the current generation as already logged by the HTTP transporter.
+	 *
+	 * Called by {@see Logging_Http_Transporter::send()} so the after-event does not
+	 * write a duplicate row for transporter-based providers.
+	 *
+	 * @since 1.0.0
+	 */
+	public static function mark_transporter_logged(): void {
+		self::$transporter_logged = true;
+	}
+
+	/**
+	 * Resets per-generation state at the start of a generation.
+	 *
+	 * @since 1.0.0
+	 */
+	public function handle_before_generate(): void {
+		self::$transporter_logged = false;
+		$this->timer              = $this->log_manager->start_timer();
+	}
+
+	/**
+	 * Logs the generation result unless the transporter already logged it.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param object $event The after-generate event.
+	 */
+	public function handle_after_generate( object $event ): void {
+		$timer       = $this->timer;
+		$this->timer = null;
+
+		// The SDK transporter already captured this generation; avoid a duplicate row.
+		if ( self::$transporter_logged ) {
+			return;
+		}
+
+		if ( ! $event instanceof AfterGenerateResultEvent ) {
+			return;
+		}
+
+		$model      = $event->getModel();
+		$provider   = $model->providerMetadata()->getId();
+		$model_id   = $model->metadata()->getId();
+		$capability = $event->getCapability();
+		$capability = null !== $capability ? (string) $capability : '';
+		$tokens     = $event->getResult()->getTokenUsage();
+
+		$log_data = array(
+			'type'          => 'ai_client',
+			'operation'     => '' !== $capability ? $provider . ':' . $capability : $provider,
+			'provider'      => $provider,
+			'model'         => $model_id,
+			'tokens_input'  => $tokens->getPromptTokens(),
+			'tokens_output' => $tokens->getCompletionTokens(),
+			'status'        => 'success',
+			'context'       => array( 'logged_via' => 'generation_event' ),
+		);
+
+		if ( null !== $timer ) {
+			$log_data['duration_ms'] = $this->log_manager->end_timer( $timer );
+		}
+
+		$this->log_manager->log( $log_data );
+	}
+}

--- a/includes/Logging/Logging_Event_Listener.php
+++ b/includes/Logging/Logging_Event_Listener.php
@@ -31,22 +31,22 @@ defined( 'ABSPATH' ) || exit;
  *
  * To avoid double-logging transporter-based providers (which fire the event *and*
  * pass through the decorator), a per-generation flag is reset on the before-event and
- * set by {@see Logging_Http_Transporter::send()}; the after-event only writes a row
- * when the transporter did not already log the current generation.
+ * set via {@see Logging_Event_Listener::mark_generation_logged()}; the after-event only
+ * writes a row when the generation was not already logged.
  *
  * Known limitation: the SDK's after-event fires on success only (there is no error
  * event), so failed custom-transport generations are not captured here.
  *
- * @since 1.0.0
+ * @since x.x.x
  */
 class Logging_Event_Listener {
 
 	/**
-	 * Whether the transporter logged the current generation.
+	 * Whether another logger already recorded the current generation.
 	 *
 	 * @var bool
 	 */
-	private static bool $transporter_logged = false;
+	private static bool $generation_logged = false;
 
 	/**
 	 * The log manager instance.
@@ -65,7 +65,7 @@ class Logging_Event_Listener {
 	/**
 	 * Constructor.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 *
 	 * @param \WordPress\AI\Logging\AI_Request_Log_Manager $log_manager The log manager.
 	 */
@@ -76,7 +76,7 @@ class Logging_Event_Listener {
 	/**
 	 * Registers the generation lifecycle listeners.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function register(): void {
 		add_action( 'wp_ai_client_before_generate_result', array( $this, 'handle_before_generate' ) );
@@ -84,31 +84,33 @@ class Logging_Event_Listener {
 	}
 
 	/**
-	 * Marks the current generation as already logged by the HTTP transporter.
+	 * Marks the current generation as already logged by another logger.
 	 *
-	 * Called by {@see Logging_Http_Transporter::send()} so the after-event does not
-	 * write a duplicate row for transporter-based providers.
+	 * Called by {@see Logging_Http_Transporter::send()} for transporter-based
+	 * providers, and available to any provider that records a generation through its
+	 * own path (for example a custom-transport provider with its own log bridge) so
+	 * the after-event does not write a duplicate row.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
-	public static function mark_transporter_logged(): void {
-		self::$transporter_logged = true;
+	public static function mark_generation_logged(): void {
+		self::$generation_logged = true;
 	}
 
 	/**
 	 * Resets per-generation state at the start of a generation.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function handle_before_generate(): void {
-		self::$transporter_logged = false;
+		self::$generation_logged = false;
 		$this->timer              = $this->log_manager->start_timer();
 	}
 
 	/**
 	 * Logs the generation result unless the transporter already logged it.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 *
 	 * @param object $event The after-generate event.
 	 */
@@ -116,8 +118,8 @@ class Logging_Event_Listener {
 		$timer       = $this->timer;
 		$this->timer = null;
 
-		// The SDK transporter already captured this generation; avoid a duplicate row.
-		if ( self::$transporter_logged ) {
+		// Another logger already captured this generation; avoid a duplicate row.
+		if ( self::$generation_logged ) {
 			return;
 		}
 

--- a/includes/Logging/Logging_Http_Transporter.php
+++ b/includes/Logging/Logging_Http_Transporter.php
@@ -98,6 +98,10 @@ class Logging_Http_Transporter implements HttpTransporterInterface {
 
 			// @phpstan-ignore argument.type (array shape is built incrementally)
 			$this->log_manager->log( $log_data );
+
+			// Signal the event-based fallback that this generation was already logged,
+			// so Logging_Event_Listener does not write a duplicate row.
+			Logging_Event_Listener::mark_transporter_logged();
 		}
 	}
 

--- a/includes/Logging/Logging_Http_Transporter.php
+++ b/includes/Logging/Logging_Http_Transporter.php
@@ -101,7 +101,7 @@ class Logging_Http_Transporter implements HttpTransporterInterface {
 
 			// Signal the event-based fallback that this generation was already logged,
 			// so Logging_Event_Listener does not write a duplicate row.
-			Logging_Event_Listener::mark_transporter_logged();
+			Logging_Event_Listener::mark_generation_logged();
 		}
 	}
 

--- a/includes/Logging/Logging_Integration.php
+++ b/includes/Logging/Logging_Integration.php
@@ -52,6 +52,10 @@ class Logging_Integration {
 
 		self::$log_manager = $log_manager;
 
+		// Provider-agnostic fallback: log generations that bypass the SDK HTTP
+		// transporter (e.g. custom-transport or localhost sidecar providers).
+		( new Logging_Event_Listener( $log_manager ) )->register();
+
 		// Check if the AiClient SDK is available.
 		if ( ! class_exists( AiClient::class ) ) {
 			return;

--- a/tests/Integration/Includes/Logging/Logging_Event_ListenerTest.php
+++ b/tests/Integration/Includes/Logging/Logging_Event_ListenerTest.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Integration tests for the event-based logging fallback.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Logging
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Logging;
+
+use ReflectionProperty;
+use WP_UnitTestCase;
+use WordPress\AI\Logging\AI_Request_Log_Manager;
+use WordPress\AI\Logging\AI_Request_Log_Schema;
+use WordPress\AI\Logging\Logging_Integration;
+use WordPress\AiClient\Events\AfterGenerateResultEvent;
+use WordPress\AiClient\Events\BeforeGenerateResultEvent;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+
+/**
+ * Tests that generations which bypass the SDK HTTP transporter are still logged.
+ *
+ * @since 1.0.0
+ *
+ * @covers \WordPress\AI\Logging\Logging_Event_Listener
+ */
+class Logging_Event_ListenerTest extends WP_UnitTestCase {
+
+	/**
+	 * Manager bound to the freshly-prepared log table.
+	 *
+	 * @var \WordPress\AI\Logging\AI_Request_Log_Manager
+	 */
+	private AI_Request_Log_Manager $manager;
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Force schema recreation in case a prior test's TRUNCATE broke the table state.
+		delete_option( 'wpai_request_logs_schema_version' );
+
+		$schema = new AI_Request_Log_Schema();
+		$schema->maybe_upgrade_table();
+
+		$this->manager = new AI_Request_Log_Manager();
+
+		global $wpdb;
+		$table = $wpdb->prefix . AI_Request_Log_Schema::TABLE_NAME;
+		$wpdb->query( "DELETE FROM {$table} WHERE 1=1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+
+		// Reset the one-shot init guard so init() wires the listener against our manager.
+		$this->reset_integration();
+		Logging_Integration::init( $this->manager );
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since 1.0.0
+	 */
+	protected function tearDown(): void {
+		remove_all_actions( 'wp_ai_client_before_generate_result' );
+		remove_all_actions( 'wp_ai_client_after_generate_result' );
+		$this->reset_integration();
+		delete_option( 'wpai_request_logs_schema_version' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Resets the static state on Logging_Integration so init() runs afresh.
+	 *
+	 * @since 1.0.0
+	 */
+	private function reset_integration(): void {
+		$initialized = new ReflectionProperty( Logging_Integration::class, 'initialized' );
+		$initialized->setAccessible( true );
+		$initialized->setValue( null, false );
+
+		$log_manager = new ReflectionProperty( Logging_Integration::class, 'log_manager' );
+		$log_manager->setAccessible( true );
+		$log_manager->setValue( null, null );
+	}
+
+	/**
+	 * Builds a model whose provider/model identifiers are known.
+	 *
+	 * @param string $provider Provider identifier.
+	 * @param string $model    Model identifier.
+	 * @return \WordPress\AiClient\Providers\Models\Contracts\ModelInterface
+	 */
+	private function make_model( string $provider, string $model ): ModelInterface {
+		$provider_meta = $this->createMock( ProviderMetadata::class );
+		$provider_meta->method( 'getId' )->willReturn( $provider );
+
+		$model_meta = $this->createMock( ModelMetadata::class );
+		$model_meta->method( 'getId' )->willReturn( $model );
+
+		$model_obj = $this->createMock( ModelInterface::class );
+		$model_obj->method( 'providerMetadata' )->willReturn( $provider_meta );
+		$model_obj->method( 'metadata' )->willReturn( $model_meta );
+
+		return $model_obj;
+	}
+
+	/**
+	 * Builds a result carrying the given token usage.
+	 *
+	 * @param int $input  Prompt tokens.
+	 * @param int $output Completion tokens.
+	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult
+	 */
+	private function make_result( int $input, int $output ): GenerativeAiResult {
+		$result = $this->createMock( GenerativeAiResult::class );
+		$result->method( 'getTokenUsage' )->willReturn(
+			new TokenUsage( $input, $output, $input + $output )
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Fires the core generation lifecycle hooks for a non-transporter provider.
+	 *
+	 * @param \WordPress\AiClient\Providers\Models\Contracts\ModelInterface $model  The model.
+	 * @param \WordPress\AiClient\Results\DTO\GenerativeAiResult            $result The result.
+	 */
+	private function dispatch_generation( ModelInterface $model, GenerativeAiResult $result ): void {
+		$capability = CapabilityEnum::textGeneration();
+
+		do_action(
+			'wp_ai_client_before_generate_result', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core hook bridged from the SDK.
+			new BeforeGenerateResultEvent( array(), $model, $capability )
+		);
+		do_action(
+			'wp_ai_client_after_generate_result', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core hook bridged from the SDK.
+			new AfterGenerateResultEvent( array(), $model, $capability, $result )
+		);
+	}
+
+	/**
+	 * A generation that never touches the SDK transporter must still be logged.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_logs_generation_that_bypasses_the_transporter(): void {
+		$model  = $this->make_model( 'codex', 'codex-mini' );
+		$result = $this->make_result( 10, 20 );
+
+		$this->dispatch_generation( $model, $result );
+
+		$logs = $this->manager->get_logs();
+
+		$this->assertSame( 1, $logs['total'], 'Expected the sidecar generation to produce one log row.' );
+
+		$item = $logs['items'][0];
+		$this->assertSame( 'codex', $item['provider'] );
+		$this->assertSame( 'codex-mini', $item['model'] );
+		$this->assertSame( 10, $item['tokens_input'] );
+		$this->assertSame( 20, $item['tokens_output'] );
+		$this->assertSame( 'success', $item['status'] );
+	}
+
+	/**
+	 * Transporter-based generations must not be logged twice.
+	 *
+	 * When a provider routes through the SDK transporter, Logging_Http_Transporter
+	 * logs the row and flags the generation; the after-event fallback must then skip
+	 * it rather than write a duplicate.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_does_not_double_log_transporter_based_generations(): void {
+		$capability = CapabilityEnum::textGeneration();
+		$model      = $this->make_model( 'openai', 'gpt-4o' );
+
+		do_action(
+			'wp_ai_client_before_generate_result', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core hook bridged from the SDK.
+			new BeforeGenerateResultEvent( array(), $model, $capability )
+		);
+
+		// Simulate the transporter handling the request: it writes its own row and
+		// flags the generation as already logged (mirrors Logging_Http_Transporter::send()).
+		$this->manager->log(
+			array(
+				'type'      => 'ai_client',
+				'operation' => 'openai:chat/completions',
+				'provider'  => 'openai',
+				'model'     => 'gpt-4o',
+				'status'    => 'success',
+			)
+		);
+		\WordPress\AI\Logging\Logging_Event_Listener::mark_transporter_logged();
+
+		do_action(
+			'wp_ai_client_after_generate_result', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core hook bridged from the SDK.
+			new AfterGenerateResultEvent( array(), $model, $capability, $this->make_result( 5, 7 ) )
+		);
+
+		$logs = $this->manager->get_logs();
+
+		$this->assertSame(
+			1,
+			$logs['total'],
+			'Transporter-based generation should yield exactly one row (no event-based duplicate).'
+		);
+	}
+}

--- a/tests/Integration/Includes/Logging/Logging_Event_ListenerTest.php
+++ b/tests/Integration/Includes/Logging/Logging_Event_ListenerTest.php
@@ -24,7 +24,7 @@ use WordPress\AiClient\Results\DTO\TokenUsage;
 /**
  * Tests that generations which bypass the SDK HTTP transporter are still logged.
  *
- * @since 1.0.0
+ * @since x.x.x
  *
  * @covers \WordPress\AI\Logging\Logging_Event_Listener
  */
@@ -40,7 +40,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 	/**
 	 * Set up test case.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -65,7 +65,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 	/**
 	 * Tear down test case.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	protected function tearDown(): void {
 		remove_all_actions( 'wp_ai_client_before_generate_result' );
@@ -79,7 +79,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 	/**
 	 * Resets the static state on Logging_Integration so init() runs afresh.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	private function reset_integration(): void {
 		$initialized = new ReflectionProperty( Logging_Integration::class, 'initialized' );
@@ -150,7 +150,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 	/**
 	 * A generation that never touches the SDK transporter must still be logged.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function test_logs_generation_that_bypasses_the_transporter(): void {
 		$model  = $this->make_model( 'codex', 'codex-mini' );
@@ -177,7 +177,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 	 * logs the row and flags the generation; the after-event fallback must then skip
 	 * it rather than write a duplicate.
 	 *
-	 * @since 1.0.0
+	 * @since x.x.x
 	 */
 	public function test_does_not_double_log_transporter_based_generations(): void {
 		$capability = CapabilityEnum::textGeneration();
@@ -199,7 +199,7 @@ class Logging_Event_ListenerTest extends WP_UnitTestCase {
 				'status'    => 'success',
 			)
 		);
-		\WordPress\AI\Logging\Logging_Event_Listener::mark_transporter_logged();
+		\WordPress\AI\Logging\Logging_Event_Listener::mark_generation_logged();
 
 		do_action(
 			'wp_ai_client_after_generate_result', // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Core hook bridged from the SDK.


### PR DESCRIPTION
## What?
Closes #732

Adds a provider-agnostic logging fallback so the **AI Request Logging** experiment captures successful generations from providers that don't route through the SDK's HTTP transporter (e.g. a provider that proxies to a localhost sidecar).

## Why?
Today logging is installed purely by decorating the SDK HTTP transporter (`Logging_Http_Transporter`), and `Logging_Http_Transporter::send()` is the only place that calls `AI_Request_Log_Manager::log()`. A request is logged **iff** it flows through that transporter. Any first-class provider reachable via `wp_ai_client_prompt()` that uses a custom transport is therefore silently absent from **Tools → AI Request Log**, even though the log presents itself as a record of *every* AI request. The concrete case in #732 is a `codex` provider that brokers requests through a localhost sidecar.

## How?
WordPress core registers a PSR-14 dispatcher in `wp-settings.php` (`WordPress\AiClient\AiClient::setEventDispatcher( new WP_AI_Client_Event_Dispatcher() )`) that bridges the SDK's `BeforeGenerateResultEvent` / `AfterGenerateResultEvent` to the action hooks `wp_ai_client_before_generate_result` / `wp_ai_client_after_generate_result`. These fire from `PromptBuilder::generateResult()`, through which **all** `generate*()` calls funnel — for every provider, regardless of transport.

This PR adds `Logging_Event_Listener`, wired up in `Logging_Integration::init()`, which:

- On `wp_ai_client_after_generate_result`, writes a log row using the event:
  - provider = `getModel()->providerMetadata()->getId()`
  - model = `getModel()->metadata()->getId()`
  - tokens = `getResult()->getTokenUsage()` (prompt/completion)
  - duration = before-event → after-event
- Avoids double-logging transporter-based providers (which fire the event **and** pass through the decorator) with a per-generation flag: reset on the before-event, set by `Logging_Http_Transporter::send()`. When the transporter already logged the current generation, the after-event listener skips it.

**Known limitation (documented in the code):** the SDK's after-event fires on success only — there is no error event — so failed *custom-transport* generations remain uncaptured. Transporter-based providers still log errors as before. Closing the failure case for custom transports would require an SDK-level error event and is out of scope here.

The diff is surgical: +8 lines across the two existing files, plus one new listener class and one new test file.

### Use of AI Tools
AI assistance: Yes
Tool(s): AI coding assistant (agentic CLI)
Used for: investigating the SDK event/dispatcher flow in `wp-includes/php-ai-client` and `wp-includes/ai-client`, drafting the listener + tests, and writing this description. All code was written test-first, executed, and reviewed by me; I take responsibility for it.

## Testing Instructions
Automated (PHPUnit, via `wp-env`):

```
npm run wp-env:test start
npm run test:php -- --filter Logging
```

- New tests: `tests/Integration/Includes/Logging/Logging_Event_ListenerTest.php`
  - `test_logs_generation_that_bypasses_the_transporter` — a generation that never touches `Logging_Http_Transporter` produces one row with the right provider/model/tokens.
  - `test_does_not_double_log_transporter_based_generations` — a transporter-logged generation yields exactly one row (no event-based duplicate).
- Full Logging suite (`--filter Logging`) is green (120 tests); the full integration suite is green (838 tests, 34 pre-existing skips).

**Fail-before / pass-after** (source stashed, test kept):

```
# before (unmodified source):
1) ...Logging_Event_ListenerTest::test_logs_generation_that_bypasses_the_transporter
Expected the sidecar generation to produce one log row.
Failed asserting that 0 is identical to 1.

# after (with fix):
OK (2 tests, 7 assertions)
```

Manual: enable **AI Request Logging**, run a generation through a provider with a custom transport (localhost sidecar), and confirm a row now appears in **Tools → AI Request Log**.

## Changelog Entry
> Fixed - AI Request Logging now captures successful generations from providers that use a custom transport (e.g. localhost sidecars), not only those routed through the SDK HTTP transporter.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-757-92ddff8b548b3dfc6099e146994bbe6cceed162f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->