### PR TITLE
PoC: Basic integration with Chrome DevTools for agents

### DIFF
--- a/src/experiments/alt-text-generation/index.tsx
+++ b/src/experiments/alt-text-generation/index.tsx
@@ -13,6 +13,13 @@ import { createHigherOrderComponent } from '@wordpress/compose';
  */
 import { AltTextControls } from './components/AltTextControls';
 import type { ImageBlockAttributes } from './types';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Alt Text Generation',
+	description: 'Generates descriptive alt text for image blocks using AI.',
+	abilitySlug: 'ai/alt-text-generation',
+} );
 
 interface BlockEditProps {
 	clientId: string;

--- a/src/experiments/comment-moderation/index.tsx
+++ b/src/experiments/comment-moderation/index.tsx
@@ -14,6 +14,13 @@ import { createRoot } from '@wordpress/element';
  * Internal dependencies
  */
 import { LazyAnalysisController } from './components/LazyAnalysisController';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Comment Moderation',
+	description: 'Analyses pending comments for spam and quality using AI.',
+	abilitySlug: 'ai/comment-analysis',
+} );
 
 /**
  * Initialize the comment moderation experiment.

--- a/src/experiments/content-classification/index.tsx
+++ b/src/experiments/content-classification/index.tsx
@@ -11,11 +11,18 @@ import { addFilter } from '@wordpress/hooks';
  * Internal dependencies
  */
 import SuggestionPanel from './components/SuggestionPanel';
+import { exposeToDevTools } from '../../utils/devtools';
 
 /**
  * Styles
  */
 import './index.scss';
+
+exposeToDevTools( {
+	name: 'Content Classification',
+	description: 'Suggests tags and categories for the current post using AI.',
+	abilitySlug: 'ai/content-classification',
+} );
 
 const SUPPORTED_TAXONOMIES = [ 'post_tag', 'category' ];
 

--- a/src/experiments/content-resizing/index.tsx
+++ b/src/experiments/content-resizing/index.tsx
@@ -14,6 +14,13 @@ import { addFilter } from '@wordpress/hooks';
  */
 import ContentResizingToolbar from './components/ContentResizingToolbar';
 import './index.scss';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Content Resizing',
+	description: 'Expands or condenses selected paragraph content using AI.',
+	abilitySlug: 'ai/content-resizing',
+} );
 
 const { aiContentResizingData } = window as any;
 

--- a/src/experiments/editorial-notes/index.tsx
+++ b/src/experiments/editorial-notes/index.tsx
@@ -12,6 +12,13 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import EditorialNotesPlugin from './components/EditorialNotesPlugin';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Editorial Notes',
+	description: 'Reviews the post and provides editorial feedback using AI.',
+	abilitySlug: 'ai/editorial-notes',
+} );
 
 registerPlugin( 'ai-editorial-notes', {
 	render: () => (

--- a/src/experiments/editorial-updates/index.tsx
+++ b/src/experiments/editorial-updates/index.tsx
@@ -12,6 +12,14 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import EditorialUpdatesPlugin from './components/EditorialUpdatesPlugin';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Editorial Updates',
+	description:
+		'Rewrites selected post content based on editorial instructions using AI.',
+	abilitySlug: 'ai/editorial-updates',
+} );
 
 if ( ( window as any ).aiEditorialUpdatesData?.enabled ) {
 	registerPlugin( 'ai-editorial-updates', {

--- a/src/experiments/excerpt-generation/index.tsx
+++ b/src/experiments/excerpt-generation/index.tsx
@@ -19,6 +19,13 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import ExcerptGeneration from './components/ExcerptGeneration';
 import ExcerptInlineWrapper from './components/ExcerptInlineWrapper';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Excerpt Generation',
+	description: 'Generates a post excerpt from the post body using AI.',
+	abilitySlug: 'ai/excerpt-generation',
+} );
 
 /**
  * Plugin component that adds a generate button to the excerpt panel.

--- a/src/experiments/meta-description/index.tsx
+++ b/src/experiments/meta-description/index.tsx
@@ -14,6 +14,13 @@ import { __ } from '@wordpress/i18n';
  */
 import MetaDescriptionPanel from './components/MetaDescriptionPanel';
 import './index.scss';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Meta Description',
+	description: 'Generates an SEO meta description for the post using AI.',
+	abilitySlug: 'ai/meta-description',
+} );
 
 import type { MetaDescriptionData } from './types';
 

