### PR TITLE
E2E[Title Generation|Editorial Notes]: Prefer user-facing attributes

### DIFF
--- a/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
+++ b/src/experiments/editorial-notes/components/EditorialNotesPlugin.tsx
@@ -22,6 +22,7 @@ import { PluginPostStatusInfo } from '@wordpress/editor';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { commentContent } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -63,6 +64,11 @@ export default function EditorialNotesPlugin() {
 		return ( select( blockEditorStore ) as any ).getSettings()
 			.isPreviewMode;
 	}, [] );
+
+	const descriptionId = useInstanceId(
+		EditorialNotesPlugin,
+		'editorial-notes-plugin-description'
+	);
 
 	if ( ! ( window as any ).aiEditorialNotesData?.enabled ) {
 		return null;
@@ -113,13 +119,14 @@ export default function EditorialNotesPlugin() {
 								width: '100%',
 							} }
 							__next40pxDefaultSize
+							aria-describedby={ descriptionId }
 						>
 							{ buttonLabel }
 						</Button>
 					</FlexItem>
 					{ lastRunCount !== null && (
 						<FlexItem>
-							<span className="description">
+							<span className="description" role="status">
 								{ lastRunCount === 0
 									? __( 'No new suggestions found.', 'ai' )
 									: createInterpolateElement(
@@ -149,6 +156,7 @@ export default function EditorialNotesPlugin() {
 					) }
 					<FlexItem>
 						<span
+							id={ descriptionId }
 							className="description"
 							style={ { color: '#757575' } }
 						>

--- a/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
+++ b/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
@@ -9,6 +9,7 @@
  * WordPress dependencies
  */
 import { createRoot, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -309,6 +310,11 @@ function TitleToolbarWrapper(): React.JSX.Element {
 			// Create a container for our toolbar
 			toolbarContainer = editorDoc.createElement( 'div' );
 			toolbarContainer.className = 'ai-title-toolbar-container';
+			toolbarContainer.setAttribute( 'role', 'toolbar' );
+			toolbarContainer.setAttribute(
+				'aria-label',
+				__( 'Generate title toolbar', 'ai' )
+			);
 			toolbarContainer.style.cssText =
 				'display: none; position: absolute; z-index: 1000; top: -60px;';
 

--- a/tests/e2e/specs/experiments/editorial-notes.spec.js
+++ b/tests/e2e/specs/experiments/editorial-notes.spec.js
@@ -58,12 +58,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 		await expect( reviewButton ).toBeVisible();
 		await expect( reviewButton ).toBeDisabled();
 
-		await expect(
-			page.locator( '.description', {
-				hasText:
-					'Editorial Notes will be available when the post content has at least 15 words.',
-			} )
-		).toBeVisible();
+		await expect( reviewButton ).toHaveAccessibleDescription(
+			/Editorial Notes will be available when the post content has at least 15 words./
+		);
 	} );
 
 	test( 'Enables Editorial Notes once the post content meets the minimum length', async ( {
@@ -85,11 +82,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 		await expect( reviewButton ).toBeVisible();
 		await expect( reviewButton ).toBeEnabled();
 
-		await expect(
-			page.locator( '.description', {
-				hasText: 'at least 15 words.',
-			} )
-		).toHaveCount( 0 );
+		await expect( reviewButton ).not.toHaveAccessibleDescription(
+			/at least 15 words./
+		);
 	} );
 
 	test( 'Shows the "Review with AI" button in the block toolbar', async ( {
@@ -113,8 +108,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 
 		// The button should be visible in the block toolbar.
 		await expect(
-			page.locator( 'button', {
-				hasText: 'Generate Editorial Note',
+			page.getByRole( 'menuitem', {
+				name: 'Generate Editorial Note',
+				exact: true,
 			} )
 		).toBeVisible();
 	} );
@@ -173,8 +169,8 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 
 		// Wait for completion and check for suggestion count feedback.
 		await expect(
-			page.locator( '.description', {
-				hasText: '1 suggestion added',
+			page.getByRole( 'status' ).filter( {
+				hasText: /1 suggestion added/,
 			} )
 		).toBeVisible();
 	} );
@@ -202,8 +198,8 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 
 		// Wait for completion and check for suggestion count feedback.
 		await expect(
-			page.locator( '.components-snackbar', {
-				hasText: '1 suggestion added',
+			page.getByTestId( 'snackbar' ).filter( {
+				hasText: /1 suggestion added/,
 			} )
 		).toBeVisible();
 	} );
@@ -225,12 +221,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 		await expect( reviewButton ).toBeDisabled();
 
 		// The descriptive text should explain when the button becomes available.
-		await expect(
-			page.locator( '.description', {
-				hasText:
-					'Editorial Notes will be available when the post content has at least 15 words.',
-			} )
-		).toBeVisible();
+		await expect( reviewButton ).toHaveAccessibleDescription(
+			/Editorial Notes will be available when the post content has at least 15 words./
+		);
 	} );
 
 	test( 'Button is hidden when experiments are globally disabled', async ( {
@@ -265,8 +258,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 
 		// The button should not be visible in the block toolbar.
 		await expect(
-			page.locator( 'button', {
-				hasText: 'Generate Editorial Note',
+			page.getByRole( 'menuitem', {
+				name: 'Generate Editorial Note',
+				exact: true,
 			} )
 		).not.toBeVisible();
 	} );
@@ -303,8 +297,9 @@ test.describe( 'AI Editorial Notes Experiment', () => {
 
 		// The button should be visible in the block toolbar.
 		await expect(
-			page.locator( 'button', {
-				hasText: 'Generate Editorial Note',
+			page.getByRole( 'menuitem', {
+				name: 'Generate Editorial Note',
+				exact: true,
 			} )
 		).not.toBeVisible();
 	} );

--- a/tests/e2e/specs/experiments/title-generation.spec.js
+++ b/tests/e2e/specs/experiments/title-generation.spec.js
@@ -50,44 +50,39 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 
 		// Click into the title field.
-		await editor.canvas.locator( '.editor-post-title__input' ).click();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.click();
 
 		// Ensure the title toolbar is visible with "Generate" label.
 		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container', {
-				hasText: 'Generate',
-			} )
+			editor.canvas.getByRole( 'button', { name: 'Generate' } )
 		).toBeVisible();
 
 		// Click the Generate button.
-		await editor.canvas
-			.locator( '.ai-title-toolbar-container button' )
-			.click();
+		await editor.canvas.getByRole( 'button', { name: 'Generate' } ).click();
+
+		const modal = page.getByRole( 'dialog', {
+			name: 'Title suggestion',
+		} );
 
 		// Ensure the title modal is visible.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).toBeVisible();
+		await expect( modal ).toBeVisible();
 
 		// Ensure the generated title textarea is visible.
 		await expect(
-			page.locator( '.ai-title-generation-modal textarea' )
+			page.getByRole( 'textbox', { name: 'Generated title' } )
 		).toBeVisible();
 
 		// Click Insert to apply the generated title.
-		await page
-			.locator( '.ai-title-generation-modal' )
-			.getByRole( 'button', { name: 'Insert' } )
-			.click();
+		await modal.getByRole( 'button', { name: 'Insert' } ).click();
 
 		// Ensure the title modal is closed.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).not.toBeVisible();
+		await expect( modal ).not.toBeVisible();
 
 		// Ensure the title is updated.
 		await expect(
-			editor.canvas.locator( '.editor-post-title__input' )
+			editor.canvas.getByRole( 'textbox', { name: 'Add Title' } )
 		).toHaveText(
 			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
 			{ timeout: 10000 }
@@ -119,44 +114,41 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 
 		// Click into the title field.
-		await editor.canvas.locator( '.editor-post-title__input' ).click();
-
-		// Ensure the title toolbar is visible with "Regenerate" label.
-		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container', {
-				hasText: 'Regenerate',
-			} )
-		).toBeVisible();
-
-		// Click the Regenerate button.
 		await editor.canvas
-			.locator( '.ai-title-toolbar-container button' )
+			.getByRole( 'textbox', { name: 'Add Title' } )
 			.click();
 
+		const generateTitleToolbar = editor.canvas.getByRole( 'toolbar', {
+			name: 'Generate title toolbar',
+		} );
+
+		// Ensure the title toolbar is visible.
+		await expect( generateTitleToolbar ).toBeVisible();
+
+		// Click the Regenerate button.
+		await generateTitleToolbar
+			.getByRole( 'button', { name: 'Regenerate' } )
+			.click();
+
+		const modal = page.getByRole( 'dialog', { name: 'Title suggestion' } );
+
 		// Ensure the title modal is visible.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).toBeVisible();
+		await expect( modal ).toBeVisible();
 
 		// Ensure the generated title textarea is visible.
 		await expect(
-			page.locator( '.ai-title-generation-modal textarea' )
+			page.getByRole( 'textbox', { name: 'Generated title' } )
 		).toBeVisible();
 
 		// Click Insert to apply the generated title.
-		await page
-			.locator( '.ai-title-generation-modal' )
-			.getByRole( 'button', { name: 'Insert' } )
-			.click();
+		await modal.getByRole( 'button', { name: 'Insert' } ).click();
 
 		// Ensure the title modal is closed.
-		await expect(
-			page.locator( '.ai-title-generation-modal' )
-		).not.toBeVisible();
+		await expect( modal ).not.toBeVisible();
 
 		// Ensure the title is updated.
 		await expect(
-			editor.canvas.locator( '.editor-post-title__input' )
+			editor.canvas.getByRole( 'textbox', { name: 'Add Title' } )
 		).toHaveText(
 			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure',
 			{ timeout: 10000 }
@@ -188,18 +180,22 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 
 		// Click into the title field to reveal the toolbar.
-		await editor.canvas.locator( '.editor-post-title__input' ).click();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.click();
+
+		const generateTitleToolbar = editor.canvas.getByRole( 'toolbar', {
+			name: 'Generate title toolbar',
+		} );
 
 		// The toolbar is visible with the "Generate" label.
-		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container', {
-				hasText: 'Generate',
-			} )
-		).toBeVisible();
+		await expect( generateTitleToolbar ).toBeVisible();
 
 		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container button' )
-		).toHaveAttribute( 'aria-disabled', 'true' );
+			generateTitleToolbar
+				.getByRole( 'button' )
+				.filter( { hasText: 'Generate' } )
+		).toBeDisabled();
 	} );
 
 	test( 'Ensure the Title Generation Experiment UI is not visible when Experiments are globally disabled', async ( {
@@ -225,11 +221,15 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 
 		// Click into the title field.
-		await editor.canvas.locator( '.editor-post-title__input' ).click();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.click();
 
 		// Ensure the title toolbar is not there.
 		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container' )
+			editor.canvas.getByRole( 'toolbar', {
+				name: 'Generate title toolbar',
+			} )
 		).not.toBeVisible();
 	} );
 
