### PR TITLE
Ensure the Type Ahead experiment supports provider/model overrides and Guidelines

### DIFF
--- a/includes/Abilities/Type_Ahead/Type_Ahead.php
+++ b/includes/Abilities/Type_Ahead/Type_Ahead.php
@@ -11,6 +11,7 @@ namespace WordPress\AI\Abilities\Type_Ahead;
 
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
+use WordPress\AI\Experiments\Type_Ahead\Type_Ahead as Type_Ahead_Experiment;
 
 use function WordPress\AI\normalize_content;
 
@@ -323,12 +324,9 @@ class Type_Ahead extends Abstract_Ability {
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() )
-			->using_model_preference(
-				array( 'anthropic', 'claude-haiku-4-5' ),
-				array( 'google', 'gemini-2.5-flash' ),
-				array( 'openai', 'gpt-4.1-nano' )
-			)
 			->as_json_response( $this->suggestion_schema() );
+
+		$prompt_builder = $this->set_provider_model_preference( $prompt_builder, Type_Ahead_Experiment::class, array( 'claude-haiku-4-5', 'gemini-2.5-flash', 'gpt-4.1-nano' ) );
 
 		return $this->ensure_text_generation_supported(
 			$prompt_builder,

--- a/includes/Abilities/Type_Ahead/Type_Ahead.php
+++ b/includes/Abilities/Type_Ahead/Type_Ahead.php
@@ -335,7 +335,15 @@ class Type_Ahead extends Abstract_Ability {
 			->using_system_instruction( $this->get_system_instruction() )
 			->as_json_response( $this->suggestion_schema() );
 
-		$prompt_builder = $this->set_provider_model_preference( $prompt_builder, Type_Ahead_Experiment::class, array( 'claude-haiku-4-5', 'gemini-2.5-flash', 'gpt-4.1-nano' ) );
+		$prompt_builder = $this->set_provider_model_preference(
+			$prompt_builder,
+			Type_Ahead_Experiment::class,
+			array(
+				array( 'anthropic', 'claude-haiku-4-5' ),
+				array( 'google', 'gemini-2.5-flash' ),
+				array( 'openai', 'gpt-4.1-nano' ),
+			)
+		);
 
 		return $this->ensure_text_generation_supported(
 			$prompt_builder,

--- a/includes/Abilities/Type_Ahead/Type_Ahead.php
+++ b/includes/Abilities/Type_Ahead/Type_Ahead.php
@@ -332,7 +332,7 @@ class Type_Ahead extends Abstract_Ability {
 	 */
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction() )
+			->using_system_instruction( $this->get_system_instruction( null, array( 'block_name' => 'core/paragraph' ) ) )
 			->as_json_response( $this->suggestion_schema() );
 
 		$prompt_builder = $this->set_provider_model_preference(

--- a/includes/Abilities/Type_Ahead/Type_Ahead.php
+++ b/includes/Abilities/Type_Ahead/Type_Ahead.php
@@ -46,6 +46,15 @@ class Type_Ahead extends Abstract_Ability {
 	 *
 	 * @since x.x.x
 	 */
+	protected function guideline_categories(): array {
+		return array( 'site', 'copy' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since x.x.x
+	 */
 	protected function input_schema(): array {
 		return array(
 			'type'       => 'object',

--- a/tests/Integration/Includes/Abilities/Type_AheadTest.php
+++ b/tests/Integration/Includes/Abilities/Type_AheadTest.php
@@ -108,6 +108,22 @@ class Type_AheadTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that guideline_categories() returns site and copy.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_guideline_categories_returns_site_and_copy(): void {
+		$reflection = new \ReflectionClass( $this->ability );
+		$method     = $reflection->getMethod( 'guideline_categories' );
+		$method->setAccessible( true );
+
+		$this->assertSame(
+			array( 'site', 'copy' ),
+			$method->invoke( $this->ability )
+		);
+	}
+
+	/**
 	 * Tests input schema structure.
 	 *
 	 * @since x.x.x


### PR DESCRIPTION
## What?

Ensure the Type Ahead experiment supports the ability to override the Provider and Model used from the developer settings and ensure any related Guidelines are pulled into the system instructions.

## Why?

Recently merged in #151 but realized after the fact that there are a few new things we've implemented in other experiments that didn't exist when that PR was worked on, namely the ability to set the Provider and Model from our developer settings and integration with Guidelines. This PR updates both.

## How?

- Use the `set_provider_model_preference` method to ensure our Provider and Model can be filtered by our developer settings
- Use the `guideline_categories` to ensure Guidelines are pulled in to the system instructions

### Use of AI Tools

None

## Testing Instructions

Same testing instructions from #151 for the most part, just ensuring the Type Ahead experiment still works

## Changelog Entry

n/a, will be pulled from #151

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-776-20af03fa32183b3c1b2c367f475d8d0f54d67de7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->