### PR TITLE
Update bundled wp deps (theme, ui, dataviews, admin-ui)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"dependencies": {
 				"@wordpress/a11y": "^4.44.0",
 				"@wordpress/abilities": "^0.11.0",
-				"@wordpress/admin-ui": "^2.0.0",
+				"@wordpress/admin-ui": "^2.4.0",
 				"@wordpress/api-fetch": "^7.44.0",
 				"@wordpress/block-editor": "^15.17.0",
 				"@wordpress/blocks": "^15.17.0",
@@ -18,7 +18,7 @@
 				"@wordpress/core-abilities": "^0.10.0",
 				"@wordpress/core-data": "^7.44.0",
 				"@wordpress/data": "^10.44.0",
-				"@wordpress/dataviews": "^14.1.0",
+				"@wordpress/dataviews": "^17.0.0",
 				"@wordpress/date": "^5.44.0",
 				"@wordpress/dom": "^4.47.0",
 				"@wordpress/dom-ready": "^4.44.0",
@@ -31,7 +31,8 @@
 				"@wordpress/notices": "^5.44.0",
 				"@wordpress/plugins": "^7.44.0",
 				"@wordpress/primitives": "^4.45.0",
-				"@wordpress/ui": "^0.12.0",
+				"@wordpress/theme": "^0.16.0",
+				"@wordpress/ui": "^0.16.0",
 				"@wordpress/url": "^4.44.0",
 				"@wordpress/wordcount": "^4.44.0",
 				"react": "^18.3.1"
@@ -71,19 +72,23 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@ariakit/core": {
-			"version": "0.4.20",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.20.tgz",
-			"integrity": "sha512-DJbUnui0fM+2ZgiWLOMuFOmlWSJDNV3f6tqghIYRTWEm51TN/LoU6uM8og6/g7Nrwl4Uo5l8AoQT9Kkr/i/uRg==",
-			"license": "MIT"
-		},
-		"node_modules/@ariakit/react": {
-			"version": "0.4.26",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.26.tgz",
-			"integrity": "sha512-NcoPrYE4vgwyODAhdpNNuA7ldwODDuFqZl6jORPVDY3l+oRjl/OYwtQyyC3ZhC/4mjntYBYuKKrPJEizLmoxpg==",
+		"node_modules/@ariakit/components": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.3.tgz",
+			"integrity": "sha512-l22VB1g0Dz6zrKyDjykg8uXemUGolaeJjcLKf9XY5iSxzuU0PZTLSmRfJFq4pjTHsRroL4HM96f6J0Pivu2oOg==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.26"
+				"@ariakit/store": "0.1.3",
+				"@ariakit/utils": "0.1.3"
+			}
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.4.30",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.30.tgz",
+			"integrity": "sha512-7QAS4uAoSp1Avekp1ve8xLRPm4E7wLIQFfYM08cHfgMfBBGQGkxrXFqP3QmqEMTUa99H4ZHK9unL05+752cBhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-components": "0.2.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -94,20 +99,66 @@
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@ariakit/react-core": {
-			"version": "0.4.26",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.26.tgz",
-			"integrity": "sha512-/Peh1KiVpjj79nCJIa6lEdzSTT9P9FZoy+CxByIFKL3YKdlXmDIIhS1E/tAqKbDq4ODVdynnqmrIDxE5wCoZYw==",
+		"node_modules/@ariakit/react-components": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.2.0.tgz",
+			"integrity": "sha512-hoAwGSh5xQ0va4oWSTOmoNIIDS+90eVzg6XceCC9WMyhRn1I1YVluxCqltZ9UY+6vzu7PpJDvC4g5N2rmCh6og==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.20",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.6.0"
+				"@ariakit/components": "0.1.3",
+				"@ariakit/react-store": "0.1.3",
+				"@ariakit/react-utils": "0.1.3",
+				"@ariakit/store": "0.1.3",
+				"@ariakit/utils": "0.1.3",
+				"@floating-ui/dom": "^1.0.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/@ariakit/react-store": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.3.tgz",
+			"integrity": "sha512-x8kjHcDoEkTX5bu3qkSfnvRCZuqXtjQZ1seohIWq8NPAfB0qe6q3GlGwCVCXw62Tlcf44SwxpuRQYQyj0/eurw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-utils": "0.1.3",
+				"@ariakit/store": "0.1.3",
+				"@ariakit/utils": "0.1.3",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-utils": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.1.3.tgz",
+			"integrity": "sha512-eaqLU+7lknPWzcWK7CYQw9Mu52c6If3jc8wm08Fw/hobOCeeG97Z865PQeNYQMK7BYqb01ByVNaIPEWYwcPkfw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.3",
+				"@ariakit/utils": "0.1.3"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/store": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.3.tgz",
+			"integrity": "sha512-EAKGIUbHGKH9Kx53ae17+5l/b/z1VUKqiyHcV675AKn1ed1qsLEHX2KovFf+eHLtGBgINSd0NXv11LIe3x/uFA==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/utils": "0.1.3"
+			}
+		},
+		"node_modules/@ariakit/utils": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.3.tgz",
+			"integrity": "sha512-OMdM631rIiDLYr1nnd1vtGyLvlYt08APMa2TJACA8Myn80PF+XtH9ZLBXTVUuUnlrYVyY2duX+EOkg6z9/NeCA==",
+			"license": "MIT"
 		},
 		"node_modules/@arraypress/waveform-player": {
 			"version": "1.2.1",
@@ -2065,14 +2116,14 @@
 			}
 		},
 		"node_modules/@base-ui/utils": {
-			"version": "0.2.8",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.8.tgz",
-			"integrity": "sha512-jvOi+c+ftGlGotNcKnzPVg2IhCaDTB6/6R3JeqdjdXktuAJi3wKH9T7+svuaKh1mmfVU11UWzUZVH74JDfi/wQ==",
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
 				"@floating-ui/utils": "^0.2.11",
-				"reselect": "^5.1.1",
+				"reselect": "^5.2.0",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"peerDependencies": {
@@ -2606,7 +2657,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2623,7 +2673,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2640,7 +2689,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2657,7 +2705,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2674,7 +2721,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2691,7 +2737,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2708,7 +2753,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2725,7 +2769,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2742,7 +2785,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2759,7 +2801,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2776,7 +2817,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2793,7 +2833,6 @@
 			"cpu": [
 				"loong64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2810,7 +2849,6 @@
 			"cpu": [
 				"mips64el"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2827,7 +2865,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2844,7 +2881,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2861,7 +2897,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2878,7 +2913,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2895,7 +2929,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2912,7 +2945,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2929,7 +2961,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2946,7 +2977,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2963,7 +2993,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2980,7 +3009,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2997,7 +3025,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3014,7 +3041,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3031,7 +3057,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -10263,13 +10288,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.48.0.tgz",
-			"integrity": "sha512-MXwBc2sYaemZCn1dqVutTbLdM6iy4bx/HS9hHR/+pRpaSVJUlguZ1aQ0BaoIbE4u0uOezGGc5d2bDfWCti3Dww==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.49.0.tgz",
+			"integrity": "sha512-owb2VJYS54F6R0cjxZzb/Jp+ogGaMpSkuZAWG8VqMW6I8PnFCva+6H4PP3flF7QnaiCvvgEIl2grsSJmUm9O7g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0"
+				"@wordpress/dom-ready": "^4.49.0",
+				"@wordpress/i18n": "^6.22.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10294,18 +10319,18 @@
 			}
 		},
 		"node_modules/@wordpress/admin-ui": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.3.0.tgz",
-			"integrity": "sha512-AfLzd3YrzGtitEyuzmyHafEuZzD/4LnXA8Wg+RbXyLtYWZzrKDNJRopGMtSVHNxqaz6E/NSlpbJY5P0qet6w+g==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/admin-ui/-/admin-ui-2.4.0.tgz",
+			"integrity": "sha512-ybYRlXS/hhppzv/ihPx9srqnqkbnmdjZajGH27VxdP0x1mbbfryzzfpOkBSXx5ydISK+JN8I3raKDQ9VYaMrTQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/components": "^35.0.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/route": "^0.14.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
+				"@wordpress/components": "^36.0.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/route": "^0.15.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/ui": "^0.16.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -10313,68 +10338,62 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/base-styles": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-9.1.0.tgz",
-			"integrity": "sha512-QONqtlA7IRYb6cbCjwTEiXJwfkWPpHl6PSS+F1TDeDP0L7m+hXfpRbH1qfKjSffWlyDaBqLFWwXZ3evpeFw5bg==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/components": {
-			"version": "35.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-35.0.0.tgz",
-			"integrity": "sha512-zXhErp2/alcdvQST6pq/kkZGkiOvTGbYqRc3FuoQIDpCJJE70r243PRxokDvZ5ikHvBtg26kARN+JhXdzN4qjw==",
+			"version": "36.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
+			"integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.22",
+				"@ariakit/react": "^0.4.29",
 				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.14.0",
 				"@emotion/css": "^11.13.5",
-				"@emotion/native": "^11.11.0",
 				"@emotion/react": "^11.14.0",
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/styled": "^11.14.1",
 				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/base-styles": "^9.1.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/date": "^5.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/hooks": "^4.48.0",
-				"@wordpress/html-entities": "^4.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/rich-text": "^7.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/ui": "^0.15.0",
-				"@wordpress/warning": "^3.48.0",
+				"@wordpress/a11y": "^4.49.0",
+				"@wordpress/base-styles": "^10.1.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/date": "^5.49.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"@wordpress/hooks": "^4.49.0",
+				"@wordpress/html-entities": "^4.49.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/icons": "^15.0.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/primitives": "^4.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/rich-text": "^7.49.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/ui": "^0.16.0",
+				"@wordpress/warning": "^3.49.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
+				"colord": "^2.9.3",
 				"csstype": "^3.2.3",
 				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
+				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
+				"gradient-parser": "^1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
@@ -10390,25 +10409,31 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -10418,23 +10443,29 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -10442,133 +10473,27 @@
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/icons": {
-			"version": "13.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
-			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
+			"integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/primitives": "^4.48.0",
-				"change-case": "4.1.2"
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/primitives": "^4.49.0",
+				"change-case": "^4.1.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/style-runtime": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.4.0.tgz",
-			"integrity": "sha512-frzAg1rsn8X0KNgrxxLxszLvWCKY0Nk2e8j8Mjm2pI2URmS8Et7NefuXP3JnHBD4U1L1Ug9yKO/FA65ojQ7CEA==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/ui": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.15.0.tgz",
-			"integrity": "sha512-7aAx1ovnC6JOb4Qfcnfk8ESfB0RTm6rqsdFrUn7TEY3LON/aEQisCb/bd7Yb8s9txb1GfaJYkgjiTvrr0M6EWA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@base-ui/react": "^1.4.1",
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/icons": "^13.3.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/primitives": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/style-runtime": "^0.4.0",
-				"@wordpress/theme": "^0.15.0",
-				"clsx": "^2.1.1",
-				"tabbable": "^6.4.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.5.0.tgz",
-			"integrity": "sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.2.9",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@date-fns/tz": "^1.2.0",
-				"@types/react": "^17 || ^18 || ^19",
-				"date-fns": "^4.0.0",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@date-fns/tz": {
-					"optional": true
-				},
-				"@types/react": {
-					"optional": true
-				},
-				"date-fns": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/ui/node_modules/@base-ui/utils": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.9.tgz",
-			"integrity": "sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@floating-ui/utils": "^0.2.11",
-				"reselect": "^5.1.1",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"peerDependencies": {
-				"@types/react": "^17 || ^18 || ^19",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-			"license": "MIT",
-			"dependencies": {
-				"@floating-ui/dom": "^1.7.6"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/date-fns": {
@@ -10651,9 +10576,9 @@
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
-			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-10.1.0.tgz",
+			"integrity": "sha512-5OHdZC1wwIvT+tEufMwdFXdM5DZtEoY/wZCq5DmQYiLsRz22v5/xm4i4e489E1prlS3s4+cbFpFP7foVU12emg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -12022,19 +11947,19 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.48.0.tgz",
-			"integrity": "sha512-6SjfTBlXu5fuJWmmlHlwV2wcrcsWL+M5O227AoEvrPSLo96UuMj2kAx3cKLtP3xyOMDyd38koQSf6+SS522bTA==",
+			"version": "10.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.49.0.tgz",
+			"integrity": "sha512-ONKvC5lXscRwBEiMP74qp8XgFNnLtB0Z0JS/Rnpq+CQKVHg4rGnpPudc0XeqS9yjJx3jJT4dG4XAtFsMFjJuzg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/redux-routine": "^5.48.0",
-				"deepmerge": "^4.3.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/redux-routine": "^5.49.0",
+				"deepmerge": "^4.3.1",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
@@ -12047,24 +11972,30 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/data/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -12074,23 +12005,29 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12098,30 +12035,30 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
-			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-17.0.0.tgz",
+			"integrity": "sha512-d+0tCa0xWP1QXbEdXesp0wlthRmSAXtp1X0bkVnlDlJdGbY2s7crgUMALQJ/R37Wkch3B1IdNBaa8GM+nc3z1A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.21",
-				"@wordpress/base-styles": "^8.0.0",
-				"@wordpress/components": "^33.1.0",
-				"@wordpress/compose": "^7.46.0",
-				"@wordpress/data": "^10.46.0",
-				"@wordpress/date": "^5.46.0",
-				"@wordpress/deprecated": "^4.46.0",
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/i18n": "^6.19.0",
-				"@wordpress/icons": "^13.1.0",
-				"@wordpress/keycodes": "^4.46.0",
-				"@wordpress/primitives": "^4.46.0",
-				"@wordpress/private-apis": "^1.46.0",
-				"@wordpress/ui": "^0.13.0",
-				"@wordpress/warning": "^3.46.0",
+				"@ariakit/react": "^0.4.29",
+				"@wordpress/base-styles": "^10.1.0",
+				"@wordpress/components": "^36.0.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/data": "^10.49.0",
+				"@wordpress/date": "^5.49.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/icons": "^15.0.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/primitives": "^4.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/ui": "^0.16.0",
+				"@wordpress/warning": "^3.49.0",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
+				"colord": "^2.9.3",
 				"date-fns": "^4.1.0",
-				"deepmerge": "4.3.1",
+				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"
 			},
@@ -12130,17 +12067,23 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-			"version": "33.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
-			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"version": "36.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-36.0.0.tgz",
+			"integrity": "sha512-rsAktFvGnQkcybfAaijQvBQB8ymZvlfbpxwocSnFm46SB3+ZebujGtetLQBP9EsoI2yRDQCOLBGvxORRl3/dfQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.22",
+				"@ariakit/react": "^0.4.29",
 				"@date-fns/utc": "^2.1.1",
 				"@emotion/cache": "^11.14.0",
 				"@emotion/css": "^11.13.5",
@@ -12148,39 +12091,39 @@
 				"@emotion/serialize": "^1.3.3",
 				"@emotion/styled": "^11.14.1",
 				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.46.0",
-				"@wordpress/base-styles": "^8.0.0",
-				"@wordpress/compose": "^7.46.0",
-				"@wordpress/date": "^5.46.0",
-				"@wordpress/deprecated": "^4.46.0",
-				"@wordpress/dom": "^4.46.0",
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/escape-html": "^3.46.0",
-				"@wordpress/hooks": "^4.46.0",
-				"@wordpress/html-entities": "^4.46.0",
-				"@wordpress/i18n": "^6.19.0",
-				"@wordpress/icons": "^13.1.0",
-				"@wordpress/is-shallow-equal": "^5.46.0",
-				"@wordpress/keycodes": "^4.46.0",
-				"@wordpress/primitives": "^4.46.0",
-				"@wordpress/private-apis": "^1.46.0",
-				"@wordpress/rich-text": "^7.46.0",
-				"@wordpress/style-runtime": "^0.2.0",
-				"@wordpress/warning": "^3.46.0",
+				"@wordpress/a11y": "^4.49.0",
+				"@wordpress/base-styles": "^10.1.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/date": "^5.49.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"@wordpress/hooks": "^4.49.0",
+				"@wordpress/html-entities": "^4.49.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/icons": "^15.0.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/primitives": "^4.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/rich-text": "^7.49.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/ui": "^0.16.0",
+				"@wordpress/warning": "^3.49.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
+				"colord": "^2.9.3",
 				"csstype": "^3.2.3",
 				"date-fns": "^4.1.0",
-				"deepmerge": "^4.3.0",
+				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
+				"gradient-parser": "^1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
@@ -12196,112 +12139,97 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.1.0.tgz",
-			"integrity": "sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==",
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/primitives": "^4.46.0",
-				"change-case": "4.1.2"
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/ui": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
-			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@base-ui/react": "^1.4.1",
-				"@wordpress/a11y": "^4.46.0",
-				"@wordpress/compose": "^7.46.0",
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/i18n": "^6.19.0",
-				"@wordpress/icons": "^13.1.0",
-				"@wordpress/keycodes": "^4.46.0",
-				"@wordpress/primitives": "^4.46.0",
-				"@wordpress/private-apis": "^1.46.0",
-				"@wordpress/style-runtime": "^0.2.0",
-				"@wordpress/theme": "^0.13.0",
-				"clsx": "^2.1.1",
-				"tabbable": "^6.4.0"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
-			"integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.2.8",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@date-fns/tz": "^1.2.0",
-				"@types/react": "^17 || ^18 || ^19",
-				"date-fns": "^4.0.0",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
 			},
 			"peerDependenciesMeta": {
-				"@date-fns/tz": {
-					"optional": true
-				},
 				"@types/react": {
-					"optional": true
-				},
-				"date-fns": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
-			"version": "2.1.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
-			"integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
-			"license": "MIT",
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@floating-ui/dom": "^1.7.6"
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
+			"integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/primitives": "^4.49.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -12309,12 +12237,12 @@
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.48.0.tgz",
-			"integrity": "sha512-HgXtYAD2IOrPDY83xzkT/8abYj2nMlkbC+lfSpB4lExlSVrIbz5oYUtktH8k5EBZjVBMFsE7mdMQyQjUeCQbeQ==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.49.0.tgz",
+			"integrity": "sha512-6Q7tvwjwNI2W0KDIATd4WAOc1n5Ppp/v/ofOwPjvaXr/9O4s2fsduR//ziQL3c5a5oYohCIsNHSHmOic+/Jofg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.48.0",
+				"@wordpress/deprecated": "^4.49.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -12348,12 +12276,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.48.0.tgz",
-			"integrity": "sha512-aTa7oww6hvTjfIvxLsxlcwYj7skAGPnr1V2S0iBVQfiIn5wJPiGjM9hz4QEf6kyR44Vh0IYjW9wSxVuDMGZUdw==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.49.0.tgz",
+			"integrity": "sha512-xK0l4psQpjpyIeE++Aml8tLLNeRN4vEjmBaCd6VbNqbbluW8LzZJtV60JATH8blcW5MaGCGl7rlpSevaBjp0hQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.48.0"
+				"@wordpress/hooks": "^4.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12361,12 +12289,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.48.0.tgz",
-			"integrity": "sha512-9UARZ0YQfmhx9VAi+QynSwu5fOJoG4mmPNTpYW8jDmtKh+9c2YIi1YSQFuOa1sipj78ZLPaBxaceZ7dbxKc3UA==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.49.0.tgz",
+			"integrity": "sha512-ysZvqyw1PvClTWqVwLzsE7cqfYU+QppJwu2Ji/rUGyFL9WSNdMIgIQhJWZMBiw0gBtD/uuiQe7OoVJfEGw0JYw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.48.0"
+				"@wordpress/deprecated": "^4.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12374,9 +12302,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.48.0.tgz",
-			"integrity": "sha512-jtH9/4FBTsfYLJDzgiXs41nceTrfvuLXqaWa5IN8drHvXZde6Dhz78m3KCZLrOB5DEE1tbyBNyZkcWM8HNVZ0Q==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.49.0.tgz",
+			"integrity": "sha512-faTCKkv9zjxKKq5RNmA20piRog14+KgAy7/Pw1hbxB1JCsimxFr7f+Vg268TIFbWQJiqX1S+YuKySFGQ/hpk8Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13142,9 +13070,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.48.0.tgz",
-			"integrity": "sha512-phw399RofSqTqIM4DikmkDfgJ7exDYgPfDuxjv3D2YnUTTUsR+U9fA+pA+/rNUiZD1YOmVILQmkJt6oLaVM+nQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.49.0.tgz",
+			"integrity": "sha512-eOSPRJhmocfi/hztIlbCXbksg54VWIvrbfRbS7AsHY8BelbMyP4YUGEXCZf2jqf5beMB/jqulcsNLsYJ/wC+yw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13894,9 +13822,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.48.0.tgz",
-			"integrity": "sha512-rU1yGEy0Mb+2oRG5QX/bKIIwKQmYAvATfUQeXIF20/mbR0qutYeVTCIvWEyb4pf71tvnQFiN18RWRXWsvKrDbQ==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.49.0.tgz",
+			"integrity": "sha512-65FZ3UXWkSIwFbELFABmcWn1KTA1AUdGAUH8pQlO7HKNO8F+zIrDkkO8gZA/zUHbI3I2vI1PyTA+rherPXg+Kg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13904,9 +13832,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.48.0.tgz",
-			"integrity": "sha512-KGxdaLC36wE10GybSfjYGcyWiy+KQCYheB6T8jhZhQ9mlf2Zwx6aJgfZm/L6BLwNN33Efx+sJY3nvMIxI5UwnA==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.49.0.tgz",
+			"integrity": "sha512-/ZYK6CPks3VAGFQZ+h56jOy4LB4CC1ZB1SMVY3eeUPStyH84YSz7nTa2P7gw/4uGJhaITMQCmFl7yGFPQOROtg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13914,13 +13842,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.21.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.21.0.tgz",
-			"integrity": "sha512-IXGGUJqN6b7QddU0dZB3HLJKu6uDQuhLsrrzYpUYTjDhfa43XEaikA9xHNgZhqzRtOVYqsNHVliWcISvJ/xjZQ==",
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.22.0.tgz",
+			"integrity": "sha512-o6JEr26/W3Lr/Tyu6M2Xexk+wPdt/Q+GS1o4c1T3zp1t0g+L279HFLblkSciOEIteoJYx7Eodma6/VV0kCKxow==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.48.0",
+				"@wordpress/hooks": "^4.49.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -14563,9 +14491,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.48.0.tgz",
-			"integrity": "sha512-7ipiZ1+m84RfuVhiMbtKm6RN571W3ERV/pTL+fSG2qOVhLqccFmliuFHTKQG+0KIhV8DegOlE6eoKOenf+I9ng==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.49.0.tgz",
+			"integrity": "sha512-pKvFYoExyT/A5h0Y5wLYs+8gQRaisJps2YF0jICo/LOfXR+TF8mYLH2txrA8ZCDGS0FPLSPjMxAl9hjUGrELRg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -14648,16 +14576,24 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.48.0.tgz",
-			"integrity": "sha512-u3Uxxe3rDAqEmerAiJ2X94s7iO3ZVgS+10MFyD4nWhfuB/C6m/M2TqHPgZiKvyDH04EIhe+pIF2KFO4pq7NWsw==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.49.0.tgz",
+			"integrity": "sha512-nz9i9W9uD2ZZ9lD0e75CwsLK5KF+/sw8o8TxR/OPojwHBSDKet84vtdijErQg68UxKHYnAoDjfF1otIJZ9J+pw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.21.0"
+				"@wordpress/i18n": "^6.22.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/latex-to-mathml": {
@@ -16892,12 +16828,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.48.0.tgz",
-			"integrity": "sha512-dfF7IZotIqb6LUiGs7oPwKbSF8RPoC0JDSIrtxvgwFA/yvbc/pDIp/Zs0O8GvxZNxu4JIVnKskOhoLq7lAeziQ==",
+			"version": "4.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.49.0.tgz",
+			"integrity": "sha512-mmyDQ6HLFdUhLCcdsJpPzzVjQ2H4wwS3MakMfeiKx39UUAdszoP50vjOohbcUL/7RGkNPvZ66AbpK45XMhlloA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^8.0.0",
+				"@wordpress/element": "^8.1.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -16905,23 +16841,29 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -16929,9 +16871,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.48.0.tgz",
-			"integrity": "sha512-NuGrfSSnBC794erb3xSEKrzWLGCNLa+ukob0pyVRtnebU7fPgrhx4NCBCXYK1vTcAta3NAkOVRfUZgcmLFYA6g==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.49.0.tgz",
+			"integrity": "sha512-UcVHYan6qYvDNTFEwEnPBU9I1SnImLjEh54ISgqvvndc7jfxtdi+Akwj2kgxeLRY+bsXzMQr6byD/x4dw56yqA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -16942,9 +16884,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.48.0.tgz",
-			"integrity": "sha512-HHOSXLCAlBggfMozwWtX36wgsSt22g2tZwpka47Rjzr3hNY1BZ6SrrFJumiNxooy5PDKbRgcF092PAF82hdJXg==",
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.49.0.tgz",
+			"integrity": "sha512-tGmX0XknlknSFB3UpoRQHnXW+4FufotTXYln+aXeHTFGcOuW3jSi8d8VZx7LCjUY1jqA8hCDf1vOHXW3FDcErQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -16952,9 +16894,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.48.0.tgz",
-			"integrity": "sha512-MxRgJJyddivxvVhPrn8yEFXTH3WLtoRGNCMiBRJwoIr4GkY8iOFSfRaqOJEkE1zrP4JK6qGFmv1xMvWt78c7ow==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.49.0.tgz",
+			"integrity": "sha512-pisFM/iQv23hmrBkWwlQZoMtqR3wXWoaAAf9d++laxlPRkFNfe/AG7gUK9tljhk5k6lP9pdeet4t+qSeQPDxpg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -17263,22 +17205,22 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.48.0.tgz",
-			"integrity": "sha512-rMiTTpRnpdynL9BnuI2MkSXzd12Js8gYSnlbVwxNNKNeFEXT+3Ah2oNCGvSb82pD/73Bl5BIGC5395D5a3X9yw==",
+			"version": "7.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.49.0.tgz",
+			"integrity": "sha512-RDH3dAnPTimIXYEdJ5+20KyJgmCeEDouA4Hi1Jhl1fiAzjjH1lNcwgs9eNQzaagqQTLfvvWOPX62rkFJnSvvvw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.48.0",
-				"@wordpress/compose": "^8.1.0",
-				"@wordpress/data": "^10.48.0",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/escape-html": "^3.48.0",
-				"@wordpress/i18n": "^6.21.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"colord": "2.9.3",
+				"@wordpress/a11y": "^4.49.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/data": "^10.49.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"colord": "^2.9.3",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -17286,24 +17228,30 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.1.0.tgz",
-			"integrity": "sha512-CAEQxrh3f19ku0SAnYAAiKcUe1zqaK9f0c8vJh+6qrpQnUjl7xLXj5TJOukXlzFH3Z9VZn6fJVfXqmDNAYIhQA==",
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/dom": "^4.48.0",
-				"@wordpress/element": "^8.0.0",
-				"@wordpress/is-shallow-equal": "^5.48.0",
-				"@wordpress/keycodes": "^4.48.0",
-				"@wordpress/priority-queue": "^3.48.0",
-				"@wordpress/private-apis": "^1.48.0",
-				"@wordpress/undo-manager": "^1.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -17313,23 +17261,29 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.0.0.tgz",
-			"integrity": "sha512-lQ8TB2vBr6lzcwQ2zh0xy+FC77Demb3FqL81fzpSsLbGUF9hZiTyyUuwc6SG21gCkGGjVm2TnU9BuHax/8nDfQ==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/deprecated": "^4.48.0",
-				"@wordpress/escape-html": "^3.48.0",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
-				"react": "^18.3.0",
-				"react-dom": "^18.3.0"
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18155,9 +18109,9 @@
 			}
 		},
 		"node_modules/@wordpress/style-runtime": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
-			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.5.0.tgz",
+			"integrity": "sha512-hrXvdDUJpOzT1KIomgtysysgbc5bkkwAuJyEUAXiOCgVBXBeMkZlgfN19W0PuNY51j53K7VQ42txfayxgVmfgA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=20.10.0",
@@ -18216,13 +18170,14 @@
 			}
 		},
 		"node_modules/@wordpress/theme": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.11.0.tgz",
