### PR TITLE
Fix[Meta Description | Excerpt Generation]: Use `Notice` to display warnings in modal

### DIFF
--- a/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
+++ b/src/experiments/excerpt-generation/components/ExcerptGeneration.tsx
@@ -5,9 +5,10 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
+import { Button, Notice } from '@wordpress/components';
 import { update } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+import { Stack } from '@wordpress/ui';
 
 /**
  * Internal dependencies
@@ -46,7 +47,13 @@ export default function ExcerptGeneration(): React.JSX.Element | null {
 	}
 
 	return (
-		<div>
+		<Stack direction="column" gap="md">
+			{ isContentTooShort && (
+				<Notice status="warning" isDismissible={ false }>
+					{ tooShortLabel }
+				</Notice>
+			) }
+
 			<Button
 				icon={ update }
 				variant="secondary"
@@ -56,18 +63,10 @@ export default function ExcerptGeneration(): React.JSX.Element | null {
 				accessibleWhenDisabled
 				isBusy={ isGenerating }
 				__next40pxDefaultSize
+				style={ { alignSelf: 'flex-start' } }
 			>
 				{ buttonLabel }
 			</Button>
-
-			{ isContentTooShort && (
-				<p
-					className="ai-excerpt-generation__hint components-base-control__help"
-					style={ { color: '#757575' } }
-				>
-					{ tooShortLabel }
-				</p>
-			) }
-		</div>
+		</Stack>
 	);
 }

--- a/src/experiments/meta-description/components/MetaDescriptionModal.tsx
+++ b/src/experiments/meta-description/components/MetaDescriptionModal.tsx
@@ -7,7 +7,7 @@
  */
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Modal, Button, TextareaControl } from '@wordpress/components';
+import { Modal, Button, TextareaControl, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -108,6 +108,12 @@ export default function MetaDescriptionModal( {
 			focusOnMount="firstContentElement"
 		>
 			<div className="ai-meta-description-modal__content">
+				{ isContentTooShort && (
+					<Notice status="warning" isDismissible={ false }>
+						{ tooShortLabel }
+					</Notice>
+				) }
+
 				{ /* Editable textarea */ }
 				<div className="ai-meta-description-modal__editor">
 					<TextareaControl
@@ -175,15 +181,6 @@ export default function MetaDescriptionModal( {
 						{ __( 'Cancel', 'ai' ) }
 					</Button>
 				</div>
-
-				{ isContentTooShort && (
-					<p
-						className="ai-meta-description__hint components-base-control__help"
-						style={ { color: '#757575' } }
-					>
-						{ tooShortLabel }
-					</p>
-				) }
 			</div>
 		</Modal>
 	);


### PR DESCRIPTION
## What, Why, and How?

This PR updates the meta description and excerpt generation modal to show the “content too short” message as a `Notice` instead of a small helper paragraph. The message is a warning that blocks generation, so presenting it as a warning notice at the top makes the state more visible and consistent with UI patterns.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: To perform a code review.

## Testing Instructions

1. Create a new post with enough content to meet the meta description generation threshold.
2. Generate a meta description, then save the post.
3. Edit the post content so it falls below 50 words.
4. Verify that the warning is displayed in a Notice component at the top of the modal.
5. Similarly, check the warning `Notice` within the `Excerpt Generation` popover.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| <img width="516" height="369" alt="before" src="https://github.com/user-attachments/assets/2384d8ec-d0a1-45ed-adfe-741fcbab43a6" /> | <img width="516" height="369" alt="after" src="https://github.com/user-attachments/assets/c1f4b1d4-7869-4847-aed6-49d76ec0d83f" /> |
|<img width="326" height="344" alt="before-02" src="https://github.com/user-attachments/assets/50eee8b3-40ca-44d4-a3e8-0cd7b5ea6b78" />|<img width="326" height="348" alt="after-02" src="https://github.com/user-attachments/assets/e6a34f02-713e-4b70-b93a-c83b30348d5c" />|

## Changelog Entry

> Changed - Use `Notice` component to display warnings within experiment modals.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-803-940aba67fb810232949ff009979004a13cee6d40.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->