--- a/src/experiments/summarization/index.tsx
+++ b/src/experiments/summarization/index.tsx
@@ -16,6 +16,13 @@ import { registerPlugin } from '@wordpress/plugins';
 import SummarizationPlugin from './components/SummarizationPlugin';
 import SummarizationBlockControls from './components/SummarizationBlockControls';
 import './index.scss';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Summarization',
+	description: 'Generates a summary of the current post content using AI.',
+	abilitySlug: 'ai/summarization',
+} );
 
 // Register the plugin.
 registerPlugin( 'classifai-plugin-summarization', {

--- a/src/experiments/title-generation/index.tsx
+++ b/src/experiments/title-generation/index.tsx
@@ -16,6 +16,13 @@ import { registerPlugin } from '@wordpress/plugins';
 import './index.scss';
 import TitleToolbar from './components/TitleToolbar';
 import { TitleToolbarWrapper } from './components/TitleToolbarWrapper';
+import { exposeToDevTools } from '../../utils/devtools';
+
+exposeToDevTools( {
+	name: 'Title Generation',
+	description: 'Generates a post title from the post content using AI.',
+	abilitySlug: 'ai/title-generation',
+} );
 
 // For template preview mode (when title is a block)
 // Use filter to add toolbar to post-title block

--- a/src/features/image-generation/index.ts
+++ b/src/features/image-generation/index.ts
@@ -5,7 +5,15 @@
 /**
  * Internal dependencies
  */
+import { exposeToDevTools } from '../../utils/devtools';
 import './featured-image';
 import './media-library';
 import './media-library-editor';
 import './inline';
+
+exposeToDevTools( {
+	name: 'Image Generation',
+	description:
+		'Generates images from text prompts and inserts them into posts, media library, or as featured images.',
+	abilitySlug: 'ai/image-generation',
+} );

--- a/src/utils/devtools/index.ts
+++ b/src/utils/devtools/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Chrome DevTools 3P Tools bootstrap.
+ *
+ * Listens for the devtoolstooldiscovery event and registers the AI plugin
+ * ToolGroup. A window-level guard ensures the listener is registered exactly
+ * once even when multiple feature bundles load on the same page.
+ *
+ * @see https://developer.chrome.com/blog/devtools-for-agents-3p-tools
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getToolGroup } from './tools';
+
+export { exposeToDevTools } from './registry';
+
+// Extend Window to declare the bootstrap flag and the Chrome DevTools MCP runtime.
+declare global {
+	interface Window {
+		__aiDevToolsBootstrapped?: boolean;
+	}
+}
+
+// The devtoolstooldiscovery event carries a respondWith method.
+interface DevToolsToolDiscoveryEvent extends Event {
+	respondWith: ( toolGroup: ReturnType< typeof getToolGroup > ) => void;
+}
+
+if ( ! window.__aiDevToolsBootstrapped ) {
+	window.__aiDevToolsBootstrapped = true;
+
+	window.addEventListener( 'devtoolstooldiscovery', ( event: Event ) => {
+		const discoveryEvent = event as DevToolsToolDiscoveryEvent;
+		discoveryEvent.respondWith( getToolGroup() );
+	} );
+}

--- a/src/utils/devtools/registry.ts
+++ b/src/utils/devtools/registry.ts
@@ -1,0 +1,57 @@
+/**
+ * Feature capability registry for Chrome DevTools 3P Tools.
+ *
+ * Uses window.__aiFeatures as the backing store so registrations from
+ * multiple separate webpack bundles are all visible to the single DevTools
+ * listener that is registered by whichever bundle loads first.
+ */
+
+export interface DevToolsRegistration {
+	name: string;
+	description: string;
+	abilitySlug: string;
+}
+
+declare global {
+	interface Window {
+		__aiFeatures?: DevToolsRegistration[];
+	}
+}
+
+/**
+ * Returns the store of registered features.
+ *
+ * @since x.x.x
+ * @return {DevToolsRegistration[]} List of registered feature registrations.
+ */
+function getStore(): DevToolsRegistration[] {
+	if ( ! window.__aiFeatures ) {
+		window.__aiFeatures = [];
+	}
+	return window.__aiFeatures;
+}
+
+/**
+ * Registers an AI feature so it appears in the get_ai_capabilities DevTools tool.
+ *
+ * Call this once from the feature's entry point at module level.
+ *
+ * @since x.x.x
+ * @param {DevToolsRegistration} registration The feature metadata.
+ */
+export function exposeToDevTools( registration: DevToolsRegistration ): void {
+	const store = getStore();
+	if ( ! store.find( ( e ) => e.abilitySlug === registration.abilitySlug ) ) {
+		store.push( registration );
+	}
+}
+
+/**
+ * Returns all registered features.
+ *
+ * @since x.x.x
+ * @return {DevToolsRegistration[]} List of registered AI feature registrations.
+ */
+export function getDevToolsRegistrations(): DevToolsRegistration[] {
+	return getStore();
+}

--- a/src/utils/devtools/store.ts
+++ b/src/utils/devtools/store.ts
@@ -1,0 +1,133 @@
+/**
+ * In-memory ring buffer of AI request records for Chrome DevTools 3P Tools.
+ *
+ * Uses window.__aiRequestLog as the backing store so records written by any
+ * feature bundle are visible to the single DevTools listener registered by
+ * whichever bundle loads first.
+ */
+
+export interface AIRequestRecord {
+	id: string;
+	ability: string;
+	input: unknown;
+	output: unknown;
+	status: 'pending' | 'success' | 'error';
+	startedAt: string;
+	durationMs: number | null;
+	error: string | null;
+}
+
+declare global {
+	interface Window {
+		__aiRequestLog?: AIRequestRecord[];
+		__aiRequestLogNextId?: number;
+	}
+}
+
+const MAX_RECORDS = 50;
+
+/**
+ * Returns the store of request records.
+ *
+ * @since x.x.x
+ * @return {AIRequestRecord[]} List of request records.
+ */
+function getRecords(): AIRequestRecord[] {
+	if ( ! window.__aiRequestLog ) {
+		window.__aiRequestLog = [];
+	}
+	return window.__aiRequestLog;
+}
+
+/**
+ * Returns the next request record ID.
+ *
+ * @since x.x.x
+ * @return {string} The next request record ID.
+ */
+function nextId(): string {
+	if ( ! window.__aiRequestLogNextId ) {
+		window.__aiRequestLogNextId = 1;
+	}
+	return String( window.__aiRequestLogNextId++ );
+}
+
+/**
+ * Records the start of an ability execution.
+ *
+ * @since x.x.x
+ * @param {string}  ability The ability slug being executed.
+ * @param {unknown} input   The input passed to the ability.
+ * @return {string} The record ID, used to complete or error the record.
+ */
+export function recordStart( ability: string, input: unknown ): string {
+	const id = nextId();
+
+	const record: AIRequestRecord = {
+		id,
+		ability,
+		input,
+		output: null,
+		status: 'pending',
+		startedAt: new Date().toISOString(),
+		durationMs: null,
+		error: null,
+	};
+
+	const log = getRecords();
+	log.push( record );
+
+	if ( log.length > MAX_RECORDS ) {
+		log.shift();
+	}
+
+	return id;
+}
+
+/**
+ * Marks a pending record as successfully completed.
+ *
+ * @since x.x.x
+ * @param {string}  id     The record ID returned by recordStart.
+ * @param {unknown} output The ability response.
+ */
+export function recordComplete( id: string, output: unknown ): void {
+	const record = getRecords().find( ( r: AIRequestRecord ) => r.id === id );
+	if ( ! record ) {
+		return;
+	}
+	record.output = output;
+	record.status = 'success';
+	record.durationMs =
+		new Date().getTime() - new Date( record.startedAt ).getTime();
+}
+
+/**
+ * Marks a pending record as failed.
+ *
+ * @since x.x.x
+ * @param {string} id    The record ID returned by recordStart.
+ * @param {string} error The error message.
+ */
+export function recordError( id: string, error: string ): void {
+	const record = getRecords().find( ( r: AIRequestRecord ) => r.id === id );
+	if ( ! record ) {
+		return;
+	}
+	record.status = 'error';
+	record.error = error;
+	record.durationMs =
+		new Date().getTime() - new Date( record.startedAt ).getTime();
+}
+
+/**
+ * Returns recent records in reverse-chronological order.
+ *
+ * @since x.x.x
+ * @param {number} limit Maximum number of records to return (1–50).
+ * @return {AIRequestRecord[]} List of AI request records.
+ */
+export function getHistory( limit: number = 10 ): AIRequestRecord[] {
+	const clamped = Math.min( Math.max( limit, 1 ), MAX_RECORDS );
+	return getRecords().slice( -clamped ).reverse();
+}

--- a/src/utils/devtools/tools.ts
+++ b/src/utils/devtools/tools.ts
@@ -1,0 +1,143 @@
+/**
+ * Chrome DevTools 3P tool definitions for the AI plugin.
+ *
+ * Exposes two tools:
+ *   - get_ai_capabilities: lists registered AI features on the page
+ *   - get_ai_request_history: returns the in-page AI request log
+ */
+
+/**
+ * Internal dependencies
+ */
+import { getHistory } from './store';
+import { getDevToolsRegistrations } from './registry';
+import type { AIRequestRecord } from './store';
+
+// Minimal typings for the Chrome DevTools 3P Tools API (no @types package yet).
+export interface ToolDefinition {
+	name: string;
+	description: string;
+	inputSchema: object;
+	execute: ( args: Record< string, unknown > ) => unknown;
+}
+
+export interface ToolGroup {
+	name: string;
+	description: string;
+	tools: ToolDefinition[];
+}
+
+type FeatureStatus = 'idle' | 'loading' | 'error';
+
+interface CapabilityEntry {
+	name: string;
+	description: string;
+	abilitySlug: string;
+	status: FeatureStatus;
+}
+
+/**
+ * Derives the current status of a feature from the request log.
+ *
+ * @since x.x.x
+ * @param {string} abilitySlug The ability slug to check.
+ * @return {FeatureStatus} Current status for the feature.
+ */
+function deriveStatus( abilitySlug: string ): FeatureStatus {
+	// Get all records for this slug (most recent last).
+	const matching = getHistory( 50 ).filter(
+		( r: AIRequestRecord ) => r.ability === abilitySlug
+	);
+
+	if ( matching.length === 0 ) {
+		return 'idle';
+	}
+
+	// getHistory returns newest-first, so matching[0] is the most recent.
+	const latest = matching[ 0 ];
+
+	if ( latest?.status === 'pending' ) {
+		return 'loading';
+	}
+	if ( latest?.status === 'error' ) {
+		return 'error';
+	}
+	return 'idle';
+}
+
+const getAiCapabilities: ToolDefinition = {
+	name: 'get_ai_capabilities',
+	description:
+		'Lists the AI features registered on this page, including their name, description, ability slug, and current status (idle/loading/error).',
+	inputSchema: {
+		type: 'object',
+		properties: {},
+	},
+	execute: () => {
+		const registered = getDevToolsRegistrations();
+		const seenSlugs = new Set< string >(
+			registered.map( ( f ) => f.abilitySlug )
+		);
+
+		const features: CapabilityEntry[] = registered.map( ( f ) => ( {
+			name: f.name,
+			description: f.description,
+			abilitySlug: f.abilitySlug,
+			status: deriveStatus( f.abilitySlug ),
+		} ) );
+
+		// Include unregistered abilities that have run.
+		for ( const record of getHistory( 50 ) ) {
+			if ( ! seenSlugs.has( record.ability ) ) {
+				seenSlugs.add( record.ability );
+				features.push( {
+					name: record.ability,
+					description: record.ability,
+					abilitySlug: record.ability,
+					status: deriveStatus( record.ability ),
+				} );
+			}
+		}
+
+		return { features };
+	},
+};
+
+const getAiRequestHistory: ToolDefinition = {
+	name: 'get_ai_request_history',
+	description:
+		'Returns recent AI ability calls made on this page, including the ability slug, input, output, duration, and status.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			limit: {
+				type: 'integer',
+				minimum: 1,
+				maximum: 50,
+				default: 10,
+				description: 'Maximum number of records to return.',
+			},
+		},
+	},
+	execute: ( args ) => {
+		const { limit } = args as { limit?: number };
+		return {
+			requests: getHistory( typeof limit === 'number' ? limit : 10 ),
+		};
+	},
+};
+
+/**
+ * Returns the ToolGroup to register with Chrome DevTools.
+ *
+ * @since x.x.x
+ * @return {ToolGroup} The ToolGroup for the AI plugin.
+ */
+export function getToolGroup(): ToolGroup {
+	return {
+		name: 'WordPress AI Plugin',
+		description:
+			'Inspect AI feature capabilities and request history for the WordPress AI Plugin.',
+		tools: [ getAiCapabilities, getAiRequestHistory ],
+	};
+}

