### PR TITLE
Gate provider-backed features until valid credentials exist (#197)

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -376,23 +376,85 @@ function DisabledToggle( { field, data }: DataFormControlProps< AISettings > ) {
 	);
 }
 
+/**
+ * Returns whether a feature needs a configured AI provider to function.
+ *
+ * Features that declare a 'none' capability (e.g. the Abilities Explorer)
+ * do not call an AI provider and remain usable without credentials.
+ *
+ * @param capability The feature's declared AI capability.
+ */
+function requiresProvider( capability: string ): boolean {
+	return capability !== 'none';
+}
+
+/**
+ * Toggle shown for provider-backed features when no valid AI Connector is
+ * configured. It is disabled and points the user to the Connectors screen,
+ * preventing them from enabling a feature that would error at runtime.
+ */
+function CredentialRequiredToggle( {
+	field,
+	data,
+}: DataFormControlProps< AISettings > ) {
+	return (
+		<ToggleControl
+			label={ field.label }
+			checked={ !! field.getValue( { item: data } ) }
+			// No-op handler required to satisfy React's controlled-component warning; the toggle is disabled.
+			onChange={ noop }
+			disabled
+			help={
+				<>
+					{ __(
+						'Set up a valid AI Connector to enable this feature.',
+						'ai'
+					) }
+					{ PAGE_DATA.connectorsUrl && (
+						<>
+							{ ' ' }
+							<Link href={ PAGE_DATA.connectorsUrl }>
+								{ __( 'Manage Connectors', 'ai' ) }
+							</Link>
+						</>
+					) }
+				</>
+			}
+		/>
+	);
+}
+
 interface SectionActionsProps extends DataFormControlProps< AISettings > {
 	experimentSettings: string[];
+	blockedSettings: string[];
 	globalEnabled: boolean;
 	onBulkChange: ( edits: Record< string, boolean > ) => void;
 }
 
 function SectionActions( {
 	experimentSettings,
+	blockedSettings,
 	data,
 	globalEnabled,
 	onBulkChange,
 }: SectionActionsProps ) {
+	// Features without a valid AI Connector cannot be turned on, so "Enable all"
+	// must ignore them (otherwise it would enable features that error at runtime).
+	const enableableSettings = useMemo(
+		() =>
+			experimentSettings.filter(
+				( settingName ) => ! blockedSettings.includes( settingName )
+			),
+		[ experimentSettings, blockedSettings ]
+	);
+
 	const allEnabled = useMemo( () => {
-		return experimentSettings.every(
+		// Nothing left to enable when every eligible feature is already on (or
+		// there are no eligible features at all).
+		return enableableSettings.every(
 			( settingName ) => data[ settingName ]
 		);
-	}, [ experimentSettings, data ] );
+	}, [ enableableSettings, data ] );
 
 	const allDisabled = useMemo( () => {
 		return experimentSettings.every(
@@ -404,7 +466,7 @@ function SectionActions( {
 		const edits: Record< string, boolean > = {};
 		let enabledCount = 0;
 
-		for ( const settingName of experimentSettings ) {
+		for ( const settingName of enableableSettings ) {
 			if ( ! data[ settingName ] ) {
 				edits[ settingName ] = true;
 				enabledCount++;
@@ -414,7 +476,7 @@ function SectionActions( {
 		if ( enabledCount > 0 ) {
 			onBulkChange( edits );
 		}
-	}, [ experimentSettings, data, onBulkChange ] );
+	}, [ enableableSettings, data, onBulkChange ] );
 
 	const handleDisableAll = useCallback( () => {
 		const edits: Record< string, boolean > = {};
@@ -634,11 +696,17 @@ function VisualCardToggle( {
 	const globalEnabled = !! data[ GLOBAL_FIELD_ID ];
 	const checked = !! field.getValue( { item: data } );
 	const isDeveloperMode = useDeveloperModeContext();
+	const blockedByCredentials =
+		!! feature &&
+		! PAGE_DATA.hasValidCredentials &&
+		requiresProvider( feature.capability );
 
 	return (
 		<Card.Root
 			className={ `${
-				! globalEnabled ? ' ai-showcase-card--disabled' : ''
+				! globalEnabled || blockedByCredentials
+					? ' ai-showcase-card--disabled'
+					: ''
 			}` }
 		>
 			{ feature?.image && (
@@ -651,15 +719,38 @@ function VisualCardToggle( {
 					onChange={ ( value ) =>
 						onChange( { [ field.id ]: value } )
 					}
-					disabled={ ! globalEnabled }
-					help={ field.description }
+					disabled={ ! globalEnabled || blockedByCredentials }
+					help={
+						blockedByCredentials ? (
+							<>
+								{ __(
+									'Set up a valid AI Connector to enable this feature.',
+									'ai'
+								) }
+								{ PAGE_DATA.connectorsUrl && (
+									<>
+										{ ' ' }
+										<Link href={ PAGE_DATA.connectorsUrl }>
+											{ __( 'Manage Connectors', 'ai' ) }
+										</Link>
+									</>
+								) }
+							</>
+						) : (
+							field.description
+						)
+					}
 				/>
-				{ globalEnabled && checked && isDeveloperMode && feature && (
-					<DeveloperSettings
-						featureId={ feature.id }
-						capability={ feature.capability }
-					/>
-				) }
+				{ globalEnabled &&
+					! blockedByCredentials &&
+					checked &&
+					isDeveloperMode &&
+					feature && (
+						<DeveloperSettings
+							featureId={ feature.id }
+							capability={ feature.capability }
+						/>
+					) }
 			</Card.Content>
 		</Card.Root>
 	);
@@ -808,12 +899,28 @@ function AISettingsPage() {
 			groupedFields.set( category, categoryFields );
 		}
 
+		// Settings that cannot be enabled because they need a valid AI Connector
+		// that is not configured. Non-provider features are never blocked.
+		const blockedBySetting = new Set(
+			featureDefinitions
+				.filter(
+					( feature ) =>
+						! PAGE_DATA.hasValidCredentials &&
+						requiresProvider( feature.capability )
+				)
+				.map( ( feature ) => feature.settingName )
+		);
+
 		// Create section action fields for each group
 		for ( const group of featureGroups ) {
 			const experimentSettings = groupedFields.get( group.id ) ?? [];
 			if ( experimentSettings.length <= 1 ) {
 				continue;
 			}
+
+			const blockedSettings = experimentSettings.filter(
+				( settingName ) => blockedBySetting.has( settingName )
+			);
 
 			const actionFieldId = `section-actions-${ group.id }`;
 			sectionActionsFields.push( {
@@ -824,6 +931,7 @@ function AISettingsPage() {
 					<SectionActions
 						{ ...props }
 						experimentSettings={ experimentSettings }
+						blockedSettings={ blockedSettings }
 						globalEnabled={ globalEnabled }
 						onBulkChange={ handleChange }
 					/>
@@ -840,10 +948,16 @@ function AISettingsPage() {
 				type: 'boolean' as const,
 			};
 
+			const blockedByCredentials =
+				! PAGE_DATA.hasValidCredentials &&
+				requiresProvider( feature.capability );
+
 			if ( VISUAL_CARD_FEATURES.has( feature.settingName ) ) {
 				baseField.Edit = VisualCardToggle;
 			} else if ( ! globalEnabled ) {
 				baseField.Edit = DisabledToggle;
+			} else if ( blockedByCredentials ) {
+				baseField.Edit = CredentialRequiredToggle;
 			} else if ( feature.settingsFields.length > 0 ) {
 				baseField.Edit = FeatureToggleWithSettings;
 			} else {

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -9,6 +9,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 const {
 	clearConnectors,
 	seedCredentials,
+	clearCredentials,
 	disableExperiments,
 	disableExperiment,
 	enableExperiment,
@@ -130,6 +131,44 @@ test.describe( 'Plugin settings', () => {
 		await expect(
 			page.getByText( 'Admin Experiments', { exact: true } )
 		).toBeVisible();
+	} );
+
+	test( 'Provider features are gated without credentials; non-AI features stay usable (#197)', async ( {
+		admin,
+		page,
+		requestUtils,
+	} ) => {
+		await requestUtils.activatePlugin( 'e2e-testing' );
+
+		// Remove credentials so no valid AI Connector is configured.
+		await clearCredentials( requestUtils );
+
+		// The master AI switch itself is not credential-gated.
+		await enableExperiments( admin, page );
+
+		// A provider-backed experiment (Title Generation) is disabled and
+		// directs the user to set up a Connector, instead of letting them
+		// enable a feature that errors at runtime.
+		const titleToggle = page.getByLabel( 'Title Generation' );
+		await expect( titleToggle ).toBeVisible( { timeout: 10000 } );
+		await expect( titleToggle ).toBeDisabled();
+		await expect(
+			page
+				.getByText(
+					'Set up a valid AI Connector to enable this feature.'
+				)
+				.first()
+		).toBeVisible();
+
+		// A non-AI experiment (Abilities Explorer, capability 'none') stays
+		// interactive even without credentials — the key gap that closed
+		// the previous global-lockout attempt (#731).
+		const abilitiesToggle = page.getByLabel( 'Abilities Explorer' );
+		await expect( abilitiesToggle ).toBeVisible();
+		await expect( abilitiesToggle ).toBeEnabled();
+
+		// Restore credentials so later tests start from a valid state.
+		await seedCredentials( requestUtils );
 	} );
 
 	test( 'Inline settings retain pending edits when another toggle auto-saves', async ( {


### PR DESCRIPTION
## What?

Closes #197

Disables AI experiments that require a provider until a valid AI Connector is configured, while leaving non-AI experiments (Abilities Explorer, Connector Approval, AI Request Logging) usable.

## Why?

With no valid AI Connector, the settings page still let users enable provider-backed experiments (e.g. Title Generation). The feature then appeared in the editor and **errored at runtime** when triggered, since the settings UI had no credential guard.

A previous attempt (#731) was closed because it disabled *all* experiment toggles globally, including the non-AI ones. As @dkotter and @juanfra noted on the issue, some experiments don't require AI at all, so a global lockout is the wrong tool. This implements the scoped, per-feature approach the maintainers asked for.

## How?

Frontend-only (`routes/ai-home/stage.tsx`). The plugin already tracks a per-feature `capability`, non-AI features already declare `capability: 'none'`, and `develop` already localizes `capability` / `hasValidCredentials` / `connectorsUrl` to the settings page:

- Add `requiresProvider( capability ) => capability !== 'none'`.
- When AI is enabled globally but there are no valid credentials, provider-backed features render a disabled toggle with **"Set up a valid AI Connector to enable this feature."** and a *Manage Connectors* link (new `CredentialRequiredToggle`; the showcase/visual-card features get the same treatment).
- Non-provider features stay interactive.
- `SectionActions` ("Enable all") skips credential-blocked features so a bulk action can't enable something that would error.

No backend change is needed — `get_settings_feature_metadata()` already exposes `capability` (covered by `Settings_PageTest.php`).

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.x
Used for: Implementation, tests, and drafting this PR description — reviewed and edited by me.

## Testing Instructions

1. Configure the plugin with **no** valid AI Connector (or invalid credentials).
2. Go to **Settings → AI** and enable the global AI toggle.
3. Confirm provider-backed experiments (e.g. Title Generation, Alt Text, Image Generation) are **disabled** and show "Set up a valid AI Connector to enable this feature." with a *Manage Connectors* link.
4. Confirm **Abilities Explorer** (and other `capability: 'none'` experiments) remain **interactive**.
5. Confirm **"Enable all"** in a section does not enable the credential-blocked features.
6. Add a valid Connector, reload — all features become interactive again.

Automated: added an e2e test in `tests/e2e/specs/admin/settings.spec.js` (provider feature gated; non-AI feature still interactive).

> [!NOTE]
> The Playwright e2e suite was not run locally for this branch (no Docker available at the time). The spec is written to the repo's conventions; please confirm via CI.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| No credentials: provider experiments could be toggled on, then errored in the editor | No credentials: provider experiments are disabled with "Set up a valid AI Connector to enable this feature." + *Manage Connectors* link; non-AI experiments (Abilities Explorer) stay interactive |

## Changelog Entry

> Changed - Settings: experiments that require an AI provider are now disabled with setup guidance until a valid AI Connector is configured, while non-AI experiments remain usable.