-			"integrity": "sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.16.0.tgz",
+			"integrity": "sha512-4t0CM1WlDunz67br/kW3lhH6Xnxzex0G9/7jKY+PJk8XepJh5OXGkTgtvsTDpYFwhhHXI+xigwj/TRPq9a/V8g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.44.0",
-				"@wordpress/private-apis": "^1.44.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/style-runtime": "^0.5.0",
 				"colorjs.io": "^0.6.0",
 				"memize": "^2.1.0"
 			},
@@ -18231,14 +18186,83 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"esbuild": "^0.27.2",
+				"postcss": "^8.0.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0",
-				"stylelint": "^16.8.2"
+				"stylelint": "^16.8.2",
+				"vite": "^7.3.2"
 			},
 			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
 				"stylelint": {
 					"optional": true
+				},
+				"vite": {
+					"optional": true
 				}
+			}
+		},
+		"node_modules/@wordpress/theme/node_modules/@wordpress/compose": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/theme/node_modules/@wordpress/element": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/token-list": {
@@ -18252,21 +18276,21 @@
 			}
 		},
 		"node_modules/@wordpress/ui": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.12.0.tgz",
-			"integrity": "sha512-n/xfyagM90CcikLtlvNcjsFZtpt1wTpboOZPyCp9wqF6akAyJ4SUg9hXb/UA7pC8JqGe1Dg/hXJnFn/td8pvRA==",
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.16.0.tgz",
+			"integrity": "sha512-Eg8djuLvwiRy4yv/n7AmqHJXlmkZFCy3MX6Bw35IdT59vpzY60erSLifGKutyjkdIDnjhqFvpLjmRNoye21f9A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.4.1",
-				"@wordpress/a11y": "^4.45.0",
-				"@wordpress/compose": "^7.45.0",
-				"@wordpress/element": "^6.45.0",
-				"@wordpress/i18n": "^6.18.0",
-				"@wordpress/icons": "^13.0.0",
-				"@wordpress/keycodes": "^4.45.0",
-				"@wordpress/primitives": "^4.45.0",
-				"@wordpress/private-apis": "^1.45.0",
-				"@wordpress/theme": "^0.12.0",
+				"@base-ui/react": "^1.5.0",
+				"@wordpress/a11y": "^4.49.0",
+				"@wordpress/compose": "^8.2.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/i18n": "^6.22.0",
+				"@wordpress/icons": "^15.0.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/primitives": "^4.49.0",
+				"@wordpress/style-runtime": "^0.5.0",
+				"@wordpress/theme": "^0.16.0",
 				"clsx": "^2.1.1",
 				"tabbable": "^6.4.0"
 			},
