### PR TITLE
New Ability: core/read-users

### DIFF
--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -750,6 +750,7 @@ final class Users {
 			),
 			'user_registered' => array(
 				'type'        => 'string',
+				'format'      => 'date-time',
 				'description' => __( 'Registration date for the user. Present when the current user can view it.', 'ai' ),
 			),
 			'roles'           => array(
@@ -861,7 +862,7 @@ final class Users {
 				$data['locale'] = (string) get_user_locale( $user );
 			}
 			if ( $fields_requested( 'user_registered' ) ) {
-				$data['user_registered'] = (string) $user->user_registered;
+				$data['user_registered'] = gmdate( 'c', strtotime( $user->user_registered ) );
 			}
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -1,0 +1,886 @@
+<?php
+/**
+ * The `core/users` WordPress Ability.
+ *
+ * @package WordPress\AI
+ *
+ * @since x.x.x
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Abilities\Users;
+
+use WP_Error;
+use WP_User;
+use WP_User_Query;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class - Users
+ *
+ * Registers the read-only `core/users` ability, which retrieves one or more
+ * readable WordPress users. Supports fetching a single readable user by ID,
+ * email, username, or slug, or querying a paginated collection optionally
+ * filtered by roles or published-post authorship. Field-level access is enforced
+ * per user by omitting fields the current user cannot view.
+ *
+ * This class is kept almost identical to the WordPress core class `WP_Users_Abilities`
+ * so the two implementations stay in sync. Differences from the core class are marked with
+ * `// Plugin:` comments. Additionally, all user-facing strings use the 'ai' text domain.
+ *
+ * Plugin: the class is final and instance-based (with private helpers), matching the
+ * plugin's other ability classes (e.g. `Settings`) and core's `WP_Settings_Abilities`.
+ *
+ * @internal This class should not be used outside the plugin and there is no guarantee of backwards compatibility.
+ *
+ * @since x.x.x
+ */
+final class Users {
+
+	/**
+	 * The ability category used for user abilities.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	private const CATEGORY = 'user';
+
+	/**
+	 * Default number of users returned per page in collection mode.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private const DEFAULT_PER_PAGE = 10;
+
+	/**
+	 * Maximum number of users returned per page in collection mode.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private const MAX_PER_PAGE = 100;
+
+	/**
+	 * Public/read-context user fields.
+	 *
+	 * @since x.x.x
+	 * @var string[]
+	 */
+	private array $read_fields = array(
+		'id',
+		'display_name',
+		'description',
+		'url',
+		'link',
+		'slug',
+	);
+
+	/**
+	 * Fields that expose edit-context user data.
+	 *
+	 * @since x.x.x
+	 * @var string[]
+	 */
+	private array $sensitive_fields = array(
+		'username',
+		'email',
+		'first_name',
+		'last_name',
+		'nickname',
+		'locale',
+		'registered_date',
+	);
+
+	/**
+	 * Hooks the ability into the Abilities API.
+	 *
+	 * Plugin: this method has no equivalent in the core class. In core, register() is
+	 * invoked directly from wp_register_core_abilities() (already on the
+	 * `wp_abilities_api_init` hook). The plugin instead hooks register() slightly later
+	 * (priority 11) so it can override any core-provided copy, and registers the category
+	 * as a fallback in case core has not.
+	 *
+	 * @since x.x.x
+	 */
+	public function init(): void {
+		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_category' ), 11 );
+		add_action( 'wp_abilities_api_init', array( $this, 'register' ), 11 );
+	}
+
+	/**
+	 * Registers the `user` ability category if it is not already registered.
+	 *
+	 * Plugin: this method has no equivalent in the core class; core relies on
+	 * wp_register_core_ability_categories() to register the `user` category.
+	 *
+	 * @since x.x.x
+	 */
+	public function register_category(): void {
+		if ( wp_has_ability_category( self::CATEGORY ) ) {
+			return;
+		}
+
+		wp_register_ability_category(
+			self::CATEGORY,
+			array(
+				'label'       => __( 'Users', 'ai' ),
+				'description' => __( 'Abilities that retrieve or manage WordPress users.', 'ai' ),
+			)
+		);
+	}
+
+	/**
+	 * Registers all user abilities.
+	 *
+	 * Must run on the `wp_abilities_api_init` hook.
+	 *
+	 * @since x.x.x
+	 */
+	public function register(): void {
+		$this->register_get_users();
+	}
+
+	/**
+	 * Registers the read-only `core/users` ability.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_get_users(): void {
+		// Plugin: unregister any core-provided copy first so the plugin's version wins.
+		if ( wp_has_ability( 'core/users' ) ) {
+			wp_unregister_ability( 'core/users' );
+		}
+
+		wp_register_ability(
+			'core/users',
+			array(
+				'label'               => __( 'Get Users', 'ai' ),
+				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, email, username, or slug, or query a paginated collection optionally filtered by roles or published-post authorship.', 'ai' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => $this->get_users_input_schema(),
+				'output_schema'       => $this->get_users_output_schema(),
+				'execute_callback'    => array( $this, 'execute_get_users' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					),
+					'show_in_rest' => true,
+					'pagination'   => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Permission callback for the `core/users` ability.
+	 *
+	 * Implements defense in depth: this gate decides whether the request may proceed at
+	 * all, while the per-user read checks in {@see self::execute_get_users()} are the
+	 * authoritative, row-level enforcement.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return bool True if the request may proceed, false otherwise.
+	 */
+	public function check_permission( $input = array() ): bool {
+		$input = is_array( $input ) ? $input : array();
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		if ( ! empty( $input['roles'] ) && ! current_user_can( 'list_users' ) ) {
+			return false;
+		}
+
+		$lookup_type = $this->get_lookup_type( $input );
+		if ( '' === $lookup_type ) {
+			return true;
+		}
+
+		$user = $this->find_user( $input );
+		if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
+			return false;
+		}
+
+		return $this->can_read_user_for_lookup( $user, $lookup_type );
+	}
+
+	/**
+	 * Executes the `core/users` ability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return array<string, mixed>|\WP_Error A map with a `users` list, or a WP_Error on failure.
+	 */
+	public function execute_get_users( $input = array() ) {
+		$input  = is_array( $input ) ? $input : array();
+		$fields = $this->normalize_fields( $input );
+
+		$lookup_type = $this->get_lookup_type( $input );
+		if ( '' !== $lookup_type ) {
+			$user = $this->find_user( $input );
+			if ( ! $user instanceof WP_User
+				|| ! $this->is_user_member_of_site( $user )
+				|| ! $this->can_read_user_for_lookup( $user, $lookup_type )
+			) {
+				return $this->not_found_error();
+			}
+
+			return array(
+				'users'       => array( $this->format_user( $user, $fields ) ),
+				'total'       => 1,
+				'total_pages' => 1,
+			);
+		}
+
+		$per_page = $this->normalize_per_page( $input );
+		$page     = isset( $input['page'] ) ? max( 1, $this->input_int( $input['page'] ) ) : 1;
+
+		$query_args = array(
+			'number'      => $per_page,
+			'offset'      => ( $page - 1 ) * $per_page,
+			'count_total' => true,
+		);
+
+		if ( ! empty( $input['roles'] ) && current_user_can( 'list_users' ) ) {
+			$query_args['role__in'] = $this->normalize_string_list( $input['roles'] );
+		}
+
+		if ( current_user_can( 'list_users' ) ) {
+			$has_published_posts = $this->normalize_has_published_posts( $input );
+			if ( null !== $has_published_posts ) {
+				$query_args['has_published_posts'] = $has_published_posts;
+			}
+		} else {
+			$query_args['has_published_posts'] = $this->get_public_author_post_types();
+		}
+
+		$query = new WP_User_Query( $query_args );
+
+		$users = array();
+		foreach ( $query->get_results() as $user ) {
+			if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) || ! $this->can_read_user( $user ) ) {
+				continue;
+			}
+
+			$users[] = $this->format_user( $user, $fields );
+		}
+
+		$total_users = (int) $query->get_total();
+
+		return array(
+			'users'       => $users,
+			'total'       => $total_users,
+			'total_pages' => $per_page > 0 ? (int) ceil( $total_users / $per_page ) : 0,
+		);
+	}
+
+	/**
+	 * Casts a raw input value to a non-negative integer.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value The raw input value.
+	 * @return int The value as a non-negative integer, or 0 when not scalar.
+	 */
+	private function input_int( $value ): int {
+		return is_scalar( $value ) ? absint( $value ) : 0;
+	}
+
+	/**
+	 * Determines the single-user lookup type represented by the input.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return string The lookup type, or an empty string for collection mode.
+	 */
+	private function get_lookup_type( array $input ): string {
+		foreach ( array( 'id', 'email', 'username', 'slug' ) as $key ) {
+			if ( array_key_exists( $key, $input ) ) {
+				return $key;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Finds a user by one of the supported unique input identifiers.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return \WP_User|null User object, or null when not found.
+	 */
+	private function find_user( array $input ): ?WP_User {
+		if ( isset( $input['id'] ) ) {
+			$user = get_userdata( $this->input_int( $input['id'] ) );
+			return $user instanceof WP_User ? $user : null;
+		}
+
+		if ( isset( $input['email'] ) && is_string( $input['email'] ) ) {
+			$user = get_user_by( 'email', sanitize_email( $input['email'] ) );
+			return $user instanceof WP_User ? $user : null;
+		}
+
+		if ( isset( $input['username'] ) && is_string( $input['username'] ) ) {
+			$user = get_user_by( 'login', $input['username'] );
+			return $user instanceof WP_User ? $user : null;
+		}
+
+		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) ) {
+			$user = get_user_by( 'slug', sanitize_title( $input['slug'] ) );
+			return $user instanceof WP_User ? $user : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Checks whether a user belongs to the current site.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user User object.
+	 * @return bool Whether the user belongs to the current site.
+	 */
+	private function is_user_member_of_site( WP_User $user ): bool {
+		return ! is_multisite() || is_user_member_of_blog( (int) $user->ID );
+	}
+
+	/**
+	 * Checks whether a single-user lookup may return the target user.
+	 *
+	 * Email and username are identifier-sensitive lookup modes and do not use the
+	 * public-author fallback.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user        User object.
+	 * @param string   $lookup_type Lookup type.
+	 * @return bool Whether the user can be read for that lookup type.
+	 */
+	private function can_read_user_for_lookup( WP_User $user, string $lookup_type ): bool {
+		if ( $this->is_current_user( $user ) ) {
+			return true;
+		}
+
+		if ( current_user_can( 'edit_user', $user->ID ) || current_user_can( 'list_users' ) ) {
+			return true;
+		}
+
+		if ( 'email' === $lookup_type || 'username' === $lookup_type ) {
+			return false;
+		}
+
+		return $this->is_public_author( $user );
+	}
+
+	/**
+	 * Checks whether a user may be included in collection results.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user User object.
+	 * @return bool Whether the user can be read.
+	 */
+	private function can_read_user( WP_User $user ): bool {
+		return $this->is_current_user( $user )
+			|| current_user_can( 'edit_user', $user->ID )
+			|| current_user_can( 'list_users' )
+			|| $this->is_public_author( $user );
+	}
+
+	/**
+	 * Checks whether the current user is the target user.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user User object.
+	 * @return bool Whether the current user is the target user.
+	 */
+	private function is_current_user( WP_User $user ): bool {
+		return get_current_user_id() === (int) $user->ID;
+	}
+
+	/**
+	 * Checks whether a user has published posts in REST-visible author post types.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user User object.
+	 * @return bool Whether the user is publicly visible as an author.
+	 */
+	private function is_public_author( WP_User $user ): bool {
+		$post_types = $this->get_public_author_post_types();
+		if ( array() === $post_types ) {
+			return false;
+		}
+
+		return count_user_posts( (int) $user->ID, $post_types ) > 0;
+	}
+
+	/**
+	 * Returns REST-visible post types that support authors.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string[] REST-visible author post type names.
+	 */
+	private function get_public_author_post_types(): array {
+		$post_types = array();
+
+		foreach ( get_post_types( array( 'show_in_rest' => true ), 'names' ) as $post_type ) {
+			if ( is_string( $post_type ) && post_type_supports( $post_type, 'author' ) ) {
+				$post_types[] = $post_type;
+			}
+		}
+
+		return $post_types;
+	}
+
+	/**
+	 * Normalizes the requested fields to the supported set, defaulting to all fields.
+	 *
+	 * An empty or absent `fields` value selects every field. Restricted fields are
+	 * still omitted per user when the current user cannot access them.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return string[] List of requested field names.
+	 */
+	private function normalize_fields( array $input ): array {
+		$available_fields = $this->get_fields();
+
+		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
+			return $available_fields;
+		}
+
+		$requested_fields = array_filter( $input['fields'], 'is_string' );
+		$fields           = array_intersect( $available_fields, $requested_fields );
+
+		return array() === $fields ? $available_fields : array_values( $fields );
+	}
+
+	/**
+	 * Returns the supported field list in output order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string[] Supported field names.
+	 */
+	private function get_fields(): array {
+		$fields = $this->read_fields;
+
+		if ( get_option( 'show_avatars' ) ) {
+			$fields[] = 'avatar_urls';
+		}
+
+		return array_merge( $fields, $this->sensitive_fields, array( 'roles' ) );
+	}
+
+	/**
+	 * Normalizes the requested per-page value to the supported bounds.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return int The clamped per-page value.
+	 */
+	private function normalize_per_page( array $input ): int {
+		$per_page = isset( $input['per_page'] ) ? $this->input_int( $input['per_page'] ) : self::DEFAULT_PER_PAGE;
+
+		return max( 1, min( self::MAX_PER_PAGE, $per_page ) );
+	}
+
+	/**
+	 * Normalizes a mixed value into a list of non-empty strings.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string[] Normalized strings.
+	 */
+	private function normalize_string_list( $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$strings = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) || '' === $item ) {
+				continue;
+			}
+
+			$strings[] = $item;
+		}
+
+		return array_values( array_unique( $strings ) );
+	}
+
+	/**
+	 * Normalizes the `has_published_posts` collection input.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return bool|string[]|null Normalized query value, or null when absent/invalid.
+	 */
+	private function normalize_has_published_posts( array $input ) {
+		if ( ! array_key_exists( 'has_published_posts', $input ) ) {
+			return null;
+		}
+
+		if ( true === $input['has_published_posts'] ) {
+			return true;
+		}
+
+		$post_types = $this->normalize_string_list( $input['has_published_posts'] );
+
+		return array() === $post_types ? null : $post_types;
+	}
+
+	/**
+	 * Builds the input schema for the `core/users` ability.
+	 *
+	 * The ability has five mutually exclusive modes, modeled as a `oneOf` so invalid
+	 * combinations are rejected rather than silently ignored:
+	 *
+	 *   - Get a single readable user by `id`.
+	 *   - Get a single readable user by `email`.
+	 *   - Get a single readable user by `username`.
+	 *   - Get a single readable user by `slug`.
+	 *   - Query a collection of readable users.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> The input JSON Schema.
+	 */
+	private function get_users_input_schema(): array {
+		$fields = array(
+			'type'        => 'array',
+			'uniqueItems' => true,
+			'items'       => array(
+				'type' => 'string',
+				'enum' => $this->get_fields(),
+			),
+			'description' => __( 'Limit each returned user to these fields. If omitted, all fields visible to the current user are returned.', 'ai' ),
+		);
+
+		return array(
+			'type'  => 'object',
+			'oneOf' => array(
+				array(
+					'title'                => __( 'Get a single readable user by ID', 'ai' ),
+					'required'             => array( 'id' ),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'id'     => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Retrieve a single readable user by ID.', 'ai' ),
+						),
+						'fields' => $fields,
+					),
+				),
+				array(
+					'title'                => __( 'Get a single readable user by email address', 'ai' ),
+					'required'             => array( 'email' ),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'email'  => array(
+							'type'        => 'string',
+							'format'      => 'email',
+							'description' => __( 'Retrieve a single readable user by email address. Resolving another user by email requires permission to list or edit users.', 'ai' ),
+						),
+						'fields' => $fields,
+					),
+				),
+				array(
+					'title'                => __( 'Get a single readable user by username', 'ai' ),
+					'required'             => array( 'username' ),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'username' => array(
+							'type'        => 'string',
+							'description' => __( 'Retrieve a single readable user by username. Resolving another user by username requires permission to list or edit users.', 'ai' ),
+						),
+						'fields'   => $fields,
+					),
+				),
+				array(
+					'title'                => __( 'Get a single readable user by slug', 'ai' ),
+					'required'             => array( 'slug' ),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'slug'   => array(
+							'type'        => 'string',
+							'description' => __( 'Retrieve a single readable user by slug.', 'ai' ),
+						),
+						'fields' => $fields,
+					),
+				),
+				array(
+					'title'                => __( 'Query readable users', 'ai' ),
+					'additionalProperties' => false,
+					'properties'           => array(
+						'roles'               => array(
+							'type'        => 'array',
+							'uniqueItems' => true,
+							'minItems'    => 1,
+							'items'       => array(
+								'type' => 'string',
+							),
+							'description' => __( 'Filter users by one or more roles. Requires permission to list users.', 'ai' ),
+						),
+						'has_published_posts' => array(
+							'oneOf'       => array(
+								array(
+									'type' => 'boolean',
+									'enum' => array( true ),
+								),
+								array(
+									'type'        => 'array',
+									'uniqueItems' => true,
+									'minItems'    => 1,
+									'items'       => array(
+										'type' => 'string',
+									),
+								),
+							),
+							'description' => __( 'Limit results to users with published posts. Use true for all post types, or provide post type names.', 'ai' ),
+						),
+						'fields'              => $fields,
+						'page'                => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'description' => __( 'Page of results to return.', 'ai' ),
+						),
+						'per_page'            => array(
+							'type'        => 'integer',
+							'minimum'     => 1,
+							'maximum'     => self::MAX_PER_PAGE,
+							'description' => __( 'Maximum number of users to return per page.', 'ai' ),
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Builds the output schema for the `core/users` ability.
+	 *
+	 * No user field is marked required because the `fields` input lets the caller
+	 * request any subset, and restricted fields are omitted when unavailable.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> The output JSON Schema.
+	 */
+	private function get_users_output_schema(): array {
+		$user_properties = array(
+			'id'              => array(
+				'type'        => 'integer',
+				'description' => __( 'The user ID.', 'ai' ),
+			),
+			'display_name'    => array(
+				'type'        => 'string',
+				'description' => __( 'The display name for the user.', 'ai' ),
+			),
+			'description'     => array(
+				'type'        => 'string',
+				'description' => __( 'Description of the user.', 'ai' ),
+			),
+			'url'             => array(
+				'type'        => 'string',
+				'description' => __( 'URL of the user.', 'ai' ),
+			),
+			'link'            => array(
+				'type'        => 'string',
+				'description' => __( 'Author archive URL for the user.', 'ai' ),
+			),
+			'slug'            => array(
+				'type'        => 'string',
+				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
+			),
+			'username'        => array(
+				'type'        => 'string',
+				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'email'           => array(
+				'type'        => 'string',
+				'format'      => 'email',
+				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'first_name'      => array(
+				'type'        => 'string',
+				'description' => __( 'First name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'last_name'       => array(
+				'type'        => 'string',
+				'description' => __( 'Last name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'nickname'        => array(
+				'type'        => 'string',
+				'description' => __( 'The nickname for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'locale'          => array(
+				'type'        => 'string',
+				'description' => __( 'Locale for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'registered_date' => array(
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'description' => __( 'Registration date for the user in ISO 8601 format. Present when the current user can view it.', 'ai' ),
+			),
+			'roles'           => array(
+				'type'        => 'array',
+				'description' => __( 'Roles assigned to the user. Present when the current user can view them.', 'ai' ),
+				'items'       => array(
+					'type' => 'string',
+				),
+			),
+		);
+
+		if ( get_option( 'show_avatars' ) ) {
+			$user_properties['avatar_urls'] = array(
+				'type'                 => 'object',
+				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
+				'additionalProperties' => array(
+					'type' => 'string',
+				),
+			);
+		}
+
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => array( 'users', 'total', 'total_pages' ),
+			'properties'           => array(
+				'users'       => array(
+					'type'        => 'array',
+					'description' => __( 'The readable users matching the request. A single-element list when requested by a unique identifier.', 'ai' ),
+					'items'       => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => $user_properties,
+					),
+				),
+				'total'       => array(
+					'type'        => 'integer',
+					'description' => __( 'Total number of users matching the query, across all pages, after applying the permission filter to the query. Surfaced over REST as the X-WP-Total header.', 'ai' ),
+				),
+				'total_pages' => array(
+					'type'        => 'integer',
+					'description' => __( 'Total number of query result pages available after applying the permission filter to the query. Surfaced over REST as the X-WP-TotalPages header.', 'ai' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Formats a user into the ability output shape.
+	 *
+	 * Only the requested fields the current user can see are included.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_User $user   The user object.
+	 * @param string[] $fields The requested field names.
+	 * @return array<string, mixed> The formatted user data.
+	 */
+	private function format_user( WP_User $user, array $fields ): array {
+		$fields_requested = static function ( string $field ) use ( $fields ): bool {
+			return in_array( $field, $fields, true );
+		};
+
+		$user_id            = (int) $user->ID;
+		$can_view_sensitive = $this->is_current_user( $user ) || current_user_can( 'edit_user', $user_id );
+		$can_view_roles     = current_user_can( 'list_users' ) || current_user_can( 'edit_user', $user_id );
+
+		$data = array();
+
+		if ( $fields_requested( 'id' ) ) {
+			$data['id'] = $user_id;
+		}
+		if ( $fields_requested( 'display_name' ) ) {
+			$data['display_name'] = (string) $user->display_name;
+		}
+		if ( $fields_requested( 'description' ) ) {
+			$data['description'] = (string) $user->description;
+		}
+		if ( $fields_requested( 'url' ) ) {
+			$data['url'] = (string) $user->user_url;
+		}
+		if ( $fields_requested( 'link' ) ) {
+			$data['link'] = (string) get_author_posts_url( $user_id, $user->user_nicename );
+		}
+		if ( $fields_requested( 'slug' ) ) {
+			$data['slug'] = (string) $user->user_nicename;
+		}
+		if ( $fields_requested( 'avatar_urls' ) && get_option( 'show_avatars' ) ) {
+			$data['avatar_urls'] = rest_get_avatar_urls( $user );
+		}
+
+		if ( $can_view_sensitive ) {
+			if ( $fields_requested( 'username' ) ) {
+				$data['username'] = (string) $user->user_login;
+			}
+			if ( $fields_requested( 'email' ) ) {
+				$data['email'] = (string) $user->user_email;
+			}
+			if ( $fields_requested( 'first_name' ) ) {
+				$data['first_name'] = (string) $user->first_name;
+			}
+			if ( $fields_requested( 'last_name' ) ) {
+				$data['last_name'] = (string) $user->last_name;
+			}
+			if ( $fields_requested( 'nickname' ) ) {
+				$data['nickname'] = (string) $user->nickname;
+			}
+			if ( $fields_requested( 'locale' ) ) {
+				$data['locale'] = (string) get_user_locale( $user );
+			}
+			if ( $fields_requested( 'registered_date' ) ) {
+				$registered_timestamp = strtotime( (string) $user->user_registered );
+				if ( false !== $registered_timestamp ) {
+					$data['registered_date'] = gmdate( 'c', $registered_timestamp );
+				}
+			}
+		}
+
+		if ( $fields_requested( 'roles' ) && $can_view_roles ) {
+			$data['roles'] = $this->normalize_string_list( $user->roles );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Returns a generic not-found error for missing or inaccessible user lookups.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WP_Error Not found error.
+	 */
+	private function not_found_error(): WP_Error {
+		return new WP_Error(
+			'user_not_found',
+			__( 'The requested user was not found.', 'ai' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -28,7 +28,7 @@ defined( 'ABSPATH' ) || exit;
  * per user by omitting fields the current user cannot view.
  *
  * This class is kept almost identical to the WordPress core class `WP_Users_Abilities`
- * so the two implementations stay in sync. Differences from the core class are marked with
+ * so the two implementations stay in sync. Most differences from the core class are marked with
  * `// Plugin:` comments. Additionally, all user-facing strings use the 'ai' text domain.
  *
  * Plugin: the class is final and instance-based (with private helpers), matching the
@@ -101,36 +101,12 @@ final class Users {
 	 * Plugin: this method has no equivalent in the core class. In core, register() is
 	 * invoked directly from wp_register_core_abilities() (already on the
 	 * `wp_abilities_api_init` hook). The plugin instead hooks register() slightly later
-	 * (priority 11) so it can override any core-provided copy, and registers the category
-	 * as a fallback in case core has not.
+	 * (priority 11) so it can override any core-provided copy.
 	 *
 	 * @since x.x.x
 	 */
 	public function init(): void {
-		add_action( 'wp_abilities_api_categories_init', array( $this, 'register_category' ), 11 );
 		add_action( 'wp_abilities_api_init', array( $this, 'register' ), 11 );
-	}
-
-	/**
-	 * Registers the `user` ability category if it is not already registered.
-	 *
-	 * Plugin: this method has no equivalent in the core class; core relies on
-	 * wp_register_core_ability_categories() to register the `user` category.
-	 *
-	 * @since x.x.x
-	 */
-	public function register_category(): void {
-		if ( wp_has_ability_category( self::CATEGORY ) ) {
-			return;
-		}
-
-		wp_register_ability_category(
-			self::CATEGORY,
-			array(
-				'label'       => __( 'User', 'ai' ),
-				'description' => __( 'Abilities that retrieve or modify user information and settings.', 'ai' ),
-			)
-		);
 	}
 
 	/**
@@ -339,22 +315,34 @@ final class Users {
 	 * @return \WP_User|null User object, or null when not found.
 	 */
 	private function find_user( array $input ): ?WP_User {
-		if ( isset( $input['id'] ) ) {
+		if ( array_key_exists( 'id', $input ) ) {
 			$user = get_userdata( $this->input_int( $input['id'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['user_email'] ) && is_string( $input['user_email'] ) ) {
+		if ( array_key_exists( 'user_email', $input ) ) {
+			if ( ! is_string( $input['user_email'] ) ) {
+				return null;
+			}
+
 			$user = get_user_by( 'email', sanitize_email( $input['user_email'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['user_login'] ) && is_string( $input['user_login'] ) ) {
+		if ( array_key_exists( 'user_login', $input ) ) {
+			if ( ! is_string( $input['user_login'] ) ) {
+				return null;
+			}
+
 			$user = get_user_by( 'login', $input['user_login'] );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['user_nicename'] ) && is_string( $input['user_nicename'] ) ) {
+		if ( array_key_exists( 'user_nicename', $input ) ) {
+			if ( ! is_string( $input['user_nicename'] ) ) {
+				return null;
+			}
+
 			$user = get_user_by( 'slug', sanitize_title( $input['user_nicename'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -428,6 +428,7 @@ final class Users {
 			return false;
 		}
 
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts -- Mirrors the Core REST users controller public-author visibility check.
 		return count_user_posts( (int) $user->ID, $post_types ) > 0;
 	}
 
@@ -442,9 +443,11 @@ final class Users {
 		$post_types = array();
 
 		foreach ( get_post_types( array( 'show_in_rest' => true ), 'names' ) as $post_type ) {
-			if ( is_string( $post_type ) && post_type_supports( $post_type, 'author' ) ) {
-				$post_types[] = $post_type;
+			if ( ! is_string( $post_type ) || ! post_type_supports( $post_type, 'author' ) ) {
+				continue;
 			}
+
+			$post_types[] = $post_type;
 		}
 
 		return $post_types;

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Registers the read-only `core/users` ability, which retrieves one or more
  * readable WordPress users. Supports fetching a single readable user by ID,
- * email, username, or slug, or querying a paginated collection optionally
+ * user email, user login, or user nicename, or querying a paginated collection optionally
  * filtered by roles or published-post authorship. Field-level access is enforced
  * per user by omitting fields the current user cannot view.
  *
@@ -74,9 +74,9 @@ final class Users {
 		'id',
 		'display_name',
 		'description',
-		'url',
+		'user_url',
 		'link',
-		'slug',
+		'user_nicename',
 	);
 
 	/**
@@ -86,13 +86,13 @@ final class Users {
 	 * @var string[]
 	 */
 	private array $sensitive_fields = array(
-		'username',
-		'email',
+		'user_login',
+		'user_email',
 		'first_name',
 		'last_name',
 		'nickname',
 		'locale',
-		'registered_date',
+		'user_registered',
 	);
 
 	/**
@@ -159,7 +159,7 @@ final class Users {
 			'core/users',
 			array(
 				'label'               => __( 'Get Users', 'ai' ),
-				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, email, username, or slug, or query a paginated collection optionally filtered by roles or published-post authorship.', 'ai' ),
+				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, user email, user login, or user nicename, or query a paginated collection optionally filtered by roles or published-post authorship.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_users_input_schema(),
 				'output_schema'       => $this->get_users_output_schema(),
@@ -306,7 +306,7 @@ final class Users {
 	 * @return string The lookup type, or an empty string for collection mode.
 	 */
 	private function get_lookup_type( array $input ): string {
-		foreach ( array( 'id', 'email', 'username', 'slug' ) as $key ) {
+		foreach ( array( 'id', 'user_email', 'user_login', 'user_nicename' ) as $key ) {
 			if ( array_key_exists( $key, $input ) ) {
 				return $key;
 			}
@@ -329,18 +329,18 @@ final class Users {
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['email'] ) && is_string( $input['email'] ) ) {
-			$user = get_user_by( 'email', sanitize_email( $input['email'] ) );
+		if ( isset( $input['user_email'] ) && is_string( $input['user_email'] ) ) {
+			$user = get_user_by( 'email', sanitize_email( $input['user_email'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['username'] ) && is_string( $input['username'] ) ) {
-			$user = get_user_by( 'login', $input['username'] );
+		if ( isset( $input['user_login'] ) && is_string( $input['user_login'] ) ) {
+			$user = get_user_by( 'login', $input['user_login'] );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) ) {
-			$user = get_user_by( 'slug', sanitize_title( $input['slug'] ) );
+		if ( isset( $input['user_nicename'] ) && is_string( $input['user_nicename'] ) ) {
+			$user = get_user_by( 'slug', sanitize_title( $input['user_nicename'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
@@ -362,7 +362,7 @@ final class Users {
 	/**
 	 * Checks whether a single-user lookup may return the target user.
 	 *
-	 * Email and username are identifier-sensitive lookup modes and do not use the
+	 * User email and login are identifier-sensitive lookup modes and do not use the
 	 * public-author fallback.
 	 *
 	 * @since x.x.x
@@ -380,7 +380,7 @@ final class Users {
 			return true;
 		}
 
-		if ( 'email' === $lookup_type || 'username' === $lookup_type ) {
+		if ( 'user_email' === $lookup_type || 'user_login' === $lookup_type ) {
 			return false;
 		}
 
@@ -562,9 +562,9 @@ final class Users {
 	 * combinations are rejected rather than silently ignored:
 	 *
 	 *   - Get a single readable user by `id`.
-	 *   - Get a single readable user by `email`.
-	 *   - Get a single readable user by `username`.
-	 *   - Get a single readable user by `slug`.
+	 *   - Get a single readable user by `user_email`.
+	 *   - Get a single readable user by `user_login`.
+	 *   - Get a single readable user by `user_nicename`.
 	 *   - Query a collection of readable users.
 	 *
 	 * @since x.x.x
@@ -601,39 +601,39 @@ final class Users {
 				),
 				array(
 					'title'                => __( 'Get a single readable user by email address', 'ai' ),
-					'required'             => array( 'email' ),
+					'required'             => array( 'user_email' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'email'  => array(
+						'user_email' => array(
 							'type'        => 'string',
 							'format'      => 'email',
 							'description' => __( 'Retrieve a single readable user by email address. Resolving another user by email requires permission to list or edit users.', 'ai' ),
 						),
-						'fields' => $fields,
+						'fields'     => $fields,
 					),
 				),
 				array(
-					'title'                => __( 'Get a single readable user by username', 'ai' ),
-					'required'             => array( 'username' ),
+					'title'                => __( 'Get a single readable user by login', 'ai' ),
+					'required'             => array( 'user_login' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'username' => array(
+						'user_login' => array(
 							'type'        => 'string',
-							'description' => __( 'Retrieve a single readable user by username. Resolving another user by username requires permission to list or edit users.', 'ai' ),
+							'description' => __( 'Retrieve a single readable user by login. Resolving another user by login requires permission to list or edit users.', 'ai' ),
 						),
-						'fields'   => $fields,
+						'fields'     => $fields,
 					),
 				),
 				array(
-					'title'                => __( 'Get a single readable user by slug', 'ai' ),
-					'required'             => array( 'slug' ),
+					'title'                => __( 'Get a single readable user by nicename', 'ai' ),
+					'required'             => array( 'user_nicename' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'slug'   => array(
+						'user_nicename' => array(
 							'type'        => 'string',
-							'description' => __( 'Retrieve a single readable user by slug.', 'ai' ),
+							'description' => __( 'Retrieve a single readable user by nicename.', 'ai' ),
 						),
-						'fields' => $fields,
+						'fields'        => $fields,
 					),
 				),
 				array(
@@ -708,7 +708,7 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Description of the user.', 'ai' ),
 			),
-			'url'             => array(
+			'user_url'        => array(
 				'type'        => 'string',
 				'description' => __( 'URL of the user.', 'ai' ),
 			),
@@ -716,15 +716,15 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Author archive URL for the user.', 'ai' ),
 			),
-			'slug'            => array(
+			'user_nicename'   => array(
 				'type'        => 'string',
 				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
 			),
-			'username'        => array(
+			'user_login'      => array(
 				'type'        => 'string',
 				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
 			),
-			'email'           => array(
+			'user_email'      => array(
 				'type'        => 'string',
 				'format'      => 'email',
 				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
@@ -745,10 +745,9 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Locale for the user. Present when the current user can view it.', 'ai' ),
 			),
-			'registered_date' => array(
+			'user_registered' => array(
 				'type'        => 'string',
-				'format'      => 'date-time',
-				'description' => __( 'Registration date for the user in ISO 8601 format. Present when the current user can view it.', 'ai' ),
+				'description' => __( 'Registration date for the user. Present when the current user can view it.', 'ai' ),
 			),
 			'roles'           => array(
 				'type'        => 'array',
@@ -826,25 +825,25 @@ final class Users {
 		if ( $fields_requested( 'description' ) ) {
 			$data['description'] = (string) $user->description;
 		}
-		if ( $fields_requested( 'url' ) ) {
-			$data['url'] = (string) $user->user_url;
+		if ( $fields_requested( 'user_url' ) ) {
+			$data['user_url'] = (string) $user->user_url;
 		}
 		if ( $fields_requested( 'link' ) ) {
 			$data['link'] = (string) get_author_posts_url( $user_id, $user->user_nicename );
 		}
-		if ( $fields_requested( 'slug' ) ) {
-			$data['slug'] = (string) $user->user_nicename;
+		if ( $fields_requested( 'user_nicename' ) ) {
+			$data['user_nicename'] = (string) $user->user_nicename;
 		}
 		if ( $fields_requested( 'avatar_urls' ) && get_option( 'show_avatars' ) ) {
 			$data['avatar_urls'] = rest_get_avatar_urls( $user );
 		}
 
 		if ( $can_view_sensitive ) {
-			if ( $fields_requested( 'username' ) ) {
-				$data['username'] = (string) $user->user_login;
+			if ( $fields_requested( 'user_login' ) ) {
+				$data['user_login'] = (string) $user->user_login;
 			}
-			if ( $fields_requested( 'email' ) ) {
-				$data['email'] = (string) $user->user_email;
+			if ( $fields_requested( 'user_email' ) ) {
+				$data['user_email'] = (string) $user->user_email;
 			}
 			if ( $fields_requested( 'first_name' ) ) {
 				$data['first_name'] = (string) $user->first_name;
@@ -858,11 +857,8 @@ final class Users {
 			if ( $fields_requested( 'locale' ) ) {
 				$data['locale'] = (string) get_user_locale( $user );
 			}
-			if ( $fields_requested( 'registered_date' ) ) {
-				$registered_timestamp = strtotime( (string) $user->user_registered );
-				if ( false !== $registered_timestamp ) {
-					$data['registered_date'] = gmdate( 'c', $registered_timestamp );
-				}
+			if ( $fields_requested( 'user_registered' ) ) {
+				$data['user_registered'] = (string) $user->user_registered;
 			}
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -262,7 +262,22 @@ final class Users {
 				$query_args['has_published_posts'] = $has_published_posts;
 			}
 		} else {
-			$query_args['has_published_posts'] = $this->get_public_author_post_types();
+			$public_post_types   = $this->get_public_post_types();
+			$has_published_posts = $this->normalize_has_published_posts( $input );
+
+			if ( is_array( $has_published_posts ) ) {
+				$public_post_types = array_values( array_intersect( $public_post_types, $has_published_posts ) );
+			}
+
+			if ( array() === $public_post_types ) {
+				return array(
+					'users'       => array(),
+					'total'       => 0,
+					'total_pages' => 0,
+				);
+			}
+
+			$query_args['has_published_posts'] = $public_post_types;
 		}
 
 		$query = new WP_User_Query( $query_args );
@@ -415,7 +430,7 @@ final class Users {
 	}
 
 	/**
-	 * Checks whether a user has published posts in REST-visible author post types.
+	 * Checks whether a user has published posts in public post types.
 	 *
 	 * @since x.x.x
 	 *
@@ -423,27 +438,27 @@ final class Users {
 	 * @return bool Whether the user is publicly visible as an author.
 	 */
 	private function is_public_author( WP_User $user ): bool {
-		$post_types = $this->get_public_author_post_types();
+		$post_types = $this->get_public_post_types();
 		if ( array() === $post_types ) {
 			return false;
 		}
 
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts -- Mirrors the Core REST users controller public-author visibility check.
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts -- Public-author checks only consider public post types.
 		return count_user_posts( (int) $user->ID, $post_types ) > 0;
 	}
 
 	/**
-	 * Returns REST-visible post types that support authors.
+	 * Returns public post types.
 	 *
 	 * @since x.x.x
 	 *
-	 * @return string[] REST-visible author post type names.
+	 * @return string[] Public post type names.
 	 */
-	private function get_public_author_post_types(): array {
+	private function get_public_post_types(): array {
 		$post_types = array();
 
-		foreach ( get_post_types( array( 'show_in_rest' => true ), 'names' ) as $post_type ) {
-			if ( ! is_string( $post_type ) || ! post_type_supports( $post_type, 'author' ) ) {
+		foreach ( get_post_types( array( 'public' => true ), 'names' ) as $post_type ) {
+			if ( ! is_string( $post_type ) ) {
 				continue;
 			}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The `core/users` WordPress Ability.
+ * The `core/read-users` WordPress Ability.
  *
  * @package WordPress\AI
  *
@@ -21,7 +21,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class - Users
  *
- * Registers the read-only `core/users` ability, which retrieves one or more
+ * Registers the read-only `core/read-users` ability, which retrieves one or more
  * readable WordPress users. Supports fetching a single readable user by ID,
  * user email, user login, or user nicename, or querying a paginated collection optionally
  * filtered by roles or published-post authorship. Field-level access is enforced
@@ -153,20 +153,20 @@ final class Users {
 	}
 
 	/**
-	 * Registers the read-only `core/users` ability.
+	 * Registers the read-only `core/read-users` ability.
 	 *
 	 * @since x.x.x
 	 */
 	private function register_get_users(): void {
 		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/users' ) ) {
-			wp_unregister_ability( 'core/users' );
+		if ( wp_has_ability( 'core/read-users' ) ) {
+			wp_unregister_ability( 'core/read-users' );
 		}
 
 		wp_register_ability(
-			'core/users',
+			'core/read-users',
 			array(
-				'label'               => __( 'Get Users', 'ai' ),
+				'label'               => __( 'Read Users', 'ai' ),
 				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, user email, user login, or user nicename, or query a paginated collection optionally filtered by roles or published-post authorship.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_users_input_schema(),
@@ -187,7 +187,7 @@ final class Users {
 	}
 
 	/**
-	 * Permission callback for the `core/users` ability.
+	 * Permission callback for the `core/read-users` ability.
 	 *
 	 * Implements defense in depth: this gate decides whether the request may proceed at
 	 * all, while the per-user read checks in {@see self::execute_get_users()} are the
@@ -223,7 +223,7 @@ final class Users {
 	}
 
 	/**
-	 * Executes the `core/users` ability.
+	 * Executes the `core/read-users` ability.
 	 *
 	 * @since x.x.x
 	 *
@@ -623,7 +623,7 @@ final class Users {
 	}
 
 	/**
-	 * Builds the input schema for the `core/users` ability.
+	 * Builds the input schema for the `core/read-users` ability.
 	 *
 	 * The ability has five mutually exclusive modes, modeled as a `oneOf` so invalid
 	 * combinations are rejected rather than silently ignored:
@@ -756,7 +756,7 @@ final class Users {
 	}
 
 	/**
-	 * Builds the output schema for the `core/users` ability.
+	 * Builds the output schema for the `core/read-users` ability.
 	 *
 	 * No user field is marked required because the `fields` input lets the caller
 	 * request any subset, and restricted fields are omitted when unavailable.

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -583,8 +583,9 @@ final class Users {
 		);
 
 		return array(
-			'type'  => 'object',
-			'oneOf' => array(
+			'type'    => 'object',
+			'default' => (object) array(),
+			'oneOf'   => array(
 				array(
 					'title'                => __( 'Get a single readable user by ID', 'ai' ),
 					'required'             => array( 'id' ),

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -24,7 +24,7 @@ defined( 'ABSPATH' ) || exit;
  * Registers the read-only `core/read-users` ability, which retrieves one or more
  * readable WordPress users. Supports fetching a single readable user by ID,
  * user email, user login, or user nicename, or querying a paginated collection optionally
- * filtered by roles or published-post authorship. Field-level access is enforced
+ * filtered by roles, published-post authorship, or included IDs. Field-level access is enforced
  * per user by omitting fields the current user cannot view.
  *
  * This class is kept almost identical to the WordPress core class `WP_Users_Abilities`
@@ -180,7 +180,7 @@ final class Users {
 			'core/read-users',
 			array(
 				'label'               => __( 'Read Users', 'ai' ),
-				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, user email, user login, or user nicename, or query a paginated collection optionally filtered by roles or published-post authorship.', 'ai' ),
+				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, user email, user login, or user nicename, or query a paginated collection optionally filtered by roles, published-post authorship, or included IDs.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_users_input_schema(),
 				'output_schema'       => $this->get_users_output_schema(),
@@ -268,6 +268,12 @@ final class Users {
 			'offset'      => ( $page - 1 ) * $per_page,
 			'count_total' => true,
 		);
+
+		$include = $this->normalize_include( $input );
+		if ( array() !== $include ) {
+			$query_args['include'] = $include;
+			$query_args['orderby'] = 'include';
+		}
 
 		if ( ! empty( $input['roles'] ) && current_user_can( 'list_users' ) ) {
 			$query_args['role__in'] = $this->normalize_string_list( $input['roles'] );
@@ -627,6 +633,25 @@ final class Users {
 	}
 
 	/**
+	 * Normalizes collection-mode included user IDs.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return int[] User IDs.
+	 */
+	private function normalize_include( array $input ): array {
+		if ( empty( $input['include'] ) || ! is_array( $input['include'] ) ) {
+			return array();
+		}
+
+		$ids = array_map( array( $this, 'input_int' ), $input['include'] );
+		$ids = array_filter( $ids );
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
 	 * Normalizes the `has_published_posts` collection input.
 	 *
 	 * @since x.x.x
@@ -675,6 +700,16 @@ final class Users {
 				'enum' => $this->get_fields(),
 			),
 			'description' => __( 'Limit each returned user to these fields. If omitted, a lean set of common read fields is returned.', 'ai' ),
+		);
+		$include           = array(
+			'type'        => 'array',
+			'uniqueItems' => true,
+			'minItems'    => 1,
+			'items'       => array(
+				'type'    => 'integer',
+				'minimum' => 1,
+			),
+			'description' => __( 'Limit the query to these user IDs. Results preserve this order where possible and still respect read permissions.', 'ai' ),
 		);
 
 		return array(
@@ -763,6 +798,7 @@ final class Users {
 							),
 							'description' => __( 'Limit results to users with published posts. Use true for all post types, or provide post type names.', 'ai' ),
 						),
+						'include'             => $include,
 						'fields'              => $fields,
 						'page'                => array(
 							'type'        => 'integer',

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -931,7 +931,10 @@ final class Users {
 				$data['locale'] = (string) get_user_locale( $user );
 			}
 			if ( $fields_requested( 'user_registered' ) ) {
-				$data['user_registered'] = gmdate( 'c', strtotime( $user->user_registered ) );
+				$registered_timestamp = strtotime( $user->user_registered );
+				if ( false !== $registered_timestamp ) {
+					$data['user_registered'] = gmdate( 'c', $registered_timestamp );
+				}
 			}
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -127,8 +127,8 @@ final class Users {
 		wp_register_ability_category(
 			self::CATEGORY,
 			array(
-				'label'       => __( 'Users', 'ai' ),
-				'description' => __( 'Abilities that retrieve or manage WordPress users.', 'ai' ),
+				'label'       => __( 'User', 'ai' ),
+				'description' => __( 'Abilities that retrieve or modify user information and settings.', 'ai' ),
 			)
 		);
 	}

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -96,6 +96,19 @@ final class Users {
 	);
 
 	/**
+	 * Default fields returned when the caller does not request a field subset.
+	 *
+	 * @since x.x.x
+	 * @var string[]
+	 */
+	private array $default_fields = array(
+		'id',
+		'display_name',
+		'link',
+		'user_nicename',
+	);
+
+	/**
 	 * Cached public post type names.
 	 *
 	 * @since x.x.x
@@ -228,7 +241,7 @@ final class Users {
 	 * @since x.x.x
 	 *
 	 * @param mixed $input Optional. The ability input. Default empty array.
-	 * @return array<string, mixed>|\WP_Error A map with a `users` list, or a WP_Error on failure.
+	 * @return array<string, mixed>|\WP_Error A user object in single-user mode, a map with a `users` list in collection mode, or a WP_Error on failure.
 	 */
 	public function execute_get_users( $input = array() ) {
 		$input  = is_array( $input ) ? $input : array();
@@ -244,11 +257,7 @@ final class Users {
 				return $this->not_found_error();
 			}
 
-			return array(
-				'users'       => array( $this->format_user( $user, $fields ) ),
-				'total'       => 1,
-				'total_pages' => 1,
-			);
+			return $this->format_user( $user, $fields );
 		}
 
 		$per_page = $this->normalize_per_page( $input );
@@ -495,10 +504,10 @@ final class Users {
 	}
 
 	/**
-	 * Normalizes the requested fields to the supported set, defaulting to all fields.
+	 * Normalizes the requested fields to the supported set, defaulting to a lean field set.
 	 *
-	 * An empty or absent `fields` value selects every field. Restricted fields are
-	 * still omitted per user when the current user cannot access them.
+	 * An empty or absent `fields` value selects common read-context fields. Restricted
+	 * fields are still omitted per user when the current user cannot access them.
 	 *
 	 * @since x.x.x
 	 *
@@ -509,13 +518,13 @@ final class Users {
 		$available_fields = $this->get_fields();
 
 		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
-			return $available_fields;
+			return $this->get_default_fields();
 		}
 
 		$requested_fields = array_filter( $input['fields'], 'is_string' );
 		$fields           = array_intersect( $available_fields, $requested_fields );
 
-		return array() === $fields ? $available_fields : array_values( $fields );
+		return array() === $fields ? $this->get_default_fields() : array_values( $fields );
 	}
 
 	/**
@@ -542,6 +551,23 @@ final class Users {
 		$this->fields_include_avatars = $include_avatars;
 
 		return $this->fields;
+	}
+
+	/**
+	 * Returns the default field list in output order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string[] Default field names.
+	 */
+	private function get_default_fields(): array {
+		$fields = $this->default_fields;
+
+		if ( get_option( 'show_avatars' ) ) {
+			$fields[] = 'avatar_urls';
+		}
+
+		return $fields;
 	}
 
 	/**
@@ -648,7 +674,7 @@ final class Users {
 				'type' => 'string',
 				'enum' => $this->get_fields(),
 			),
-			'description' => __( 'Limit each returned user to these fields. If omitted, all fields visible to the current user are returned.', 'ai' ),
+			'description' => __( 'Limit each returned user to these fields. If omitted, a lean set of common read fields is returned.', 'ai' ),
 		);
 
 		return array(
@@ -760,6 +786,8 @@ final class Users {
 	 *
 	 * No user field is marked required because the `fields` input lets the caller
 	 * request any subset, and restricted fields are omitted when unavailable.
+	 * Single-user mode returns the user object directly, while collection mode returns
+	 * a paginated wrapper.
 	 *
 	 * @since x.x.x
 	 *
@@ -841,19 +869,21 @@ final class Users {
 			);
 		}
 
-		return array(
+		$user_schema = array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => $user_properties,
+		);
+
+		$collection_schema = array(
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'required'             => array( 'users', 'total', 'total_pages' ),
 			'properties'           => array(
 				'users'       => array(
 					'type'        => 'array',
-					'description' => __( 'The readable users matching the request. A single-element list when requested by a unique identifier.', 'ai' ),
-					'items'       => array(
-						'type'                 => 'object',
-						'additionalProperties' => false,
-						'properties'           => $user_properties,
-					),
+					'description' => __( 'The readable users matching the collection request.', 'ai' ),
+					'items'       => $user_schema,
 				),
 				'total'       => array(
 					'type'        => 'integer',
@@ -863,6 +893,13 @@ final class Users {
 					'type'        => 'integer',
 					'description' => __( 'Total number of query result pages available after applying the permission filter to the query. Surfaced over REST as the X-WP-TotalPages header.', 'ai' ),
 				),
+			),
+		);
+
+		return array(
+			'oneOf' => array(
+				$user_schema,
+				$collection_schema,
 			),
 		);
 	}

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -96,6 +96,38 @@ final class Users {
 	);
 
 	/**
+	 * Cached public post type names.
+	 *
+	 * @since x.x.x
+	 * @var string[]|null
+	 */
+	private ?array $public_post_types = null;
+
+	/**
+	 * Cached supported field list.
+	 *
+	 * @since x.x.x
+	 * @var string[]|null
+	 */
+	private ?array $fields = null;
+
+	/**
+	 * Whether the cached supported field list includes avatars.
+	 *
+	 * @since x.x.x
+	 * @var bool|null
+	 */
+	private ?bool $fields_include_avatars = null;
+
+	/**
+	 * Cached role names.
+	 *
+	 * @since x.x.x
+	 * @var string[]|null
+	 */
+	private ?array $role_names = null;
+
+	/**
 	 * Hooks the ability into the Abilities API.
 	 *
 	 * Plugin: this method has no equivalent in the core class. In core, register() is
@@ -443,6 +475,10 @@ final class Users {
 	 * @return string[] Public post type names.
 	 */
 	private function get_public_post_types(): array {
+		if ( null !== $this->public_post_types ) {
+			return $this->public_post_types;
+		}
+
 		$post_types = array();
 
 		foreach ( get_post_types( array( 'public' => true ), 'names' ) as $post_type ) {
@@ -453,7 +489,9 @@ final class Users {
 			$post_types[] = $post_type;
 		}
 
-		return $post_types;
+		$this->public_post_types = $post_types;
+
+		return $this->public_post_types;
 	}
 
 	/**
@@ -488,13 +526,39 @@ final class Users {
 	 * @return string[] Supported field names.
 	 */
 	private function get_fields(): array {
+		$include_avatars = (bool) get_option( 'show_avatars' );
+
+		if ( null !== $this->fields && $include_avatars === $this->fields_include_avatars ) {
+			return $this->fields;
+		}
+
 		$fields = $this->read_fields;
 
-		if ( get_option( 'show_avatars' ) ) {
+		if ( $include_avatars ) {
 			$fields[] = 'avatar_urls';
 		}
 
-		return array_merge( $fields, $this->sensitive_fields, array( 'roles' ) );
+		$this->fields                 = array_merge( $fields, $this->sensitive_fields, array( 'roles' ) );
+		$this->fields_include_avatars = $include_avatars;
+
+		return $this->fields;
+	}
+
+	/**
+	 * Returns registered role names.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string[] Role names.
+	 */
+	private function get_role_names(): array {
+		if ( null !== $this->role_names ) {
+			return $this->role_names;
+		}
+
+		$this->role_names = array_keys( wp_roles()->roles );
+
+		return $this->role_names;
 	}
 
 	/**
@@ -575,7 +639,9 @@ final class Users {
 	 * @return array<string, mixed> The input JSON Schema.
 	 */
 	private function get_users_input_schema(): array {
-		$fields = array(
+		$role_names        = $this->get_role_names();
+		$public_post_types = $this->get_public_post_types();
+		$fields            = array(
 			'type'        => 'array',
 			'uniqueItems' => true,
 			'items'       => array(
@@ -649,6 +715,7 @@ final class Users {
 							'minItems'    => 1,
 							'items'       => array(
 								'type' => 'string',
+								'enum' => $role_names,
 							),
 							'description' => __( 'Filter users by one or more roles. Requires permission to list users.', 'ai' ),
 						),
@@ -664,6 +731,7 @@ final class Users {
 									'minItems'    => 1,
 									'items'       => array(
 										'type' => 'string',
+										'enum' => $public_post_types,
 									),
 								),
 							),
@@ -758,6 +826,7 @@ final class Users {
 				'description' => __( 'Roles assigned to the user. Present when the current user can view them.', 'ai' ),
 				'items'       => array(
 					'type' => 'string',
+					'enum' => $this->get_role_names(),
 				),
 			),
 		);

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -264,12 +264,15 @@ final class Users {
 		// so the row count and the reported totals stay in agreement. Collections
 		// are not post-filtered by site membership, matching the REST users
 		// controller, whose collection endpoint applies no per-row membership check
-		// and reports `get_total()` directly. On multisite a bare collection query
-		// (no roles/has_published_posts) is network-wide for callers who can list
-		// users; callers who cannot are scoped to the current site because the
-		// forced `has_published_posts` joins the current blog's posts table.
-		// Single-user lookups remain site-scoped via {@see self::is_user_member_of_site()},
-		// matching the controller's single-user membership check.
+		// and reports `get_total()` directly. On multisite the collection is still
+		// scoped to the current site: WP_User_Query adds a capabilities meta clause
+		// restricting results to members of the queried blog whenever `blog_id`
+		// (defaulted to the current blog) is set, even for a bare query with no
+		// roles/has_published_posts. Callers who cannot list users are additionally
+		// narrowed by the forced `has_published_posts`, which joins the current
+		// blog's posts table. Single-user lookups remain site-scoped via
+		// {@see self::is_user_member_of_site()}, matching the controller's
+		// single-user membership check.
 		$total_users = (int) $query->get_total();
 
 		return array(

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -79,7 +79,7 @@ final class Users {
 	 * @since x.x.x
 	 * @var string[]
 	 */
-	private const DEFAULT_FIELDS = array(
+	private const DEFAULT_FIELDS = array( // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
 		'id',
 		'name',
 		'link',
@@ -627,87 +627,15 @@ final class Users {
 	}
 
 	/**
-	 * Normalizes the requested per-page value to the supported bounds.
+	 * Reads the validated `has_published_posts` collection input.
+	 *
+	 * The value is `true` (all post types) or a list of post type names; the
+	 * input schema has already validated the shape before the ability runs.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
-	 * @return int The clamped per-page value.
-	 */
-	private function normalize_per_page( array $input ): int {
-		$per_page = isset( $input['per_page'] ) ? $this->input_int( $input['per_page'] ) : self::DEFAULT_PER_PAGE;
-
-		return max( 1, min( self::MAX_PER_PAGE, $per_page ) );
-	}
-
-	/**
-	 * Normalizes a mixed value into a list of non-empty strings.
-	 *
-	 * Accepts arrays and CSV strings, since REST `GET` requests deliver list
-	 * input as strings that schema validation coerces only for the check.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param mixed $value Raw value.
-	 * @return string[] Normalized strings.
-	 */
-	private function normalize_string_list( $value ): array {
-		if ( is_string( $value ) ) {
-			$value = wp_parse_list( $value );
-		}
-
-		if ( ! is_array( $value ) ) {
-			return array();
-		}
-
-		$strings = array();
-		foreach ( $value as $item ) {
-			if ( ! is_string( $item ) || '' === $item ) {
-				continue;
-			}
-
-			$strings[] = $item;
-		}
-
-		return array_values( array_unique( $strings ) );
-	}
-
-	/**
-	 * Normalizes collection-mode included user IDs.
-	 *
-	 * Accepts arrays and CSV strings via {@see wp_parse_id_list()}, which also
-	 * deduplicates IDs that only differ as strings (e.g. `'1'` and `'01'`).
-	 *
-	 * @since x.x.x
-	 *
-	 * @param array<mixed> $input The ability input.
-	 * @return int[] User IDs.
-	 */
-	private function normalize_include( array $input ): array {
-		if ( empty( $input['include'] ) ) {
-			return array();
-		}
-
-		$include = $input['include'];
-		if ( is_scalar( $include ) ) {
-			$include = (string) $include;
-		} elseif ( ! is_array( $include ) ) {
-			return array();
-		}
-
-		return array_values( array_filter( wp_parse_id_list( $include ) ) );
-	}
-
-	/**
-	 * Normalizes the `has_published_posts` collection input.
-	 *
-	 * Accepts the string and integer forms of `true` that schema validation
-	 * accepts for REST `GET` input, alongside the native boolean.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param array<mixed> $input The ability input.
-	 * @return bool|string[]|null Normalized query value, or null when omitted.
+	 * @return bool|string[]|null Query value, or null when omitted or empty.
 	 */
 	private function normalize_has_published_posts( array $input ) {
 		if ( ! array_key_exists( 'has_published_posts', $input ) ) {
@@ -716,15 +644,15 @@ final class Users {
 
 		$value = $input['has_published_posts'];
 
-		if ( true === $value || 1 === $value
-			|| ( is_string( $value ) && in_array( strtolower( $value ), array( 'true', '1' ), true ) )
-		) {
+		if ( true === $value ) {
 			return true;
 		}
 
-		$post_types = $this->normalize_string_list( $value );
+		if ( is_array( $value ) && array() !== $value ) {
+			return array_values( $value );
+		}
 
-		return array() === $post_types ? null : $post_types;
+		return null;
 	}
 
 	/**

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -27,8 +27,8 @@ defined( 'ABSPATH' ) || exit;
  * filtered by roles, published-post authorship, or included IDs. Field-level access is enforced
  * per user by omitting fields the current user cannot view.
  *
- * This class is kept almost identical to the WordPress core class `WP_Users_Abilities`
- * so the two implementations stay in sync. Most differences from the core class are marked with
+ * This class is kept almost identical to the proposed WordPress core implementation
+ * so the two implementations stay in sync. Most differences from the core version are marked with
  * `// Plugin:` comments. Additionally, all user-facing strings use the 'ai' text domain.
  *
  * Plugin: the class is final and instance-based (with private helpers), matching the
@@ -78,7 +78,7 @@ final class Users {
 	 * @since x.x.x
 	 * @var string[]
 	 */
-	private array $default_fields = array(
+	private const DEFAULT_FIELDS = array(
 		'id',
 		'name',
 		'link',
@@ -199,7 +199,10 @@ final class Users {
 				|| ! $this->is_user_member_of_site( $user )
 				|| ! $this->can_read_user_for_lookup( $user, $lookup_type )
 			) {
-				return $this->not_found_error();
+				return new WP_Error(
+					'ability_invalid_permissions',
+					__( 'The requested user cannot be read.', 'ai' )
+				);
 			}
 
 			return $this->format_user( $user, $fields );
@@ -257,7 +260,8 @@ final class Users {
 
 		$users = array();
 		foreach ( $query->get_results() as $user ) {
-			// Collection queries enforce read access through query arguments.
+			// WP_User_Query already scopes multisite collections to current-site members.
+			// Keep this as a defensive guard for filtered/custom query results.
 			if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
 				continue;
 			}
@@ -270,7 +274,7 @@ final class Users {
 		return array(
 			'users'       => $users,
 			'total'       => $total_users,
-			'total_pages' => $per_page > 0 ? (int) ceil( $total_users / $per_page ) : 0,
+			'total_pages' => (int) ceil( $total_users / $per_page ),
 		);
 	}
 
@@ -562,7 +566,7 @@ final class Users {
 	 * @return string[] Default field names.
 	 */
 	private function get_default_fields(): array {
-		return array_values( array_intersect( array_keys( $this->get_user_properties() ), $this->default_fields ) );
+		return array_values( array_intersect( array_keys( $this->get_user_properties() ), self::DEFAULT_FIELDS ) );
 	}
 
 	/**
@@ -686,6 +690,7 @@ final class Users {
 		$fields            = array(
 			'type'        => 'array',
 			'uniqueItems' => true,
+			'minItems'    => 1,
 			'items'       => array(
 				'type' => 'string',
 				'enum' => array_keys( $this->get_user_properties() ),
@@ -932,20 +937,5 @@ final class Users {
 		}
 
 		return $data;
-	}
-
-	/**
-	 * Returns a generic not-found error for missing or inaccessible user lookups.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return \WP_Error Not found error.
-	 */
-	private function not_found_error(): WP_Error {
-		return new WP_Error(
-			'user_not_found',
-			__( 'The requested user was not found.', 'ai' ),
-			array( 'status' => 404 )
-		);
 	}
 }

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -962,7 +962,6 @@ final class Users {
 
 		$user_id            = (int) $user->ID;
 		$can_view_sensitive = $this->is_current_user( $user ) || current_user_can( 'edit_user', $user_id );
-		$can_view_roles     = current_user_can( 'list_users' ) || current_user_can( 'edit_user', $user_id );
 
 		$data = array();
 
@@ -1017,7 +1016,12 @@ final class Users {
 			}
 		}
 
-		if ( $fields_requested( 'roles' ) && $can_view_roles ) {
+		// Roles reveal a user's privilege level, so they are gated like the other
+		// sensitive fields: visible only for the current user or a user the caller
+		// can edit. `list_users` alone (which grants no edit rights) is not enough,
+		// matching the REST users controller, where `roles` is an edit-context
+		// field and rows the caller cannot edit are dropped from collections.
+		if ( $fields_requested( 'roles' ) && $can_view_sensitive ) {
 			$data['roles'] = $this->normalize_string_list( $user->roles );
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -14,6 +14,7 @@ namespace WordPress\AI\Abilities\Users;
 use WP_Error;
 use WP_User;
 use WP_User_Query;
+use stdClass;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -157,7 +158,7 @@ final class Users {
 	 * @return bool True if the request may proceed, false otherwise.
 	 */
 	public function check_permission( $input = array() ): bool {
-		$input = $this->sanitize_input( $input );
+		$input = $this->to_input_array( $input );
 
 		if ( ! is_user_logged_in() ) {
 			return false;
@@ -184,7 +185,7 @@ final class Users {
 	 * @return array<string, mixed>|\stdClass|\WP_Error User data, paginated collection data, or a WP_Error on failure.
 	 */
 	public function execute_get_users( $input = array() ) {
-		$input  = $this->sanitize_input( $input );
+		$input  = $this->to_input_array( $input );
 		$fields = $this->normalize_fields( $input );
 
 		$lookup_type = $this->get_lookup_type( $input );
@@ -271,33 +272,30 @@ final class Users {
 	}
 
 	/**
-	 * Sanitizes raw ability input against the input schema.
+	 * Casts raw ability input to an array.
+	 *
+	 * Schema validation accepts object input (`rest_is_object()` allows a
+	 * `stdClass`, and the input schema's own `default` is one), so it must be
+	 * treated as equivalent to its array form rather than discarded. Any other
+	 * non-array input is replaced with an empty array.
 	 *
 	 * The Abilities API validates input against the schema but does not coerce
 	 * it, and REST `GET` requests (the only method for read-only abilities)
-	 * deliver every scalar as a string. Sanitizing applies the coercions that
-	 * validation already accepted (`'true'` to `true`, CSV strings to arrays,
-	 * numeric strings to integers) before the values reach the strict
-	 * normalizers.
+	 * deliver every scalar as a string. Each normalizer below therefore accepts
+	 * the string forms validation accepted (`'true'` for `true`, CSV strings
+	 * for arrays, numeric strings for integers).
 	 *
 	 * @since x.x.x
 	 *
 	 * @param mixed $input The raw ability input.
-	 * @return array<mixed> The sanitized input.
+	 * @return array<mixed> The input as an array.
 	 */
-	private function sanitize_input( $input ): array {
-		if ( ! is_array( $input ) ) {
-			return array();
+	private function to_input_array( $input ): array {
+		if ( $input instanceof stdClass ) {
+			$input = (array) $input;
 		}
 
-		$sanitized = rest_sanitize_value_from_schema( $input, $this->get_users_input_schema(), 'input' );
-		if ( is_wp_error( $sanitized ) || ! is_array( $sanitized ) ) {
-			// Input that does not match the schema is left as-is; it has either
-			// already passed validation or will be rejected by it.
-			return $input;
-		}
-
-		return $sanitized;
+		return is_array( $input ) ? $input : array();
 	}
 
 	/**
@@ -486,8 +484,13 @@ final class Users {
 	 * Returns the requested fields, or a lean default set when none are given.
 	 *
 	 * An empty or absent `fields` value selects a lean set of common read fields.
-	 * Otherwise the requested fields are returned as-is. The input schema has already
-	 * validated them against the supported set before the ability executes.
+	 * Otherwise the requested fields are returned; REST `GET` requests may
+	 * deliver the list as a CSV string. The input schema has already validated
+	 * the names against the supported set before the ability executes.
+	 *
+	 * The `id` field is always included, matching the REST users controller
+	 * where `id` is present in every context. This also guarantees the result
+	 * is never empty, so it always serializes as a JSON object.
 	 *
 	 * @since x.x.x
 	 *
@@ -495,12 +498,14 @@ final class Users {
 	 * @return string[] List of requested field names.
 	 */
 	private function normalize_fields( array $input ): array {
-		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
-			return $this->get_default_fields();
+		$fields = isset( $input['fields'] ) ? $this->normalize_string_list( $input['fields'] ) : array();
+		if ( array() === $fields ) {
+			$fields = $this->get_default_fields();
 		}
 
-		/** @var string[] $fields */
-		$fields = $input['fields'];
+		if ( ! in_array( 'id', $fields, true ) ) {
+			array_unshift( $fields, 'id' );
+		}
 
 		return $fields;
 	}
@@ -638,12 +643,19 @@ final class Users {
 	/**
 	 * Normalizes a mixed value into a list of non-empty strings.
 	 *
+	 * Accepts arrays and CSV strings, since REST `GET` requests deliver list
+	 * input as strings that schema validation coerces only for the check.
+	 *
 	 * @since x.x.x
 	 *
 	 * @param mixed $value Raw value.
 	 * @return string[] Normalized strings.
 	 */
 	private function normalize_string_list( $value ): array {
+		if ( is_string( $value ) ) {
+			$value = wp_parse_list( $value );
+		}
+
 		if ( ! is_array( $value ) ) {
 			return array();
 		}
@@ -663,24 +675,34 @@ final class Users {
 	/**
 	 * Normalizes collection-mode included user IDs.
 	 *
+	 * Accepts arrays and CSV strings via {@see wp_parse_id_list()}, which also
+	 * deduplicates IDs that only differ as strings (e.g. `'1'` and `'01'`).
+	 *
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
 	 * @return int[] User IDs.
 	 */
 	private function normalize_include( array $input ): array {
-		if ( empty( $input['include'] ) || ! is_array( $input['include'] ) ) {
+		if ( empty( $input['include'] ) ) {
 			return array();
 		}
 
-		$ids = array_map( array( $this, 'input_int' ), $input['include'] );
-		$ids = array_filter( $ids );
+		$include = $input['include'];
+		if ( is_scalar( $include ) ) {
+			$include = (string) $include;
+		} elseif ( ! is_array( $include ) ) {
+			return array();
+		}
 
-		return array_values( array_unique( $ids ) );
+		return array_values( array_filter( wp_parse_id_list( $include ) ) );
 	}
 
 	/**
 	 * Normalizes the `has_published_posts` collection input.
+	 *
+	 * Accepts the string and integer forms of `true` that schema validation
+	 * accepts for REST `GET` input, alongside the native boolean.
 	 *
 	 * @since x.x.x
 	 *
@@ -692,11 +714,15 @@ final class Users {
 			return null;
 		}
 
-		if ( true === $input['has_published_posts'] ) {
+		$value = $input['has_published_posts'];
+
+		if ( true === $value || 1 === $value
+			|| ( is_string( $value ) && in_array( strtolower( $value ), array( 'true', '1' ), true ) )
+		) {
 			return true;
 		}
 
-		$post_types = $this->normalize_string_list( $input['has_published_posts'] );
+		$post_types = $this->normalize_string_list( $value );
 
 		return array() === $post_types ? null : $post_types;
 	}
@@ -902,16 +928,20 @@ final class Users {
 	/**
 	 * Formats a user into the ability output shape.
 	 *
-	 * Only the requested fields the current user can see are included.
+	 * Only the requested fields the current user can see are included, except
+	 * `id`, which {@see self::normalize_fields()} always requests.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param \WP_User $user   The user object.
 	 * @param string[] $fields The requested field names.
-	 * @return array<string, mixed>|\stdClass The formatted user data. A fully
-	 *                                        redacted user is returned as an
-	 *                                        object so it serializes as `{}`
-	 *                                        rather than `[]`.
+	 * @return array<string, mixed>|\stdClass The formatted user data. An empty
+	 *                                        result is returned as an object so
+	 *                                        it serializes as `{}` rather than
+	 *                                        `[]`; unreachable while `id` is
+	 *                                        ungated, since REST post-processing
+	 *                                        (`_fields`) cannot handle a
+	 *                                        top-level object response.
 	 */
 	private function format_user( WP_User $user, array $fields ) {
 		$fields_requested = static function ( string $field ) use ( $fields ): bool {

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -570,9 +570,9 @@ final class Users {
 			),
 			'avatar_urls'     => array(
 				'type'                 => 'object',
-				'description'          => __( 'Avatar URLs for the user at various sizes. Present when the show_avatars option is enabled.', 'ai' ),
+				'description'          => __( 'Avatar URLs for the user, keyed by image size in pixels. A size is null when no avatar URL can be resolved for it. Present when the show_avatars option is enabled.', 'ai' ),
 				'additionalProperties' => array(
-					'type' => 'string',
+					'type' => array( 'string', 'null' ),
 				),
 			),
 			'username'        => array(
@@ -580,9 +580,9 @@ final class Users {
 				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
 			),
 			'email'           => array(
-				'type'        => 'string',
+				'type'        => array( 'string', 'null' ),
 				'format'      => 'email',
-				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
+				'description' => __( 'The email address for the user. Null when the user has no stored address, or when the stored address is not a valid email. Present when the current user can view it.', 'ai' ),
 			),
 			'first_name'      => array(
 				'type'        => 'string',
@@ -994,7 +994,12 @@ final class Users {
 		// The schemas always declare avatar_urls; availability is enforced here,
 		// since the option can change after the schemas are registered.
 		if ( $fields_requested( 'avatar_urls' ) && get_option( 'show_avatars' ) ) {
-			$data['avatar_urls'] = rest_get_avatar_urls( $user );
+			$data['avatar_urls'] = array_map(
+				static function ( $url ) {
+					return is_string( $url ) ? $url : null;
+				},
+				rest_get_avatar_urls( $user )
+			);
 		}
 
 		if ( $can_view_sensitive ) {
@@ -1002,7 +1007,7 @@ final class Users {
 				$data['username'] = (string) $user->user_login;
 			}
 			if ( $fields_requested( 'email' ) ) {
-				$data['email'] = (string) $user->user_email;
+				$data['email'] = is_email( $user->user_email ) ? (string) $user->user_email : null;
 			}
 			if ( $fields_requested( 'first_name' ) ) {
 				$data['first_name'] = (string) $user->first_name;

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -212,8 +212,8 @@ final class Users {
 
 		$include = $this->normalize_include( $input );
 		if ( array() !== $include ) {
-			// Default ordering is kept so queries with the same include set can
-			// share the WP_User_Query cache regardless of the requested order.
+			// The include order is not applied as `orderby`. Keeping the default
+			// ordering lets WP_User_Query share cached results with other queries.
 			$query_args['include'] = $include;
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -163,7 +163,6 @@ final class Users {
 						'idempotent'  => true,
 					),
 					'show_in_rest' => true,
-					'pagination'   => true,
 				),
 			)
 		);
@@ -257,7 +256,7 @@ final class Users {
 		} else {
 			// Callers who cannot list users only see public authors in a collection,
 			// matching core. This intentionally excludes the caller's own account when
-			// they have no published posts; self is read through a single-user lookup
+			// they have no published posts. Self is read through a single-user lookup
 			// (like the REST `/users/me` endpoint) instead.
 			$public_post_types   = $this->get_public_post_types();
 			$has_published_posts = $this->normalize_has_published_posts( $input );
@@ -684,7 +683,7 @@ final class Users {
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
-	 * @return bool|string[]|null Normalized query value, or null when absent/invalid.
+	 * @return bool|string[]|null Normalized query value, or null when omitted.
 	 */
 	private function normalize_has_published_posts( array $input ) {
 		if ( ! array_key_exists( 'has_published_posts', $input ) ) {

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -87,30 +87,6 @@ final class Users {
 	);
 
 	/**
-	 * Cached public post type names.
-	 *
-	 * @since x.x.x
-	 * @var string[]|null
-	 */
-	private ?array $public_post_types = null;
-
-	/**
-	 * Cached user field definitions, keyed by field name in output order.
-	 *
-	 * @since x.x.x
-	 * @var array<string, mixed>|null
-	 */
-	private ?array $user_properties = null;
-
-	/**
-	 * Cached role names.
-	 *
-	 * @since x.x.x
-	 * @var string[]|null
-	 */
-	private ?array $role_names = null;
-
-	/**
 	 * Hooks the ability into the Abilities API.
 	 *
 	 * Plugin: this method has no equivalent in the core class. In core, register() is
@@ -424,7 +400,7 @@ final class Users {
 	}
 
 	/**
-	 * Checks whether a user has published posts in public post types.
+	 * Checks whether a user has published posts in publicly viewable post types.
 	 *
 	 * @since x.x.x
 	 *
@@ -437,35 +413,25 @@ final class Users {
 			return false;
 		}
 
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts -- Public-author checks only consider public post types.
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.count_user_posts_count_user_posts -- Public-author checks only consider publicly viewable post types.
 		return count_user_posts( (int) $user->ID, $post_types ) > 0;
 	}
 
 	/**
-	 * Returns public post types.
+	 * Returns publicly viewable post types.
+	 *
+	 * Uses {@see is_post_type_viewable()} rather than the `public` registration
+	 * argument, since `public` alone does not guarantee a post type is viewable
+	 * on the front end. Deliberately resolved on every call rather than cached:
+	 * post types can be unregistered or re-registered with different arguments
+	 * between the ability being registered and the ability being used.
 	 *
 	 * @since x.x.x
 	 *
-	 * @return string[] Public post type names.
+	 * @return string[] Publicly viewable post type names.
 	 */
 	private function get_public_post_types(): array {
-		if ( null !== $this->public_post_types ) {
-			return $this->public_post_types;
-		}
-
-		$post_types = array();
-
-		foreach ( get_post_types( array( 'public' => true ), 'names' ) as $post_type ) {
-			if ( ! is_string( $post_type ) ) {
-				continue;
-			}
-
-			$post_types[] = $post_type;
-		}
-
-		$this->public_post_types = $post_types;
-
-		return $this->public_post_types;
+		return array_values( array_filter( get_post_types(), 'is_post_type_viewable' ) );
 	}
 
 	/**
@@ -497,17 +463,15 @@ final class Users {
 	 * This is the single source of truth for the ability's user fields: the output
 	 * schema uses the definitions directly, while the input schema and field
 	 * normalization use the keys. The `avatar_urls` field is dropped when the
-	 * `show_avatars` option is disabled.
+	 * `show_avatars` option is disabled. Deliberately resolved on every call rather
+	 * than cached, since the option and the registered roles can change between the
+	 * ability being registered and the ability being used.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return array<string, mixed> User field definitions.
 	 */
 	private function get_user_properties(): array {
-		if ( null !== $this->user_properties ) {
-			return $this->user_properties;
-		}
-
 		$user_properties = array(
 			'id'              => array(
 				'type'        => 'integer',
@@ -584,9 +548,7 @@ final class Users {
 			unset( $user_properties['avatar_urls'] );
 		}
 
-		$this->user_properties = $user_properties;
-
-		return $this->user_properties;
+		return $user_properties;
 	}
 
 	/**
@@ -605,18 +567,15 @@ final class Users {
 	/**
 	 * Returns registered role names.
 	 *
+	 * Deliberately resolved on every call rather than cached, since roles can be
+	 * registered or unregistered at runtime.
+	 *
 	 * @since x.x.x
 	 *
 	 * @return string[] Role names.
 	 */
 	private function get_role_names(): array {
-		if ( null !== $this->role_names ) {
-			return $this->role_names;
-		}
-
-		$this->role_names = array_keys( wp_roles()->roles );
-
-		return $this->role_names;
+		return array_keys( wp_roles()->roles );
 	}
 
 	/**
@@ -716,6 +675,11 @@ final class Users {
 	 * @return array<string, mixed> The input JSON Schema.
 	 */
 	private function get_users_input_schema(): array {
+		/*
+		 * The schema enums reflect the roles and post types available at registration
+		 * time; the permission/execute callbacks re-resolve these sets at call time,
+		 * since both can change in between.
+		 */
 		$role_names        = $this->get_role_names();
 		$public_post_types = $this->get_public_post_types();
 		$fields            = array(

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -466,10 +466,11 @@ final class Users {
 	}
 
 	/**
-	 * Normalizes the requested fields to the supported set, defaulting to a lean field set.
+	 * Returns the requested fields, or a lean default set when none are given.
 	 *
-	 * An empty or absent `fields` value selects common read-context fields. Restricted
-	 * fields are still omitted per user when the current user cannot access them.
+	 * An empty or absent `fields` value selects a lean set of common read fields.
+	 * Otherwise the requested fields are returned as-is. The input schema has already
+	 * validated them against the supported set before the ability executes.
 	 *
 	 * @since x.x.x
 	 *
@@ -477,16 +478,14 @@ final class Users {
 	 * @return string[] List of requested field names.
 	 */
 	private function normalize_fields( array $input ): array {
-		$available_fields = array_keys( $this->get_user_properties() );
-
 		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
 			return $this->get_default_fields();
 		}
 
-		$requested_fields = array_filter( $input['fields'], 'is_string' );
-		$fields           = array_intersect( $available_fields, $requested_fields );
+		/** @var string[] $fields */
+		$fields = $input['fields'];
 
-		return array() === $fields ? $this->get_default_fields() : array_values( $fields );
+		return $fields;
 	}
 
 	/**

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -253,25 +253,25 @@ final class Users {
 
 		$users = array();
 		foreach ( $query->get_results() as $user ) {
-			// WP_User_Query already scopes multisite collections to current-site members.
-			// Keep this as a defensive guard for filtered/custom query results.
-			if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
+			if ( ! $user instanceof WP_User ) {
 				continue;
 			}
 
 			$users[] = $this->format_user( $user, $fields );
 		}
 
+		// `users` and `total`/`total_pages` all derive from the same WP_User_Query,
+		// so the row count and the reported totals stay in agreement. Collections
+		// are not post-filtered by site membership, matching the REST users
+		// controller, whose collection endpoint applies no per-row membership check
+		// and reports `get_total()` directly. On multisite a bare collection query
+		// (no roles/has_published_posts) is network-wide for callers who can list
+		// users; callers who cannot are scoped to the current site because the
+		// forced `has_published_posts` joins the current blog's posts table.
+		// Single-user lookups remain site-scoped via {@see self::is_user_member_of_site()},
+		// matching the controller's single-user membership check.
 		$total_users = (int) $query->get_total();
 
-		/*
-		 * `total`/`total_pages` reflect the underlying WP_User_Query count. The
-		 * defensive guard above can skip individual rows (e.g. non-site members
-		 * surfaced by a custom query filter on multisite), so the returned
-		 * `users` array may contain fewer entries than `total` implies for the
-		 * page. Consumers should treat `total` as the query-wide count rather
-		 * than assume `count( users ) === per_page` on a full page.
-		 */
 		return array(
 			'users'       => $users,
 			'total'       => $total_users,

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -79,7 +79,7 @@ final class Users {
 	 * @since x.x.x
 	 * @var string[]
 	 */
-	private const DEFAULT_FIELDS = array( // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
+	private const DEFAULT_FIELDS = array(
 		'id',
 		'name',
 		'link',
@@ -264,6 +264,14 @@ final class Users {
 
 		$total_users = (int) $query->get_total();
 
+		/*
+		 * `total`/`total_pages` reflect the underlying WP_User_Query count. The
+		 * defensive guard above can skip individual rows (e.g. non-site members
+		 * surfaced by a custom query filter on multisite), so the returned
+		 * `users` array may contain fewer entries than `total` implies for the
+		 * page. Consumers should treat `total` as the query-wide count rather
+		 * than assume `count( users ) === per_page` on a full page.
+		 */
 		return array(
 			'users'       => $users,
 			'total'       => $total_users,
@@ -377,7 +385,7 @@ final class Users {
 				return null;
 			}
 
-			$user = get_user_by( 'login', $input['username'] );
+			$user = get_user_by( 'login', sanitize_user( $input['username'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
@@ -386,7 +394,11 @@ final class Users {
 				return null;
 			}
 
-			$user = get_user_by( 'slug', sanitize_title( $input['slug'] ) );
+			// Query the raw nicename, matching the REST users controller. Applying
+			// sanitize_title() here would miss users whose stored user_nicename is
+			// not a sanitize_title() fixed point (e.g. set via the pre_user_nicename
+			// filter or an import).
+			$user = get_user_by( 'slug', $input['slug'] );
 			return $user instanceof WP_User ? $user : null;
 		}
 
@@ -627,15 +639,87 @@ final class Users {
 	}
 
 	/**
-	 * Reads the validated `has_published_posts` collection input.
-	 *
-	 * The value is `true` (all post types) or a list of post type names; the
-	 * input schema has already validated the shape before the ability runs.
+	 * Normalizes the requested per-page value to the supported bounds.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
-	 * @return bool|string[]|null Query value, or null when omitted or empty.
+	 * @return int The clamped per-page value.
+	 */
+	private function normalize_per_page( array $input ): int {
+		$per_page = isset( $input['per_page'] ) ? $this->input_int( $input['per_page'] ) : self::DEFAULT_PER_PAGE;
+
+		return max( 1, min( self::MAX_PER_PAGE, $per_page ) );
+	}
+
+	/**
+	 * Normalizes a mixed value into a list of non-empty strings.
+	 *
+	 * Accepts arrays and CSV strings, since REST `GET` requests deliver list
+	 * input as strings that schema validation coerces only for the check.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string[] Normalized strings.
+	 */
+	private function normalize_string_list( $value ): array {
+		if ( is_string( $value ) ) {
+			$value = wp_parse_list( $value );
+		}
+
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$strings = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) || '' === $item ) {
+				continue;
+			}
+
+			$strings[] = $item;
+		}
+
+		return array_values( array_unique( $strings ) );
+	}
+
+	/**
+	 * Normalizes collection-mode included user IDs.
+	 *
+	 * Accepts arrays and CSV strings via {@see wp_parse_id_list()}, which also
+	 * deduplicates IDs that only differ as strings (e.g. `'1'` and `'01'`).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return int[] User IDs.
+	 */
+	private function normalize_include( array $input ): array {
+		if ( empty( $input['include'] ) ) {
+			return array();
+		}
+
+		$include = $input['include'];
+		if ( is_scalar( $include ) ) {
+			$include = (string) $include;
+		} elseif ( ! is_array( $include ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( wp_parse_id_list( $include ) ) );
+	}
+
+	/**
+	 * Normalizes the `has_published_posts` collection input.
+	 *
+	 * Accepts the string and integer forms of `true` that schema validation
+	 * accepts for REST `GET` input, alongside the native boolean.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return bool|string[]|null Normalized query value, or null when omitted.
 	 */
 	private function normalize_has_published_posts( array $input ) {
 		if ( ! array_key_exists( 'has_published_posts', $input ) ) {
@@ -644,15 +728,15 @@ final class Users {
 
 		$value = $input['has_published_posts'];
 
-		if ( true === $value ) {
+		if ( true === $value || 1 === $value
+			|| ( is_string( $value ) && in_array( strtolower( $value ), array( 'true', '1' ), true ) )
+		) {
 			return true;
 		}
 
-		if ( is_array( $value ) && array() !== $value ) {
-			return array_values( $value );
-		}
+		$post_types = $this->normalize_string_list( $value );
 
-		return null;
+		return array() === $post_types ? null : $post_types;
 	}
 
 	/**

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -23,7 +23,7 @@ defined( 'ABSPATH' ) || exit;
  *
  * Registers the read-only `core/read-users` ability, which retrieves one or more
  * readable WordPress users. Supports fetching a single readable user by ID,
- * user email, user login, or user nicename, or querying a paginated collection optionally
+ * email, username, or slug, or querying a paginated collection optionally
  * filtered by roles, published-post authorship, or included IDs. Field-level access is enforced
  * per user by omitting fields the current user cannot view.
  *
@@ -80,9 +80,9 @@ final class Users {
 	 */
 	private array $default_fields = array(
 		'id',
-		'display_name',
+		'name',
 		'link',
-		'user_nicename',
+		'slug',
 		'avatar_urls',
 	);
 
@@ -150,7 +150,7 @@ final class Users {
 			'core/read-users',
 			array(
 				'label'               => __( 'Read Users', 'ai' ),
-				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, user email, user login, or user nicename, or query a paginated collection optionally filtered by roles, published-post authorship, or included IDs.', 'ai' ),
+				'description'         => __( 'Retrieves one or more readable WordPress users. Fetch a single readable user by ID, email, username, or slug, or query a paginated collection optionally filtered by roles, published-post authorship, or included IDs.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_users_input_schema(),
 				'output_schema'       => $this->get_users_output_schema(),
@@ -318,7 +318,7 @@ final class Users {
 	 * @return string The lookup type, or {@see self::LOOKUP_COLLECTION}.
 	 */
 	private function get_lookup_type( array $input ): string {
-		foreach ( array( 'id', 'user_email', 'user_login', 'user_nicename' ) as $key ) {
+		foreach ( array( 'id', 'email', 'username', 'slug' ) as $key ) {
 			if ( array_key_exists( $key, $input ) ) {
 				return $key;
 			}
@@ -341,30 +341,30 @@ final class Users {
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( array_key_exists( 'user_email', $input ) ) {
-			if ( ! is_string( $input['user_email'] ) ) {
+		if ( array_key_exists( 'email', $input ) ) {
+			if ( ! is_string( $input['email'] ) ) {
 				return null;
 			}
 
-			$user = get_user_by( 'email', sanitize_email( $input['user_email'] ) );
+			$user = get_user_by( 'email', sanitize_email( $input['email'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( array_key_exists( 'user_login', $input ) ) {
-			if ( ! is_string( $input['user_login'] ) ) {
+		if ( array_key_exists( 'username', $input ) ) {
+			if ( ! is_string( $input['username'] ) ) {
 				return null;
 			}
 
-			$user = get_user_by( 'login', $input['user_login'] );
+			$user = get_user_by( 'login', $input['username'] );
 			return $user instanceof WP_User ? $user : null;
 		}
 
-		if ( array_key_exists( 'user_nicename', $input ) ) {
-			if ( ! is_string( $input['user_nicename'] ) ) {
+		if ( array_key_exists( 'slug', $input ) ) {
+			if ( ! is_string( $input['slug'] ) ) {
 				return null;
 			}
 
-			$user = get_user_by( 'slug', sanitize_title( $input['user_nicename'] ) );
+			$user = get_user_by( 'slug', sanitize_title( $input['slug'] ) );
 			return $user instanceof WP_User ? $user : null;
 		}
 
@@ -386,7 +386,7 @@ final class Users {
 	/**
 	 * Checks whether a single-user lookup may return the target user.
 	 *
-	 * User email and login are identifier-sensitive lookup modes and do not use the
+	 * Email and username are identifier-sensitive lookup modes and do not use the
 	 * public-author fallback.
 	 *
 	 * @since x.x.x
@@ -404,7 +404,7 @@ final class Users {
 			return true;
 		}
 
-		if ( 'user_email' === $lookup_type || 'user_login' === $lookup_type ) {
+		if ( 'email' === $lookup_type || 'username' === $lookup_type ) {
 			return false;
 		}
 
@@ -513,7 +513,7 @@ final class Users {
 				'type'        => 'integer',
 				'description' => __( 'The user ID.', 'ai' ),
 			),
-			'display_name'    => array(
+			'name'            => array(
 				'type'        => 'string',
 				'description' => __( 'The display name for the user.', 'ai' ),
 			),
@@ -521,7 +521,7 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Description of the user.', 'ai' ),
 			),
-			'user_url'        => array(
+			'url'             => array(
 				'type'        => 'string',
 				'description' => __( 'URL of the user.', 'ai' ),
 			),
@@ -529,7 +529,7 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Author archive URL for the user.', 'ai' ),
 			),
-			'user_nicename'   => array(
+			'slug'            => array(
 				'type'        => 'string',
 				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
 			),
@@ -540,11 +540,11 @@ final class Users {
 					'type' => 'string',
 				),
 			),
-			'user_login'      => array(
+			'username'        => array(
 				'type'        => 'string',
 				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
 			),
-			'user_email'      => array(
+			'email'           => array(
 				'type'        => 'string',
 				'format'      => 'email',
 				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
@@ -565,7 +565,7 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'Locale for the user. Present when the current user can view it.', 'ai' ),
 			),
-			'user_registered' => array(
+			'registered_date' => array(
 				'type'        => 'string',
 				'format'      => 'date-time',
 				'description' => __( 'Registration date for the user. Present when the current user can view it.', 'ai' ),
@@ -706,9 +706,9 @@ final class Users {
 	 * combinations are rejected rather than silently ignored:
 	 *
 	 *   - Get a single readable user by `id`.
-	 *   - Get a single readable user by `user_email`.
-	 *   - Get a single readable user by `user_login`.
-	 *   - Get a single readable user by `user_nicename`.
+	 *   - Get a single readable user by `email`.
+	 *   - Get a single readable user by `username`.
+	 *   - Get a single readable user by `slug`.
 	 *   - Query a collection of readable users.
 	 *
 	 * @since x.x.x
@@ -757,39 +757,39 @@ final class Users {
 				),
 				array(
 					'title'                => __( 'Get a single readable user by email address', 'ai' ),
-					'required'             => array( 'user_email' ),
+					'required'             => array( 'email' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'user_email' => array(
+						'email'  => array(
 							'type'        => 'string',
 							'format'      => 'email',
 							'description' => __( 'Retrieve a single readable user by email address. Resolving another user by email requires permission to list or edit users.', 'ai' ),
 						),
-						'fields'     => $fields,
+						'fields' => $fields,
 					),
 				),
 				array(
-					'title'                => __( 'Get a single readable user by login', 'ai' ),
-					'required'             => array( 'user_login' ),
+					'title'                => __( 'Get a single readable user by username', 'ai' ),
+					'required'             => array( 'username' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'user_login' => array(
+						'username' => array(
 							'type'        => 'string',
-							'description' => __( 'Retrieve a single readable user by login. Resolving another user by login requires permission to list or edit users.', 'ai' ),
+							'description' => __( 'Retrieve a single readable user by username. Resolving another user by username requires permission to list or edit users.', 'ai' ),
 						),
-						'fields'     => $fields,
+						'fields'   => $fields,
 					),
 				),
 				array(
-					'title'                => __( 'Get a single readable user by nicename', 'ai' ),
-					'required'             => array( 'user_nicename' ),
+					'title'                => __( 'Get a single readable user by slug', 'ai' ),
+					'required'             => array( 'slug' ),
 					'additionalProperties' => false,
 					'properties'           => array(
-						'user_nicename' => array(
+						'slug'   => array(
 							'type'        => 'string',
-							'description' => __( 'Retrieve a single readable user by nicename.', 'ai' ),
+							'description' => __( 'Retrieve a single readable user by slug.', 'ai' ),
 						),
-						'fields'        => $fields,
+						'fields' => $fields,
 					),
 				),
 				array(
@@ -916,31 +916,31 @@ final class Users {
 		if ( $fields_requested( 'id' ) ) {
 			$data['id'] = $user_id;
 		}
-		if ( $fields_requested( 'display_name' ) ) {
-			$data['display_name'] = (string) $user->display_name;
+		if ( $fields_requested( 'name' ) ) {
+			$data['name'] = (string) $user->display_name;
 		}
 		if ( $fields_requested( 'description' ) ) {
 			$data['description'] = (string) $user->description;
 		}
-		if ( $fields_requested( 'user_url' ) ) {
-			$data['user_url'] = (string) $user->user_url;
+		if ( $fields_requested( 'url' ) ) {
+			$data['url'] = (string) $user->user_url;
 		}
 		if ( $fields_requested( 'link' ) ) {
 			$data['link'] = (string) get_author_posts_url( $user_id, $user->user_nicename );
 		}
-		if ( $fields_requested( 'user_nicename' ) ) {
-			$data['user_nicename'] = (string) $user->user_nicename;
+		if ( $fields_requested( 'slug' ) ) {
+			$data['slug'] = (string) $user->user_nicename;
 		}
 		if ( $fields_requested( 'avatar_urls' ) ) {
 			$data['avatar_urls'] = rest_get_avatar_urls( $user );
 		}
 
 		if ( $can_view_sensitive ) {
-			if ( $fields_requested( 'user_login' ) ) {
-				$data['user_login'] = (string) $user->user_login;
+			if ( $fields_requested( 'username' ) ) {
+				$data['username'] = (string) $user->user_login;
 			}
-			if ( $fields_requested( 'user_email' ) ) {
-				$data['user_email'] = (string) $user->user_email;
+			if ( $fields_requested( 'email' ) ) {
+				$data['email'] = (string) $user->user_email;
 			}
 			if ( $fields_requested( 'first_name' ) ) {
 				$data['first_name'] = (string) $user->first_name;
@@ -954,10 +954,10 @@ final class Users {
 			if ( $fields_requested( 'locale' ) ) {
 				$data['locale'] = (string) get_user_locale( $user );
 			}
-			if ( $fields_requested( 'user_registered' ) ) {
+			if ( $fields_requested( 'registered_date' ) ) {
 				$registered_timestamp = strtotime( $user->user_registered );
 				if ( false !== $registered_timestamp ) {
-					$data['user_registered'] = gmdate( 'c', $registered_timestamp );
+					$data['registered_date'] = gmdate( 'c', $registered_timestamp );
 				}
 			}
 		}

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -531,9 +531,9 @@ final class Users {
 	 * the registered schemas are a registration-time snapshot, so conditional
 	 * availability (such as `avatar_urls` honoring the `show_avatars` option) is
 	 * enforced per call in {@see self::format_user()} instead of here, where the
-	 * option could change between registration and use. Deliberately resolved on
-	 * every call rather than cached, since the registered roles can change at
-	 * runtime.
+	 * option could change between registration and use. Resolved on every call
+	 * rather than cached: it is the single source of truth for the field set and
+	 * inexpensive to rebuild.
 	 *
 	 * @since x.x.x
 	 *
@@ -605,9 +605,14 @@ final class Users {
 			'roles'           => array(
 				'type'        => 'array',
 				'description' => __( 'Roles assigned to the user. Present when the current user can view them.', 'ai' ),
+				// Output roles are not pinned to an enum. The schema is a
+				// registration-time snapshot, but a role can be registered after
+				// registration and still be held by a returned user; a snapshot enum
+				// would reject that legitimate value during output validation and
+				// fail the whole call. This also matches the REST users controller,
+				// whose `roles` output items are plain strings.
 				'items'       => array(
 					'type' => 'string',
-					'enum' => $this->get_role_names(),
 				),
 			),
 		);

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -216,8 +216,9 @@ final class Users {
 
 		$include = $this->normalize_include( $input );
 		if ( array() !== $include ) {
+			// Default ordering is kept so queries with the same include set can
+			// share the WP_User_Query cache regardless of the requested order.
 			$query_args['include'] = $include;
-			$query_args['orderby'] = 'include';
 		}
 
 		if ( ! empty( $input['roles'] ) && current_user_can( 'list_users' ) ) {
@@ -699,7 +700,7 @@ final class Users {
 				'type'    => 'integer',
 				'minimum' => 1,
 			),
-			'description' => __( 'Limit the query to these user IDs, preserving this order where possible. Collection results are limited to users the caller can read, which for callers without permission to list users means only public authors. To read your own account, use a single-user lookup by ID.', 'ai' ),
+			'description' => __( 'Limit the query to these user IDs. Collection results are limited to users the caller can read, which for callers without permission to list users means only public authors. To read your own account, use a single-user lookup by ID.', 'ai' ),
 		);
 
 		return array(

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -65,6 +65,14 @@ final class Users {
 	private const MAX_PER_PAGE = 100;
 
 	/**
+	 * Lookup type returned for collection requests.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	private const LOOKUP_COLLECTION = 'collection';
+
+	/**
 	 * Public/read-context user fields.
 	 *
 	 * @since x.x.x
@@ -77,6 +85,7 @@ final class Users {
 		'user_url',
 		'link',
 		'user_nicename',
+		'avatar_urls',
 	);
 
 	/**
@@ -106,6 +115,7 @@ final class Users {
 		'display_name',
 		'link',
 		'user_nicename',
+		'avatar_urls',
 	);
 
 	/**
@@ -123,14 +133,6 @@ final class Users {
 	 * @var string[]|null
 	 */
 	private ?array $fields = null;
-
-	/**
-	 * Whether the cached supported field list includes avatars.
-	 *
-	 * @since x.x.x
-	 * @var bool|null
-	 */
-	private ?bool $fields_include_avatars = null;
 
 	/**
 	 * Cached role names.
@@ -202,9 +204,9 @@ final class Users {
 	/**
 	 * Permission callback for the `core/read-users` ability.
 	 *
-	 * Implements defense in depth: this gate decides whether the request may proceed at
-	 * all, while the per-user read checks in {@see self::execute_get_users()} are the
-	 * authoritative, row-level enforcement.
+	 * Performs request-level checks. Single-user requests are checked against
+	 * the target user, while collection requests rely on query arguments in
+	 * {@see self::execute_get_users()} for row-level access.
 	 *
 	 * @since x.x.x
 	 *
@@ -223,7 +225,7 @@ final class Users {
 		}
 
 		$lookup_type = $this->get_lookup_type( $input );
-		if ( '' === $lookup_type ) {
+		if ( self::LOOKUP_COLLECTION === $lookup_type ) {
 			return true;
 		}
 
@@ -241,14 +243,14 @@ final class Users {
 	 * @since x.x.x
 	 *
 	 * @param mixed $input Optional. The ability input. Default empty array.
-	 * @return array<string, mixed>|\WP_Error A user object in single-user mode, a map with a `users` list in collection mode, or a WP_Error on failure.
+	 * @return array<string, mixed>|\WP_Error User data, paginated collection data, or a WP_Error on failure.
 	 */
 	public function execute_get_users( $input = array() ) {
 		$input  = is_array( $input ) ? $input : array();
 		$fields = $this->normalize_fields( $input );
 
 		$lookup_type = $this->get_lookup_type( $input );
-		if ( '' !== $lookup_type ) {
+		if ( self::LOOKUP_COLLECTION !== $lookup_type ) {
 			$user = $this->find_user( $input );
 			if ( ! $user instanceof WP_User
 				|| ! $this->is_user_member_of_site( $user )
@@ -307,7 +309,8 @@ final class Users {
 
 		$users = array();
 		foreach ( $query->get_results() as $user ) {
-			if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) || ! $this->can_read_user( $user ) ) {
+			// Collection queries enforce read access through query arguments.
+			if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
 				continue;
 			}
 
@@ -341,7 +344,7 @@ final class Users {
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
-	 * @return string The lookup type, or an empty string for collection mode.
+	 * @return string The lookup type, or {@see self::LOOKUP_COLLECTION}.
 	 */
 	private function get_lookup_type( array $input ): string {
 		foreach ( array( 'id', 'user_email', 'user_login', 'user_nicename' ) as $key ) {
@@ -350,7 +353,7 @@ final class Users {
 			}
 		}
 
-		return '';
+		return self::LOOKUP_COLLECTION;
 	}
 
 	/**
@@ -435,21 +438,6 @@ final class Users {
 		}
 
 		return $this->is_public_author( $user );
-	}
-
-	/**
-	 * Checks whether a user may be included in collection results.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param \WP_User $user User object.
-	 * @return bool Whether the user can be read.
-	 */
-	private function can_read_user( WP_User $user ): bool {
-		return $this->is_current_user( $user )
-			|| current_user_can( 'edit_user', $user->ID )
-			|| current_user_can( 'list_users' )
-			|| $this->is_public_author( $user );
 	}
 
 	/**
@@ -541,20 +529,17 @@ final class Users {
 	 * @return string[] Supported field names.
 	 */
 	private function get_fields(): array {
-		$include_avatars = (bool) get_option( 'show_avatars' );
-
-		if ( null !== $this->fields && $include_avatars === $this->fields_include_avatars ) {
+		if ( null !== $this->fields ) {
 			return $this->fields;
 		}
 
 		$fields = $this->read_fields;
 
-		if ( $include_avatars ) {
-			$fields[] = 'avatar_urls';
+		if ( ! get_option( 'show_avatars' ) ) {
+			$fields = array_diff( $fields, array( 'avatar_urls' ) );
 		}
 
-		$this->fields                 = array_merge( $fields, $this->sensitive_fields, array( 'roles' ) );
-		$this->fields_include_avatars = $include_avatars;
+		$this->fields = array_merge( array_values( $fields ), $this->sensitive_fields, array( 'roles' ) );
 
 		return $this->fields;
 	}
@@ -562,18 +547,14 @@ final class Users {
 	/**
 	 * Returns the default field list in output order.
 	 *
+	 * Unavailable fields are dropped through {@see self::get_fields()}.
+	 *
 	 * @since x.x.x
 	 *
 	 * @return string[] Default field names.
 	 */
 	private function get_default_fields(): array {
-		$fields = $this->default_fields;
-
-		if ( get_option( 'show_avatars' ) ) {
-			$fields[] = 'avatar_urls';
-		}
-
-		return $fields;
+		return array_values( array_intersect( $this->get_fields(), $this->default_fields ) );
 	}
 
 	/**
@@ -855,6 +836,13 @@ final class Users {
 				'type'        => 'string',
 				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
 			),
+			'avatar_urls'     => array(
+				'type'                 => 'object',
+				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
+				'additionalProperties' => array(
+					'type' => 'string',
+				),
+			),
 			'user_login'      => array(
 				'type'        => 'string',
 				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
@@ -895,14 +883,8 @@ final class Users {
 			),
 		);
 
-		if ( get_option( 'show_avatars' ) ) {
-			$user_properties['avatar_urls'] = array(
-				'type'                 => 'object',
-				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
-				'additionalProperties' => array(
-					'type' => 'string',
-				),
-			);
+		if ( ! in_array( 'avatar_urls', $this->get_fields(), true ) ) {
+			unset( $user_properties['avatar_urls'] );
 		}
 
 		$user_schema = array(
@@ -923,11 +905,11 @@ final class Users {
 				),
 				'total'       => array(
 					'type'        => 'integer',
-					'description' => __( 'Total number of users matching the query, across all pages, after applying the permission filter to the query. Surfaced over REST as the X-WP-Total header.', 'ai' ),
+					'description' => __( 'Total number of users matching the query, across all pages.', 'ai' ),
 				),
 				'total_pages' => array(
 					'type'        => 'integer',
-					'description' => __( 'Total number of query result pages available after applying the permission filter to the query. Surfaced over REST as the X-WP-TotalPages header.', 'ai' ),
+					'description' => __( 'Total number of result pages available for the query.', 'ai' ),
 				),
 			),
 		);
@@ -980,7 +962,7 @@ final class Users {
 		if ( $fields_requested( 'user_nicename' ) ) {
 			$data['user_nicename'] = (string) $user->user_nicename;
 		}
-		if ( $fields_requested( 'avatar_urls' ) && get_option( 'show_avatars' ) ) {
+		if ( $fields_requested( 'avatar_urls' ) ) {
 			$data['avatar_urls'] = rest_get_avatar_urls( $user );
 		}
 

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -221,24 +221,29 @@ final class Users {
 			$query_args['role__in'] = $this->normalize_string_list( $input['roles'] );
 		}
 
-		if ( current_user_can( 'list_users' ) ) {
-			$has_published_posts = $this->normalize_has_published_posts( $input );
-			if ( null !== $has_published_posts ) {
-				$query_args['has_published_posts'] = $has_published_posts;
-			}
-		} else {
-			// Callers who cannot list users only see public authors in a collection,
-			// matching core. This intentionally excludes the caller's own account when
-			// they have no published posts. Self is read through a single-user lookup
-			// (like the REST `/users/me` endpoint) instead.
-			$public_post_types   = $this->get_public_post_types();
-			$has_published_posts = $this->normalize_has_published_posts( $input );
+		$has_published_posts = $this->normalize_has_published_posts( $input );
 
-			if ( is_array( $has_published_posts ) ) {
-				$public_post_types = array_values( array_intersect( $public_post_types, $has_published_posts ) );
-			}
+		// Callers who cannot list users only see public authors in a collection,
+		// matching core, so the filter is always applied for them. This intentionally
+		// excludes the caller's own account when they have no published posts. Self is
+		// read through a single-user lookup (like the REST `/users/me` endpoint) instead.
+		$requires_published_posts = ! current_user_can( 'list_users' );
 
-			if ( array() === $public_post_types ) {
+		if ( null !== $has_published_posts || $requires_published_posts ) {
+			/*
+			 * The post types are always resolved here rather than passed as `true`.
+			 * WP_User_Query reads `true` as `get_post_types( array( 'public' => true ) )`,
+			 * which is not the same as the publicly viewable set the rest of the ability
+			 * uses. Resolving here also picks up post types registered or unregistered
+			 * after the input schema was built.
+			 */
+			$public_post_types = $this->get_public_post_types();
+
+			$has_published_posts = is_array( $has_published_posts )
+				? array_values( array_intersect( $public_post_types, $has_published_posts ) )
+				: $public_post_types;
+
+			if ( array() === $has_published_posts ) {
 				return array(
 					'users'       => array(),
 					'total'       => 0,
@@ -246,7 +251,7 @@ final class Users {
 				);
 			}
 
-			$query_args['has_published_posts'] = $public_post_types;
+			$query_args['has_published_posts'] = $has_published_posts;
 		}
 
 		$query = new WP_User_Query( $query_args );
@@ -884,7 +889,7 @@ final class Users {
 									),
 								),
 							),
-							'description' => __( 'Limit results to users with published posts. Use true for all post types, or provide post type names.', 'ai' ),
+							'description' => __( 'Limit results to users with published posts. Use true for all publicly viewable post types, or provide post type names.', 'ai' ),
 						),
 						'include'             => $include,
 						'fields'              => $fields,

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -157,7 +157,7 @@ final class Users {
 	 * @return bool True if the request may proceed, false otherwise.
 	 */
 	public function check_permission( $input = array() ): bool {
-		$input = is_array( $input ) ? $input : array();
+		$input = $this->sanitize_input( $input );
 
 		if ( ! is_user_logged_in() ) {
 			return false;
@@ -172,12 +172,7 @@ final class Users {
 			return true;
 		}
 
-		$user = $this->find_user( $input );
-		if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
-			return false;
-		}
-
-		return $this->can_read_user_for_lookup( $user, $lookup_type );
+		return $this->resolve_readable_user( $input, $lookup_type ) instanceof WP_User;
 	}
 
 	/**
@@ -186,19 +181,16 @@ final class Users {
 	 * @since x.x.x
 	 *
 	 * @param mixed $input Optional. The ability input. Default empty array.
-	 * @return array<string, mixed>|\WP_Error User data, paginated collection data, or a WP_Error on failure.
+	 * @return array<string, mixed>|\stdClass|\WP_Error User data, paginated collection data, or a WP_Error on failure.
 	 */
 	public function execute_get_users( $input = array() ) {
-		$input  = is_array( $input ) ? $input : array();
+		$input  = $this->sanitize_input( $input );
 		$fields = $this->normalize_fields( $input );
 
 		$lookup_type = $this->get_lookup_type( $input );
 		if ( self::LOOKUP_COLLECTION !== $lookup_type ) {
-			$user = $this->find_user( $input );
-			if ( ! $user instanceof WP_User
-				|| ! $this->is_user_member_of_site( $user )
-				|| ! $this->can_read_user_for_lookup( $user, $lookup_type )
-			) {
+			$user = $this->resolve_readable_user( $input, $lookup_type );
+			if ( ! $user instanceof WP_User ) {
 				return new WP_Error(
 					'ability_invalid_permissions',
 					__( 'The requested user cannot be read.', 'ai' )
@@ -279,6 +271,36 @@ final class Users {
 	}
 
 	/**
+	 * Sanitizes raw ability input against the input schema.
+	 *
+	 * The Abilities API validates input against the schema but does not coerce
+	 * it, and REST `GET` requests (the only method for read-only abilities)
+	 * deliver every scalar as a string. Sanitizing applies the coercions that
+	 * validation already accepted (`'true'` to `true`, CSV strings to arrays,
+	 * numeric strings to integers) before the values reach the strict
+	 * normalizers.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input The raw ability input.
+	 * @return array<mixed> The sanitized input.
+	 */
+	private function sanitize_input( $input ): array {
+		if ( ! is_array( $input ) ) {
+			return array();
+		}
+
+		$sanitized = rest_sanitize_value_from_schema( $input, $this->get_users_input_schema(), 'input' );
+		if ( is_wp_error( $sanitized ) || ! is_array( $sanitized ) ) {
+			// Input that does not match the schema is left as-is; it has either
+			// already passed validation or will be rejected by it.
+			return $input;
+		}
+
+		return $sanitized;
+	}
+
+	/**
 	 * Casts a raw input value to a non-negative integer.
 	 *
 	 * @since x.x.x
@@ -306,6 +328,27 @@ final class Users {
 		}
 
 		return self::LOOKUP_COLLECTION;
+	}
+
+	/**
+	 * Resolves the target of a single-user lookup when the current user may read it.
+	 *
+	 * Shared by the permission and execute callbacks so the single-user
+	 * authorization decision has exactly one implementation.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input       The ability input.
+	 * @param string       $lookup_type The single-user lookup type.
+	 * @return \WP_User|null The readable user, or null when not found or not readable.
+	 */
+	private function resolve_readable_user( array $input, string $lookup_type ): ?WP_User {
+		$user = $this->find_user( $input );
+		if ( ! $user instanceof WP_User || ! $this->is_user_member_of_site( $user ) ) {
+			return null;
+		}
+
+		return $this->can_read_user_for_lookup( $user, $lookup_type ) ? $user : null;
 	}
 
 	/**
@@ -467,17 +510,20 @@ final class Users {
 	 *
 	 * This is the single source of truth for the ability's user fields: the output
 	 * schema uses the definitions directly, while the input schema and field
-	 * normalization use the keys. The `avatar_urls` field is dropped when the
-	 * `show_avatars` option is disabled. Deliberately resolved on every call rather
-	 * than cached, since the option and the registered roles can change between the
-	 * ability being registered and the ability being used.
+	 * normalization use the keys. The field set is deliberately unconditional:
+	 * the registered schemas are a registration-time snapshot, so conditional
+	 * availability (such as `avatar_urls` honoring the `show_avatars` option) is
+	 * enforced per call in {@see self::format_user()} instead of here, where the
+	 * option could change between registration and use. Deliberately resolved on
+	 * every call rather than cached, since the registered roles can change at
+	 * runtime.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return array<string, mixed> User field definitions.
 	 */
 	private function get_user_properties(): array {
-		$user_properties = array(
+		return array(
 			'id'              => array(
 				'type'        => 'integer',
 				'description' => __( 'The user ID.', 'ai' ),
@@ -504,7 +550,7 @@ final class Users {
 			),
 			'avatar_urls'     => array(
 				'type'                 => 'object',
-				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
+				'description'          => __( 'Avatar URLs for the user at various sizes. Present when the show_avatars option is enabled.', 'ai' ),
 				'additionalProperties' => array(
 					'type' => 'string',
 				),
@@ -548,18 +594,10 @@ final class Users {
 				),
 			),
 		);
-
-		if ( ! get_option( 'show_avatars' ) ) {
-			unset( $user_properties['avatar_urls'] );
-		}
-
-		return $user_properties;
 	}
 
 	/**
 	 * Returns the default field list in output order.
-	 *
-	 * Unavailable fields are dropped through {@see self::get_user_properties()}.
 	 *
 	 * @since x.x.x
 	 *
@@ -870,9 +908,12 @@ final class Users {
 	 *
 	 * @param \WP_User $user   The user object.
 	 * @param string[] $fields The requested field names.
-	 * @return array<string, mixed> The formatted user data.
+	 * @return array<string, mixed>|\stdClass The formatted user data. A fully
+	 *                                        redacted user is returned as an
+	 *                                        object so it serializes as `{}`
+	 *                                        rather than `[]`.
 	 */
-	private function format_user( WP_User $user, array $fields ): array {
+	private function format_user( WP_User $user, array $fields ) {
 		$fields_requested = static function ( string $field ) use ( $fields ): bool {
 			return in_array( $field, $fields, true );
 		};
@@ -901,7 +942,9 @@ final class Users {
 		if ( $fields_requested( 'slug' ) ) {
 			$data['slug'] = (string) $user->user_nicename;
 		}
-		if ( $fields_requested( 'avatar_urls' ) ) {
+		// The schemas always declare avatar_urls; availability is enforced here,
+		// since the option can change after the schemas are registered.
+		if ( $fields_requested( 'avatar_urls' ) && get_option( 'show_avatars' ) ) {
 			$data['avatar_urls'] = rest_get_avatar_urls( $user );
 		}
 
@@ -936,6 +979,7 @@ final class Users {
 			$data['roles'] = $this->normalize_string_list( $user->roles );
 		}
 
-		return $data;
+		// An empty result must serialize as a JSON object, not an empty array.
+		return array() === $data ? (object) $data : $data;
 	}
 }

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -773,9 +773,9 @@ final class Users {
 	 */
 	private function get_users_input_schema(): array {
 		/*
-		 * The schema enums reflect the roles and post types available at registration
-		 * time; the permission/execute callbacks re-resolve these sets at call time,
-		 * since both can change in between.
+		 * Input enums intentionally reflect roles and post types available at
+		 * ability registration time. This makes the schema a stable contract that
+		 * developers can filter when registering the ability.
 		 */
 		$role_names        = $this->get_role_names();
 		$public_post_types = $this->get_public_post_types();

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -255,6 +255,10 @@ final class Users {
 				$query_args['has_published_posts'] = $has_published_posts;
 			}
 		} else {
+			// Callers who cannot list users only see public authors in a collection,
+			// matching core. This intentionally excludes the caller's own account when
+			// they have no published posts; self is read through a single-user lookup
+			// (like the REST `/users/me` endpoint) instead.
 			$public_post_types   = $this->get_public_post_types();
 			$has_published_posts = $this->normalize_has_published_posts( $input );
 
@@ -732,7 +736,7 @@ final class Users {
 				'type'    => 'integer',
 				'minimum' => 1,
 			),
-			'description' => __( 'Limit the query to these user IDs. Results preserve this order where possible and still respect read permissions.', 'ai' ),
+			'description' => __( 'Limit the query to these user IDs, preserving this order where possible. Collection results are limited to users the caller can read, which for callers without permission to list users means only public authors. To read your own account, use a single-user lookup by ID.', 'ai' ),
 		);
 
 		return array(

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -79,7 +79,7 @@ final class Users {
 	 * @since x.x.x
 	 * @var string[]
 	 */
-	private const DEFAULT_FIELDS = array(
+	private const DEFAULT_FIELDS = array( // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
 		'id',
 		'name',
 		'link',

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -73,38 +73,6 @@ final class Users {
 	private const LOOKUP_COLLECTION = 'collection';
 
 	/**
-	 * Public/read-context user fields.
-	 *
-	 * @since x.x.x
-	 * @var string[]
-	 */
-	private array $read_fields = array(
-		'id',
-		'display_name',
-		'description',
-		'user_url',
-		'link',
-		'user_nicename',
-		'avatar_urls',
-	);
-
-	/**
-	 * Fields that expose edit-context user data.
-	 *
-	 * @since x.x.x
-	 * @var string[]
-	 */
-	private array $sensitive_fields = array(
-		'user_login',
-		'user_email',
-		'first_name',
-		'last_name',
-		'nickname',
-		'locale',
-		'user_registered',
-	);
-
-	/**
 	 * Default fields returned when the caller does not request a field subset.
 	 *
 	 * @since x.x.x
@@ -127,12 +95,12 @@ final class Users {
 	private ?array $public_post_types = null;
 
 	/**
-	 * Cached supported field list.
+	 * Cached user field definitions, keyed by field name in output order.
 	 *
 	 * @since x.x.x
-	 * @var string[]|null
+	 * @var array<string, mixed>|null
 	 */
-	private ?array $fields = null;
+	private ?array $user_properties = null;
 
 	/**
 	 * Cached role names.
@@ -509,7 +477,7 @@ final class Users {
 	 * @return string[] List of requested field names.
 	 */
 	private function normalize_fields( array $input ): array {
-		$available_fields = $this->get_fields();
+		$available_fields = array_keys( $this->get_user_properties() );
 
 		if ( empty( $input['fields'] ) || ! is_array( $input['fields'] ) ) {
 			return $this->get_default_fields();
@@ -522,39 +490,114 @@ final class Users {
 	}
 
 	/**
-	 * Returns the supported field list in output order.
+	 * Returns the user field definitions, keyed by field name in output order.
+	 *
+	 * This is the single source of truth for the ability's user fields: the output
+	 * schema uses the definitions directly, while the input schema and field
+	 * normalization use the keys. The `avatar_urls` field is dropped when the
+	 * `show_avatars` option is disabled.
 	 *
 	 * @since x.x.x
 	 *
-	 * @return string[] Supported field names.
+	 * @return array<string, mixed> User field definitions.
 	 */
-	private function get_fields(): array {
-		if ( null !== $this->fields ) {
-			return $this->fields;
+	private function get_user_properties(): array {
+		if ( null !== $this->user_properties ) {
+			return $this->user_properties;
 		}
 
-		$fields = $this->read_fields;
+		$user_properties = array(
+			'id'              => array(
+				'type'        => 'integer',
+				'description' => __( 'The user ID.', 'ai' ),
+			),
+			'display_name'    => array(
+				'type'        => 'string',
+				'description' => __( 'The display name for the user.', 'ai' ),
+			),
+			'description'     => array(
+				'type'        => 'string',
+				'description' => __( 'Description of the user.', 'ai' ),
+			),
+			'user_url'        => array(
+				'type'        => 'string',
+				'description' => __( 'URL of the user.', 'ai' ),
+			),
+			'link'            => array(
+				'type'        => 'string',
+				'description' => __( 'Author archive URL for the user.', 'ai' ),
+			),
+			'user_nicename'   => array(
+				'type'        => 'string',
+				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
+			),
+			'avatar_urls'     => array(
+				'type'                 => 'object',
+				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
+				'additionalProperties' => array(
+					'type' => 'string',
+				),
+			),
+			'user_login'      => array(
+				'type'        => 'string',
+				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'user_email'      => array(
+				'type'        => 'string',
+				'format'      => 'email',
+				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'first_name'      => array(
+				'type'        => 'string',
+				'description' => __( 'First name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'last_name'       => array(
+				'type'        => 'string',
+				'description' => __( 'Last name for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'nickname'        => array(
+				'type'        => 'string',
+				'description' => __( 'The nickname for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'locale'          => array(
+				'type'        => 'string',
+				'description' => __( 'Locale for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'user_registered' => array(
+				'type'        => 'string',
+				'format'      => 'date-time',
+				'description' => __( 'Registration date for the user. Present when the current user can view it.', 'ai' ),
+			),
+			'roles'           => array(
+				'type'        => 'array',
+				'description' => __( 'Roles assigned to the user. Present when the current user can view them.', 'ai' ),
+				'items'       => array(
+					'type' => 'string',
+					'enum' => $this->get_role_names(),
+				),
+			),
+		);
 
 		if ( ! get_option( 'show_avatars' ) ) {
-			$fields = array_diff( $fields, array( 'avatar_urls' ) );
+			unset( $user_properties['avatar_urls'] );
 		}
 
-		$this->fields = array_merge( array_values( $fields ), $this->sensitive_fields, array( 'roles' ) );
+		$this->user_properties = $user_properties;
 
-		return $this->fields;
+		return $this->user_properties;
 	}
 
 	/**
 	 * Returns the default field list in output order.
 	 *
-	 * Unavailable fields are dropped through {@see self::get_fields()}.
+	 * Unavailable fields are dropped through {@see self::get_user_properties()}.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return string[] Default field names.
 	 */
 	private function get_default_fields(): array {
-		return array_values( array_intersect( $this->get_fields(), $this->default_fields ) );
+		return array_values( array_intersect( array_keys( $this->get_user_properties() ), $this->default_fields ) );
 	}
 
 	/**
@@ -678,7 +721,7 @@ final class Users {
 			'uniqueItems' => true,
 			'items'       => array(
 				'type' => 'string',
-				'enum' => $this->get_fields(),
+				'enum' => array_keys( $this->get_user_properties() ),
 			),
 			'description' => __( 'Limit each returned user to these fields. If omitted, a lean set of common read fields is returned.', 'ai' ),
 		);
@@ -811,86 +854,10 @@ final class Users {
 	 * @return array<string, mixed> The output JSON Schema.
 	 */
 	private function get_users_output_schema(): array {
-		$user_properties = array(
-			'id'              => array(
-				'type'        => 'integer',
-				'description' => __( 'The user ID.', 'ai' ),
-			),
-			'display_name'    => array(
-				'type'        => 'string',
-				'description' => __( 'The display name for the user.', 'ai' ),
-			),
-			'description'     => array(
-				'type'        => 'string',
-				'description' => __( 'Description of the user.', 'ai' ),
-			),
-			'user_url'        => array(
-				'type'        => 'string',
-				'description' => __( 'URL of the user.', 'ai' ),
-			),
-			'link'            => array(
-				'type'        => 'string',
-				'description' => __( 'Author archive URL for the user.', 'ai' ),
-			),
-			'user_nicename'   => array(
-				'type'        => 'string',
-				'description' => __( 'An alphanumeric identifier for the user.', 'ai' ),
-			),
-			'avatar_urls'     => array(
-				'type'                 => 'object',
-				'description'          => __( 'Avatar URLs for the user at various sizes.', 'ai' ),
-				'additionalProperties' => array(
-					'type' => 'string',
-				),
-			),
-			'user_login'      => array(
-				'type'        => 'string',
-				'description' => __( 'Login name for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'user_email'      => array(
-				'type'        => 'string',
-				'format'      => 'email',
-				'description' => __( 'The email address for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'first_name'      => array(
-				'type'        => 'string',
-				'description' => __( 'First name for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'last_name'       => array(
-				'type'        => 'string',
-				'description' => __( 'Last name for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'nickname'        => array(
-				'type'        => 'string',
-				'description' => __( 'The nickname for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'locale'          => array(
-				'type'        => 'string',
-				'description' => __( 'Locale for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'user_registered' => array(
-				'type'        => 'string',
-				'format'      => 'date-time',
-				'description' => __( 'Registration date for the user. Present when the current user can view it.', 'ai' ),
-			),
-			'roles'           => array(
-				'type'        => 'array',
-				'description' => __( 'Roles assigned to the user. Present when the current user can view them.', 'ai' ),
-				'items'       => array(
-					'type' => 'string',
-					'enum' => $this->get_role_names(),
-				),
-			),
-		);
-
-		if ( ! in_array( 'avatar_urls', $this->get_fields(), true ) ) {
-			unset( $user_properties['avatar_urls'] );
-		}
-
 		$user_schema = array(
 			'type'                 => 'object',
 			'additionalProperties' => false,
-			'properties'           => $user_properties,
+			'properties'           => $this->get_user_properties(),
 		);
 
 		$collection_schema = array(

--- a/includes/Abilities/Users/Users.php
+++ b/includes/Abilities/Users/Users.php
@@ -461,12 +461,20 @@ final class Users {
 	}
 
 	/**
-	 * Checks whether a user has published posts in publicly viewable post types.
+	 * Checks whether the current user can see a post by this user in a publicly
+	 * viewable post type.
+	 *
+	 * Published posts always count. Private posts also count for a caller who holds
+	 * `read_private_posts` for the post type, because `count_user_posts()` defaults to
+	 * `$public_only = false`. This matches how the REST users controller resolves a
+	 * single user. Collection mode is filtered by `WP_User_Query`'s
+	 * `has_published_posts`, which matches published posts only, so the two modes
+	 * disagree about an author whose posts are all private.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param \WP_User $user User object.
-	 * @return bool Whether the user is publicly visible as an author.
+	 * @return bool Whether the user is visible as an author to the current user.
 	 */
 	private function is_public_author( WP_User $user ): bool {
 		$post_types = $this->get_public_post_types();

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -13,6 +13,7 @@ namespace WordPress\AI;
 
 use WordPress\AI\Abilities\Settings\Settings as Settings_Ability;
 use WordPress\AI\Abilities\Show_In_Abilities;
+use WordPress\AI\Abilities\Users\Users as Users_Ability;
 use WordPress\AI\Abilities\Utilities\Posts;
 use WordPress\AI\Admin\Activation;
 use WordPress\AI\Admin\Dashboard\Dashboard_Widgets;
@@ -133,9 +134,10 @@ final class Main {
 			( new Posts() )->register();
 
 			// Expose curated core objects to the Abilities API, then register the
-			// `core/settings` ability (overriding any core-provided copy).
+			// core abilities (overriding any core-provided copies).
 			( new Show_In_Abilities() )->register();
 			( new Settings_Ability() )->init();
+			( new Users_Ability() )->init();
 		} catch ( \Throwable $e ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -13,6 +13,7 @@ namespace WordPress\AI;
 
 use WordPress\AI\Abilities\Settings\Settings as Settings_Ability;
 use WordPress\AI\Abilities\Show_In_Abilities;
+use WordPress\AI\Abilities\Users\Users as Users_Ability;
 use WordPress\AI\Abilities\Utilities\Posts;
 use WordPress\AI\Admin\Activation;
 use WordPress\AI\Admin\Dashboard\Dashboard_Widgets;
@@ -135,9 +136,10 @@ final class Main {
 			( new Posts() )->register();
 
 			// Expose curated core objects to the Abilities API, then register the
-			// `core/read-settings` ability (overriding any core-provided copy).
+			// core abilities (overriding any core-provided copies).
 			( new Show_In_Abilities() )->register();
 			( new Settings_Ability() )->init();
+			( new Users_Ability() )->init();
 		} catch ( \Throwable $e ) {
 			_doing_it_wrong(
 				__METHOD__,

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -71,27 +71,27 @@ class UsersTest extends WP_UnitTestCase {
 
 		$this->admin_id = self::factory()->user->create(
 			array(
-				'role'         => 'administrator',
-				'user_login'   => 'users_ability_admin',
-				'user_email'   => 'users-ability-admin@example.com',
+				'role'          => 'administrator',
+				'user_login'    => 'users_ability_admin',
+				'user_email'    => 'users-ability-admin@example.com',
 				'user_nicename' => 'users-ability-admin',
 			)
 		);
 
 		$this->subscriber_id = self::factory()->user->create(
 			array(
-				'role'         => 'subscriber',
-				'user_login'   => 'users_ability_subscriber',
-				'user_email'   => 'users-ability-subscriber@example.com',
+				'role'          => 'subscriber',
+				'user_login'    => 'users_ability_subscriber',
+				'user_email'    => 'users-ability-subscriber@example.com',
 				'user_nicename' => 'users-ability-subscriber',
 			)
 		);
 
 		$this->public_author_id = self::factory()->user->create(
 			array(
-				'role'         => 'author',
-				'user_login'   => 'users_ability_author',
-				'user_email'   => 'users-ability-author@example.com',
+				'role'          => 'author',
+				'user_login'    => 'users_ability_author',
+				'user_email'    => 'users-ability-author@example.com',
 				'user_nicename' => 'users-ability-author',
 			)
 		);

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -9,6 +9,7 @@ namespace WordPress\AI\Tests\Integration\Includes\Abilities\Users;
 
 use WP_Ability;
 use WP_UnitTestCase;
+use WP_UnitTest_Factory;
 use WordPress\AI\Abilities\Users\Users;
 
 /**
@@ -17,6 +18,14 @@ use WordPress\AI\Abilities\Users\Users;
  * @since x.x.x
  */
 class UsersTest extends WP_UnitTestCase {
+
+	/**
+	 * Shared fixture IDs.
+	 *
+	 * @since x.x.x
+	 * @var array<string, int>
+	 */
+	private static $fixture_ids = array();
 
 	/**
 	 * Administrator user ID.
@@ -59,6 +68,92 @@ class UsersTest extends WP_UnitTestCase {
 	private $show_avatars;
 
 	/**
+	 * Set up shared test fixtures.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_UnitTest_Factory $factory The WordPress unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ): void {
+		self::$fixture_ids['administrator'] = $factory->user->create(
+			array(
+				'role'          => 'administrator',
+				'user_login'    => 'users_ability_admin',
+				'user_email'    => 'users-ability-admin@example.com',
+				'user_nicename' => 'users-ability-admin',
+			)
+		);
+
+		self::$fixture_ids['editor'] = $factory->user->create(
+			array(
+				'role'          => 'editor',
+				'user_login'    => 'users_ability_editor',
+				'user_email'    => 'users-ability-editor@example.com',
+				'user_nicename' => 'users-ability-editor',
+			)
+		);
+
+		self::$fixture_ids['author'] = $factory->user->create(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'users_ability_author_current',
+				'user_email'    => 'users-ability-author-current@example.com',
+				'user_nicename' => 'users-ability-author-current',
+			)
+		);
+
+		self::$fixture_ids['contributor'] = $factory->user->create(
+			array(
+				'role'          => 'contributor',
+				'user_login'    => 'users_ability_contributor',
+				'user_email'    => 'users-ability-contributor@example.com',
+				'user_nicename' => 'users-ability-contributor',
+			)
+		);
+
+		self::$fixture_ids['subscriber'] = $factory->user->create(
+			array(
+				'role'          => 'subscriber',
+				'user_login'    => 'users_ability_subscriber',
+				'user_email'    => 'users-ability-subscriber@example.com',
+				'user_nicename' => 'users-ability-subscriber',
+			)
+		);
+
+		self::$fixture_ids['public_author'] = $factory->user->create(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'users_ability_author',
+				'user_email'    => 'users-ability-author@example.com',
+				'user_nicename' => 'users-ability-author',
+			)
+		);
+
+		self::$fixture_ids['public_post'] = $factory->post->create(
+			array(
+				'post_author' => self::$fixture_ids['public_author'],
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+	}
+
+	/**
+	 * Tear down shared test fixtures.
+	 *
+	 * @since x.x.x
+	 */
+	public static function wpTearDownAfterClass(): void {
+		wp_delete_post( self::$fixture_ids['public_post'], true );
+
+		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber', 'public_author' ) as $fixture_name ) {
+			wp_delete_user( self::$fixture_ids[ $fixture_name ] );
+		}
+
+		self::$fixture_ids = array();
+	}
+
+	/**
 	 * Set up test case.
 	 *
 	 * @since x.x.x
@@ -69,40 +164,10 @@ class UsersTest extends WP_UnitTestCase {
 		$this->show_avatars = get_option( 'show_avatars' );
 		update_option( 'show_avatars', 1 );
 
-		$this->admin_id = self::factory()->user->create(
-			array(
-				'role'          => 'administrator',
-				'user_login'    => 'users_ability_admin',
-				'user_email'    => 'users-ability-admin@example.com',
-				'user_nicename' => 'users-ability-admin',
-			)
-		);
-
-		$this->subscriber_id = self::factory()->user->create(
-			array(
-				'role'          => 'subscriber',
-				'user_login'    => 'users_ability_subscriber',
-				'user_email'    => 'users-ability-subscriber@example.com',
-				'user_nicename' => 'users-ability-subscriber',
-			)
-		);
-
-		$this->public_author_id = self::factory()->user->create(
-			array(
-				'role'          => 'author',
-				'user_login'    => 'users_ability_author',
-				'user_email'    => 'users-ability-author@example.com',
-				'user_nicename' => 'users-ability-author',
-			)
-		);
-
-		$this->public_post_id = self::factory()->post->create(
-			array(
-				'post_author' => $this->public_author_id,
-				'post_status' => 'publish',
-				'post_type'   => 'post',
-			)
-		);
+		$this->admin_id         = self::$fixture_ids['administrator'];
+		$this->subscriber_id    = self::$fixture_ids['subscriber'];
+		$this->public_author_id = self::$fixture_ids['public_author'];
+		$this->public_post_id   = self::$fixture_ids['public_post'];
 
 		$this->ensure_user_category();
 		$this->ensure_site_category();
@@ -118,7 +183,6 @@ class UsersTest extends WP_UnitTestCase {
 			wp_unregister_ability( 'core/users' );
 		}
 
-		wp_delete_post( $this->public_post_id, true );
 		update_option( 'show_avatars', $this->show_avatars );
 		wp_set_current_user( 0 );
 
@@ -201,14 +265,14 @@ class UsersTest extends WP_UnitTestCase {
 
 		$ability = wp_get_ability( 'core/users' );
 
-		$this->assertInstanceOf( WP_Ability::class, $ability );
-		$this->assertSame( 'user', $ability->get_category() );
-		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
-		$this->assertTrue( $ability->get_meta_item( 'pagination', false ) );
+		$this->assertInstanceOf( WP_Ability::class, $ability, 'The users ability should be registered.' );
+		$this->assertSame( 'user', $ability->get_category(), 'The users ability should use the user category.' );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'The users ability should be exposed over REST.' );
+		$this->assertTrue( $ability->get_meta_item( 'pagination', false ), 'The users ability should advertise pagination support.' );
 
 		$annotations = $ability->get_meta_item( 'annotations', array() );
-		$this->assertTrue( $annotations['readonly'] );
-		$this->assertFalse( $annotations['destructive'] );
+		$this->assertTrue( $annotations['readonly'], 'The users ability should be marked read-only.' );
+		$this->assertFalse( $annotations['destructive'], 'The users ability should not be marked destructive.' );
 	}
 
 	/**
@@ -236,13 +300,13 @@ class UsersTest extends WP_UnitTestCase {
 			array_pop( $wp_current_filter );
 		}
 
-		$this->assertSame( 'Core Provided', wp_get_ability( 'core/users' )->get_label() );
+		$this->assertSame( 'Core Provided', wp_get_ability( 'core/users' )->get_label(), 'The test should start with the fake core ability registered.' );
 
 		$this->register_ability();
 
 		$ability = wp_get_ability( 'core/users' );
-		$this->assertSame( 'Get Users', $ability->get_label() );
-		$this->assertCount( 5, $ability->get_input_schema()['oneOf'] );
+		$this->assertSame( 'Get Users', $ability->get_label(), 'The plugin ability should replace the fake core ability.' );
+		$this->assertCount( 5, $ability->get_input_schema()['oneOf'], 'The replacement ability should expose all supported input modes.' );
 	}
 
 	/**
@@ -255,20 +319,21 @@ class UsersTest extends WP_UnitTestCase {
 
 		$schema = wp_get_ability( 'core/users' )->get_input_schema();
 
-		$this->assertSame( 'object', $schema['type'] );
-		$this->assertEquals( (object) array(), $schema['default'] );
-		$this->assertCount( 5, $schema['oneOf'] );
+		$this->assertSame( 'object', $schema['type'], 'The users ability input schema should describe an object.' );
+		$this->assertEquals( (object) array(), $schema['default'], 'The users ability input schema should default to empty collection mode.' );
+		$this->assertCount( 5, $schema['oneOf'], 'The users ability input schema should expose four lookup modes and collection mode.' );
 
-		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'] );
-		$this->assertSame( array( 'user_email' ), $schema['oneOf'][1]['required'] );
-		$this->assertSame( array( 'user_login' ), $schema['oneOf'][2]['required'] );
-		$this->assertSame( array( 'user_nicename' ), $schema['oneOf'][3]['required'] );
-		$this->assertArrayNotHasKey( 'required', $schema['oneOf'][4] );
+		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'], 'The first input mode should require an ID.' );
+		$this->assertSame( array( 'user_email' ), $schema['oneOf'][1]['required'], 'The second input mode should require a user email.' );
+		$this->assertSame( array( 'user_login' ), $schema['oneOf'][2]['required'], 'The third input mode should require a user login.' );
+		$this->assertSame( array( 'user_nicename' ), $schema['oneOf'][3]['required'], 'The fourth input mode should require a user nicename.' );
+		$this->assertArrayNotHasKey( 'required', $schema['oneOf'][4], 'Collection mode should allow an empty request.' );
 
 		$collection_properties = $schema['oneOf'][4]['properties'];
 		$this->assertEqualSets(
 			array( 'roles', 'has_published_posts', 'fields', 'page', 'per_page' ),
-			array_keys( $collection_properties )
+			array_keys( $collection_properties ),
+			'Collection mode should expose only the supported query parameters.'
 		);
 		$excluded_properties = array(
 			'search',
@@ -289,16 +354,24 @@ class UsersTest extends WP_UnitTestCase {
 			'capabilities',
 		);
 		foreach ( $excluded_properties as $excluded_property ) {
-			$this->assertArrayNotHasKey( $excluded_property, $collection_properties );
+			$this->assertArrayNotHasKey( $excluded_property, $collection_properties, sprintf( 'Collection mode should not expose %s.', $excluded_property ) );
 		}
 
 		$fields = $schema['oneOf'][4]['properties']['fields']['items']['enum'];
-		$this->assertContains( 'roles', $fields );
-		$this->assertContains( 'avatar_urls', $fields );
+		$this->assertContains( 'roles', $fields, 'The fields enum should expose the roles field.' );
+		$this->assertContains( 'avatar_urls', $fields, 'The fields enum should expose avatar_urls when avatars are enabled.' );
+
+		$role_names = $schema['oneOf'][4]['properties']['roles']['items']['enum'];
+		$this->assertEqualSets( array_keys( wp_roles()->roles ), $role_names, 'The roles query enum should expose registered role names.' );
+
+		$post_type_names = $schema['oneOf'][4]['properties']['has_published_posts']['oneOf'][1]['items']['enum'];
+		$this->assertContains( 'post', $post_type_names, 'The has_published_posts enum should expose public post types.' );
+		$this->assertNotContains( 'revision', $post_type_names, 'The has_published_posts enum should omit non-public post types.' );
 
 		$output_schema   = wp_get_ability( 'core/users' )->get_output_schema();
 		$user_properties = $output_schema['properties']['users']['items']['properties'];
-		$this->assertSame( 'date-time', $user_properties['user_registered']['format'] );
+		$this->assertSame( 'date-time', $user_properties['user_registered']['format'], 'The user_registered output schema should use date-time format.' );
+		$this->assertEqualSets( array_keys( wp_roles()->roles ), $user_properties['roles']['items']['enum'], 'The roles output enum should expose registered role names.' );
 	}
 
 	/**
@@ -314,14 +387,14 @@ class UsersTest extends WP_UnitTestCase {
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
 
-		$this->assertNotContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'] );
-		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['properties']['users']['items']['properties'] );
+		$this->assertNotContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'], 'The fields enum should omit avatar_urls when avatars are disabled.' );
+		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['properties']['users']['items']['properties'], 'The output schema should omit avatar_urls when avatars are disabled.' );
 
 		wp_set_current_user( $this->subscriber_id );
 		$result = $ability->execute( array( 'id' => $this->subscriber_id ) );
 
-		$this->assertIsArray( $result );
-		$this->assertArrayNotHasKey( 'avatar_urls', $result['users'][0] );
+		$this->assertIsArray( $result, 'The current user should still be readable when avatars are disabled.' );
+		$this->assertArrayNotHasKey( 'avatar_urls', $result['users'][0], 'The ability result should omit avatar_urls when avatars are disabled.' );
 	}
 
 	/**
@@ -334,8 +407,8 @@ class UsersTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'core/users' )->execute( array() );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertWPError( $result, 'Logged-out users should not be allowed to execute the users ability.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Logged-out users should receive an invalid permissions error.' );
 	}
 
 	/**
@@ -356,25 +429,31 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
-		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['user_email'] );
-		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['user_login'] );
-		$this->assertContains( 'subscriber', $result['users'][0]['roles'] );
+		$this->assertIsArray( $result, 'A user should be able to read themselves by ID.' );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The ID lookup should return the current user.' );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['user_email'], 'The current user should receive their own email.' );
+		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['user_login'], 'The current user should receive their own login.' );
+		$this->assertContains( 'subscriber', $result['users'][0]['roles'], 'The current user should receive their own roles.' );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-subscriber@example.com' ) );
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'A user should be able to read themselves by email.' );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The email lookup should return the current user.' );
 
 		$result = $ability->execute( array( 'user_login' => 'users_ability_subscriber' ) );
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'A user should be able to read themselves by login.' );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The login lookup should return the current user.' );
 
-		$result = $ability->execute( array( 'id' => $this->subscriber_id, 'fields' => array( 'id', 'user_registered' ) ) );
-		$this->assertIsArray( $result );
+		$result = $ability->execute(
+			array(
+				'id'     => $this->subscriber_id,
+				'fields' => array( 'id', 'user_registered' ),
+			)
+		);
+		$this->assertIsArray( $result, 'A user should be able to request their registration date.' );
 		$this->assertSame(
 			gmdate( 'c', strtotime( get_userdata( $this->subscriber_id )->user_registered ) ),
-			$result['users'][0]['user_registered']
+			$result['users'][0]['user_registered'],
+			'The registration date should be formatted as an ISO 8601 date-time string.'
 		);
 	}
 
@@ -396,15 +475,15 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
-		$this->assertSame( 'users-ability-author', $result['users'][0]['user_nicename'] );
-		$this->assertArrayNotHasKey( 'user_email', $result['users'][0] );
+		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by ID.' );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The ID lookup should return the public author.' );
+		$this->assertSame( 'users-ability-author', $result['users'][0]['user_nicename'], 'The public author nicename should be returned.' );
+		$this->assertArrayNotHasKey( 'user_email', $result['users'][0], 'Public-author access should not expose another user email.' );
 
 		$result = $ability->execute( array( 'user_nicename' => 'users-ability-author' ) );
 
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by nicename.' );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The nicename lookup should return the public author.' );
 	}
 
 	/**
@@ -419,22 +498,22 @@ class UsersTest extends WP_UnitTestCase {
 		$ability = wp_get_ability( 'core/users' );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
-		$this->assertWPError( $result );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertWPError( $result, 'A subscriber should not be able to resolve another user by email.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Email lookup denial should use the invalid permissions error.' );
 
 		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
-		$this->assertWPError( $result );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertWPError( $result, 'A subscriber should not be able to resolve another user by login.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Login lookup denial should use the invalid permissions error.' );
 
 		wp_set_current_user( $this->admin_id );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'An administrator should be able to resolve another user by email.' );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The email lookup should return the public author for an administrator.' );
 
 		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
-		$this->assertIsArray( $result );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'An administrator should be able to resolve another user by login.' );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The login lookup should return the public author for an administrator.' );
 	}
 
 	/**
@@ -448,12 +527,12 @@ class UsersTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'core/users' )->execute( array() );
 
-		$this->assertIsArray( $result );
-		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ) );
-		$this->assertNotContains( $this->admin_id, wp_list_pluck( $result['users'], 'id' ) );
-		$this->assertNotContains( $this->subscriber_id, wp_list_pluck( $result['users'], 'id' ) );
-		$this->assertIsInt( $result['total'] );
-		$this->assertIsInt( $result['total_pages'] );
+		$this->assertIsArray( $result, 'Collection mode should return an array for logged-in users.' );
+		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ), 'Collection mode should include public authors.' );
+		$this->assertNotContains( $this->admin_id, wp_list_pluck( $result['users'], 'id' ), 'Collection mode should omit non-author administrators for users without list_users.' );
+		$this->assertNotContains( $this->subscriber_id, wp_list_pluck( $result['users'], 'id' ), 'Collection mode should omit subscribers for users without list_users.' );
+		$this->assertIsInt( $result['total'], 'Collection mode should include an integer total.' );
+		$this->assertIsInt( $result['total_pages'], 'Collection mode should include an integer total_pages value.' );
 	}
 
 	/**
@@ -494,13 +573,19 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		try {
-			$this->assertFalse( get_post_type_object( 'wpai_public_pt' )->show_in_rest );
+			$this->assertFalse( get_post_type_object( 'wpai_public_pt' )->show_in_rest, 'The public fixture post type should remain hidden from REST.' );
 
 			wp_set_current_user( $this->subscriber_id );
 			$this->register_ability();
 
 			$ability = wp_get_ability( 'core/users' );
-			$result  = $ability->execute(
+			$schema  = $ability->get_input_schema();
+			$enum    = $schema['oneOf'][4]['properties']['has_published_posts']['oneOf'][1]['items']['enum'];
+
+			$this->assertContains( 'wpai_public_pt', $enum, 'The has_published_posts enum should include public post types even when hidden from REST.' );
+			$this->assertNotContains( 'wpai_private_pt', $enum, 'The has_published_posts enum should omit private post types.' );
+
+			$result = $ability->execute(
 				array(
 					'has_published_posts' => array( 'wpai_public_pt' ),
 					'fields'              => array( 'id' ),
@@ -508,11 +593,11 @@ class UsersTest extends WP_UnitTestCase {
 				)
 			);
 
-			$this->assertIsArray( $result );
+			$this->assertIsArray( $result, 'A public post type author query should return an array.' );
 			$ids = wp_list_pluck( $result['users'], 'id' );
-			$this->assertContains( $public_author_id, $ids );
-			$this->assertNotContains( $this->public_author_id, $ids );
-			$this->assertNotContains( $private_author_id, $ids );
+			$this->assertContains( $public_author_id, $ids, 'The query should include authors of the requested public post type.' );
+			$this->assertNotContains( $this->public_author_id, $ids, 'The query should exclude authors without posts in the requested public post type.' );
+			$this->assertNotContains( $private_author_id, $ids, 'The query should exclude authors of private post types.' );
 
 			$result = $ability->execute(
 				array(
@@ -521,10 +606,8 @@ class UsersTest extends WP_UnitTestCase {
 				)
 			);
 
-			$this->assertIsArray( $result );
-			$this->assertSame( array(), $result['users'] );
-			$this->assertSame( 0, $result['total'] );
-			$this->assertSame( 0, $result['total_pages'] );
+			$this->assertWPError( $result, 'Private post type filters should fail schema validation.' );
+			$this->assertSame( 'ability_invalid_input', $result->get_error_code(), 'Private post type filters should use the invalid input error.' );
 		} finally {
 			wp_delete_post( $public_post_id, true );
 			wp_delete_post( $private_post_id, true );
@@ -552,11 +635,66 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $result );
-		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ) );
+		$this->assertIsArray( $result, 'An administrator role query should return an array.' );
+		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ), 'The author role query should include the public author.' );
 		foreach ( $result['users'] as $user ) {
-			$this->assertContains( 'author', $user['roles'] );
+			$this->assertContains( 'author', $user['roles'], 'Each user returned by an author role query should include the author role.' );
 		}
+	}
+
+	/**
+	 * Field visibility for another public author matches the current user's role.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_roles_for_another_public_author_field_visibility
+	 *
+	 * @param string $role               Current user's role.
+	 * @param bool   $can_view_sensitive Whether the role can view another user's sensitive fields.
+	 * @param bool   $can_view_roles     Whether the role can view another user's roles.
+	 */
+	public function test_roles_have_expected_field_visibility_for_another_public_author( string $role, bool $can_view_sensitive, bool $can_view_roles ): void {
+		wp_set_current_user( self::$fixture_ids[ $role ] );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute(
+			array(
+				'id'     => $this->public_author_id,
+				'fields' => array( 'id', 'user_email', 'roles' ),
+			)
+		);
+
+		$this->assertIsArray( $result, sprintf( 'The %s role should be able to execute a public-author lookup.', $role ) );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The %s role should receive the requested public author.', $role ) );
+		$this->assertSame( $can_view_sensitive, array_key_exists( 'user_email', $result['users'][0] ), sprintf( 'The %s role email visibility should match expectations.', $role ) );
+		$this->assertSame( $can_view_roles, array_key_exists( 'roles', $result['users'][0] ), sprintf( 'The %s role roles visibility should match expectations.', $role ) );
+
+		if ( $can_view_sensitive ) {
+			$this->assertSame( 'users-ability-author@example.com', $result['users'][0]['user_email'], sprintf( 'The %s role should receive the public author email when allowed.', $role ) );
+		}
+
+		if ( ! $can_view_roles ) {
+			return;
+		}
+
+		$this->assertContains( 'author', $result['users'][0]['roles'], sprintf( 'The %s role should receive the public author role when allowed.', $role ) );
+	}
+
+	/**
+	 * Data provider for role-based field visibility checks.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, array{0: string, 1: bool, 2: bool}>
+	 */
+	public static function data_roles_for_another_public_author_field_visibility(): array {
+		return array(
+			'administrator' => array( 'administrator', true, true ),
+			'editor'        => array( 'editor', false, false ),
+			'author'        => array( 'author', false, false ),
+			'contributor'   => array( 'contributor', false, false ),
+			'subscriber'    => array( 'subscriber', false, false ),
+		);
 	}
 
 	/**
@@ -570,8 +708,8 @@ class UsersTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'core/users' )->execute( array( 'roles' => array( 'author' ) ) );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertWPError( $result, 'A subscriber should not be able to filter users by role.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Role filter denial should use the invalid permissions error.' );
 	}
 
 	/**
@@ -590,9 +728,9 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertIsArray( $result );
-		$this->assertSame( array( 'id' ), array_keys( $result['users'][0] ) );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+		$this->assertIsArray( $result, 'A public-author lookup should return an array.' );
+		$this->assertSame( array( 'id' ), array_keys( $result['users'][0] ), 'Restricted requested fields should be omitted instead of failing the request.' );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The public-author lookup should still return unrestricted fields.' );
 	}
 
 	/**
@@ -606,7 +744,7 @@ class UsersTest extends WP_UnitTestCase {
 
 		$result = wp_get_ability( 'core/users' )->execute( array( 'id' => 999999 ) );
 
-		$this->assertWPError( $result );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertWPError( $result, 'Missing single-user lookups should fail closed.' );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Missing single-user lookups should use the invalid permissions error.' );
 	}
 }

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -1,0 +1,477 @@
+<?php
+/**
+ * Integration tests for the core/users Ability provided by the plugin.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Users
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Users;
+
+use WP_Ability;
+use WP_UnitTestCase;
+use WordPress\AI\Abilities\Users\Users;
+
+/**
+ * Users ability test case.
+ *
+ * @since x.x.x
+ */
+class UsersTest extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private $admin_id;
+
+	/**
+	 * Subscriber user ID.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private $subscriber_id;
+
+	/**
+	 * Author user ID with a published post.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private $public_author_id;
+
+	/**
+	 * Author post ID.
+	 *
+	 * @since x.x.x
+	 * @var int
+	 */
+	private $public_post_id;
+
+	/**
+	 * Original show_avatars option.
+	 *
+	 * @since x.x.x
+	 * @var mixed
+	 */
+	private $show_avatars;
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since x.x.x
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->show_avatars = get_option( 'show_avatars' );
+		update_option( 'show_avatars', 1 );
+
+		$this->admin_id = self::factory()->user->create(
+			array(
+				'role'         => 'administrator',
+				'user_login'   => 'users_ability_admin',
+				'user_email'   => 'users-ability-admin@example.com',
+				'user_nicename' => 'users-ability-admin',
+			)
+		);
+
+		$this->subscriber_id = self::factory()->user->create(
+			array(
+				'role'         => 'subscriber',
+				'user_login'   => 'users_ability_subscriber',
+				'user_email'   => 'users-ability-subscriber@example.com',
+				'user_nicename' => 'users-ability-subscriber',
+			)
+		);
+
+		$this->public_author_id = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'user_login'   => 'users_ability_author',
+				'user_email'   => 'users-ability-author@example.com',
+				'user_nicename' => 'users-ability-author',
+			)
+		);
+
+		$this->public_post_id = self::factory()->post->create(
+			array(
+				'post_author' => $this->public_author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'post',
+			)
+		);
+
+		$this->ensure_user_category();
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since x.x.x
+	 */
+	public function tearDown(): void {
+		if ( wp_has_ability( 'core/users' ) ) {
+			wp_unregister_ability( 'core/users' );
+		}
+
+		wp_delete_post( $this->public_post_id, true );
+		update_option( 'show_avatars', $this->show_avatars );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensures the `user` ability category exists for the ability to attach to.
+	 *
+	 * @since x.x.x
+	 */
+	private function ensure_user_category(): void {
+		if ( wp_has_ability_category( 'user' ) ) {
+			return;
+		}
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability_category(
+				'user',
+				array(
+					'label'       => 'Users',
+					'description' => 'Users.',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Registers the plugin's core/users ability inside a faked init action.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_ability(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			( new Users() )->register();
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * The ability is registered in the `user` category and flagged read-only.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_core_users_ability_is_registered(): void {
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/users' );
+
+		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertSame( 'user', $ability->get_category() );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
+		$this->assertTrue( $ability->get_meta_item( 'pagination', false ) );
+
+		$annotations = $ability->get_meta_item( 'annotations', array() );
+		$this->assertTrue( $annotations['readonly'] );
+		$this->assertFalse( $annotations['destructive'] );
+	}
+
+	/**
+	 * When core already provides core/users, the plugin's version replaces it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_override_replaces_existing_core_users(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability(
+				'core/users',
+				array(
+					'label'               => 'Core Provided',
+					'description'         => 'Core provided users ability.',
+					'category'            => 'user',
+					'execute_callback'    => static function (): array {
+						return array();
+					},
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->assertSame( 'Core Provided', wp_get_ability( 'core/users' )->get_label() );
+
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/users' );
+		$this->assertSame( 'Get Users', $ability->get_label() );
+		$this->assertCount( 5, $ability->get_input_schema()['oneOf'] );
+	}
+
+	/**
+	 * The input schema exposes strict single-user and collection modes.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_core_users_input_schema_exposes_strict_modes(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/users' )->get_input_schema();
+
+		$this->assertSame( 'object', $schema['type'] );
+		$this->assertArrayNotHasKey( 'default', $schema );
+		$this->assertCount( 5, $schema['oneOf'] );
+
+		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'] );
+		$this->assertSame( array( 'email' ), $schema['oneOf'][1]['required'] );
+		$this->assertSame( array( 'username' ), $schema['oneOf'][2]['required'] );
+		$this->assertSame( array( 'slug' ), $schema['oneOf'][3]['required'] );
+		$this->assertArrayNotHasKey( 'required', $schema['oneOf'][4] );
+
+		$collection_properties = $schema['oneOf'][4]['properties'];
+		$this->assertEqualSets(
+			array( 'roles', 'has_published_posts', 'fields', 'page', 'per_page' ),
+			array_keys( $collection_properties )
+		);
+		foreach ( array( 'search', 'include', 'exclude', 'slug', 'order', 'orderby', 'search_columns', 'offset', 'context', 'who', 'capabilities' ) as $excluded_property ) {
+			$this->assertArrayNotHasKey( $excluded_property, $collection_properties );
+		}
+
+		$fields = $schema['oneOf'][4]['properties']['fields']['items']['enum'];
+		$this->assertContains( 'roles', $fields );
+		$this->assertContains( 'avatar_urls', $fields );
+	}
+
+	/**
+	 * Avatar fields are not requestable when avatars are disabled.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_avatar_urls_respects_show_avatars_option(): void {
+		update_option( 'show_avatars', 0 );
+		$this->register_ability();
+
+		$ability       = wp_get_ability( 'core/users' );
+		$input_schema  = $ability->get_input_schema();
+		$output_schema = $ability->get_output_schema();
+
+		$this->assertNotContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'] );
+		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['properties']['users']['items']['properties'] );
+
+		wp_set_current_user( $this->subscriber_id );
+		$result = $ability->execute( array( 'id' => $this->subscriber_id ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'avatar_urls', $result['users'][0] );
+	}
+
+	/**
+	 * Logged-out users cannot run the ability.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_core_users_requires_logged_in_user(): void {
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute( array() );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+
+	/**
+	 * The current user can read themselves by ID, email, and username.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_current_user_can_read_themselves_by_sensitive_identifiers(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/users' );
+
+		$result = $ability->execute(
+			array(
+				'id'     => $this->subscriber_id,
+				'fields' => array( 'id', 'email', 'username', 'roles' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['email'] );
+		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['username'] );
+		$this->assertContains( 'subscriber', $result['users'][0]['roles'] );
+
+		$result = $ability->execute( array( 'email' => 'users-ability-subscriber@example.com' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+
+		$result = $ability->execute( array( 'username' => 'users_ability_subscriber' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+	}
+
+	/**
+	 * Public-author users can be read by ID or slug by logged-in users.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_public_author_can_be_read_by_id_and_slug(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/users' );
+
+		$result = $ability->execute(
+			array(
+				'id'     => $this->public_author_id,
+				'fields' => array( 'id', 'slug', 'email' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+		$this->assertSame( 'users-ability-author', $result['users'][0]['slug'] );
+		$this->assertArrayNotHasKey( 'email', $result['users'][0] );
+
+		$result = $ability->execute( array( 'slug' => 'users-ability-author' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+	}
+
+	/**
+	 * Email and username lookups for another user require list or edit permissions.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_email_and_username_lookup_for_another_user_requires_permission(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/users' );
+
+		$result = $ability->execute( array( 'email' => 'users-ability-author@example.com' ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+
+		$result = $ability->execute( array( 'username' => 'users_ability_author' ) );
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+
+		wp_set_current_user( $this->admin_id );
+
+		$result = $ability->execute( array( 'email' => 'users-ability-author@example.com' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+
+		$result = $ability->execute( array( 'username' => 'users_ability_author' ) );
+		$this->assertIsArray( $result );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+	}
+
+	/**
+	 * Empty collection mode returns only public authors for users without list_users.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_empty_collection_mode_restricts_users_without_list_users_to_public_authors(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ) );
+		$this->assertNotContains( $this->admin_id, wp_list_pluck( $result['users'], 'id' ) );
+		$this->assertNotContains( $this->subscriber_id, wp_list_pluck( $result['users'], 'id' ) );
+		$this->assertIsInt( $result['total'] );
+		$this->assertIsInt( $result['total_pages'] );
+	}
+
+	/**
+	 * Administrators can query by role and receive roles.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_admin_can_query_by_role_and_receive_roles(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute(
+			array(
+				'roles'    => array( 'author' ),
+				'fields'   => array( 'id', 'roles' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ) );
+		foreach ( $result['users'] as $user ) {
+			$this->assertContains( 'author', $user['roles'] );
+		}
+	}
+
+	/**
+	 * Role filtering requires list_users.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_role_filter_requires_list_users(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute( array( 'roles' => array( 'author' ) ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+
+	/**
+	 * Restricted fields are omitted per user instead of failing the whole result.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_restricted_requested_fields_are_omitted_per_user(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute(
+			array(
+				'id'     => $this->public_author_id,
+				'fields' => array( 'id', 'email', 'roles' ),
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'id' ), array_keys( $result['users'][0] ) );
+		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
+	}
+
+	/**
+	 * Missing or inaccessible single-user lookups fail closed.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_missing_single_user_lookup_fails_closed(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/users' )->execute( array( 'id' => 999999 ) );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+	}
+}

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -105,6 +105,7 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->ensure_user_category();
+		$this->ensure_site_category();
 	}
 
 	/**
@@ -142,6 +143,32 @@ class UsersTest extends WP_UnitTestCase {
 				array(
 					'label'       => 'Users',
 					'description' => 'Users.',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Ensures the `site` ability category exists, used by the plugin's `core/settings`
+	 * ability which registers on the same hook as `core/users`.
+	 *
+	 * @since x.x.x
+	 */
+	private function ensure_site_category(): void {
+		if ( wp_has_ability_category( 'site' ) ) {
+			return;
+		}
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability_category(
+				'site',
+				array(
+					'label'       => 'Site',
+					'description' => 'Site.',
 				)
 			);
 		} finally {

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -331,13 +331,12 @@ class UsersTest extends WP_UnitTestCase {
 
 		$collection_properties = $schema['oneOf'][4]['properties'];
 		$this->assertEqualSets(
-			array( 'roles', 'has_published_posts', 'fields', 'page', 'per_page' ),
+			array( 'roles', 'has_published_posts', 'include', 'fields', 'page', 'per_page' ),
 			array_keys( $collection_properties ),
 			'Collection mode should expose only the supported query parameters.'
 		);
 		$excluded_properties = array(
 			'search',
-			'include',
 			'exclude',
 			'email',
 			'username',
@@ -367,6 +366,11 @@ class UsersTest extends WP_UnitTestCase {
 		$post_type_names = $schema['oneOf'][4]['properties']['has_published_posts']['oneOf'][1]['items']['enum'];
 		$this->assertContains( 'post', $post_type_names, 'The has_published_posts enum should expose public post types.' );
 		$this->assertNotContains( 'revision', $post_type_names, 'The has_published_posts enum should omit non-public post types.' );
+
+		$this->assertSame( 1, $collection_properties['include']['minItems'], 'The include option should require at least one user ID.' );
+		$this->assertTrue( $collection_properties['include']['uniqueItems'], 'The include option should reject duplicate user IDs.' );
+		$this->assertSame( 'integer', $collection_properties['include']['items']['type'], 'The include option should contain user IDs.' );
+		$this->assertSame( 1, $collection_properties['include']['items']['minimum'], 'The include option should contain positive user IDs.' );
 
 		$output_schema     = wp_get_ability( 'core/read-users' )->get_output_schema();
 		$user_schema       = $output_schema['oneOf'][0];
@@ -583,6 +587,86 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertNotContains( $this->subscriber_id, wp_list_pluck( $result['users'], 'id' ), 'Collection mode should omit subscribers for users without list_users.' );
 		$this->assertIsInt( $result['total'], 'Collection mode should include an integer total.' );
 		$this->assertIsInt( $result['total_pages'], 'Collection mode should include an integer total_pages value.' );
+	}
+
+	/**
+	 * Collection include limits results and preserves requested order.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_collection_include_limits_results_and_preserves_order(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'include'  => array( $this->public_author_id, $this->subscriber_id ),
+				'fields'   => array( 'id' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'An included user query should return an array.' );
+		$this->assertSame(
+			array( $this->public_author_id, $this->subscriber_id ),
+			wp_list_pluck( $result['users'], 'id' ),
+			'Included user queries should preserve the requested order.'
+		);
+		$this->assertSame( 2, $result['total'], 'Included user queries should report the matching included total.' );
+	}
+
+	/**
+	 * Collection include still respects row-level read permissions.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_collection_include_respects_read_permissions(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'include'  => array( $this->admin_id, $this->public_author_id ),
+				'fields'   => array( 'id' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'An included user query should return an array.' );
+		$this->assertSame(
+			array( $this->public_author_id ),
+			wp_list_pluck( $result['users'], 'id' ),
+			'Included user queries should omit users the current user cannot read.'
+		);
+	}
+
+	/**
+	 * Include is a collection-only option.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_include_cannot_be_combined_with_single_user_modes(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$by_id = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'      => $this->subscriber_id,
+				'include' => array( $this->subscriber_id ),
+			)
+		);
+
+		$by_login = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'user_login' => 'users_ability_subscriber',
+				'include'    => array( $this->subscriber_id ),
+			)
+		);
+
+		$this->assertWPError( $by_id, 'ID plus include should fail validation.' );
+		$this->assertWPError( $by_login, 'Login plus include should fail validation.' );
+		$this->assertSame( 'ability_invalid_input', $by_id->get_error_code(), 'ID plus include should return an input error.' );
+		$this->assertSame( 'ability_invalid_input', $by_login->get_error_code(), 'Login plus include should return an input error.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -368,8 +368,14 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertContains( 'post', $post_type_names, 'The has_published_posts enum should expose public post types.' );
 		$this->assertNotContains( 'revision', $post_type_names, 'The has_published_posts enum should omit non-public post types.' );
 
-		$output_schema   = wp_get_ability( 'core/read-users' )->get_output_schema();
-		$user_properties = $output_schema['properties']['users']['items']['properties'];
+		$output_schema     = wp_get_ability( 'core/read-users' )->get_output_schema();
+		$user_schema       = $output_schema['oneOf'][0];
+		$collection_schema = $output_schema['oneOf'][1];
+		$user_properties   = $user_schema['properties'];
+
+		$this->assertCount( 2, $output_schema['oneOf'], 'The output schema should describe single-user and collection responses.' );
+		$this->assertArrayNotHasKey( 'required', $user_schema, 'Single-user fields should remain optional.' );
+		$this->assertSame( array( 'users', 'total', 'total_pages' ), $collection_schema['required'], 'Collection responses should require the wrapper fields.' );
 		$this->assertSame( 'date-time', $user_properties['user_registered']['format'], 'The user_registered output schema should use date-time format.' );
 		$this->assertEqualSets( array_keys( wp_roles()->roles ), $user_properties['roles']['items']['enum'], 'The roles output enum should expose registered role names.' );
 	}
@@ -388,13 +394,34 @@ class UsersTest extends WP_UnitTestCase {
 		$output_schema = $ability->get_output_schema();
 
 		$this->assertNotContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'], 'The fields enum should omit avatar_urls when avatars are disabled.' );
-		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['properties']['users']['items']['properties'], 'The output schema should omit avatar_urls when avatars are disabled.' );
+		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['oneOf'][0]['properties'], 'The output schema should omit avatar_urls when avatars are disabled.' );
 
 		wp_set_current_user( $this->subscriber_id );
 		$result = $ability->execute( array( 'id' => $this->subscriber_id ) );
 
 		$this->assertIsArray( $result, 'The current user should still be readable when avatars are disabled.' );
-		$this->assertArrayNotHasKey( 'avatar_urls', $result['users'][0], 'The ability result should omit avatar_urls when avatars are disabled.' );
+		$this->assertArrayNotHasKey( 'avatar_urls', $result, 'The ability result should omit avatar_urls when avatars are disabled.' );
+	}
+
+	/**
+	 * Omitted fields return a lean default shape.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_omitted_fields_return_lean_defaults(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute( array( 'id' => $this->subscriber_id ) );
+
+		$this->assertIsArray( $result, 'A current-user lookup should return an array.' );
+		$this->assertSame(
+			array( 'id', 'display_name', 'link', 'user_nicename', 'avatar_urls' ),
+			array_keys( $result ),
+			'Omitted fields should return the lean default field set.'
+		);
+		$this->assertArrayNotHasKey( 'user_email', $result, 'Default fields should not include sensitive user fields.' );
+		$this->assertArrayNotHasKey( 'description', $result, 'Default fields should omit less common read-context fields.' );
 	}
 
 	/**
@@ -430,18 +457,18 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, 'A user should be able to read themselves by ID.' );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The ID lookup should return the current user.' );
-		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['user_email'], 'The current user should receive their own email.' );
-		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['user_login'], 'The current user should receive their own login.' );
-		$this->assertContains( 'subscriber', $result['users'][0]['roles'], 'The current user should receive their own roles.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'The ID lookup should return the current user.' );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['user_email'], 'The current user should receive their own email.' );
+		$this->assertSame( 'users_ability_subscriber', $result['user_login'], 'The current user should receive their own login.' );
+		$this->assertContains( 'subscriber', $result['roles'], 'The current user should receive their own roles.' );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-subscriber@example.com' ) );
 		$this->assertIsArray( $result, 'A user should be able to read themselves by email.' );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The email lookup should return the current user.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'The email lookup should return the current user.' );
 
 		$result = $ability->execute( array( 'user_login' => 'users_ability_subscriber' ) );
 		$this->assertIsArray( $result, 'A user should be able to read themselves by login.' );
-		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'], 'The login lookup should return the current user.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'The login lookup should return the current user.' );
 
 		$result = $ability->execute(
 			array(
@@ -452,7 +479,7 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'A user should be able to request their registration date.' );
 		$this->assertSame(
 			gmdate( 'c', strtotime( get_userdata( $this->subscriber_id )->user_registered ) ),
-			$result['users'][0]['user_registered'],
+			$result['user_registered'],
 			'The registration date should be formatted as an ISO 8601 date-time string.'
 		);
 	}
@@ -476,14 +503,14 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by ID.' );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The ID lookup should return the public author.' );
-		$this->assertSame( 'users-ability-author', $result['users'][0]['user_nicename'], 'The public author nicename should be returned.' );
-		$this->assertArrayNotHasKey( 'user_email', $result['users'][0], 'Public-author access should not expose another user email.' );
+		$this->assertSame( $this->public_author_id, $result['id'], 'The ID lookup should return the public author.' );
+		$this->assertSame( 'users-ability-author', $result['user_nicename'], 'The public author nicename should be returned.' );
+		$this->assertArrayNotHasKey( 'user_email', $result, 'Public-author access should not expose another user email.' );
 
 		$result = $ability->execute( array( 'user_nicename' => 'users-ability-author' ) );
 
 		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by nicename.' );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The nicename lookup should return the public author.' );
+		$this->assertSame( $this->public_author_id, $result['id'], 'The nicename lookup should return the public author.' );
 	}
 
 	/**
@@ -505,7 +532,7 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
 		if ( $can_resolve ) {
 			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by email.', $role ) );
-			$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The email lookup should return the public author for the %s role.', $role ) );
+			$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The email lookup should return the public author for the %s role.', $role ) );
 		} else {
 			$this->assertWPError( $result, sprintf( 'The %s role should not be able to resolve another user by email.', $role ) );
 			$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Email lookup denial for the %s role should use the invalid permissions error.', $role ) );
@@ -514,7 +541,7 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
 		if ( $can_resolve ) {
 			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by login.', $role ) );
-			$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The login lookup should return the public author for the %s role.', $role ) );
+			$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The login lookup should return the public author for the %s role.', $role ) );
 			return;
 		}
 
@@ -688,19 +715,19 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, sprintf( 'The %s role should be able to execute a public-author lookup.', $role ) );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The %s role should receive the requested public author.', $role ) );
-		$this->assertSame( $can_view_sensitive, array_key_exists( 'user_email', $result['users'][0] ), sprintf( 'The %s role email visibility should match expectations.', $role ) );
-		$this->assertSame( $can_view_roles, array_key_exists( 'roles', $result['users'][0] ), sprintf( 'The %s role roles visibility should match expectations.', $role ) );
+		$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The %s role should receive the requested public author.', $role ) );
+		$this->assertSame( $can_view_sensitive, array_key_exists( 'user_email', $result ), sprintf( 'The %s role email visibility should match expectations.', $role ) );
+		$this->assertSame( $can_view_roles, array_key_exists( 'roles', $result ), sprintf( 'The %s role roles visibility should match expectations.', $role ) );
 
 		if ( $can_view_sensitive ) {
-			$this->assertSame( 'users-ability-author@example.com', $result['users'][0]['user_email'], sprintf( 'The %s role should receive the public author email when allowed.', $role ) );
+			$this->assertSame( 'users-ability-author@example.com', $result['user_email'], sprintf( 'The %s role should receive the public author email when allowed.', $role ) );
 		}
 
 		if ( ! $can_view_roles ) {
 			return;
 		}
 
-		$this->assertContains( 'author', $result['users'][0]['roles'], sprintf( 'The %s role should receive the public author role when allowed.', $role ) );
+		$this->assertContains( 'author', $result['roles'], sprintf( 'The %s role should receive the public author role when allowed.', $role ) );
 	}
 
 	/**
@@ -752,8 +779,8 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, 'A public-author lookup should return an array.' );
-		$this->assertSame( array( 'id' ), array_keys( $result['users'][0] ), 'Restricted requested fields should be omitted instead of failing the request.' );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The public-author lookup should still return unrestricted fields.' );
+		$this->assertSame( array( 'id' ), array_keys( $result ), 'Restricted requested fields should be omitted instead of failing the request.' );
+		$this->assertSame( $this->public_author_id, $result['id'], 'The public-author lookup should still return unrestricted fields.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -446,6 +446,85 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Collection mode for users without list_users honors public post type filters.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_collection_mode_for_users_without_list_users_uses_public_post_types(): void {
+		register_post_type(
+			'wpai_public_pt',
+			array(
+				'public'       => true,
+				'show_in_rest' => false,
+			)
+		);
+		register_post_type(
+			'wpai_private_pt',
+			array(
+				'public' => false,
+			)
+		);
+
+		$public_author_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$private_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$public_post_id    = self::factory()->post->create(
+			array(
+				'post_author' => $public_author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'wpai_public_pt',
+			)
+		);
+		$private_post_id   = self::factory()->post->create(
+			array(
+				'post_author' => $private_author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'wpai_private_pt',
+			)
+		);
+
+		try {
+			$this->assertFalse( get_post_type_object( 'wpai_public_pt' )->show_in_rest );
+
+			wp_set_current_user( $this->subscriber_id );
+			$this->register_ability();
+
+			$ability = wp_get_ability( 'core/users' );
+			$result  = $ability->execute(
+				array(
+					'has_published_posts' => array( 'wpai_public_pt' ),
+					'fields'              => array( 'id' ),
+					'per_page'            => 100,
+				)
+			);
+
+			$this->assertIsArray( $result );
+			$ids = wp_list_pluck( $result['users'], 'id' );
+			$this->assertContains( $public_author_id, $ids );
+			$this->assertNotContains( $this->public_author_id, $ids );
+			$this->assertNotContains( $private_author_id, $ids );
+
+			$result = $ability->execute(
+				array(
+					'has_published_posts' => array( 'wpai_private_pt' ),
+					'fields'              => array( 'id' ),
+				)
+			);
+
+			$this->assertIsArray( $result );
+			$this->assertSame( array(), $result['users'] );
+			$this->assertSame( 0, $result['total'] );
+			$this->assertSame( 0, $result['total_pages'] );
+		} finally {
+			wp_delete_post( $public_post_id, true );
+			wp_delete_post( $private_post_id, true );
+			wp_delete_user( $public_author_id );
+			wp_delete_user( $private_author_id );
+			unregister_post_type( 'wpai_public_pt' );
+			unregister_post_type( 'wpai_private_pt' );
+		}
+	}
+
+	/**
 	 * Administrators can query by role and receive roles.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -256,7 +256,7 @@ class UsersTest extends WP_UnitTestCase {
 		$schema = wp_get_ability( 'core/users' )->get_input_schema();
 
 		$this->assertSame( 'object', $schema['type'] );
-		$this->assertArrayNotHasKey( 'default', $schema );
+		$this->assertEquals( (object) array(), $schema['default'] );
 		$this->assertCount( 5, $schema['oneOf'] );
 
 		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'] );

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Integration tests for the core/users Ability provided by the plugin.
+ * Integration tests for the core/read-users Ability provided by the plugin.
  *
  * @package WordPress\AI\Tests\Integration\Includes\Abilities\Users
  */
@@ -179,8 +179,8 @@ class UsersTest extends WP_UnitTestCase {
 	 * @since x.x.x
 	 */
 	public function tearDown(): void {
-		if ( wp_has_ability( 'core/users' ) ) {
-			wp_unregister_ability( 'core/users' );
+		if ( wp_has_ability( 'core/read-users' ) ) {
+			wp_unregister_ability( 'core/read-users' );
 		}
 
 		update_option( 'show_avatars', $this->show_avatars );
@@ -216,7 +216,7 @@ class UsersTest extends WP_UnitTestCase {
 
 	/**
 	 * Ensures the `site` ability category exists, used by the plugin's `core/settings`
-	 * ability which registers on the same hook as `core/users`.
+	 * ability which registers on the same hook as `core/read-users`.
 	 *
 	 * @since x.x.x
 	 */
@@ -241,7 +241,7 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers the plugin's core/users ability inside a faked init action.
+	 * Registers the plugin's core/read-users ability inside a faked init action.
 	 *
 	 * @since x.x.x
 	 */
@@ -263,7 +263,7 @@ class UsersTest extends WP_UnitTestCase {
 	public function test_core_users_ability_is_registered(): void {
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/users' );
+		$ability = wp_get_ability( 'core/read-users' );
 
 		$this->assertInstanceOf( WP_Ability::class, $ability, 'The users ability should be registered.' );
 		$this->assertSame( 'user', $ability->get_category(), 'The users ability should use the user category.' );
@@ -276,7 +276,7 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When core already provides core/users, the plugin's version replaces it.
+	 * When core already provides core/read-users, the plugin's version replaces it.
 	 *
 	 * @since x.x.x
 	 */
@@ -285,7 +285,7 @@ class UsersTest extends WP_UnitTestCase {
 		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
 		try {
 			wp_register_ability(
-				'core/users',
+				'core/read-users',
 				array(
 					'label'               => 'Core Provided',
 					'description'         => 'Core provided users ability.',
@@ -300,12 +300,12 @@ class UsersTest extends WP_UnitTestCase {
 			array_pop( $wp_current_filter );
 		}
 
-		$this->assertSame( 'Core Provided', wp_get_ability( 'core/users' )->get_label(), 'The test should start with the fake core ability registered.' );
+		$this->assertSame( 'Core Provided', wp_get_ability( 'core/read-users' )->get_label(), 'The test should start with the fake core ability registered.' );
 
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/users' );
-		$this->assertSame( 'Get Users', $ability->get_label(), 'The plugin ability should replace the fake core ability.' );
+		$ability = wp_get_ability( 'core/read-users' );
+		$this->assertSame( 'Read Users', $ability->get_label(), 'The plugin ability should replace the fake core ability.' );
 		$this->assertCount( 5, $ability->get_input_schema()['oneOf'], 'The replacement ability should expose all supported input modes.' );
 	}
 
@@ -317,7 +317,7 @@ class UsersTest extends WP_UnitTestCase {
 	public function test_core_users_input_schema_exposes_strict_modes(): void {
 		$this->register_ability();
 
-		$schema = wp_get_ability( 'core/users' )->get_input_schema();
+		$schema = wp_get_ability( 'core/read-users' )->get_input_schema();
 
 		$this->assertSame( 'object', $schema['type'], 'The users ability input schema should describe an object.' );
 		$this->assertEquals( (object) array(), $schema['default'], 'The users ability input schema should default to empty collection mode.' );
@@ -368,7 +368,7 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertContains( 'post', $post_type_names, 'The has_published_posts enum should expose public post types.' );
 		$this->assertNotContains( 'revision', $post_type_names, 'The has_published_posts enum should omit non-public post types.' );
 
-		$output_schema   = wp_get_ability( 'core/users' )->get_output_schema();
+		$output_schema   = wp_get_ability( 'core/read-users' )->get_output_schema();
 		$user_properties = $output_schema['properties']['users']['items']['properties'];
 		$this->assertSame( 'date-time', $user_properties['user_registered']['format'], 'The user_registered output schema should use date-time format.' );
 		$this->assertEqualSets( array_keys( wp_roles()->roles ), $user_properties['roles']['items']['enum'], 'The roles output enum should expose registered role names.' );
@@ -383,7 +383,7 @@ class UsersTest extends WP_UnitTestCase {
 		update_option( 'show_avatars', 0 );
 		$this->register_ability();
 
-		$ability       = wp_get_ability( 'core/users' );
+		$ability       = wp_get_ability( 'core/read-users' );
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
 
@@ -405,7 +405,7 @@ class UsersTest extends WP_UnitTestCase {
 	public function test_core_users_requires_logged_in_user(): void {
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute( array() );
+		$result = wp_get_ability( 'core/read-users' )->execute( array() );
 
 		$this->assertWPError( $result, 'Logged-out users should not be allowed to execute the users ability.' );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Logged-out users should receive an invalid permissions error.' );
@@ -420,7 +420,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/users' );
+		$ability = wp_get_ability( 'core/read-users' );
 
 		$result = $ability->execute(
 			array(
@@ -466,7 +466,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/users' );
+		$ability = wp_get_ability( 'core/read-users' );
 
 		$result = $ability->execute(
 			array(
@@ -500,7 +500,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( self::$fixture_ids[ $role ] );
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/users' );
+		$ability = wp_get_ability( 'core/read-users' );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
 		if ( $can_resolve ) {
@@ -548,7 +548,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute( array() );
+		$result = wp_get_ability( 'core/read-users' )->execute( array() );
 
 		$this->assertIsArray( $result, 'Collection mode should return an array for logged-in users.' );
 		$this->assertContains( $this->public_author_id, wp_list_pluck( $result['users'], 'id' ), 'Collection mode should include public authors.' );
@@ -601,7 +601,7 @@ class UsersTest extends WP_UnitTestCase {
 			wp_set_current_user( $this->subscriber_id );
 			$this->register_ability();
 
-			$ability = wp_get_ability( 'core/users' );
+			$ability = wp_get_ability( 'core/read-users' );
 			$schema  = $ability->get_input_schema();
 			$enum    = $schema['oneOf'][4]['properties']['has_published_posts']['oneOf'][1]['items']['enum'];
 
@@ -650,7 +650,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->admin_id );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute(
+		$result = wp_get_ability( 'core/read-users' )->execute(
 			array(
 				'roles'    => array( 'author' ),
 				'fields'   => array( 'id', 'roles' ),
@@ -680,7 +680,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( self::$fixture_ids[ $role ] );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute(
+		$result = wp_get_ability( 'core/read-users' )->execute(
 			array(
 				'id'     => $this->public_author_id,
 				'fields' => array( 'id', 'user_email', 'roles' ),
@@ -729,7 +729,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute( array( 'roles' => array( 'author' ) ) );
+		$result = wp_get_ability( 'core/read-users' )->execute( array( 'roles' => array( 'author' ) ) );
 
 		$this->assertWPError( $result, 'A subscriber should not be able to filter users by role.' );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Role filter denial should use the invalid permissions error.' );
@@ -744,7 +744,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute(
+		$result = wp_get_ability( 'core/read-users' )->execute(
 			array(
 				'id'     => $this->public_author_id,
 				'fields' => array( 'id', 'user_email', 'roles' ),
@@ -765,7 +765,7 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->admin_id );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/users' )->execute( array( 'id' => 999999 ) );
+		$result = wp_get_ability( 'core/read-users' )->execute( array( 'id' => 999999 ) );
 
 		$this->assertWPError( $result, 'Missing single-user lookups should fail closed.' );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Missing single-user lookups should use the invalid permissions error.' );

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -260,9 +260,9 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertCount( 5, $schema['oneOf'] );
 
 		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'] );
-		$this->assertSame( array( 'email' ), $schema['oneOf'][1]['required'] );
-		$this->assertSame( array( 'username' ), $schema['oneOf'][2]['required'] );
-		$this->assertSame( array( 'slug' ), $schema['oneOf'][3]['required'] );
+		$this->assertSame( array( 'user_email' ), $schema['oneOf'][1]['required'] );
+		$this->assertSame( array( 'user_login' ), $schema['oneOf'][2]['required'] );
+		$this->assertSame( array( 'user_nicename' ), $schema['oneOf'][3]['required'] );
 		$this->assertArrayNotHasKey( 'required', $schema['oneOf'][4] );
 
 		$collection_properties = $schema['oneOf'][4]['properties'];
@@ -270,7 +270,25 @@ class UsersTest extends WP_UnitTestCase {
 			array( 'roles', 'has_published_posts', 'fields', 'page', 'per_page' ),
 			array_keys( $collection_properties )
 		);
-		foreach ( array( 'search', 'include', 'exclude', 'slug', 'order', 'orderby', 'search_columns', 'offset', 'context', 'who', 'capabilities' ) as $excluded_property ) {
+		$excluded_properties = array(
+			'search',
+			'include',
+			'exclude',
+			'email',
+			'username',
+			'slug',
+			'user_email',
+			'user_login',
+			'user_nicename',
+			'order',
+			'orderby',
+			'search_columns',
+			'offset',
+			'context',
+			'who',
+			'capabilities',
+		);
+		foreach ( $excluded_properties as $excluded_property ) {
 			$this->assertArrayNotHasKey( $excluded_property, $collection_properties );
 		}
 
@@ -317,7 +335,7 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The current user can read themselves by ID, email, and username.
+	 * The current user can read themselves by ID, user email, and user login.
 	 *
 	 * @since x.x.x
 	 */
@@ -330,31 +348,31 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute(
 			array(
 				'id'     => $this->subscriber_id,
-				'fields' => array( 'id', 'email', 'username', 'roles' ),
+				'fields' => array( 'id', 'user_email', 'user_login', 'roles' ),
 			)
 		);
 
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
-		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['email'] );
-		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['username'] );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['user_email'] );
+		$this->assertSame( 'users_ability_subscriber', $result['users'][0]['user_login'] );
 		$this->assertContains( 'subscriber', $result['users'][0]['roles'] );
 
-		$result = $ability->execute( array( 'email' => 'users-ability-subscriber@example.com' ) );
+		$result = $ability->execute( array( 'user_email' => 'users-ability-subscriber@example.com' ) );
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
 
-		$result = $ability->execute( array( 'username' => 'users_ability_subscriber' ) );
+		$result = $ability->execute( array( 'user_login' => 'users_ability_subscriber' ) );
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
 	}
 
 	/**
-	 * Public-author users can be read by ID or slug by logged-in users.
+	 * Public-author users can be read by ID or user nicename by logged-in users.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_public_author_can_be_read_by_id_and_slug(): void {
+	public function test_public_author_can_be_read_by_id_and_user_nicename(): void {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
@@ -363,47 +381,47 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute(
 			array(
 				'id'     => $this->public_author_id,
-				'fields' => array( 'id', 'slug', 'email' ),
+				'fields' => array( 'id', 'user_nicename', 'user_email' ),
 			)
 		);
 
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
-		$this->assertSame( 'users-ability-author', $result['users'][0]['slug'] );
-		$this->assertArrayNotHasKey( 'email', $result['users'][0] );
+		$this->assertSame( 'users-ability-author', $result['users'][0]['user_nicename'] );
+		$this->assertArrayNotHasKey( 'user_email', $result['users'][0] );
 
-		$result = $ability->execute( array( 'slug' => 'users-ability-author' ) );
+		$result = $ability->execute( array( 'user_nicename' => 'users-ability-author' ) );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
 	}
 
 	/**
-	 * Email and username lookups for another user require list or edit permissions.
+	 * User email and login lookups for another user require list or edit permissions.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_email_and_username_lookup_for_another_user_requires_permission(): void {
+	public function test_user_email_and_login_lookup_for_another_user_requires_permission(): void {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
 		$ability = wp_get_ability( 'core/users' );
 
-		$result = $ability->execute( array( 'email' => 'users-ability-author@example.com' ) );
+		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
 		$this->assertWPError( $result );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 
-		$result = $ability->execute( array( 'username' => 'users_ability_author' ) );
+		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
 		$this->assertWPError( $result );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
 
 		wp_set_current_user( $this->admin_id );
 
-		$result = $ability->execute( array( 'email' => 'users-ability-author@example.com' ) );
+		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
 
-		$result = $ability->execute( array( 'username' => 'users_ability_author' ) );
+		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->public_author_id, $result['users'][0]['id'] );
 	}
@@ -478,7 +496,7 @@ class UsersTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'core/users' )->execute(
 			array(
 				'id'     => $this->public_author_id,
-				'fields' => array( 'id', 'email', 'roles' ),
+				'fields' => array( 'id', 'user_email', 'roles' ),
 			)
 		);
 

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -295,6 +295,10 @@ class UsersTest extends WP_UnitTestCase {
 		$fields = $schema['oneOf'][4]['properties']['fields']['items']['enum'];
 		$this->assertContains( 'roles', $fields );
 		$this->assertContains( 'avatar_urls', $fields );
+
+		$output_schema   = wp_get_ability( 'core/users' )->get_output_schema();
+		$user_properties = $output_schema['properties']['users']['items']['properties'];
+		$this->assertSame( 'date-time', $user_properties['user_registered']['format'] );
 	}
 
 	/**
@@ -365,6 +369,13 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute( array( 'user_login' => 'users_ability_subscriber' ) );
 		$this->assertIsArray( $result );
 		$this->assertSame( $this->subscriber_id, $result['users'][0]['id'] );
+
+		$result = $ability->execute( array( 'id' => $this->subscriber_id, 'fields' => array( 'id', 'user_registered' ) ) );
+		$this->assertIsArray( $result );
+		$this->assertSame(
+			gmdate( 'c', strtotime( get_userdata( $this->subscriber_id )->user_registered ) ),
+			$result['users'][0]['user_registered']
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -487,33 +487,56 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * User email and login lookups for another user require list or edit permissions.
+	 * User email and login lookups for another user require list or edit permissions across roles.
 	 *
 	 * @since x.x.x
+	 *
+	 * @dataProvider data_roles_for_sensitive_identifier_lookup_permissions
+	 *
+	 * @param string $role        Current user's role.
+	 * @param bool   $can_resolve Whether the role can resolve another user by sensitive identifiers.
 	 */
-	public function test_user_email_and_login_lookup_for_another_user_requires_permission(): void {
-		wp_set_current_user( $this->subscriber_id );
+	public function test_roles_have_expected_sensitive_identifier_lookup_permissions( string $role, bool $can_resolve ): void {
+		wp_set_current_user( self::$fixture_ids[ $role ] );
 		$this->register_ability();
 
 		$ability = wp_get_ability( 'core/users' );
 
 		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
-		$this->assertWPError( $result, 'A subscriber should not be able to resolve another user by email.' );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Email lookup denial should use the invalid permissions error.' );
+		if ( $can_resolve ) {
+			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by email.', $role ) );
+			$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The email lookup should return the public author for the %s role.', $role ) );
+		} else {
+			$this->assertWPError( $result, sprintf( 'The %s role should not be able to resolve another user by email.', $role ) );
+			$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Email lookup denial for the %s role should use the invalid permissions error.', $role ) );
+		}
 
 		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
-		$this->assertWPError( $result, 'A subscriber should not be able to resolve another user by login.' );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), 'Login lookup denial should use the invalid permissions error.' );
+		if ( $can_resolve ) {
+			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by login.', $role ) );
+			$this->assertSame( $this->public_author_id, $result['users'][0]['id'], sprintf( 'The login lookup should return the public author for the %s role.', $role ) );
+			return;
+		}
 
-		wp_set_current_user( $this->admin_id );
+		$this->assertWPError( $result, sprintf( 'The %s role should not be able to resolve another user by login.', $role ) );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Login lookup denial for the %s role should use the invalid permissions error.', $role ) );
+	}
 
-		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
-		$this->assertIsArray( $result, 'An administrator should be able to resolve another user by email.' );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The email lookup should return the public author for an administrator.' );
-
-		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
-		$this->assertIsArray( $result, 'An administrator should be able to resolve another user by login.' );
-		$this->assertSame( $this->public_author_id, $result['users'][0]['id'], 'The login lookup should return the public author for an administrator.' );
+	/**
+	 * Data provider for role-based sensitive identifier lookup checks.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function data_roles_for_sensitive_identifier_lookup_permissions(): array {
+		return array(
+			'administrator' => array( 'administrator', true ),
+			'editor'        => array( 'editor', false ),
+			'author'        => array( 'author', false ),
+			'contributor'   => array( 'contributor', false ),
+			'subscriber'    => array( 'subscriber', false ),
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -641,6 +641,45 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Collection mode excludes a caller with no published posts, even via include,
+	 * while single-user mode still lets them read themselves.
+	 *
+	 * This mirrors WordPress core: a caller without permission to list users only sees
+	 * public authors in a collection, and reads their own account through a single-user
+	 * lookup (like the REST `/users/me` endpoint) rather than the collection.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_collection_mode_excludes_self_without_published_posts(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		$collection = $ability->execute(
+			array(
+				'include'  => array( $this->subscriber_id ),
+				'fields'   => array( 'id' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $collection, 'A collection include query should return an array.' );
+		$this->assertSame( array(), $collection['users'], 'Collection mode should exclude a caller with no published posts, even when they include their own ID.' );
+		$this->assertSame( 0, $collection['total'], 'The excluded self should not be counted in the collection total.' );
+
+		$single = $ability->execute(
+			array(
+				'id'     => $this->subscriber_id,
+				'fields' => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $single, 'A single-user self lookup should return an array.' );
+		$this->assertSame( $this->subscriber_id, $single['id'], 'Single-user mode should still let the caller read themselves.' );
+	}
+
+	/**
 	 * Include is a collection-only option.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -11,6 +11,7 @@ use WP_Ability;
 use WP_UnitTestCase;
 use WP_UnitTest_Factory;
 use WordPress\AI\Abilities\Users\Users;
+use stdClass;
 
 /**
  * Users ability test case.
@@ -385,7 +386,11 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Avatar fields are not requestable when avatars are disabled.
+	 * Avatar availability is enforced when formatting, not in the schemas.
+	 *
+	 * The registered schemas are a registration-time snapshot, so they always
+	 * declare avatar_urls; the show_avatars option is honored per call instead,
+	 * even when it changes after the ability is registered.
 	 *
 	 * @since x.x.x
 	 */
@@ -397,14 +402,22 @@ class UsersTest extends WP_UnitTestCase {
 		$input_schema  = $ability->get_input_schema();
 		$output_schema = $ability->get_output_schema();
 
-		$this->assertNotContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'], 'The fields enum should omit avatar_urls when avatars are disabled.' );
-		$this->assertArrayNotHasKey( 'avatar_urls', $output_schema['oneOf'][0]['properties'], 'The output schema should omit avatar_urls when avatars are disabled.' );
+		$this->assertContains( 'avatar_urls', $input_schema['oneOf'][0]['properties']['fields']['items']['enum'], 'The fields enum should keep declaring avatar_urls when avatars are disabled.' );
+		$this->assertArrayHasKey( 'avatar_urls', $output_schema['oneOf'][0]['properties'], 'The output schema should keep declaring avatar_urls when avatars are disabled.' );
 
 		wp_set_current_user( $this->subscriber_id );
 		$result = $ability->execute( array( 'id' => $this->subscriber_id ) );
 
 		$this->assertIsArray( $result, 'The current user should still be readable when avatars are disabled.' );
 		$this->assertArrayNotHasKey( 'avatar_urls', $result, 'The ability result should omit avatar_urls when avatars are disabled.' );
+
+		// Enabling the option after registration takes effect immediately; the
+		// registration-time schema must not reject the field.
+		update_option( 'show_avatars', 1 );
+		$result = $ability->execute( array( 'id' => $this->subscriber_id ) );
+
+		$this->assertIsArray( $result, 'Default-fields lookups should succeed after avatars are enabled post-registration.' );
+		$this->assertArrayHasKey( 'avatar_urls', $result, 'The ability result should include avatar_urls once avatars are enabled.' );
 	}
 
 	/**
@@ -907,6 +920,95 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A fully redacted user is returned as an empty object, not an empty array.
+	 *
+	 * When every requested field is inaccessible, the result must still
+	 * serialize as a JSON object (`{}`) to honor the declared output type.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_fully_redacted_user_returns_empty_object(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		$result = $ability->execute(
+			array(
+				'id'     => $this->public_author_id,
+				'fields' => array( 'email', 'roles' ),
+			)
+		);
+
+		$this->assertInstanceOf( stdClass::class, $result, 'A fully redacted user should be returned as an object.' );
+		$this->assertSame( '{}', wp_json_encode( $result ), 'A fully redacted user should serialize as a JSON object.' );
+
+		$collection = $ability->execute(
+			array(
+				'include' => array( $this->public_author_id ),
+				'fields'  => array( 'email' ),
+			)
+		);
+
+		$this->assertIsArray( $collection, 'A collection with redacted fields should return the wrapper.' );
+		$this->assertSame( '{}', wp_json_encode( $collection['users'][0] ), 'Redacted collection entries should serialize as JSON objects.' );
+	}
+
+	/**
+	 * REST-style string input is sanitized against the schema before use.
+	 *
+	 * Read-only abilities run over REST `GET`, where booleans arrive as the
+	 * string 'true' and arrays may arrive as CSV strings. Those values pass
+	 * schema validation, which coerces only for the check, so the ability must
+	 * sanitize them itself before its strict normalizers run.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_rest_style_string_input_is_coerced(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		$result = $ability->execute(
+			array(
+				'has_published_posts' => 'true',
+				'fields'              => array( 'id' ),
+				'per_page'            => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'A string boolean published-posts filter should execute.' );
+		$ids = wp_list_pluck( $result['users'], 'id' );
+		$this->assertContains( $this->public_author_id, $ids, 'The published-posts filter should include public authors.' );
+		$this->assertNotContains( $this->subscriber_id, $ids, 'A string "true" must enable the published-posts filter rather than being silently dropped.' );
+
+		$result = $ability->execute(
+			array(
+				'roles'    => 'editor',
+				'fields'   => array( 'id' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'A CSV roles filter should execute.' );
+		$ids = wp_list_pluck( $result['users'], 'id' );
+		$this->assertContains( self::$fixture_ids['editor'], $ids, 'The roles filter should include editors.' );
+		$this->assertNotContains( $this->subscriber_id, $ids, 'A CSV roles value must filter by role rather than being silently dropped.' );
+
+		$result = $ability->execute(
+			array(
+				'include' => (string) $this->subscriber_id,
+				'fields'  => 'id,email',
+			)
+		);
+
+		$this->assertIsArray( $result, 'A CSV include filter should execute.' );
+		$this->assertSame( array( $this->subscriber_id ), wp_list_pluck( $result['users'], 'id' ), 'A string include value must limit the query to the included IDs.' );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['email'], 'A CSV fields value must select the requested fields.' );
+	}
+
+	/**
 	 * An unknown requested field name fails schema validation.
 	 *
 	 * Unlike inaccessible fields, which are omitted per user, a field name that is
@@ -930,14 +1032,15 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Requesting an unavailable field fails schema validation.
+	 * Requesting an unavailable field omits it instead of failing.
 	 *
-	 * When avatars are disabled, avatar_urls is not part of the supported set, so
-	 * requesting it is rejected before the ability executes.
+	 * When avatars are disabled, avatar_urls stays requestable (the schema is a
+	 * registration-time snapshot) and is omitted per user, matching how
+	 * permission-restricted fields behave.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_unavailable_requested_field_fails_schema_validation(): void {
+	public function test_unavailable_requested_field_is_omitted(): void {
 		update_option( 'show_avatars', 0 );
 		wp_set_current_user( $this->admin_id );
 		$this->register_ability();
@@ -949,8 +1052,8 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertWPError( $result, 'Requesting avatar_urls while avatars are disabled should fail the request.' );
-		$this->assertSame( 'ability_invalid_input', $result->get_error_code(), 'Unavailable fields should use the invalid input error.' );
+		$this->assertIsArray( $result, 'Requesting avatar_urls while avatars are disabled should still succeed.' );
+		$this->assertSame( array( 'id' ), array_keys( $result ), 'The avatar_urls field should be omitted while avatars are disabled.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -589,11 +589,11 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Collection include limits results and preserves requested order.
+	 * Collection include limits results to the requested users.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_collection_include_limits_results_and_preserves_order(): void {
+	public function test_collection_include_limits_results(): void {
 		wp_set_current_user( $this->admin_id );
 		$this->register_ability();
 
@@ -606,10 +606,10 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $result, 'An included user query should return an array.' );
-		$this->assertSame(
+		$this->assertEqualSets(
 			array( $this->public_author_id, $this->subscriber_id ),
 			wp_list_pluck( $result['users'], 'id' ),
-			'Included user queries should preserve the requested order.'
+			'Included user queries should return exactly the readable included users.'
 		);
 		$this->assertSame( 2, $result['total'], 'Included user queries should report the matching included total.' );
 	}

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -1206,6 +1206,200 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Creates a user whose stored email is empty.
+	 *
+	 * WordPress allows this: wp_insert_user() rejects an empty login and an empty
+	 * nicename, but never an empty email. Imports and single sign-on plugins can
+	 * leave such rows behind.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int The new user ID.
+	 */
+	private function create_user_without_email(): int {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => '',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertSame( '', get_userdata( $user_id )->user_email, 'The fixture user should have an empty stored email.' );
+
+		return $user_id;
+	}
+
+	/**
+	 * A user with an empty stored email is still readable.
+	 *
+	 * WP_Ability::execute() validates the result against the output schema, so an
+	 * email the schema cannot describe must be reported as null rather than passed
+	 * through, which would fail the whole lookup.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_empty_stored_email_does_not_fail_single_user_output(): void {
+		$user_id = $this->create_user_without_email();
+
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'     => $user_id,
+				'fields' => array( 'id', 'email' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'A user with an empty stored email should still be readable.' );
+		$this->assertArrayHasKey( 'email', $result, 'A viewable email field should be present even when there is no address.' );
+		$this->assertNull( $result['email'], 'An empty stored email should be reported as null.' );
+	}
+
+	/**
+	 * A stored email that is_email() rejects is reported as null.
+	 *
+	 * WordPress runs sanitize_email() when saving, and that can repair an address
+	 * into a shape is_email() refuses. Saving `a@@b.c` stores `a@b.c`, which is one
+	 * character too short for is_email(). The declared `email` format only holds
+	 * because such values become null.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_invalid_stored_email_is_reported_as_null(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		wp_update_user(
+			array(
+				'ID'         => $user_id,
+				'user_email' => 'a@@b.c',
+			)
+		);
+		clean_user_cache( $user_id );
+
+		$this->assertSame( 'a@b.c', get_userdata( $user_id )->user_email, 'WordPress should store the repaired address.' );
+		$this->assertFalse( is_email( 'a@b.c' ), 'The repaired address should still be rejected by is_email().' );
+
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'     => $user_id,
+				'fields' => array( 'id', 'email' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'A user with an unusable stored email should still be readable.' );
+		$this->assertNull( $result['email'], 'An email that is_email() rejects should be reported as null.' );
+	}
+
+	/**
+	 * One user with an empty stored email does not break a whole collection page.
+	 *
+	 * Collection output is validated as a single value, so an invalid field on one
+	 * row rejects every row on the page, not just the offending user.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_empty_stored_email_does_not_fail_collection_output(): void {
+		$user_id = $this->create_user_without_email();
+
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'fields'   => array( 'id', 'email' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'One user with an empty stored email should not fail the whole collection.' );
+
+		$ids = wp_list_pluck( $result['users'], 'id' );
+		$this->assertContains( $this->admin_id, $ids, 'Users with valid emails should still be returned.' );
+		$this->assertContains( $user_id, $ids, 'The user with an empty stored email should still be returned.' );
+	}
+
+	/**
+	 * A suppressed avatar URL does not break the default field set.
+	 *
+	 * get_avatar_url() documents `string|false` as its return type, and plugins that
+	 * disable Gravatar short-circuit the avatar data. Since avatar_urls is part of the
+	 * default field set, a false URL would fail every call rather than only the ones
+	 * that opt in.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_suppressed_avatar_url_does_not_fail_output(): void {
+		update_option( 'show_avatars', 1 );
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		add_filter(
+			'pre_get_avatar_data',
+			static function ( $args ) {
+				$args['url'] = false;
+
+				return $args;
+			}
+		);
+
+		$result = wp_get_ability( 'core/read-users' )->execute( array( 'id' => $this->admin_id ) );
+
+		$this->assertIsArray( $result, 'A suppressed avatar URL should not fail a default-fields lookup.' );
+		$this->assertSame( $this->admin_id, $result['id'], 'The lookup should still resolve the requested user.' );
+		$this->assertSame(
+			array(
+				24 => null,
+				48 => null,
+				96 => null,
+			),
+			$result['avatar_urls'],
+			'Every avatar size should be reported as null when no URL can be resolved.'
+		);
+	}
+
+	/**
+	 * Avatar sizes that resolve to a URL survive when other sizes do not.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_partially_suppressed_avatar_urls_keep_the_resolved_sizes(): void {
+		update_option( 'show_avatars', 1 );
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		add_filter(
+			'pre_get_avatar_data',
+			static function ( $args ) {
+				if ( 24 === $args['size'] ) {
+					$args['url'] = false;
+				}
+
+				return $args;
+			}
+		);
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'     => $this->admin_id,
+				'fields' => array( 'id', 'avatar_urls' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'A partially suppressed avatar set should not fail the lookup.' );
+		$this->assertSame( array( 24, 48, 96 ), array_keys( $result['avatar_urls'] ), 'Every avatar size should still be reported.' );
+		$this->assertNull( $result['avatar_urls'][24], 'A size with no resolvable URL should be null.' );
+		$this->assertIsString( $result['avatar_urls'][48], 'A size that resolves should keep its URL.' );
+		$this->assertIsString( $result['avatar_urls'][96], 'A size that resolves should keep its URL.' );
+	}
+
+	/**
 	 * Missing or inaccessible single-user lookups fail closed.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -323,9 +323,9 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertCount( 5, $schema['oneOf'], 'The users ability input schema should expose four lookup modes and collection mode.' );
 
 		$this->assertSame( array( 'id' ), $schema['oneOf'][0]['required'], 'The first input mode should require an ID.' );
-		$this->assertSame( array( 'user_email' ), $schema['oneOf'][1]['required'], 'The second input mode should require a user email.' );
-		$this->assertSame( array( 'user_login' ), $schema['oneOf'][2]['required'], 'The third input mode should require a user login.' );
-		$this->assertSame( array( 'user_nicename' ), $schema['oneOf'][3]['required'], 'The fourth input mode should require a user nicename.' );
+		$this->assertSame( array( 'email' ), $schema['oneOf'][1]['required'], 'The second input mode should require an email.' );
+		$this->assertSame( array( 'username' ), $schema['oneOf'][2]['required'], 'The third input mode should require a username.' );
+		$this->assertSame( array( 'slug' ), $schema['oneOf'][3]['required'], 'The fourth input mode should require a slug.' );
 		$this->assertArrayNotHasKey( 'required', $schema['oneOf'][4], 'Collection mode should allow an empty request.' );
 
 		$collection_properties = $schema['oneOf'][4]['properties'];
@@ -379,7 +379,7 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $output_schema['oneOf'], 'The output schema should describe single-user and collection responses.' );
 		$this->assertArrayNotHasKey( 'required', $user_schema, 'Single-user fields should remain optional.' );
 		$this->assertSame( array( 'users', 'total', 'total_pages' ), $collection_schema['required'], 'Collection responses should require the wrapper fields.' );
-		$this->assertSame( 'date-time', $user_properties['user_registered']['format'], 'The user_registered output schema should use date-time format.' );
+		$this->assertSame( 'date-time', $user_properties['registered_date']['format'], 'The registered_date output schema should use date-time format.' );
 		$this->assertEqualSets( array_keys( wp_roles()->roles ), $user_properties['roles']['items']['enum'], 'The roles output enum should expose registered role names.' );
 	}
 
@@ -419,11 +419,11 @@ class UsersTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result, 'A current-user lookup should return an array.' );
 		$this->assertSame(
-			array( 'id', 'display_name', 'link', 'user_nicename', 'avatar_urls' ),
+			array( 'id', 'name', 'link', 'slug', 'avatar_urls' ),
 			array_keys( $result ),
 			'Omitted fields should return the lean default field set.'
 		);
-		$this->assertArrayNotHasKey( 'user_email', $result, 'Default fields should not include sensitive user fields.' );
+		$this->assertArrayNotHasKey( 'email', $result, 'Default fields should not include sensitive user fields.' );
 		$this->assertArrayNotHasKey( 'description', $result, 'Default fields should omit less common read-context fields.' );
 	}
 
@@ -442,7 +442,7 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The current user can read themselves by ID, user email, and user login.
+	 * The current user can read themselves by ID, email, and username.
 	 *
 	 * @since x.x.x
 	 */
@@ -455,44 +455,44 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute(
 			array(
 				'id'     => $this->subscriber_id,
-				'fields' => array( 'id', 'user_email', 'user_login', 'roles' ),
+				'fields' => array( 'id', 'email', 'username', 'roles' ),
 			)
 		);
 
 		$this->assertIsArray( $result, 'A user should be able to read themselves by ID.' );
 		$this->assertSame( $this->subscriber_id, $result['id'], 'The ID lookup should return the current user.' );
-		$this->assertSame( 'users-ability-subscriber@example.com', $result['user_email'], 'The current user should receive their own email.' );
-		$this->assertSame( 'users_ability_subscriber', $result['user_login'], 'The current user should receive their own login.' );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['email'], 'The current user should receive their own email.' );
+		$this->assertSame( 'users_ability_subscriber', $result['username'], 'The current user should receive their own username.' );
 		$this->assertContains( 'subscriber', $result['roles'], 'The current user should receive their own roles.' );
 
-		$result = $ability->execute( array( 'user_email' => 'users-ability-subscriber@example.com' ) );
+		$result = $ability->execute( array( 'email' => 'users-ability-subscriber@example.com' ) );
 		$this->assertIsArray( $result, 'A user should be able to read themselves by email.' );
 		$this->assertSame( $this->subscriber_id, $result['id'], 'The email lookup should return the current user.' );
 
-		$result = $ability->execute( array( 'user_login' => 'users_ability_subscriber' ) );
-		$this->assertIsArray( $result, 'A user should be able to read themselves by login.' );
-		$this->assertSame( $this->subscriber_id, $result['id'], 'The login lookup should return the current user.' );
+		$result = $ability->execute( array( 'username' => 'users_ability_subscriber' ) );
+		$this->assertIsArray( $result, 'A user should be able to read themselves by username.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'The username lookup should return the current user.' );
 
 		$result = $ability->execute(
 			array(
 				'id'     => $this->subscriber_id,
-				'fields' => array( 'id', 'user_registered' ),
+				'fields' => array( 'id', 'registered_date' ),
 			)
 		);
 		$this->assertIsArray( $result, 'A user should be able to request their registration date.' );
 		$this->assertSame(
 			gmdate( 'c', strtotime( get_userdata( $this->subscriber_id )->user_registered ) ),
-			$result['user_registered'],
+			$result['registered_date'],
 			'The registration date should be formatted as an ISO 8601 date-time string.'
 		);
 	}
 
 	/**
-	 * Public-author users can be read by ID or user nicename by logged-in users.
+	 * Public-author users can be read by ID or slug by logged-in users.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_public_author_can_be_read_by_id_and_user_nicename(): void {
+	public function test_public_author_can_be_read_by_id_and_slug(): void {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
@@ -501,23 +501,23 @@ class UsersTest extends WP_UnitTestCase {
 		$result = $ability->execute(
 			array(
 				'id'     => $this->public_author_id,
-				'fields' => array( 'id', 'user_nicename', 'user_email' ),
+				'fields' => array( 'id', 'slug', 'email' ),
 			)
 		);
 
 		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by ID.' );
 		$this->assertSame( $this->public_author_id, $result['id'], 'The ID lookup should return the public author.' );
-		$this->assertSame( 'users-ability-author', $result['user_nicename'], 'The public author nicename should be returned.' );
-		$this->assertArrayNotHasKey( 'user_email', $result, 'Public-author access should not expose another user email.' );
+		$this->assertSame( 'users-ability-author', $result['slug'], 'The public author slug should be returned.' );
+		$this->assertArrayNotHasKey( 'email', $result, 'Public-author access should not expose another user email.' );
 
-		$result = $ability->execute( array( 'user_nicename' => 'users-ability-author' ) );
+		$result = $ability->execute( array( 'slug' => 'users-ability-author' ) );
 
-		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by nicename.' );
-		$this->assertSame( $this->public_author_id, $result['id'], 'The nicename lookup should return the public author.' );
+		$this->assertIsArray( $result, 'A logged-in user should be able to read a public author by slug.' );
+		$this->assertSame( $this->public_author_id, $result['id'], 'The slug lookup should return the public author.' );
 	}
 
 	/**
-	 * User email and login lookups for another user require list or edit permissions across roles.
+	 * Email and username lookups for another user require list or edit permissions across roles.
 	 *
 	 * @since x.x.x
 	 *
@@ -532,7 +532,7 @@ class UsersTest extends WP_UnitTestCase {
 
 		$ability = wp_get_ability( 'core/read-users' );
 
-		$result = $ability->execute( array( 'user_email' => 'users-ability-author@example.com' ) );
+		$result = $ability->execute( array( 'email' => 'users-ability-author@example.com' ) );
 		if ( $can_resolve ) {
 			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by email.', $role ) );
 			$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The email lookup should return the public author for the %s role.', $role ) );
@@ -541,15 +541,15 @@ class UsersTest extends WP_UnitTestCase {
 			$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Email lookup denial for the %s role should use the invalid permissions error.', $role ) );
 		}
 
-		$result = $ability->execute( array( 'user_login' => 'users_ability_author' ) );
+		$result = $ability->execute( array( 'username' => 'users_ability_author' ) );
 		if ( $can_resolve ) {
-			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by login.', $role ) );
-			$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The login lookup should return the public author for the %s role.', $role ) );
+			$this->assertIsArray( $result, sprintf( 'The %s role should be able to resolve another user by username.', $role ) );
+			$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The username lookup should return the public author for the %s role.', $role ) );
 			return;
 		}
 
-		$this->assertWPError( $result, sprintf( 'The %s role should not be able to resolve another user by login.', $role ) );
-		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Login lookup denial for the %s role should use the invalid permissions error.', $role ) );
+		$this->assertWPError( $result, sprintf( 'The %s role should not be able to resolve another user by username.', $role ) );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code(), sprintf( 'Username lookup denial for the %s role should use the invalid permissions error.', $role ) );
 	}
 
 	/**
@@ -694,17 +694,17 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$by_login = wp_get_ability( 'core/read-users' )->execute(
+		$by_username = wp_get_ability( 'core/read-users' )->execute(
 			array(
-				'user_login' => 'users_ability_subscriber',
-				'include'    => array( $this->subscriber_id ),
+				'username' => 'users_ability_subscriber',
+				'include'  => array( $this->subscriber_id ),
 			)
 		);
 
 		$this->assertWPError( $by_id, 'ID plus include should fail validation.' );
-		$this->assertWPError( $by_login, 'Login plus include should fail validation.' );
+		$this->assertWPError( $by_username, 'Username plus include should fail validation.' );
 		$this->assertSame( 'ability_invalid_input', $by_id->get_error_code(), 'ID plus include should return an input error.' );
-		$this->assertSame( 'ability_invalid_input', $by_login->get_error_code(), 'Login plus include should return an input error.' );
+		$this->assertSame( 'ability_invalid_input', $by_username->get_error_code(), 'Username plus include should return an input error.' );
 	}
 
 	/**
@@ -832,17 +832,17 @@ class UsersTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'core/read-users' )->execute(
 			array(
 				'id'     => $this->public_author_id,
-				'fields' => array( 'id', 'user_email', 'roles' ),
+				'fields' => array( 'id', 'email', 'roles' ),
 			)
 		);
 
 		$this->assertIsArray( $result, sprintf( 'The %s role should be able to execute a public-author lookup.', $role ) );
 		$this->assertSame( $this->public_author_id, $result['id'], sprintf( 'The %s role should receive the requested public author.', $role ) );
-		$this->assertSame( $can_view_sensitive, array_key_exists( 'user_email', $result ), sprintf( 'The %s role email visibility should match expectations.', $role ) );
+		$this->assertSame( $can_view_sensitive, array_key_exists( 'email', $result ), sprintf( 'The %s role email visibility should match expectations.', $role ) );
 		$this->assertSame( $can_view_roles, array_key_exists( 'roles', $result ), sprintf( 'The %s role roles visibility should match expectations.', $role ) );
 
 		if ( $can_view_sensitive ) {
-			$this->assertSame( 'users-ability-author@example.com', $result['user_email'], sprintf( 'The %s role should receive the public author email when allowed.', $role ) );
+			$this->assertSame( 'users-ability-author@example.com', $result['email'], sprintf( 'The %s role should receive the public author email when allowed.', $role ) );
 		}
 
 		if ( ! $can_view_roles ) {
@@ -896,7 +896,7 @@ class UsersTest extends WP_UnitTestCase {
 		$result = wp_get_ability( 'core/read-users' )->execute(
 			array(
 				'id'     => $this->public_author_id,
-				'fields' => array( 'id', 'user_email', 'roles' ),
+				'fields' => array( 'id', 'email', 'roles' ),
 			)
 		);
 

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -883,6 +883,47 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A caller who can list users but not edit them does not receive another
+	 * user's roles.
+	 *
+	 * `list_users` grants no edit rights, so it must not disclose a user's roles,
+	 * matching the REST users controller, which confines `roles` to users the
+	 * caller can edit.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_list_users_without_edit_does_not_expose_other_users_roles(): void {
+		add_role( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role -- Registering a throwaway role in an integration test.
+			'users_ability_list_only',
+			'List Only',
+			array(
+				'read'       => true,
+				'list_users' => true,
+			)
+		);
+
+		$lister_id = self::factory()->user->create( array( 'role' => 'users_ability_list_only' ) );
+
+		try {
+			wp_set_current_user( $lister_id );
+			$this->register_ability();
+
+			$result = wp_get_ability( 'core/read-users' )->execute(
+				array(
+					'id'     => $this->public_author_id,
+					'fields' => array( 'id', 'roles' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'A list-only caller should still resolve a public author.' );
+			$this->assertArrayNotHasKey( 'roles', $result, 'A caller who cannot edit a user must not receive that user\'s roles.' );
+		} finally {
+			wp_delete_user( $lister_id );
+			remove_role( 'users_ability_list_only' );
+		}
+	}
+
+	/**
 	 * Role filtering requires list_users.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -358,6 +358,7 @@ class UsersTest extends WP_UnitTestCase {
 		$fields = $schema['oneOf'][4]['properties']['fields']['items']['enum'];
 		$this->assertContains( 'roles', $fields, 'The fields enum should expose the roles field.' );
 		$this->assertContains( 'avatar_urls', $fields, 'The fields enum should expose avatar_urls when avatars are enabled.' );
+		$this->assertSame( 1, $schema['oneOf'][4]['properties']['fields']['minItems'], 'The fields option should require at least one field when provided.' );
 
 		$role_names = $schema['oneOf'][4]['properties']['roles']['items']['enum'];
 		$this->assertEqualSets( array_keys( wp_roles()->roles ), $role_names, 'The roles query enum should expose registered role names.' );

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -763,6 +763,84 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A post type that is public but not publicly viewable never makes a user visible.
+	 *
+	 * `public => true` does not mean a post type can be viewed on the front end, so the
+	 * ability uses is_post_type_viewable() everywhere. A boolean has_published_posts
+	 * must not fall back to WP_User_Query's own reading of `true`, which resolves to
+	 * get_post_types( array( 'public' => true ) ) and would match such an author.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_public_but_not_viewable_post_type_never_exposes_an_author(): void {
+		register_post_type(
+			'wpai_not_viewable_pt',
+			array(
+				'public'             => true,
+				'publicly_queryable' => false,
+			)
+		);
+
+		$this->assertContains( 'wpai_not_viewable_pt', get_post_types( array( 'public' => true ) ), 'The post type should be in the public set.' );
+		$this->assertFalse( is_post_type_viewable( 'wpai_not_viewable_pt' ), 'The post type should not be publicly viewable.' );
+
+		$author_id = self::factory()->user->create(
+			array(
+				'role'          => 'author',
+				'user_nicename' => 'users-ability-hidden-author',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'publish',
+				'post_type'   => 'wpai_not_viewable_pt',
+			)
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		$schema = $ability->get_input_schema();
+		$this->assertNotContains(
+			'wpai_not_viewable_pt',
+			$schema['oneOf'][4]['properties']['has_published_posts']['oneOf'][1]['items']['enum'],
+			'The post type should not be offered in the has_published_posts enum.'
+		);
+
+		$result = $ability->execute(
+			array(
+				'has_published_posts' => true,
+				'fields'              => array( 'id' ),
+				'per_page'            => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'A boolean published-posts filter should execute.' );
+		$this->assertNotContains(
+			$author_id,
+			wp_list_pluck( $result['users'], 'id' ),
+			'A boolean published-posts filter should not match an author whose only post type is not publicly viewable.'
+		);
+
+		// The same author stays hidden from the single-user lookup used for public authors.
+		wp_set_current_user( $this->subscriber_id );
+
+		$result = $ability->execute(
+			array(
+				'slug'   => 'users-ability-hidden-author',
+				'fields' => array( 'id' ),
+			)
+		);
+
+		$this->assertWPError( $result, 'A non-viewable post type should not make its author publicly readable.' );
+
+		unregister_post_type( 'wpai_not_viewable_pt' );
+	}
+
+	/**
 	 * Collection mode excludes a caller with no published posts, even via include,
 	 * while single-user mode still lets them read themselves.
 	 *

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -702,6 +702,42 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Collection results keep the default ordering, not the order of the include list.
+	 *
+	 * The query deliberately leaves `orderby` alone rather than setting it to
+	 * `include`, so that queries over the same users can share a WP_User_Query cache
+	 * entry. This test fails if that ordering is ever applied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_include_order_does_not_control_the_result_order(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		// WP_User_Query orders by user_login ascending by default, and
+		// 'users_ability_admin' sorts before 'users_ability_subscriber'.
+		$expected = array( $this->admin_id, $this->subscriber_id );
+
+		foreach ( array( $expected, array_reverse( $expected ) ) as $include ) {
+			$result = $ability->execute(
+				array(
+					'include' => $include,
+					'fields'  => array( 'id' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'An included user query should succeed.' );
+			$this->assertSame(
+				$expected,
+				wp_list_pluck( $result['users'], 'id' ),
+				'Included users should be ordered by login, whichever order the include list uses.'
+			);
+		}
+	}
+
+	/**
 	 * Collection include still respects row-level read permissions.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -868,6 +868,53 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An unknown requested field name fails schema validation.
+	 *
+	 * Unlike inaccessible fields, which are omitted per user, a field name that is
+	 * not part of the supported set is rejected before the ability executes.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_unknown_requested_field_fails_schema_validation(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'     => $this->admin_id,
+				'fields' => array( 'id', 'bogus_field' ),
+			)
+		);
+
+		$this->assertWPError( $result, 'An unknown requested field should fail the request.' );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code(), 'Unknown fields should use the invalid input error.' );
+	}
+
+	/**
+	 * Requesting an unavailable field fails schema validation.
+	 *
+	 * When avatars are disabled, avatar_urls is not part of the supported set, so
+	 * requesting it is rejected before the ability executes.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_unavailable_requested_field_fails_schema_validation(): void {
+		update_option( 'show_avatars', 0 );
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			array(
+				'id'     => $this->admin_id,
+				'fields' => array( 'id', 'avatar_urls' ),
+			)
+		);
+
+		$this->assertWPError( $result, 'Requesting avatar_urls while avatars are disabled should fail the request.' );
+		$this->assertSame( 'ability_invalid_input', $result->get_error_code(), 'Unavailable fields should use the invalid input error.' );
+	}
+
+	/**
 	 * Missing or inaccessible single-user lookups fail closed.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -1335,10 +1335,10 @@ class UsersTest extends WP_UnitTestCase {
 	/**
 	 * A stored email that is_email() rejects is reported as null.
 	 *
-	 * WordPress runs sanitize_email() when saving, and that can repair an address
-	 * into a shape is_email() refuses. Saving `a@@b.c` stores `a@b.c`, which is one
-	 * character too short for is_email(). The declared `email` format only holds
-	 * because such values become null.
+	 * WordPress runs sanitize_email() when saving. Depending on the WordPress
+	 * version, saving `a@@b.c` either stores an empty string or repairs it to
+	 * `a@b.c`, which is one character too short for is_email(). The declared
+	 * `email` format only holds because such values become null.
 	 *
 	 * @since x.x.x
 	 */
@@ -1353,8 +1353,10 @@ class UsersTest extends WP_UnitTestCase {
 		);
 		clean_user_cache( $user_id );
 
-		$this->assertSame( 'a@b.c', get_userdata( $user_id )->user_email, 'WordPress should store the repaired address.' );
-		$this->assertFalse( is_email( 'a@b.c' ), 'The repaired address should still be rejected by is_email().' );
+		$stored_email = get_userdata( $user_id )->user_email;
+
+		$this->assertContains( $stored_email, array( '', 'a@b.c' ), 'WordPress should either discard or repair the invalid address.' );
+		$this->assertFalse( is_email( $stored_email ), 'The stored address should still be rejected by is_email().' );
 
 		wp_set_current_user( $this->admin_id );
 		$this->register_ability();

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -531,6 +531,79 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A single-user lookup resolves an author whose posts are all private, while
+	 * collection mode does not.
+	 *
+	 * The two modes enforce access differently. A single-user lookup calls
+	 * count_user_posts(), which counts private posts for a caller holding
+	 * read_private_posts, matching the REST users controller. Collection mode is
+	 * filtered by WP_User_Query's has_published_posts, which matches published posts
+	 * only, so it never returns such an author.
+	 *
+	 * This exposes nothing new. An editor who can read the private post already sees
+	 * its author through the post itself.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_private_only_author_resolves_by_lookup_but_not_in_a_collection(): void {
+		$author_id = self::factory()->user->create(
+			array(
+				'role'          => 'author',
+				'user_nicename' => 'users-ability-private-author',
+			)
+		);
+		self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'private',
+				'post_type'   => 'post',
+			)
+		);
+
+		wp_set_current_user( self::$fixture_ids['editor'] );
+		$this->register_ability();
+
+		$this->assertFalse( current_user_can( 'list_users' ), 'An editor should not be able to list users.' );
+		$this->assertFalse( current_user_can( 'edit_user', $author_id ), 'An editor should not be able to edit the author.' );
+		$this->assertTrue( current_user_can( 'read_private_posts' ), 'An editor should be able to read private posts.' );
+
+		$ability = wp_get_ability( 'core/read-users' );
+
+		$result = $ability->execute(
+			array(
+				'slug'   => 'users-ability-private-author',
+				'fields' => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'An editor should resolve an author whose posts are all private.' );
+		$this->assertSame( $author_id, $result['id'], 'The slug lookup should return the private-only author.' );
+
+		$result = $ability->execute(
+			array(
+				'include'  => array( $author_id ),
+				'fields'   => array( 'id' ),
+				'per_page' => 100,
+			)
+		);
+
+		$this->assertIsArray( $result, 'The collection request should succeed.' );
+		$this->assertSame( array(), $result['users'], 'Collection mode should omit an author whose posts are all private.' );
+
+		// The lookup is gated on the capability, not merely on being logged in.
+		wp_set_current_user( $this->subscriber_id );
+
+		$result = $ability->execute(
+			array(
+				'slug'   => 'users-ability-private-author',
+				'fields' => array( 'id' ),
+			)
+		);
+
+		$this->assertWPError( $result, 'A subscriber should not resolve an author whose posts are all private.' );
+	}
+
+	/**
 	 * Email and username lookups for another user require list or edit permissions across roles.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -268,7 +268,6 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( WP_Ability::class, $ability, 'The users ability should be registered.' );
 		$this->assertSame( 'user', $ability->get_category(), 'The users ability should use the user category.' );
 		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'The users ability should be exposed over REST.' );
-		$this->assertTrue( $ability->get_meta_item( 'pagination', false ), 'The users ability should advertise pagination support.' );
 
 		$annotations = $ability->get_meta_item( 'annotations', array() );
 		$this->assertTrue( $annotations['readonly'], 'The users ability should be marked read-only.' );

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -11,7 +11,6 @@ use WP_Ability;
 use WP_UnitTestCase;
 use WP_UnitTest_Factory;
 use WordPress\AI\Abilities\Users\Users;
-use stdClass;
 
 /**
  * Users ability test case.
@@ -920,14 +919,17 @@ class UsersTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A fully redacted user is returned as an empty object, not an empty array.
+	 * A fully redacted field request still returns the user's ID.
 	 *
-	 * When every requested field is inaccessible, the result must still
-	 * serialize as a JSON object (`{}`) to honor the declared output type.
+	 * The `id` field is always included, matching the REST users controller
+	 * where `id` is present in every context. This also guarantees the result
+	 * serializes as a JSON object (`{}`-shaped, never `[]`), honoring the
+	 * declared output type without returning a top-level empty object, which
+	 * REST post-processing (`_fields`) cannot handle.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_fully_redacted_user_returns_empty_object(): void {
+	public function test_fully_redacted_field_request_still_returns_id(): void {
 		wp_set_current_user( $this->subscriber_id );
 		$this->register_ability();
 
@@ -940,8 +942,13 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
-		$this->assertInstanceOf( stdClass::class, $result, 'A fully redacted user should be returned as an object.' );
-		$this->assertSame( '{}', wp_json_encode( $result ), 'A fully redacted user should serialize as a JSON object.' );
+		$this->assertIsArray( $result, 'A fully redacted field request should still succeed.' );
+		$this->assertSame( array( 'id' => $this->public_author_id ), $result, 'A fully redacted field request should return only the user ID.' );
+		$this->assertSame(
+			sprintf( '{"id":%d}', $this->public_author_id ),
+			wp_json_encode( $result ),
+			'A fully redacted field request should serialize as a JSON object.'
+		);
 
 		$collection = $ability->execute(
 			array(
@@ -951,16 +958,46 @@ class UsersTest extends WP_UnitTestCase {
 		);
 
 		$this->assertIsArray( $collection, 'A collection with redacted fields should return the wrapper.' );
-		$this->assertSame( '{}', wp_json_encode( $collection['users'][0] ), 'Redacted collection entries should serialize as JSON objects.' );
+		$this->assertSame(
+			array( 'id' => $this->public_author_id ),
+			$collection['users'][0],
+			'Redacted collection entries should still contain the user ID.'
+		);
 	}
 
 	/**
-	 * REST-style string input is sanitized against the schema before use.
+	 * Schema-valid object input behaves like its array form.
+	 *
+	 * Schema validation accepts `stdClass` input (the input schema's own
+	 * `default` is one), so it must not be discarded and silently turned into
+	 * an unrestricted collection query.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_object_input_behaves_like_array_input(): void {
+		wp_set_current_user( $this->subscriber_id );
+		$this->register_ability();
+
+		$result = wp_get_ability( 'core/read-users' )->execute(
+			(object) array(
+				'id'     => $this->subscriber_id,
+				'fields' => array( 'id', 'email' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Object input should execute the single-user lookup.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'Object input must resolve the requested user, not fall back to collection mode.' );
+		$this->assertSame( 'users-ability-subscriber@example.com', $result['email'], 'Object input should honor the requested fields.' );
+	}
+
+	/**
+	 * REST-style string input is coerced by the normalizers.
 	 *
 	 * Read-only abilities run over REST `GET`, where booleans arrive as the
-	 * string 'true' and arrays may arrive as CSV strings. Those values pass
-	 * schema validation, which coerces only for the check, so the ability must
-	 * sanitize them itself before its strict normalizers run.
+	 * string 'true', arrays may arrive as CSV strings, and integers arrive as
+	 * numeric strings. Those values pass schema validation, which coerces only
+	 * for the check, so the normalizers must accept the string forms instead
+	 * of silently dropping the filters they carry.
 	 *
 	 * @since x.x.x
 	 */
@@ -1006,6 +1043,42 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result, 'A CSV include filter should execute.' );
 		$this->assertSame( array( $this->subscriber_id ), wp_list_pluck( $result['users'], 'id' ), 'A string include value must limit the query to the included IDs.' );
 		$this->assertSame( 'users-ability-subscriber@example.com', $result['users'][0]['email'], 'A CSV fields value must select the requested fields.' );
+
+		// IDs that are distinct as strings but equal as integers ('7' vs '07')
+		// pass schema validation; they must still collapse to one filtered ID.
+		$result = $ability->execute(
+			array(
+				'include' => array( (string) $this->subscriber_id, '0' . $this->subscriber_id ),
+				'fields'  => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'A string-duplicate include filter should execute.' );
+		$this->assertSame( array( $this->subscriber_id ), wp_list_pluck( $result['users'], 'id' ), 'String-duplicate IDs must be deduplicated, not silently drop the include filter.' );
+		$this->assertSame( 1, $result['total'], 'String-duplicate IDs should count as one included user.' );
+
+		// Scalars arrive as numeric strings over GET.
+		$result = $ability->execute(
+			array(
+				'id'     => (string) $this->subscriber_id,
+				'fields' => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'A numeric-string ID lookup should execute.' );
+		$this->assertSame( $this->subscriber_id, $result['id'], 'A numeric-string ID must resolve the single-user lookup.' );
+
+		$result = $ability->execute(
+			array(
+				'per_page' => '1',
+				'page'     => '2',
+				'fields'   => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Numeric-string pagination should execute.' );
+		$this->assertCount( 1, $result['users'], 'A numeric-string per_page must limit the page size.' );
+		$this->assertGreaterThan( 1, $result['total_pages'], 'A numeric-string per_page must be reflected in total_pages.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -381,7 +381,8 @@ class UsersTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'required', $user_schema, 'Single-user fields should remain optional.' );
 		$this->assertSame( array( 'users', 'total', 'total_pages' ), $collection_schema['required'], 'Collection responses should require the wrapper fields.' );
 		$this->assertSame( 'date-time', $user_properties['registered_date']['format'], 'The registered_date output schema should use date-time format.' );
-		$this->assertEqualSets( array_keys( wp_roles()->roles ), $user_properties['roles']['items']['enum'], 'The roles output enum should expose registered role names.' );
+		$this->assertSame( 'string', $user_properties['roles']['items']['type'], 'The roles output schema should describe role name strings.' );
+		$this->assertArrayNotHasKey( 'enum', $user_properties['roles']['items'], 'The roles output schema must not pin an enum, so a role registered after the schema snapshot still validates.' );
 	}
 
 	/**
@@ -920,6 +921,40 @@ class UsersTest extends WP_UnitTestCase {
 		} finally {
 			wp_delete_user( $lister_id );
 			remove_role( 'users_ability_list_only' );
+		}
+	}
+
+	/**
+	 * A role registered after the ability's schema snapshot does not fail output
+	 * validation when a returned user holds it.
+	 *
+	 * The output schema is a registration-time snapshot; a role added afterwards
+	 * still appears on a user, so the roles output must not be pinned to a frozen
+	 * enum that would reject the value and fail the whole call.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_roles_registered_after_registration_do_not_fail_output_validation(): void {
+		wp_set_current_user( $this->admin_id );
+		$this->register_ability();
+
+		// Register the role only after the ability (and its output schema) exist.
+		add_role( 'users_ability_late_role', 'Late Role', array( 'read' => true ) ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.custom_role_add_role -- Registering a throwaway role in an integration test.
+		$user_id = self::factory()->user->create( array( 'role' => 'users_ability_late_role' ) );
+
+		try {
+			$result = wp_get_ability( 'core/read-users' )->execute(
+				array(
+					'id'     => $user_id,
+					'fields' => array( 'id', 'roles' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'Reading a user with a role added after registration should not fail output validation.' );
+			$this->assertContains( 'users_ability_late_role', $result['roles'], 'The late-registered role should be returned.' );
+		} finally {
+			wp_delete_user( $user_id );
+			remove_role( 'users_ability_late_role' );
 		}
 	}
 

--- a/tests/e2e/specs/abilities/core-read-users.spec.js
+++ b/tests/e2e/specs/abilities/core-read-users.spec.js
@@ -12,7 +12,7 @@ const {
 } = require( '../../utils/helpers' );
 
 /**
- * Runs the `core/users` ability through the client-side Abilities API, exactly
+ * Runs the `core/read-users` ability through the client-side Abilities API, exactly
  * as a consumer would in the browser.
  *
  * Mirrors the plugin's own sequence in `src/utils/run-ability.ts`: importing
@@ -42,8 +42,8 @@ async function runCoreUsers( page, input ) {
 
 			try {
 				const result = shouldPassInput
-					? await executeAbility( 'core/users', abilityInput )
-					: await executeAbility( 'core/users' );
+					? await executeAbility( 'core/read-users', abilityInput )
+					: await executeAbility( 'core/read-users' );
 				return { ok: true, result };
 			} catch ( e ) {
 				return { ok: false, code: e && e.code ? e.code : null };
@@ -53,7 +53,7 @@ async function runCoreUsers( page, input ) {
 	);
 }
 
-test.describe( 'core/users ability (client-side Abilities API)', () => {
+test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 	let currentUser;
 
 	test.beforeAll( async ( { requestUtils } ) => {
@@ -75,7 +75,7 @@ test.describe( 'core/users ability (client-side Abilities API)', () => {
 		// Run from the block editor, where the abilities client modules are available.
 		await admin.createNewPost( {
 			postType: 'post',
-			title: 'core/users ability test',
+			title: 'core/read-users ability test',
 		} );
 	} );
 

--- a/tests/e2e/specs/abilities/core-read-users.spec.js
+++ b/tests/e2e/specs/abilities/core-read-users.spec.js
@@ -151,6 +151,18 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 		}
 	} );
 
+	test( 'limits collection results to included users', async ( { page } ) => {
+		const outcome = await runCoreUsers( page, {
+			include: [ currentUser.id ],
+			fields: [ 'id' ],
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.users ).toEqual( [ { id: currentUser.id } ] );
+		expect( typeof outcome.result.total ).toBe( 'number' );
+		expect( typeof outcome.result.total_pages ).toBe( 'number' );
+	} );
+
 	test( 'filters collection mode by role', async ( { page } ) => {
 		const outcome = await runCoreUsers( page, {
 			roles: [ 'administrator' ],

--- a/tests/e2e/specs/abilities/core-read-users.spec.js
+++ b/tests/e2e/specs/abilities/core-read-users.spec.js
@@ -86,13 +86,28 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 		} );
 
 		expect( outcome.ok ).toBe( true );
-		expect( outcome.result.users ).toHaveLength( 1 );
-		expect( outcome.result.users[ 0 ].id ).toBe( currentUser.id );
-		expect( outcome.result.users[ 0 ].user_email ).toBe(
-			currentUser.email
-		);
-		expect( typeof outcome.result.total ).toBe( 'number' );
-		expect( typeof outcome.result.total_pages ).toBe( 'number' );
+		expect( outcome.result.id ).toBe( currentUser.id );
+		expect( outcome.result.user_email ).toBe( currentUser.email );
+		expect( outcome.result.users ).toBeUndefined();
+		expect( outcome.result.total ).toBeUndefined();
+		expect( outcome.result.total_pages ).toBeUndefined();
+	} );
+
+	test( 'returns lean fields by default for a single user', async ( {
+		page,
+	} ) => {
+		const outcome = await runCoreUsers( page, {
+			id: currentUser.id,
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( Object.keys( outcome.result ).sort() ).toEqual( [
+			'avatar_urls',
+			'display_name',
+			'id',
+			'link',
+			'user_nicename',
+		] );
 	} );
 
 	test( 'returns a users collection for an empty request', async ( {

--- a/tests/e2e/specs/abilities/core-read-users.spec.js
+++ b/tests/e2e/specs/abilities/core-read-users.spec.js
@@ -82,12 +82,12 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 	test( 'returns the current user by ID', async ( { page } ) => {
 		const outcome = await runCoreUsers( page, {
 			id: currentUser.id,
-			fields: [ 'id', 'display_name', 'user_email' ],
+			fields: [ 'id', 'name', 'email' ],
 		} );
 
 		expect( outcome.ok ).toBe( true );
 		expect( outcome.result.id ).toBe( currentUser.id );
-		expect( outcome.result.user_email ).toBe( currentUser.email );
+		expect( outcome.result.email ).toBe( currentUser.email );
 		expect( outcome.result.users ).toBeUndefined();
 		expect( outcome.result.total ).toBeUndefined();
 		expect( outcome.result.total_pages ).toBeUndefined();
@@ -103,10 +103,10 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 		expect( outcome.ok ).toBe( true );
 		expect( Object.keys( outcome.result ).sort() ).toEqual( [
 			'avatar_urls',
-			'display_name',
 			'id',
 			'link',
-			'user_nicename',
+			'name',
+			'slug',
 		] );
 	} );
 
@@ -138,15 +138,15 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 
 	test( 'limits each user to the requested fields', async ( { page } ) => {
 		const outcome = await runCoreUsers( page, {
-			fields: [ 'id', 'display_name' ],
+			fields: [ 'id', 'name' ],
 		} );
 
 		expect( outcome.ok ).toBe( true );
 		expect( outcome.result.users.length ).toBeGreaterThan( 0 );
 		for ( const user of outcome.result.users ) {
 			expect( Object.keys( user ).sort() ).toEqual( [
-				'display_name',
 				'id',
+				'name',
 			] );
 		}
 	} );

--- a/tests/e2e/specs/abilities/core-read-users.spec.js
+++ b/tests/e2e/specs/abilities/core-read-users.spec.js
@@ -144,10 +144,7 @@ test.describe( 'core/read-users ability (client-side Abilities API)', () => {
 		expect( outcome.ok ).toBe( true );
 		expect( outcome.result.users.length ).toBeGreaterThan( 0 );
 		for ( const user of outcome.result.users ) {
-			expect( Object.keys( user ).sort() ).toEqual( [
-				'id',
-				'name',
-			] );
+			expect( Object.keys( user ).sort() ).toEqual( [ 'id', 'name' ] );
 		}
 	} );
 

--- a/tests/e2e/specs/abilities/core-users.spec.js
+++ b/tests/e2e/specs/abilities/core-users.spec.js
@@ -75,13 +75,15 @@ test.describe( 'core/users ability (client-side Abilities API)', () => {
 	test( 'returns the current user by ID', async ( { page } ) => {
 		const outcome = await runCoreUsers( page, {
 			id: currentUser.id,
-			fields: [ 'id', 'display_name', 'email' ],
+			fields: [ 'id', 'display_name', 'user_email' ],
 		} );
 
 		expect( outcome.ok ).toBe( true );
 		expect( outcome.result.users ).toHaveLength( 1 );
 		expect( outcome.result.users[ 0 ].id ).toBe( currentUser.id );
-		expect( outcome.result.users[ 0 ].email ).toBe( currentUser.email );
+		expect( outcome.result.users[ 0 ].user_email ).toBe(
+			currentUser.email
+		);
 		expect( typeof outcome.result.total ).toBe( 'number' );
 		expect( typeof outcome.result.total_pages ).toBe( 'number' );
 	} );

--- a/tests/e2e/specs/abilities/core-users.spec.js
+++ b/tests/e2e/specs/abilities/core-users.spec.js
@@ -1,0 +1,129 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	enableExperiment,
+	enableExperiments,
+} = require( '../../utils/helpers' );
+
+/**
+ * Runs the `core/users` ability through the client-side Abilities API, exactly
+ * as a consumer would in the browser.
+ *
+ * Mirrors the plugin's own sequence in `src/utils/run-ability.ts`: importing
+ * `@wordpress/core-abilities` initializes the client store (WordPress core's build
+ * runs `initialize()` on load and exports the resulting `ready` promise), so we
+ * await `ready` before calling `executeAbility` from `@wordpress/abilities`.
+ *
+ * The client modules are only present in the page's import map once an AI experiment
+ * is enabled in the block editor (it declares them as `module_dependencies`), which is
+ * set up in `beforeEach`.
+ *
+ * @param {import('@playwright/test').Page} page  The Playwright page.
+ * @param {Object}                          input The ability input.
+ * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
+ */
+async function runCoreUsers( page, input ) {
+	return page.evaluate( async ( abilityInput ) => {
+		const { ready } = await import( '@wordpress/core-abilities' );
+		if ( ready ) {
+			await ready;
+		}
+
+		const { executeAbility } = await import( '@wordpress/abilities' );
+
+		try {
+			const result = await executeAbility( 'core/users', abilityInput );
+			return { ok: true, result };
+		} catch ( e ) {
+			return { ok: false, code: e && e.code ? e.code : null };
+		}
+	}, input );
+}
+
+test.describe( 'core/users ability (client-side Abilities API)', () => {
+	let currentUser;
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		currentUser = await requestUtils.rest( {
+			path: '/wp/v2/users/me',
+			params: { context: 'edit' },
+		} );
+	} );
+
+	test.beforeEach( async ( { admin, page } ) => {
+		// Enabling an experiment loads its block-editor script, which declares the
+		// `@wordpress/abilities` + `@wordpress/core-abilities` modules as dependencies
+		// and so adds them to the editor's import map.
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'Excerpt Generation' );
+
+		// Run from the block editor, where the abilities client modules are available.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'core/users ability test',
+		} );
+	} );
+
+	test( 'returns the current user by ID', async ( { page } ) => {
+		const outcome = await runCoreUsers( page, {
+			id: currentUser.id,
+			fields: [ 'id', 'display_name', 'email' ],
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.users ).toHaveLength( 1 );
+		expect( outcome.result.users[ 0 ].id ).toBe( currentUser.id );
+		expect( outcome.result.users[ 0 ].email ).toBe( currentUser.email );
+		expect( typeof outcome.result.total ).toBe( 'number' );
+		expect( typeof outcome.result.total_pages ).toBe( 'number' );
+	} );
+
+	test( 'returns a users collection for an empty request', async ( {
+		page,
+	} ) => {
+		const outcome = await runCoreUsers( page, {} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( Array.isArray( outcome.result.users ) ).toBe( true );
+		expect( outcome.result.users.length ).toBeGreaterThan( 0 );
+		expect(
+			outcome.result.users.some( ( user ) => user.id === currentUser.id )
+		).toBe( true );
+	} );
+
+	test( 'limits each user to the requested fields', async ( { page } ) => {
+		const outcome = await runCoreUsers( page, {
+			fields: [ 'id', 'display_name' ],
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( outcome.result.users.length ).toBeGreaterThan( 0 );
+		for ( const user of outcome.result.users ) {
+			expect( Object.keys( user ).sort() ).toEqual( [
+				'display_name',
+				'id',
+			] );
+		}
+	} );
+
+	test( 'filters collection mode by role', async ( { page } ) => {
+		const outcome = await runCoreUsers( page, {
+			roles: [ 'administrator' ],
+			fields: [ 'id', 'roles' ],
+		} );
+
+		expect( outcome.ok ).toBe( true );
+		expect(
+			outcome.result.users.some( ( user ) => user.id === currentUser.id )
+		).toBe( true );
+		for ( const user of outcome.result.users ) {
+			expect( user.roles ).toContain( 'administrator' );
+		}
+	} );
+} );

--- a/tests/e2e/specs/abilities/core-users.spec.js
+++ b/tests/e2e/specs/abilities/core-users.spec.js
@@ -24,12 +24,14 @@ const {
  * is enabled in the block editor (it declares them as `module_dependencies`), which is
  * set up in `beforeEach`.
  *
- * @param {import('@playwright/test').Page} page  The Playwright page.
- * @param {Object}                          input The ability input.
+ * @param {import('@playwright/test').Page} page   The Playwright page.
+ * @param {Object}                          input  Optional. The ability input.
  * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
  */
 async function runCoreUsers( page, input ) {
-	return page.evaluate( async ( abilityInput ) => {
+	const hasInput = arguments.length > 1;
+
+	return page.evaluate( async ( { abilityInput, shouldPassInput } ) => {
 		const { ready } = await import( '@wordpress/core-abilities' );
 		if ( ready ) {
 			await ready;
@@ -38,12 +40,14 @@ async function runCoreUsers( page, input ) {
 		const { executeAbility } = await import( '@wordpress/abilities' );
 
 		try {
-			const result = await executeAbility( 'core/users', abilityInput );
+			const result = shouldPassInput
+				? await executeAbility( 'core/users', abilityInput )
+				: await executeAbility( 'core/users' );
 			return { ok: true, result };
 		} catch ( e ) {
 			return { ok: false, code: e && e.code ? e.code : null };
 		}
-	}, input );
+	}, { abilityInput: input, shouldPassInput: hasInput } );
 }
 
 test.describe( 'core/users ability (client-side Abilities API)', () => {
@@ -92,6 +96,19 @@ test.describe( 'core/users ability (client-side Abilities API)', () => {
 		page,
 	} ) => {
 		const outcome = await runCoreUsers( page, {} );
+
+		expect( outcome.ok ).toBe( true );
+		expect( Array.isArray( outcome.result.users ) ).toBe( true );
+		expect( outcome.result.users.length ).toBeGreaterThan( 0 );
+		expect(
+			outcome.result.users.some( ( user ) => user.id === currentUser.id )
+		).toBe( true );
+	} );
+
+	test( 'returns a users collection when input is omitted', async ( {
+		page,
+	} ) => {
+		const outcome = await runCoreUsers( page );
 
 		expect( outcome.ok ).toBe( true );
 		expect( Array.isArray( outcome.result.users ) ).toBe( true );

--- a/tests/e2e/specs/abilities/core-users.spec.js
+++ b/tests/e2e/specs/abilities/core-users.spec.js
@@ -50,6 +50,8 @@ test.describe( 'core/users ability (client-side Abilities API)', () => {
 	let currentUser;
 
 	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activatePlugin( 'ai' );
+
 		currentUser = await requestUtils.rest( {
 			path: '/wp/v2/users/me',
 			params: { context: 'edit' },

--- a/tests/e2e/specs/abilities/core-users.spec.js
+++ b/tests/e2e/specs/abilities/core-users.spec.js
@@ -24,30 +24,33 @@ const {
  * is enabled in the block editor (it declares them as `module_dependencies`), which is
  * set up in `beforeEach`.
  *
- * @param {import('@playwright/test').Page} page   The Playwright page.
- * @param {Object}                          input  Optional. The ability input.
+ * @param {import('@playwright/test').Page} page  The Playwright page.
+ * @param {Object}                          input Optional. The ability input.
  * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
  */
 async function runCoreUsers( page, input ) {
 	const hasInput = arguments.length > 1;
 
-	return page.evaluate( async ( { abilityInput, shouldPassInput } ) => {
-		const { ready } = await import( '@wordpress/core-abilities' );
-		if ( ready ) {
-			await ready;
-		}
+	return page.evaluate(
+		async ( { abilityInput, shouldPassInput } ) => {
+			const { ready } = await import( '@wordpress/core-abilities' );
+			if ( ready ) {
+				await ready;
+			}
 
-		const { executeAbility } = await import( '@wordpress/abilities' );
+			const { executeAbility } = await import( '@wordpress/abilities' );
 
-		try {
-			const result = shouldPassInput
-				? await executeAbility( 'core/users', abilityInput )
-				: await executeAbility( 'core/users' );
-			return { ok: true, result };
-		} catch ( e ) {
-			return { ok: false, code: e && e.code ? e.code : null };
-		}
-	}, { abilityInput: input, shouldPassInput: hasInput } );
+			try {
+				const result = shouldPassInput
+					? await executeAbility( 'core/users', abilityInput )
+					: await executeAbility( 'core/users' );
+				return { ok: true, result };
+			} catch ( e ) {
+				return { ok: false, code: e && e.code ? e.code : null };
+			}
+		},
+		{ abilityInput: input, shouldPassInput: hasInput }
+	);
 }
 
 test.describe( 'core/users ability (client-side Abilities API)', () => {


### PR DESCRIPTION
## What?
- Adds a read-only `core/read-users` ability with single-user lookup by `id`, `user_email`, `user_login`, or `user_nicename`.
- Single-user lookup modes return the user object directly; collection mode returns `users`, `total`, and `total_pages`.
- Adds collection mode with optional `roles`, `has_published_posts`, `include`, `page`, `per_page`, and `fields`; omitted REST input defaults to empty collection mode.
- Uses lean default fields when `fields` is omitted, while keeping sensitive identifiers and fields opt-in and permission-gated.
- Uses WP_User-shaped field names, including `user_login`, `user_email`, `user_nicename`, `user_url`, and `user_registered`, to align with Core’s existing `core/get-user-info` ability.
- Gates sensitive identifiers and fields against Core REST users behavior, omits inaccessible fields per user, excludes capabilities/meta, and respects `get_option( 'show_avatars' )`.
- Adds PHPUnit and browser-level Abilities API coverage.

## Testing
- `php -l includes/Abilities/Users/Users.php`
- `php -l tests/Integration/Includes/Abilities/Users/UsersTest.php`
- `vendor/bin/phpcs --standard=phpcs.xml.dist`
- `vendor/bin/phpstan analyse --memory-limit=1G`
- `npx wp-scripts lint-js tests/e2e/specs/abilities/core-read-users.spec.js`
- `npm run lint:js`
- `npm run typecheck`
- `npm run build`
- `npm run test:php -- --filter UsersTest`
- `npm run test:php`
- `npm run test:e2e -- tests/e2e/specs/abilities/core-read-users.spec.js --project=chromium`

## Changelog entry

Added - New core/read-users Ability; retrieves a single user by ID, email, login, or nicename, or a filtered and paginated users collection, with sensitive fields opt-in and permission-gated.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-774-4bb161ebb7638f82f354c4bd18e6f80e1623bbee.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->