### PR TITLE
Code Quality: Extract model selection helpers for E2E tests

### DIFF
--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -20,6 +20,8 @@ const {
 	getExperimentTogglesInGroup,
 	getEnableAllButton,
 	getDisableAllButton,
+	enableModelSelection,
+	disableModelSelection,
 } = require( '../../utils/helpers' );
 
 const EXPERIMENT_GROUPS = {
@@ -449,42 +451,16 @@ test.describe( 'Plugin settings', () => {
 		// Enable the Excerpt Generation Experiment.
 		await enableExperiment( admin, page, 'Excerpt Generation' );
 
-		// Open the settings menu and verify model selection is described.
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		await expect( page.getByText( 'DEVELOPER TOOLS' ) ).toBeVisible();
-		await expect(
-			page.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-		).toBeVisible();
-		await expect(
-			page.getByText( 'Select a specific provider and model per feature' )
-		).toBeVisible();
-
-		// Toggle on model selection.
-		await page
-			.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-			.click();
-
-		// Verify the menu remains open after toggling the option.
-		await expect(
-			page.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-		).toBeVisible();
+		// Enable developer mode (Model selection).
+		await enableModelSelection( page );
 
 		// Verify the Excerpt Generation Experiment has developer settings.
 		await expect(
 			page.locator( '.ai-developer-mode-fields' ).first()
 		).toBeVisible();
 
-		// Verify the selected option shows a checkmark.
-		await expect(
-			page
-				.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-				.locator( 'svg' )
-		).toBeVisible();
-
 		// Toggle off model selection.
-		await page
-			.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-			.click();
+		await disableModelSelection( page );
 
 		// Verify the developer settings are no longer visible.
 		await expect(
@@ -520,17 +496,7 @@ test.describe( 'Plugin settings', () => {
 		await enableExperiment( admin, page, 'Content Classification' );
 
 		// Enable developer mode (Model selection).
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		const modelSelection = page.getByRole( 'menuitemcheckbox', {
-			name: /Model selection/,
-		} );
-		if (
-			( await modelSelection.getAttribute( 'aria-checked' ) ) !== 'true'
-		) {
-			await modelSelection.click();
-		}
-		// Close the menu.
-		await page.keyboard.press( 'Escape' );
+		await enableModelSelection( page );
 
 		// Scope all selectors to the first developer settings form (Content Classification).
 		const developerFields = page
@@ -585,10 +551,7 @@ test.describe( 'Plugin settings', () => {
 		} );
 
 		// Cleanup: Toggle off model selection.
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		await page
-			.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-			.click();
+		await disableModelSelection( page );
 		await expect(
 			page.locator( '.ai-developer-mode-fields' )
 		).not.toBeVisible();
@@ -625,16 +588,7 @@ test.describe( 'Plugin settings', () => {
 		await visitSettingsPage( admin );
 
 		// Enable developer mode (Model selection).
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		const modelSelection = page.getByRole( 'menuitemcheckbox', {
-			name: /Model selection/,
-		} );
-		if (
-			( await modelSelection.getAttribute( 'aria-checked' ) ) !== 'true'
-		) {
-			await modelSelection.click();
-		}
-		await page.keyboard.press( 'Escape' );
+		await enableModelSelection( page );
 
 		// Scope all selectors to the first developer settings form (Content Classification).
 		const developerFields = page
@@ -668,10 +622,7 @@ test.describe( 'Plugin settings', () => {
 		).toHaveValue( '' );
 
 		// Cleanup: Toggle off model selection.
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		await page
-			.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
-			.click();
+		await disableModelSelection( page );
 		await expect(
 			page.locator( '.ai-developer-mode-fields' )
 		).not.toBeVisible();
@@ -691,15 +642,7 @@ test.describe( 'Plugin settings', () => {
 		await enableExperiment( admin, page, 'Image Generation and Editing' );
 
 		// Turn on model selection while AI is globally enabled.
-		await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
-		const modelSelection = page.getByRole( 'menuitemcheckbox', {
-			name: /Model selection/,
-		} );
-		if (
-			( await modelSelection.getAttribute( 'aria-checked' ) ) !== 'true'
-		) {
-			await modelSelection.click();
-		}
+		await enableModelSelection( page );
 
 		// Globally disable AI. The feature card remains checked, but inactive.
 		await disableExperiments( admin, page );
@@ -720,6 +663,7 @@ test.describe( 'Plugin settings', () => {
 
 		// Restore state.
 		await enableExperiments( admin, page );
+		await disableModelSelection( page );
 		await disableExperiment( admin, page, 'Image Generation and Editing' );
 	} );
 } );

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -437,3 +437,72 @@ export const clearCredentials = async ( requestUtils: RequestUtils ) => {
 		method: 'POST',
 	} );
 };
+
+/**
+ * Enables the Model Selection feature via the Developer Tools menu.
+ *
+ * Opens the Developer Tools menu, checks whether Model Selection is already
+ * enabled, and clicks it only when it is not. Closes the menu afterwards.
+ *
+ * @param page The page object.
+ */
+export const enableModelSelection = async ( page: Page ) => {
+	await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
+
+	await expect( page.getByText( 'DEVELOPER TOOLS' ) ).toBeVisible();
+
+	await expect(
+		page.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
+	).toBeVisible();
+	await expect(
+		page.getByText( 'Select a specific provider and model per feature' )
+	).toBeVisible();
+
+	const modelSelection = page.getByRole( 'menuitemcheckbox', {
+		name: /Model selection/,
+	} );
+
+	if ( ( await modelSelection.getAttribute( 'aria-checked' ) ) !== 'true' ) {
+		await modelSelection.click();
+
+		// Verify the menu remains open after toggling the option.
+		await expect(
+			page.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
+		).toBeVisible();
+	}
+
+	// Close the menu.
+	await page.keyboard.press( 'Escape' );
+};
+
+/**
+ * Disables the Model Selection feature via the Developer Tools menu.
+ *
+ * Opens the Developer Tools menu and clicks the Model Selection item to
+ * toggle it off, then closes the menu.
+ *
+ * @param page The page object.
+ */
+export const disableModelSelection = async ( page: Page ) => {
+	await page.getByRole( 'button', { name: 'Developer Tools' } ).click();
+
+	const modelSelection = page.getByRole( 'menuitemcheckbox', {
+		name: /Model selection/,
+	} );
+
+	// Verify the selected option shows a checkmark.
+	await expect( modelSelection.locator( 'svg' ) ).toBeVisible();
+
+	// Only click if it is currently enabled.
+	if ( ( await modelSelection.getAttribute( 'aria-checked' ) ) === 'true' ) {
+		await modelSelection.click();
+
+		// Verify the menu remains open after toggling the option.
+		await expect(
+			page.getByRole( 'menuitemcheckbox', { name: /Model selection/ } )
+		).toBeVisible();
+	}
+
+	// Close the menu.
+	await page.keyboard.press( 'Escape' );
+};


### PR DESCRIPTION
## Summary

Extracts repeated inline Developer Tools menu interactions from E2E tests into two reusable utility functions in `helpers.ts`.

## Changes

### `tests/e2e/utils/helpers.ts`

- Added `enableModelSelection( page )` — opens the Developer Tools menu, asserts the menu heading and description are visible, toggles Model Selection **on** (idempotent: skips if already enabled), and verifies the menu stays open after toggling.
- Added `disableModelSelection( page )` — opens the Developer Tools menu, verifies the checkmark SVG is present, toggles Model Selection **off** (idempotent: skips if already disabled), and closes the menu.

### `tests/e2e/specs/admin/settings.spec.js`

Replaced all inline Developer Tools menu interaction blocks across the following tests with the new helpers:

- `Can use developer mode`
- `Developer settings save button appears, values persist after save, and reset does not require explicit save`
- `Unsaved developer settings do not persist on page reload`
- `Developer mode settings are hidden for disabled visual feature cards`

## Testing
No new test coverage required, existing E2E tests exercise both helpers as part of their normal flow.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-786-2f0615f33cbbbef0a666ea39c2ad516d3a51cd1e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->