@@ -18275,18 +18299,24 @@
 				"npm": ">=10.2.3"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.4.1.tgz",
-			"integrity": "sha512-Ab5/LIhcmL8BQcsBUYiOfkSDRdLpvgUBzMK30cu684JPcLclYlztharvCZyNNgzJtbAiREzI9q0pI5erHCMgCw==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.2.8",
+				"@base-ui/utils": "0.3.1",
 				"@floating-ui/react-dom": "^2.1.8",
 				"@floating-ui/utils": "^0.2.11",
 				"use-sync-external-store": "^1.6.0"
@@ -18330,22 +18360,81 @@
 				"react-dom": ">=16.8.0"
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.1.0.tgz",
-			"integrity": "sha512-KMZAeYghsLs6e5wKMZ3/Ynrsuu5yZt2gAlMHmZSkWJKQFld++Pz/pEj8nDCJ79z/zx9FO7q4teG49vHHvVosjQ==",
+		"node_modules/@wordpress/ui/node_modules/@wordpress/compose": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.2.0.tgz",
+			"integrity": "sha512-JqqnNs9mHxZ9zC+4A+YAyIoqnYNqOfLXF5EshXImssFCF1JBYx6wfmyhGAdpV4nZQSHPweV4KNzEApn2cz+fXA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.46.0",
-				"@wordpress/primitives": "^4.46.0",
-				"change-case": "4.1.2"
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/dom": "^4.49.0",
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/is-shallow-equal": "^5.49.0",
+				"@wordpress/keycodes": "^4.49.0",
+				"@wordpress/priority-queue": "^3.49.0",
+				"@wordpress/private-apis": "^1.49.0",
+				"@wordpress/undo-manager": "^1.49.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
+				"@types/react": "^18.3.27",
 				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/element": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.1.0.tgz",
