### PR TITLE
E2E[Content Summarization]: Prefer user-facing attributes

### DIFF
--- a/src/experiments/summarization/components/SummarizationPlugin.tsx
+++ b/src/experiments/summarization/components/SummarizationPlugin.tsx
@@ -9,6 +9,7 @@ import { Button, Flex, FlexItem } from '@wordpress/components';
 import { PluginPostStatusInfo } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import { update } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -29,6 +30,11 @@ export default function SummarizationPlugin() {
 		isContentTooShort,
 		minContentLength,
 	} = useSummaryGeneration();
+
+	const descriptionId = useInstanceId(
+		SummarizationPlugin,
+		'ai-summarization-plugin-description'
+	);
 
 	let buttonLabel: string = __( 'Generate Summary', 'ai' );
 
@@ -90,13 +96,16 @@ export default function SummarizationPlugin() {
 						onClick={ handleSummarize }
 						disabled={ isDisabled }
 						isBusy={ isSummarizing }
+						aria-describedby={ descriptionId }
 						__next40pxDefaultSize
 					>
 						{ buttonLabel }
 					</Button>
 				</FlexItem>
 				<FlexItem>
-					<span className="description">{ buttonDescription }</span>
+					<span id={ descriptionId } className="description">
+						{ buttonDescription }
+					</span>
 				</FlexItem>
 			</Flex>
 		</PluginPostStatusInfo>

--- a/tests/e2e/specs/experiments/content-summarization.spec.js
+++ b/tests/e2e/specs/experiments/content-summarization.spec.js
@@ -60,16 +60,23 @@ test.describe( 'Content Summarization Experiment', () => {
 		// Click the Generate Summary button.
 		await generateButton.click();
 
-		// Ensure the generated summary is inserted and contains the expected text.
+		const summaryBlock = editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Content Summary',
+			} )
+			.first();
+
+		// Ensure the summary block is visible.
+		await expect( summaryBlock ).toBeVisible();
+
+		// Ensure the summary content is inside a paragraph within the group.
+		await expect( summaryBlock ).toContainClass( 'wp-block-group' );
+
 		await expect(
-			editor.canvas
-				.getByRole( 'document', {
-					name: 'Block: Content Summary',
-				} )
-				.filter( {
-					hasText:
-						'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
-				} )
+			summaryBlock.locator( 'p', {
+				hasText:
+					'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
+			} )
 		).toBeVisible();
 
 		// Ensure the sidebar is visible and on the Post tab.
@@ -116,6 +123,7 @@ test.describe( 'Content Summarization Experiment', () => {
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Generate Summary',
+				exact: true,
 			} )
 		).not.toBeVisible();
 	} );
