### PR TITLE
add landingPage url to settings

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -85,6 +85,8 @@ jobs:
             preferredVersions: {
               wp: 'latest',
             },
+            login: true,
+            landingPage: '/wp-admin/admin.php?page=ai-wp-admin',
             steps: [
               {
                 step: 'installPlugin',


### PR DESCRIPTION


## What?
Closes #795

This updates the Playground PR function so it redirects to `/wp-admin/admin.php?page=ai-wp-admin` instead of `/`.

## Why?
Redirecting to the AI settings page improves the user flow, since that’s where configuration is actually performed. Redirecting to `/` previously led to a dead-end and required extra navigation.

## How?
Updated the blueprint schema by changing the landing page URL used by the Playground PR button to point to the AI settings page.

## Changelog Entry
Changed - Playground PR button now redirects users to `/wp-admin/admin.php?page=ai-wp-admin` instead of `/`.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-797-05dbadeced84ea3a95d5a3bd2391808267333a59.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->