@@ -256,11 +256,15 @@ test.describe( 'Title Generation Experiment', () => {
 		await editor.saveDraft();
 
 		// Click into the title field.
-		await editor.canvas.locator( '.editor-post-title__input' ).click();
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add Title' } )
+			.click();
 
 		// Ensure the title toolbar is not there.
 		await expect(
-			editor.canvas.locator( '.ai-title-toolbar-container' )
+			editor.canvas.getByRole( 'toolbar', {
+				name: 'Generate title toolbar',
+			} )
 		).not.toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/experiments/title-generation.spec.js
+++ b/tests/e2e/specs/experiments/title-generation.spec.js
@@ -54,13 +54,19 @@ test.describe( 'Title Generation Experiment', () => {
 			.getByRole( 'textbox', { name: 'Add Title' } )
 			.click();
 
+		const generateTitleToolbar = editor.canvas.getByRole( 'toolbar', {
+			name: 'Generate title toolbar',
+		} );
+
 		// Ensure the title toolbar is visible with "Generate" label.
 		await expect(
-			editor.canvas.getByRole( 'button', { name: 'Generate' } )
+			generateTitleToolbar.filter( { hasText: 'Generate' } )
 		).toBeVisible();
 
 		// Click the Generate button.
-		await editor.canvas.getByRole( 'button', { name: 'Generate' } ).click();
+		await generateTitleToolbar
+			.getByRole( 'button', { name: 'Generate' } )
+			.click();
 
 		const modal = page.getByRole( 'dialog', {
 			name: 'Title suggestion',


### PR DESCRIPTION
## What, Why, and How?

Follow-up to https://github.com/WordPress/ai/pull/762
Part of https://github.com/WordPress/ai/issues/778

Playwright recommends using user-facing locators (example, `getByRole`) instead of CSS classes or DOM-structure selectors wherever possible. This is because CSS classes and markup structure are implementation details that can change during design or refactoring without changing the actual user experience, which can make tests fail even though the feature still works ([Docs](https://playwright.dev/docs/best-practices#prefer-user-facing-attributes-to-xpath-or-css-selectors)).

This PR updates the Title Generation and Editorial Notes E2E spec to follow the Playwright best practices by replacing hard-coded `page.locator(...)` calls with role-based locators wherever possible. This should make the test less brittle because it now targets the UI the way a user, or assistive technology, understands it rather than depending on implementation details.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review

## Testing Instructions
CI Should be green.

## Changelog Entry

> Developer - Updated Title Generation and Editorial Notes E2E selectors to use Playwright user-facing attributes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-773-b28205bb817ce99e8ad9d3041c0c078445cb5291.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->