### PR TITLE
Clarify global AI toggle as a master switch (#600)

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -970,7 +970,7 @@ function AISettingsPage() {
 					<>
 						<Stack align="center" gap="xs">
 							<ToggleControl
-								label={ __( 'Enable AI', 'ai' ) }
+								label={ __( 'AI features enabled', 'ai' ) }
 								checked={ globalEnabled }
 								onChange={ ( checked ) => {
 									void handleChange( {

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -104,7 +104,9 @@ test.describe( 'Plugin settings', () => {
 		await disableExperiments( admin, page );
 
 		// Ensure global AI setting is disabled.
-		await expect( page.getByLabel( 'Enable AI' ) ).not.toBeChecked();
+		await expect(
+			page.getByLabel( 'AI features enabled' )
+		).not.toBeChecked();
 
 		// Ensure feature toggles are disabled when AI is disabled.
 		await expect(
@@ -119,7 +121,7 @@ test.describe( 'Plugin settings', () => {
 		await enableExperiments( admin, page );
 
 		// Ensure global AI setting is enabled.
-		await expect( page.getByLabel( 'Enable AI' ) ).toBeChecked();
+		await expect( page.getByLabel( 'AI features enabled' ) ).toBeChecked();
 
 		// Ensure we see the editor experiments section.
 		await expect(
@@ -130,6 +132,26 @@ test.describe( 'Plugin settings', () => {
 		await expect(
 			page.getByText( 'Admin Experiments', { exact: true } )
 		).toBeVisible();
+	} );
+
+	test( 'Global AI toggle reads as a master switch, not an aggregate (#600)', async ( {
+		admin,
+		page,
+	} ) => {
+		await enableExperiments( admin, page );
+
+		// The control is labeled as a state ("AI features enabled"), not the
+		// imperative "Enable AI" that implied an aggregate/all-on meaning.
+		const masterToggle = page.getByLabel( 'AI features enabled' );
+		await expect( masterToggle ).toBeVisible();
+		await expect( masterToggle ).toBeChecked();
+
+		// Turning a single feature off must not change the master toggle: it is
+		// a master switch, not a summary of individual feature states. This is
+		// the regression guard for the misleading solid-on toggle (#600).
+		await disableExperiment( admin, page, 'Title Generation' );
+		await expect( masterToggle ).toBeChecked();
+		await expect( page.getByLabel( 'Title Generation' ) ).not.toBeChecked();
 	} );
 
 	test( 'Inline settings retain pending edits when another toggle auto-saves', async ( {

--- a/tests/e2e/utils/helpers.ts
+++ b/tests/e2e/utils/helpers.ts
@@ -164,7 +164,7 @@ export const disableExperiments = async ( admin: Admin, page: Page ) => {
 	await visitSettingsPage( admin );
 
 	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByLabel( 'Enable AI' );
+	const globalToggle = page.getByLabel( 'AI features enabled' );
 	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
 	await expect( globalToggle ).toBeEnabled( { timeout: 10000 } );
 
@@ -190,7 +190,7 @@ export const enableExperiments = async ( admin: Admin, page: Page ) => {
 	await visitSettingsPage( admin );
 
 	// Wait for page to fully load before finding the global toggle.
-	const globalToggle = page.getByLabel( 'Enable AI' );
+	const globalToggle = page.getByLabel( 'AI features enabled' );
 	await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
 	await expect( globalToggle ).toBeEnabled( { timeout: 10000 } );
 


### PR DESCRIPTION
## What?

Closes #600

Relabels the global header toggle on **Settings → AI** from "Enable AI" to **"AI features enabled"**, so the control reads as a master on/off *state* rather than an imperative implying it switches on every feature.

## Why?

The toggle binds to a single `wpai_features_enabled` option and is never derived from the individual feature states, so it always renders solid-on even when only some features are enabled — misrepresenting the configuration (the reported problem). The imperative label "Enable AI" reinforced that misreading.

On the issue, @gziolo suggested the control should "reflect the state 'AI enabled'" and @dkotter agreed. This implements that with a minimal label change; the existing InfoTip next to the toggle already documents the master-switch behavior. It intentionally avoids the per-section toggles attempted in #617, which were closed as duplicative with the existing **Enable all** / **Disable all** buttons.

## How?

- `routes/ai-home/stage.tsx`: change the global toggle's label from `__( 'Enable AI', 'ai' )` to `__( 'AI features enabled', 'ai' )`.
- `tests/e2e/utils/helpers.ts` and `tests/e2e/specs/admin/settings.spec.js`: update the label locators, and add a regression test asserting the master toggle stays checked when a single feature is turned off (proving it is a master switch, not an aggregate).

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.x
Used for: Implementation, tests, and drafting this PR description — reviewed, tested, and edited by me.

## Testing Instructions

1. Go to **Settings → AI**.
2. Confirm the header control reads **"AI features enabled"** (not "Enable AI").
3. Enable AI, then enable only a subset of features; confirm the control still reads as a master switch (hover the info icon to see it governs all features).
4. Toggle a single feature off and confirm the master control is unaffected.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| Header control labeled **"Enable AI"** | Header control labeled **"AI features enabled"** |

## Changelog Entry

> Changed - Settings: the global AI control is now labeled "AI features enabled" to clarify it is a master switch rather than a summary of individual feature states.
