### PR TITLE
Utils: Preserve omitted ability input

### DIFF
--- a/src/utils/run-ability.ts
+++ b/src/utils/run-ability.ts
@@ -96,30 +96,37 @@ const buildFetchOptions = (
 	input: AbilityInput,
 	method: Method
 ) => {
-	const normalizedInput = input ?? null;
-
 	if ( method === 'GET' || method === 'DELETE' ) {
 		return {
 			path:
-				normalizedInput === null
+				input === undefined || input === null
 					? `/wp-abilities/v1/abilities/${ ability }/run`
 					: addQueryArgs(
 							`/wp-abilities/v1/abilities/${ ability }/run`,
 							{
-								input: normalizedInput,
+								input,
 							}
 					  ),
 			method,
 		};
 	}
 
-	return {
+	const options: {
+		path: string;
+		method: 'POST';
+		data?: {
+			input: AbilityInput;
+		};
+	} = {
 		path: `/wp-abilities/v1/abilities/${ ability }/run`,
 		method: 'POST' as const,
-		data: {
-			input: normalizedInput,
-		},
 	};
+
+	if ( input !== undefined ) {
+		options.data = { input };
+	}
+
+	return options;
 };
 
 export async function runAbility< T = unknown >(
@@ -132,7 +139,7 @@ export async function runAbility< T = unknown >(
 		if ( typeof abilitiesModule?.executeAbility === 'function' ) {
 			return ( await abilitiesModule.executeAbility(
 				ability,
-				input ?? null
+				input
 			) ) as T;
 		}
 


### PR DESCRIPTION
## What?
- Preserves omitted `runAbility()` input as `undefined` instead of normalizing it to `null`.
- Omits REST fallback input payloads when the caller does not provide input.
- Keeps explicitly provided empty-object input as request input.

## Why?
Some abilities use an object schema with a default empty object for empty collection/query mode. Passing `null` prevents the abilities client from applying that schema default and can make `runAbility( 'core/users' )` fail where `executeAbility( 'core/users' )` succeeds.

Core users is at https://github.com/WordPress/ai/pull/774.

## How?
- Passes the optional `runAbility()` input argument through to the client abilities API without coercing omitted input to `null`.
- Builds REST fallback requests without a `data.input` payload when input is omitted.
- Preserves explicitly provided input values, including `{}`, when building REST fallback requests.

### Use of AI Tools
AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5
Used for: Implementation assistance, manual test planning, and PR description updates. Final changes were reviewed and verified locally.

## Testing Instructions
Manual testing:
1. Use the Playground preview or a local environment with this PR and the `core/users` ability from https://github.com/WordPress/ai/pull/774 available.
2. Open a WordPress admin page where the abilities client modules are loaded, such as the post editor after enabling one AI experiment.
3. In the browser console, run `const { ready } = await import( '@wordpress/core-abilities' ); await ready; const { executeAbility } = await import( '@wordpress/abilities' ); await executeAbility( 'core/users' );`.
4. Confirm the call succeeds and returns the users result without passing an input argument.
5. In the same browser console, run `await wp.apiFetch( { path: '/wp-abilities/v1/abilities/core/users/run', method: 'POST' } );`.
6. Confirm the REST fallback shape with no `data.input` also succeeds.
7. Run `await wp.apiFetch( { path: '/wp-abilities/v1/abilities/core/users/run', method: 'POST', data: { input: {} } } );`.
8. Confirm the explicit empty-object input still succeeds, verifying that omitted input and `{}` remain distinct.

Automated testing:
- `npm run lint:js -- src/utils/run-ability.ts`
- `npm run typecheck`

## Screenshots or screencast
Not applicable; this is a utility behavior change without UI changes.

## Changelog Entry
> Fixed - Preserve omitted `runAbility()` input so ability schema defaults can apply when abilities are invoked without input.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-775-8d34d987f5bf8c532905bca6b5eaa20a54415333.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