@@ -146,6 +154,7 @@ test.describe( 'Content Summarization Experiment', () => {
 
 		const generateButton = page.getByRole( 'button', {
 			name: 'Generate Summary',
+			exact: true,
 		} );
 
 		// Button should be visible but disabled.
@@ -185,6 +194,7 @@ test.describe( 'Content Summarization Experiment', () => {
 
 		const generateButton = page.getByRole( 'button', {
 			name: 'Generate Summary',
+			exact: true,
 		} );
 
 		// Button should be visible and enabled.
@@ -226,6 +236,7 @@ test.describe( 'Content Summarization Experiment', () => {
 		await expect(
 			page.getByRole( 'button', {
 				name: 'Generate Summary',
+				exact: true,
 			} )
 		).not.toBeVisible();
 	} );

--- a/tests/e2e/specs/experiments/content-summarization.spec.js
+++ b/tests/e2e/specs/experiments/content-summarization.spec.js
@@ -51,40 +51,37 @@ test.describe( 'Content Summarization Experiment', () => {
 		await editor.openDocumentSettingsSidebar();
 
 		// Ensure the Generate Summary button exists, is visible, and has the correct text.
-		const generateButton = page.locator(
-			'.ai-summarization-plugin-container button'
-		);
+		const generateButton = page.getByRole( 'button', {
+			name: 'Generate Summary',
+			exact: true,
+		} );
 		await expect( generateButton ).toBeVisible();
-		await expect( generateButton ).toHaveText( 'Generate Summary' );
 
 		// Click the Generate Summary button.
 		await generateButton.click();
 
-		// Ensure the generated summary is inserted as a group block.
+		// Ensure the generated summary is inserted and contains the expected text.
 		await expect(
-			editor.canvas.locator( '.wp-block-group.ai-summarization-summary' )
-		).toBeVisible();
-
-		// Ensure the summary content is inside a paragraph within the group.
-		await expect(
-			editor.canvas.locator(
-				'.wp-block-group.ai-summarization-summary p',
-				{
+			editor.canvas
+				.getByRole( 'document', {
+					name: 'Block: Content Summary',
+				} )
+				.filter( {
 					hasText:
 						'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
-				}
-			)
+				} )
 		).toBeVisible();
 
 		// Ensure the sidebar is visible and on the Post tab.
 		await editor.openDocumentSettingsSidebar();
-		await page
-			.locator( '.editor-sidebar__panel-tabs button:has-text("Post")' )
-			.click();
+		await page.getByRole( 'tab', { name: 'Post' } ).click();
 
-		// Ensure the Generate Summary button text is updated.
-		await expect( generateButton ).toBeVisible();
-		await expect( generateButton ).toHaveText( 'Regenerate Summary' );
+		// Ensure the Regenerate Summary button is visible.
+		await expect(
+			page
+				.getByRole( 'button', { name: 'Regenerate Summary' } )
+				.filter( { hasText: 'Regenerate Summary' } )
+		).toBeVisible();
 
 		// Save the post.
 		await editor.saveDraft();
@@ -117,7 +114,9 @@ test.describe( 'Content Summarization Experiment', () => {
 
 		// Ensure the Generate Summary button doesn't exist.
 		await expect(
-			page.locator( '.ai-summarization-plugin-container button' )
+			page.getByRole( 'button', {
+				name: 'Generate Summary',
+			} )
 		).not.toBeVisible();
 	} );
 
@@ -145,18 +144,18 @@ test.describe( 'Content Summarization Experiment', () => {
 		// Ensure the sidebar is visible.
 		await editor.openDocumentSettingsSidebar();
 
-		const generateButton = page.locator(
-			'.ai-summarization-plugin-container button'
-		);
+		const generateButton = page.getByRole( 'button', {
+			name: 'Generate Summary',
+		} );
 
 		// Button should be visible but disabled.
 		await expect( generateButton ).toBeVisible();
 		await expect( generateButton ).toBeDisabled();
 
 		// The descriptive text should explain when the button will be enabled.
-		await expect(
-			page.locator( '.ai-summarization-plugin-container .description' )
-		).toContainText( '50 words' );
+		await expect( generateButton ).toHaveAccessibleDescription(
+			/50 words?/i
+		);
 	} );
 
 	test( 'Summarize button is enabled when content meets the minimum length', async ( {
@@ -184,18 +183,18 @@ test.describe( 'Content Summarization Experiment', () => {
 		// Ensure the sidebar is visible.
 		await editor.openDocumentSettingsSidebar();
 
-		const generateButton = page.locator(
-			'.ai-summarization-plugin-container button'
-		);
+		const generateButton = page.getByRole( 'button', {
+			name: 'Generate Summary',
+		} );
 
 		// Button should be visible and enabled.
 		await expect( generateButton ).toBeVisible();
 		await expect( generateButton ).toBeEnabled();
 
 		// The descriptive text should NOT mention the minimum word requirement.
-		await expect(
-			page.locator( '.ai-summarization-plugin-container .description' )
-		).not.toContainText( 'words' );
+		await expect( generateButton ).not.toHaveAccessibleDescription(
+			/words?/i
+		);
 	} );
 
 	test( 'Ensure the Content Summarization Experiment UI is not visible when the experiment is disabled', async ( {
@@ -225,7 +224,9 @@ test.describe( 'Content Summarization Experiment', () => {
 
 		// Ensure the Generate Summary button doesn't exist.
 		await expect(
-			page.locator( '.ai-summarization-plugin-container button' )
+			page.getByRole( 'button', {
+				name: 'Generate Summary',
+			} )
 		).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What, Why, and How?

Playwright recommends using user-facing locators (example, `getByRole`) instead of CSS classes or DOM-structure selectors wherever possible. This is because CSS classes and markup structure are implementation details that can change during design or refactoring without changing the actual user experience, which can make tests fail even though the feature still works ([Docs](https://playwright.dev/docs/best-practices#prefer-user-facing-attributes-to-xpath-or-css-selectors)).

This PR updates the content summarization E2E spec to follow the Playwright best practices by replacing hard-coded `page.locator(...)` calls with role-based locators. This should make the test less brittle because it now targets the UI the way a user, or assistive technology, understands it rather than depending on implementation details.

Apart from making the test more resilient to CSS and markup changes, this also makes the assertions easier to read and understand. For example:

```js
// Before:
await page
	.locator( '.editor-sidebar__panel-tabs button:has-text("Post")' )
	.click();

// After:
await page.getByRole( 'tab', { name: 'Post' } ).click();
```

_**Note:** This PR deliberately scopes the change to the Content Summarization E2E spec only. If we agree this approach is preferable for the reasons above, we can apply it to other E2E specs incrementally, a few modules at a time._

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review

## Testing Instructions
CI should be green.

## Changelog Entry
> Changed - Updated Content Summarization E2E selectors to use Playwright user-facing attributes

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-762-cab0bd59f78ff498875f6915e63c0972f4156c5f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->