### PR TITLE
dev: Update Composer deps and remediate PHPStan smells

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
 	"require-dev": {
 		"automattic/vipwpcs": "^3.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",
+		"php-stubs/wordpress-stubs": "7.0 as 6.9.4",
 		"php-stubs/wp-cli-stubs": "^2.12",
 		"phpcompatibility/phpcompatibility-wp": "^3.0.0-alpha",
 		"phpstan/extension-installer": "^1.3",
@@ -21,7 +22,7 @@
 		"slevomat/coding-standard": "^8.0",
 		"szepeviktor/phpstan-wordpress": "^2.0.2",
 		"wp-coding-standards/wpcs": "^3.2.0",
-		"wp-phpunit/wp-phpunit": "^6.9",
+		"wp-phpunit/wp-phpunit": "^7.0",
 		"yoast/phpunit-polyfills": "^4.0"
 	},
 	"autoload": {
@@ -52,7 +53,7 @@
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist",
 		"lint": "phpcs --standard=phpcs.xml.dist",
-		"phpstan": "phpstan analyse --memory-limit=1G",
+		"phpstan": "phpstan analyse --memory-limit=2G",
 		"test": "phpunit --strict-coverage"
 	},
 	"scripts-descriptions": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "89a0c10a53213f36ff8f0dad75824fd7",
+    "content-hash": "ead8c66a59688e637dff6f84de4ecdd8",
     "packages": [],
     "packages-dev": [
         {
@@ -465,16 +465,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
+            "version": "v7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+                "reference": "d74b963ed4f47303859bf73c741c80f554c83dc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/d74b963ed4f47303859bf73c741c80f554c83dc6",
+                "reference": "d74b963ed4f47303859bf73c741c80f554c83dc6",
                 "shasum": ""
             },
             "conflict": {
@@ -484,7 +484,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
+                "php-stubs/generator": "^0.8.6",
                 "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
@@ -511,9 +511,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v7.0.0"
             },
-            "time": "2026-02-03T19:29:21+00:00"
+            "time": "2026-05-21T21:41:34+00:00"
         },
         {
             "name": "php-stubs/wp-cli-stubs",
@@ -3081,16 +3081,16 @@
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.9.4",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
-                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0"
+                "reference": "06828a65f8276e31368fbe4c5f3d445332abc4c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/15fd216bf6516670d8d07b938675925bfa5c15b0",
-                "reference": "15fd216bf6516670d8d07b938675925bfa5c15b0",
+                "url": "https://api.github.com/repos/wp-phpunit/wp-phpunit/zipball/06828a65f8276e31368fbe4c5f3d445332abc4c5",
+                "reference": "06828a65f8276e31368fbe4c5f3d445332abc4c5",
                 "shasum": ""
             },
             "type": "library",
@@ -3125,7 +3125,7 @@
                 "issues": "https://github.com/wp-phpunit/issues",
                 "source": "https://github.com/wp-phpunit/wp-phpunit"
             },