--- a/src/utils/run-ability.ts
+++ b/src/utils/run-ability.ts
@@ -11,6 +11,11 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
+/**
+ * Internal dependencies
+ */
+import { recordStart, recordComplete, recordError } from './devtools/store';
+
 type AbilityInput =
 	| Record< string, unknown >
 	| Array< unknown >
@@ -122,6 +127,26 @@ const buildFetchOptions = (
 };
 
 export async function runAbility< T = unknown >(
+	ability: string,
+	input?: AbilityInput,
+	options?: RunAbilityOptions
+): Promise< T > {
+	const recordId = recordStart( ability, input );
+
+	try {
+		const result = await runAbilityInternal< T >( ability, input, options );
+		recordComplete( recordId, result );
+		return result;
+	} catch ( error ) {
+		recordError(
+			recordId,
+			error instanceof Error ? error.message : String( error )
+		);
+		throw error;
+	}
+}
+
+async function runAbilityInternal< T = unknown >(
 	ability: string,
 	input?: AbilityInput,
 	options?: RunAbilityOptions


### PR DESCRIPTION
## What?

Add a third-party integration with Chrome DevTools for agents that exposes the available AI Features and a lightweight log of which Features have recently run.

## Why?

Chrome DevTools for agents recently [added support](https://developer.chrome.com/blog/devtools-for-agents-3p-tools) for third-party integrations. This PR adds a fairly basic integration there to prove out the concept with the potential to expand the capabilities further in the future.

The two tools we expose are `get_ai_capabilities` and `get_ai_request_history`. The former will list out any available AI Features on the current page and the latter will give you a lightweight log of any Features that have been ran within that session.

## How?

- Introduce a new `exposeToDevTools` function and have all of our features run this
- Add a lightweight store system to track available features and a log of which features have run
- Register two tools with Chrome DevTools: `get_ai_capabilities` and `get_ai_request_history`
- Anytime an Ability runs, track which Ability was used and how long it took to run, as well as the input and output data, so we can put this in our log

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Reviewing the Chrome DevTools for agents documentation, proposing a plan and executing on that plan. Code reviewed, refined and tested by me

## Testing Instructions

Instructions using Claude Code + Chrome DevTools MCP

  1. Install the MCP server

  Add to your Claude Code MCP config:
```
{
  "mcpServers": {
    "chrome-devtools": {
      "command": "npx",
      "args": ["chrome-devtools-mcp@latest", "--categoryExperimentalThirdParty=true"]
    }
  }
}
```
  Restart Claude Code after saving.

  2. Ask Claude to navigate to the post editor:

   > Open Chrome and navigate to https://example.com/wp-admin/post.php?post=1&action=edit

Provide your username and password or manually log in

  3. In a Claude Code session, ask:

   > List the available developer tools on the current page accessible by Chrome DevTools

  Claude will call `list_3p_developer_tools`. You should see two tools: `get_ai_capabilities` and
  `get_ai_request_history`

  4. Ask:

  > Invoke get_ai_capabilities

  Will show all available Features accessible on that page

  5. Trigger an AI action

  If the post you're on has no content, add at least 50 words of content to the post body, then click "Generate excerpt" in the post settings sidebar and wait for it to complete.

  6. Ask:

  > Invoke get_ai_request_history

  Expect one record showing ability: "ai/excerpt-generation", status: "success", the input content, the generated excerpt, and a durationMs value.

## Changelog Entry

> Added - Expose two tools to Chrome DevTools for agents, `get_ai_capabilities` and `get_ai_request_history`, that can be triggered via the Chrome DevTools for agents MCP integration

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-760-e8836baca749c8323fce4ec7ad6389718af464bf.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->