+			"integrity": "sha512-469K4lpolw158pipMwMVVSjGvjIhOCkA19Bct5rJ54IGj8ZaPwLiCE3QGYO1oFg4KlpyP1ro4Ao3ZvznX7DeXQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.49.0",
+				"@wordpress/escape-html": "^3.49.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.0.0.tgz",
+			"integrity": "sha512-oyBRjQehISNyThq60gTYygKaGSbqmwwQVrlnCRDTWVfmMbbqtzwuzdJYCPQYpqLV1zGx8BWhM9sbOzhhUiXOBQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.1.0",
+				"@wordpress/primitives": "^4.49.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.3.27",
+				"react": "^18.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/date-fns": {
@@ -18361,12 +18450,12 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.48.0.tgz",
-			"integrity": "sha512-HqPGxMvZeWZJ6AVaCqZhfGpH6tqq5+hMlaqh4aCO0SvZ2Gvc6fbXEoVpqWfKozO1DyJW2GnRf8At8PpPt2IopQ==",
+			"version": "1.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.49.0.tgz",
+			"integrity": "sha512-af3pfl8d6rnEJ6ZijDAcCRbgaTX/m5tM2Pyl8hmlsUROf5ZCto9syiugM1+TDQ6zRtKYDoYB3SUtbHdLk8FZZg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.48.0"
+				"@wordpress/is-shallow-equal": "^5.49.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -18860,9 +18949,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.48.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.48.0.tgz",
-			"integrity": "sha512-En+A99j8aySNzUH0iXok0H2Xi+Uw2useKqYsvPm33VEMa0a0XIwa2I9srK5STp8RydCm1dK+/41K9e5xeFu23Q==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.49.0.tgz",
+			"integrity": "sha512-00KmZy5kT8vm48HKNQxsgiq3GXdgaPGClneMFTe9EWjop9Ghyq8MaYIqjYY75eOgPTFVcKKQyXK9/DAAQxsQuA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -23436,7 +23525,7 @@
 			"version": "0.27.7",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
 			"integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-			"dev": true,
+			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"bin": {
@@ -33611,9 +33700,9 @@
 			"license": "MIT"
 		},
 		"node_modules/reselect": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
-			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"license": "MIT"
 		},
 		"node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
 	"dependencies": {
 		"@wordpress/a11y": "^4.44.0",
 		"@wordpress/abilities": "^0.11.0",
-		"@wordpress/admin-ui": "^2.0.0",
+		"@wordpress/admin-ui": "^2.4.0",
 		"@wordpress/api-fetch": "^7.44.0",
 		"@wordpress/block-editor": "^15.17.0",
 		"@wordpress/blocks": "^15.17.0",
@@ -74,7 +74,7 @@
 		"@wordpress/core-abilities": "^0.10.0",
 		"@wordpress/core-data": "^7.44.0",
 		"@wordpress/data": "^10.44.0",
-		"@wordpress/dataviews": "^14.1.0",
+		"@wordpress/dataviews": "^17.0.0",
 		"@wordpress/date": "^5.44.0",
 		"@wordpress/dom": "^4.47.0",
 		"@wordpress/dom-ready": "^4.44.0",
@@ -87,7 +87,8 @@
 		"@wordpress/notices": "^5.44.0",
 		"@wordpress/plugins": "^7.44.0",
 		"@wordpress/primitives": "^4.45.0",
-		"@wordpress/ui": "^0.12.0",
+		"@wordpress/theme": "^0.16.0",
+		"@wordpress/ui": "^0.16.0",
 		"@wordpress/url": "^4.44.0",
 		"@wordpress/wordcount": "^4.44.0",
 		"react": "^18.3.1"
@@ -95,7 +96,7 @@
 	"overrides": {
 		"@babel/runtime": ">=7.26.10",
 		"@wordpress/route": "^0.10.0",
-		"@wordpress/theme": "^0.11.0",
+		"@wordpress/theme": "^0.16.0",
 		"markdownlint-cli": {
 			"minimatch": "3.1.4"
 		},

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -273,8 +273,9 @@ function InfoTip( { content }: InfoTipProps ) {
 				<Icon icon={ infoIcon } size={ 20 } />
 			</Popover.Trigger>
 			<Popover.Popup
-				side="bottom"
-				align="end"
+				positioner={
+					<Popover.Positioner side="bottom" align="end" />
+				}
 				className="ai-settings-page__infotip-popover"
 			>
 				<Popover.Arrow />

--- a/src/experiments/content-resizing/index.scss
+++ b/src/experiments/content-resizing/index.scss
@@ -100,9 +100,9 @@
 		border-radius: var(--wpds-border-radius-sm, 2px);
 		background: linear-gradient(
 			90deg,
-			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 8%, transparent) 25%,
-			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 18%, transparent) 37%,
-			color-mix(in srgb, var(--wpds-color-fg-content-neutral-weak, #707070) 8%, transparent) 63%
+			color-mix(in srgb, var(--wpds-color-foreground-content-neutral-weak, #707070) 8%, transparent) 25%,
+			color-mix(in srgb, var(--wpds-color-foreground-content-neutral-weak, #707070) 18%, transparent) 37%,
+			color-mix(in srgb, var(--wpds-color-foreground-content-neutral-weak, #707070) 8%, transparent) 63%
 		);
 		background-size: 400% 100%;
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

Updates some of the [bundled](https://github.com/WordPress/gutenberg/blob/5da7d3f6063956793daa42a6aad203cd947c62ee/packages/dependency-extraction-webpack-plugin/lib/util.js#L2-L14) WordPress packages for the AI settings route: `@wordpress/admin-ui` 2.4, `@wordpress/dataviews` 17, `@wordpress/ui` 0.16, and `@wordpress/theme` 0.16. 

Also adapts to breaking API changes: `Popover.Popup` placement props moved to `Popover.Positioner`, and `--wpds-color-fg-*` tokens renamed to `--wpds-color-foreground-*`.

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The AI settings page crashed when the Gutenberg plugin `trunk` or latest [RC2](https://github.com/WordPress/gutenberg/releases/tag/v23.5.0-rc.2) version was active (`Cannot unlock an undefined object`).

Latest stable [GB v23.4.0](https://github.com/WordPress/gutenberg/releases/tag/v23.4.0) works fine.

Bundled `@wordpress/ui` 0.12 relied on `unlock(theme.privateApis)`, but Gutenberg’s `wp.theme` no longer exports `privateApis` (theme 0.16 made `ThemeProvider` public). Aligning these bundled deps with the current Gutenberg release fixes that mismatch and keeps DataForm/UI components compatible with the runtime WordPress provides.

I tested with the latest stable WP without Gutenberg, and this seemed to work as well.

Note that we might also add back lock/unlock to theme for backwards compatibility (https://github.com/WordPress/gutenberg/pull/79594), but for now, anyway, it's a good idea to update.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update deps.

### Use of AI Tools
yes
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
yes
Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

Smoke test settings route built with `wp-build`

## Screenshots or screencast
<!-- If this PR includes UI changes, please provide screenshots or a screen recording for clarity. -->
<!-- This section can be removed if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Added - New feature.
> Changed - Existing functionality.
> Deprecated - Soon-to-be removed feature.
> Removed - Feature.
> Fixed - Bug fix.
> Security - Vulnerability.
> Developer - Development related updates.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-789-b004692695556e90e5366fb7d9fa3dadb9c5fce3.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->