-            "time": "2026-02-04T01:48:23+00:00"
+            "time": "2026-05-21T02:56:35+00:00"
         },
         {
             "name": "yoast/phpunit-polyfills",
@@ -3191,7 +3191,14 @@
             "time": "2025-02-09T18:58:54+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "php-stubs/wordpress-stubs",
+            "version": "7.0.0.0",
+            "alias": "6.9.4",
+            "alias_normalized": "6.9.4.0"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {},
     "prefer-stable": true,

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -181,7 +181,11 @@ class Generate_Image extends Abstract_Ability {
 	 *
 	 * @param string $prompt The prompt to generate an image from.
 	 * @param string|null $reference_image Optional base64-encoded image to use as a reference for edits.
-	 * @return array{data: string, provider_metadata: array<string, string>, model_metadata: array<string, string>}|\WP_Error The generated image data, or a WP_Error on failure.
+	 * @return array{
+	 *   data: string,
+	 *   provider_metadata: array<string, string|null>,
+	 *   model_metadata: array<string, string>
+	 * }|\WP_Error The generated image data, or a WP_Error on failure.
 	 */
 	protected function generate_image( string $prompt, ?string $reference_image = null ) { // phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
 		$prompt_builder = $this->get_prompt_builder( $prompt, $reference_image );
@@ -190,7 +194,13 @@ class Generate_Image extends Abstract_Ability {
 			return $prompt_builder;
 		}
 
-		// Generate the image using the AI client.
+		/**
+		 * Generate the image using the AI client.
+		 *
+		 * @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $result
+		 *
+		 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+		 */
 		$result = $prompt_builder->generate_image_result();
 
 		if ( is_wp_error( $result ) ) {
@@ -258,7 +268,9 @@ class Generate_Image extends Abstract_Ability {
 		}
 
 		$prompt_builder = wp_ai_client_prompt( $prompt )
+			/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 			->using_request_options( $request_options )
+			/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 			->as_output_file_type( FileTypeEnum::inline() );
 
 		$prompt_builder = $this->set_provider_model_preference( $prompt_builder, Image_Generation_Feature::class, get_preferred_image_models() );

--- a/includes/Abstracts/Abstract_Ability.php
+++ b/includes/Abstracts/Abstract_Ability.php
@@ -314,6 +314,7 @@ abstract class Abstract_Ability extends WP_Ability {
 
 		if ( $provider && $model ) {
 			$prompt_builder->using_model(
+				/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 				AiClient::defaultRegistry()->getProviderModel( $provider, $model )
 			);
 		} else {

--- a/includes/Abstracts/Abstract_Feature.php
+++ b/includes/Abstracts/Abstract_Feature.php
@@ -26,7 +26,7 @@ abstract class Abstract_Feature implements Feature {
 	 * Feature identifier.
 	 *
 	 * @since 0.6.0
-	 * @var non-empty-string
+	 * @var non-empty-string&lowercase-string
 	 */
 	protected string $id;
 

--- a/includes/Admin/Dashboard/AI_Capabilities_Widget.php
+++ b/includes/Admin/Dashboard/AI_Capabilities_Widget.php
@@ -144,9 +144,9 @@ class AI_Capabilities_Widget {
 				$provider_class = $registry->getProviderClassName( $provider_id );
 
 				/**
-				 * @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class
+				 * @var class-string<\WordPress\AiClient\Providers\Contracts\ProviderInterface> $provider_class
 				 *
-				 * @phpstan-ignore varTag.nativeType (@todo This can be removed when php-ai-client uses FQCN)
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
 				 */
 				$metadata  = $provider_class::metadata();
 				$model_dir = $provider_class::modelMetadataDirectory();

--- a/includes/Admin/Dashboard/AI_Capabilities_Widget.php
+++ b/includes/Admin/Dashboard/AI_Capabilities_Widget.php
@@ -143,14 +143,29 @@ class AI_Capabilities_Widget {
 			try {
 				$provider_class = $registry->getProviderClassName( $provider_id );
 
-				/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
-				$metadata     = $provider_class::metadata();
-				$model_dir    = $provider_class::modelMetadataDirectory();
+				/**
+				 * @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class
+				 *
+				 * @phpstan-ignore varTag.nativeType (@todo This can be removed when php-ai-client uses FQCN)
+				 */
+				$metadata  = $provider_class::metadata();
+				$model_dir = $provider_class::modelMetadataDirectory();
+
+				/**
+				 * @var \WordPress\AiClient\Providers\Models\DTO\ModelMetadata[] $models
+				 *
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+				 */
 				$models       = $model_dir->listModelMetadata();
 				$capabilities = array();
 
 				foreach ( $models as $model ) {
 					foreach ( $model->getSupportedCapabilities() as $capability ) {
+						/**
+						 * @var \WordPress\AiClient\Providers\Models\Enums\CapabilityEnum $capability
+						 *
+						 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+						 */
 						$capabilities[ $capability->value ] = true;
 					}
 				}

--- a/includes/Asset_Loader.php
+++ b/includes/Asset_Loader.php
@@ -102,6 +102,9 @@ final class Asset_Loader {
 		wp_enqueue_script(
 			self::HANDLE_PREFIX . $handle,
 			$script_url,
+			/**
+			 * @phpstan-ignore argument.type (@todo This is a type-error in WordPress 7.0)
+			 */
 			$asset_data['dependencies'],
 			$asset_data['version'],
 			$args

--- a/includes/Contracts/Feature.php
+++ b/includes/Contracts/Feature.php
@@ -24,7 +24,7 @@ interface Feature {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @return non-empty-string Feature ID.
+	 * @return non-empty-string&lowercase-string Feature ID.
 	 */
 	public static function get_id(): string;
 

--- a/includes/Logging/REST/AI_Request_Log_Controller.php
+++ b/includes/Logging/REST/AI_Request_Log_Controller.php
@@ -24,6 +24,19 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.0.0
  */
 class AI_Request_Log_Controller extends WP_REST_Controller {
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var non-falsy-string
+	 */
+	protected $namespace;
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var non-falsy-string
+	 */
+	protected $rest_base;
 
 	/**
 	 * Log manager instance.

--- a/includes/REST/Models_Controller.php
+++ b/includes/REST/Models_Controller.php
@@ -223,9 +223,9 @@ final class Models_Controller {
 				$provider_class = $registry->getProviderClassName( $connector_id );
 
 				/**
-				 * @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class
+				 * @var class-string<\WordPress\AiClient\Providers\Contracts\ProviderInterface> $provider_class
 				 *
-				 * @phpstan-ignore varTag.nativeType (@todo This can be removed when php-ai-client uses FQCN)
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
 				 */
 				$provider_name = $provider_class::metadata()->getName();
 

--- a/includes/REST/Models_Controller.php
+++ b/includes/REST/Models_Controller.php
@@ -157,18 +157,21 @@ final class Models_Controller {
 		switch ( $capability ) {
 			case 'text_generation':
 				return new ModelRequirements(
+					/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 					array( CapabilityEnum::textGeneration() ),
 					array()
 				);
 
 			case 'image_generation':
 				return new ModelRequirements(
+					/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 					array( CapabilityEnum::imageGeneration() ),
 					array()
 				);
 
 			case 'vision':
 				return new ModelRequirements(
+					/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 					array( CapabilityEnum::textGeneration() ),
 					array(
 						new RequiredOption(
@@ -206,6 +209,11 @@ final class Models_Controller {
 
 		foreach ( array_keys( $active_connectors ) as $connector_id ) {
 			try {
+				/**
+				 * @var list<\WordPress\AiClient\Providers\Models\DTO\ModelMetadata> $models
+				 *
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+				 */
 				$models = $registry->findProviderModelsMetadataForSupport( $connector_id, $requirements );
 
 				if ( empty( $models ) ) {
@@ -214,7 +222,11 @@ final class Models_Controller {
 
 				$provider_class = $registry->getProviderClassName( $connector_id );
 
-				/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
+				/**
+				 * @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class
+				 *
+				 * @phpstan-ignore varTag.nativeType (@todo This can be removed when php-ai-client uses FQCN)
+				 */
 				$provider_name = $provider_class::metadata()->getName();
 
 				$model_items = array();

--- a/includes/Services/AI_Service.php
+++ b/includes/Services/AI_Service.php
@@ -134,7 +134,9 @@ class AI_Service {
 		if ( ! empty( $options ) ) {
 			$config_array = $this->map_options_to_config( $options );
 			if ( ! empty( $config_array ) ) {
-				$config  = ModelConfig::fromArray( $config_array );
+				$config = ModelConfig::fromArray( $config_array );
+
+				/** @phpstan-ignore argument.type (@todo This can be removed when php-ai-client uses FQCN) */
 				$builder = $builder->using_model_config( $config );
 			}
 		}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -530,13 +530,27 @@ function has_image_generation_support( bool $reset_cache = false ): bool {
 			}
 
 			try {
+				/**
+				 * @var class-string<\WordPress\AiClient\Providers\Contracts\ProviderInterface> $provider_class
+				 *
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+				 */
 				$provider_class = $registry->getProviderClassName( $connector_id );
 
-				/** @var \WordPress\AiClient\Providers\Contracts\ProviderInterface $provider_class */
+				/**
+				 * @var list<\WordPress\AiClient\Providers\Models\DTO\ModelMetadata> $models
+				 *
+				 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+				 */
 				$models = $provider_class::modelMetadataDirectory()->listModelMetadata();
 
 				foreach ( $models as $model ) {
 					foreach ( $model->getSupportedCapabilities() as $capability ) {
+						/**
+						 * @var \WordPress\AiClient\Providers\Models\Enums\CapabilityEnum $capability
+						 *
+						 * @phpstan-ignore varTag.type (@todo This can be removed when php-ai-client uses FQCN)
+						 */
 						if ( CapabilityEnum::IMAGE_GENERATION === $capability->value ) {
 							$has_support = true;
 							break 3;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,20 +30,10 @@ parameters:
 			- vendor/phpstan/php-8-stubs/stubs/ext/standard/str_starts_with.php
 		# Temporary while WP 7.0 beta AI Client migration is in progress.
 		ignoreErrors:
-			- '#Function wp_ai_client_prompt not found\.#'
-			- '#WP_AI_Client_[A-Za-z0-9_]+#'
-			- '#WordPress\\AiClient\\#'
-			- '#Function wp_get_connectors not found\.#'
-			- '#Function wp_is_connector_registered not found\.#'
-			- '#Function wp_get_connector not found\.#'
 			- '#class cli\\progress\\Bar#'
-			- '#Function wp_supports_ai not found\.#'
-			- '#Function wp_set_script_module_translations not found\.#'
 		excludePaths:
 			analyse:
 				- tests/
 				- vendor/
-				- includes/Logging/Logging_Integration.php
-				- includes/Logging/Logging_Http_Transporter.php
 			analyseAndScan:
 				- node_modules (?)


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Bumps Composer deps to their latest versions, and remediates the resulting PHPStan errors.

More specifically, it makes `php-stubs/wordpress-stubs@7.0` a direct dependency aliased to WP 6.9.4, and then adds various inline ignores, where issues with the lack of FQCN cause type mismatches.

Now-unnecessary ignores have been removed from the PHPStan config.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Broadly, it's better to use the latest stubs - and suppress the type errors - than outdated ones, and type-hinting with inline-ignore annotations for improper hints are better than `ignoreErrors` because it allows the rest of the related code to still be typehinted correctly.

- While https://github.com/php-stubs/wp-cli-stubs/pull/24 fixed the use of SemVer to allow v7.x, releases are tied to WP-CLI and therefore it hasn't hit downstream. Aliasing to 6.9.4 solves this temporarily.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

None.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Bump Composer dev-dependencies and remediate new PHPStan smells

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-777-26e27614f36987ccbbe768f0e5243db2d1e921ad.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->