### PR TITLE
Pin settings-page snackbars to the bottom-left, off the content (#800)

### DIFF
--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -102,7 +102,7 @@ body:has(.ai-settings-page) .components-popover {
  * default, centered over the (centered) settings content, where they obscure
  * the controls the user is interacting with. Pin them to the bottom
  * inline-start of the content area instead, offsetting by the WordPress admin
- * menu width so they clear both the menu and the settings cards. See #800.
+ * menu width so they clear both the menu and the settings cards.
  */
 body.settings_page_ai-wp-admin {
 	.components-snackbar-list {

--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -96,3 +96,42 @@ body:has(.ai-settings-page) .components-popover {
 		padding-bottom: var(--wpds-dimension-gap-sm, 8px);
 	}
 }
+
+/**
+ * Snackbar notifications are rendered full-width by the route shell and, by
+ * default, centered over the (centered) settings content, where they obscure
+ * the controls the user is interacting with. Pin them to the bottom
+ * inline-start of the content area instead, offsetting by the WordPress admin
+ * menu width so they clear both the menu and the settings cards. See #800.
+ */
+body.settings_page_ai-wp-admin {
+	.components-snackbar-list {
+		box-sizing: border-box;
+		// Full admin menu width (160px) plus a gutter.
+		padding-inline-start: 184px;
+
+		.components-snackbar {
+			// Align to inline-start instead of the default centered margins.
+			margin-inline: 0 auto;
+		}
+	}
+
+	// Collapsed admin menu (manually folded) shrinks to 36px.
+	&.folded .components-snackbar-list {
+		padding-inline-start: 60px;
+	}
+
+	// auto-fold collapses the menu to 36px at this breakpoint.
+	@media screen and (max-width: 960px) {
+		.components-snackbar-list {
+			padding-inline-start: 60px;
+		}
+	}
+
+	// The admin menu moves off-canvas; align toasts to the content edge.
+	@media screen and (max-width: 782px) {
+		.components-snackbar-list {
+			padding-inline-start: 24px;
+		}
+	}
+}

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -132,6 +132,36 @@ test.describe( 'Plugin settings', () => {
 		).toBeVisible();
 	} );
 
+	test( 'Snackbar notifications do not cover the settings content (#800)', async ( {
+		admin,
+		page,
+	} ) => {
+		// Use a fixed desktop viewport so the admin menu is at full width and
+		// snackbar placement is deterministic.
+		await page.setViewportSize( { width: 1280, height: 800 } );
+		await visitSettingsPage( admin );
+
+		// Toggle the global setting to trigger a snackbar.
+		const globalToggle = page.getByLabel( 'Enable AI' );
+		await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
+		await globalToggle.click();
+
+		const snackbar = page.locator( '.components-snackbar' ).first();
+		await expect( snackbar ).toBeVisible();
+
+		// The snackbar must sit to the inline-start of the centered settings
+		// content, not on top of it (regression guard for #800).
+		const snackBox = await snackbar.boundingBox();
+		const contentBox = await page
+			.locator( '.ai-settings-page' )
+			.boundingBox();
+		expect( snackBox ).not.toBeNull();
+		expect( contentBox ).not.toBeNull();
+		expect( snackBox.x + snackBox.width ).toBeLessThanOrEqual(
+			contentBox.x
+		);
+	} );
+
 	test( 'Inline settings retain pending edits when another toggle auto-saves', async ( {
 		admin,
 		page,

--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -132,7 +132,7 @@ test.describe( 'Plugin settings', () => {
 		).toBeVisible();
 	} );
 
-	test( 'Snackbar notifications do not cover the settings content (#800)', async ( {
+	test( 'Snackbar notifications do not cover the settings content', async ( {
 		admin,
 		page,
 	} ) => {


### PR DESCRIPTION
## What?

Closes #800

Pins snackbar notifications on the **Settings → AI** screen to the bottom inline-start of the content area, so they no longer appear centered over the settings content the user is interacting with.

## Why?

The snackbar list is rendered full-width and `position: fixed` by the route shell, and each `.components-snackbar` gets `margin: 0 auto` — so toasts are **horizontally centered** over the (centered) settings column. Toggling a setting drops the "… enabled/disabled." toast directly on top of the rows being edited. WordPress's standard editor toast position is bottom-*left*; the centering here is the anomaly.

## How?

A small, **page-scoped** CSS rule (`body.settings_page_ai-wp-admin`) in `routes/ai-home/style.scss` pins toasts to the bottom inline-start of the content area, offset by the WordPress admin-menu width so they clear both the menu and the settings cards:

- `padding-inline-start: 184px` for the full (160px) admin menu, `60px` when the menu is folded / auto-folded (`max-width: 960px`), and `24px` once the menu goes off-canvas (`max-width: 782px`) — mirroring WordPress's own admin-menu breakpoints.
- The snackbar is aligned to the inline-start (`margin-inline: 0 auto`) instead of centered.
- Uses CSS **logical properties** so it works in RTL without a flipped stylesheet (as the file requires). No framework/shell code is touched.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.x
Used for: Reproduction (wp-env + Playwright), implementation, tests, and drafting this PR description — reviewed, tested, and edited by me.

## Testing Instructions

1. Go to **Settings → AI**.
2. Toggle any setting (e.g. the global **Enable AI** switch).
3. Confirm the snackbar appears at the bottom-left, in the gutter between the admin menu and the settings cards — **not** centered over the content.
4. Collapse the admin menu and/or narrow the window and confirm the toast still clears the menu and content.

Automated: added an e2e test in `tests/e2e/specs/admin/settings.spec.js` asserting the snackbar's inline-end edge does not cross into the settings content column. **Run locally against wp-env and passing** (chromium).

## Screenshots or screencast

Verified in a real browser (wp-env). Measurements at a 1200px viewport:

| Before | After |
| ------ | ----- |
| Toast centered (x ≈ 545–655), overlapping the Content Classification / Content Resizing rows | Toast at x ≈ 184–295 — clear of the admin menu (ends 160px) and the settings cards (start 336px) |

## Changelog Entry

> Fixed - Settings: snackbar notifications no longer overlap the settings content; they are pinned to the bottom-left of the content area.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-801-14c47f629f58cb95bd81aa62886627564af56335.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->