### PR TITLE
Rename settings ability to core/read-settings

### DIFF
--- a/includes/Abilities/Settings/Settings.php
+++ b/includes/Abilities/Settings/Settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The `core/settings` WordPress Ability.
+ * The `core/read-settings` WordPress Ability.
  *
  * @package WordPress\AI
  *
@@ -17,7 +17,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class - Settings
  *
- * Registers the read-only `core/settings` ability, which returns WordPress settings as a
+ * Registers the read-only `core/read-settings` ability, which returns WordPress settings as a
  * flat map of setting name to value. Only settings flagged with `show_in_abilities` are
  * exposed. It is structured to also back a future write-oriented `core/manage-settings`
  * ability via the shared helpers (get_exposed_settings(), value_schema(), cast_value()).
@@ -84,14 +84,14 @@ final class Settings {
 	}
 
 	/**
-	 * Registers the read-only `core/settings` ability.
+	 * Registers the read-only `core/read-settings` ability.
 	 *
 	 * @since x.x.x
 	 */
 	private function register_get_settings(): void {
 		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/settings' ) ) {
-			wp_unregister_ability( 'core/settings' );
+		if ( wp_has_ability( 'core/read-settings' ) ) {
+			wp_unregister_ability( 'core/read-settings' );
 		}
 
 		// Compute once; execute_get_settings() reuses this exact structure.
@@ -110,9 +110,9 @@ final class Settings {
 		}
 
 		wp_register_ability(
-			'core/settings',
+			'core/read-settings',
 			array(
-				'label'               => __( 'Get Settings', 'ai' ),
+				'label'               => __( 'Read Settings', 'ai' ),
 				'description'         => __( 'Returns WordPress settings as a flat map of setting name to value. By default returns all settings exposed to abilities, or optionally a subset filtered by settings group, by setting name, or both.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_settings_input_schema( $groups, $field_names ),
@@ -137,7 +137,7 @@ final class Settings {
 	}
 
 	/**
-	 * Executes the `core/settings` ability.
+	 * Executes the `core/read-settings` ability.
 	 *
 	 * @since x.x.x
 	 *

--- a/includes/Abilities/Show_In_Abilities.php
+++ b/includes/Abilities/Show_In_Abilities.php
@@ -18,14 +18,14 @@ defined( 'ABSPATH' ) || exit;
  * Class - Show_In_Abilities
  *
  * WordPress core does not yet ship the `show_in_abilities` flag consumed by the
- * `core/settings` ability (and, in the future, post type and meta abilities). This
+ * `core/read-settings` ability (and, in the future, post type and meta abilities). This
  * component polyfills that flag onto a curated set of core objects so the abilities
  * return data on a stock site, before/without the equivalent core change.
  *
  * It is intentionally object-type-agnostic: today it marks settings; post types and
  * meta can be marked here the same way when those abilities land.
  *
- * Timing: the `core/settings` ability snapshots the exposed settings when it registers
+ * Timing: the `core/read-settings` ability snapshots the exposed settings when it registers
  * on `wp_abilities_api_init`. A setting therefore has to be flagged with `show_in_abilities`
  * before that hook fires — i.e. its `register_setting()` call must run before abilities
  * init — for the ability to pick it up.

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -133,7 +133,7 @@ final class Main {
 			( new Posts() )->register();
 
 			// Expose curated core objects to the Abilities API, then register the
-			// `core/settings` ability (overriding any core-provided copy).
+			// `core/read-settings` ability (overriding any core-provided copy).
 			( new Show_In_Abilities() )->register();
 			( new Settings_Ability() )->init();
 		} catch ( \Throwable $e ) {

--- a/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
+++ b/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Integration tests for the core/settings Ability provided by the plugin.
+ * Integration tests for the core/read-settings Ability provided by the plugin.
  *
  * @package WordPress\AI\Tests\Integration\Includes\Abilities\Settings
  */
@@ -45,7 +45,7 @@ class SettingsTest extends WP_UnitTestCase {
 		// setting (not just the core ones) is exposed by the ability.
 		register_setting(
 			'general',
-			'core_settings_ability_test_option',
+			'core_read_settings_ability_test_option',
 			array(
 				'type'              => 'integer',
 				'label'             => 'Custom Ability Setting',
@@ -64,12 +64,12 @@ class SettingsTest extends WP_UnitTestCase {
 	 * @since x.x.x
 	 */
 	public function tearDown(): void {
-		if ( wp_has_ability( 'core/settings' ) ) {
-			wp_unregister_ability( 'core/settings' );
+		if ( wp_has_ability( 'core/read-settings' ) ) {
+			wp_unregister_ability( 'core/read-settings' );
 		}
 
 		remove_filter( 'register_setting_args', array( $this->show_in_abilities, 'mark_setting' ), 10 );
-		unregister_setting( 'general', 'core_settings_ability_test_option' );
+		unregister_setting( 'general', 'core_read_settings_ability_test_option' );
 		wp_set_current_user( 0 );
 
 		parent::tearDown();
@@ -101,7 +101,7 @@ class SettingsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Registers the plugin's core/settings ability inside a faked init action.
+	 * Registers the plugin's core/read-settings ability inside a faked init action.
 	 *
 	 * @since x.x.x
 	 */
@@ -129,12 +129,13 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_ability_is_registered(): void {
+	public function test_core_read_settings_ability_is_registered(): void {
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/settings' );
+		$ability = wp_get_ability( 'core/read-settings' );
 
 		$this->assertInstanceOf( WP_Ability::class, $ability );
+		$this->assertSame( 'core/read-settings', $ability->get_name() );
 		$this->assertSame( 'site', $ability->get_category() );
 		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ) );
 
@@ -144,17 +145,17 @@ class SettingsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * When core already provides core/settings, the plugin's version replaces it.
+	 * When core already provides core/read-settings, the plugin's version replaces it.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_override_replaces_existing_core_settings(): void {
+	public function test_override_replaces_existing_core_read_settings(): void {
 		// Simulate a core-provided ability with a different (minimal) shape.
 		global $wp_current_filter;
 		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
 		try {
 			wp_register_ability(
-				'core/settings',
+				'core/read-settings',
 				array(
 					'label'               => 'Core Provided',
 					'description'         => 'Core provided settings ability.',
@@ -169,12 +170,12 @@ class SettingsTest extends WP_UnitTestCase {
 			array_pop( $wp_current_filter );
 		}
 
-		$this->assertSame( 'Core Provided', wp_get_ability( 'core/settings' )->get_label() );
+		$this->assertSame( 'Core Provided', wp_get_ability( 'core/read-settings' )->get_label() );
 
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/settings' );
-		$this->assertSame( 'Get Settings', $ability->get_label() );
+		$ability = wp_get_ability( 'core/read-settings' );
+		$this->assertSame( 'Read Settings', $ability->get_label() );
 		// The plugin's shape exposes optional `group` and `fields` filters.
 		$this->assertArrayHasKey( 'fields', $ability->get_input_schema()['properties'] );
 	}
@@ -184,10 +185,10 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_input_schema_exposes_group_and_fields_filters(): void {
+	public function test_core_read_settings_input_schema_exposes_group_and_fields_filters(): void {
 		$this->register_ability();
 
-		$schema = wp_get_ability( 'core/settings' )->get_input_schema();
+		$schema = wp_get_ability( 'core/read-settings' )->get_input_schema();
 
 		$this->assertSame( 'object', $schema['type'] );
 		$this->assertArrayHasKey( 'default', $schema );
@@ -205,7 +206,7 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_returns_flat_typed_values(): void {
+	public function test_core_read_settings_returns_flat_typed_values(): void {
 		$this->become_admin();
 		$this->register_ability();
 
@@ -213,7 +214,7 @@ class SettingsTest extends WP_UnitTestCase {
 		update_option( 'posts_per_page', 7 );
 		update_option( 'use_smilies', '1' );
 
-		$result = wp_get_ability( 'core/settings' )->execute( array() );
+		$result = wp_get_ability( 'core/read-settings' )->execute( array() );
 
 		$this->assertIsArray( $result );
 		$this->assertSame( 'My Test Site', $result['blogname'] );
@@ -226,11 +227,11 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_filters_by_group(): void {
+	public function test_core_read_settings_filters_by_group(): void {
 		$this->become_admin();
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/settings' )->execute( array( 'group' => 'reading' ) );
+		$result = wp_get_ability( 'core/read-settings' )->execute( array( 'group' => 'reading' ) );
 
 		$this->assertArrayHasKey( 'posts_per_page', $result );
 		$this->assertArrayNotHasKey( 'blogname', $result );
@@ -241,11 +242,11 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_filters_by_fields(): void {
+	public function test_core_read_settings_filters_by_fields(): void {
 		$this->become_admin();
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/settings' )->execute( array( 'fields' => array( 'blogname', 'posts_per_page' ) ) );
+		$result = wp_get_ability( 'core/read-settings' )->execute( array( 'fields' => array( 'blogname', 'posts_per_page' ) ) );
 
 		$this->assertEqualSets( array( 'blogname', 'posts_per_page' ), array_keys( $result ) );
 	}
@@ -255,13 +256,13 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_combines_group_and_fields_filters(): void {
+	public function test_core_read_settings_combines_group_and_fields_filters(): void {
 		$this->become_admin();
 		$this->register_ability();
 
 		// `blogname` is in the `general` group and `posts_per_page` in `reading`; only the
 		// latter satisfies both filters.
-		$result = wp_get_ability( 'core/settings' )->execute(
+		$result = wp_get_ability( 'core/read-settings' )->execute(
 			array(
 				'group'  => 'reading',
 				'fields' => array( 'blogname', 'posts_per_page' ),
@@ -276,11 +277,11 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_requires_manage_options(): void {
+	public function test_core_read_settings_requires_manage_options(): void {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 		$this->register_ability();
 
-		$result = wp_get_ability( 'core/settings' )->execute( array() );
+		$result = wp_get_ability( 'core/read-settings' )->execute( array() );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
@@ -291,21 +292,21 @@ class SettingsTest extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 */
-	public function test_core_settings_exposes_a_custom_registered_setting(): void {
+	public function test_core_read_settings_exposes_a_custom_registered_setting(): void {
 		$this->register_ability();
 
-		$ability = wp_get_ability( 'core/settings' );
+		$ability = wp_get_ability( 'core/read-settings' );
 
 		// Present in both the input `fields` enum and the output schema built at registration.
-		$this->assertContains( 'core_settings_ability_test_option', $ability->get_input_schema()['properties']['fields']['items']['enum'] );
-		$this->assertArrayHasKey( 'core_settings_ability_test_option', $ability->get_output_schema()['properties'] );
+		$this->assertContains( 'core_read_settings_ability_test_option', $ability->get_input_schema()['properties']['fields']['items']['enum'] );
+		$this->assertArrayHasKey( 'core_read_settings_ability_test_option', $ability->get_output_schema()['properties'] );
 
 		// And returned, correctly typed, by execute.
 		$this->become_admin();
-		update_option( 'core_settings_ability_test_option', 7 );
+		update_option( 'core_read_settings_ability_test_option', 7 );
 
-		$result = $ability->execute( array( 'fields' => array( 'core_settings_ability_test_option' ) ) );
+		$result = $ability->execute( array( 'fields' => array( 'core_read_settings_ability_test_option' ) ) );
 
-		$this->assertSame( array( 'core_settings_ability_test_option' => 7 ), $result );
+		$this->assertSame( array( 'core_read_settings_ability_test_option' => 7 ), $result );
 	}
 }

--- a/tests/e2e-testing/e2e-testing.php
+++ b/tests/e2e-testing/e2e-testing.php
@@ -18,7 +18,7 @@ add_action( 'rest_api_init', 'ai_e2e_register_credentials_endpoint' );
 // Mock the HTTP requests and provide known responses.
 add_filter( 'pre_http_request', 'ai_e2e_test_request_mocking', 10, 3 );
 
-// Register a sample setting flagged for the Abilities API, used by the core/settings E2E spec
+// Register a sample setting flagged for the Abilities API, used by the core/read-settings E2E spec
 // to verify the ability exposes settings registered by other active plugins.
 add_action( 'init', 'ai_e2e_register_sample_setting' );
 
@@ -77,7 +77,7 @@ function ai_e2e_clear_credentials() {
 /**
  * Registers a sample setting exposed to the Abilities API.
  *
- * Used by the core/settings E2E spec to verify the ability exposes settings registered
+ * Used by the core/read-settings E2E spec to verify the ability exposes settings registered
  * by other active plugins.
  */
 function ai_e2e_register_sample_setting() {

--- a/tests/e2e/specs/abilities/core-read-settings.spec.js
+++ b/tests/e2e/specs/abilities/core-read-settings.spec.js
@@ -12,7 +12,7 @@ const {
 } = require( '../../utils/helpers' );
 
 /**
- * Runs the `core/settings` ability through the client-side Abilities API, exactly
+ * Runs the `core/read-settings` ability through the client-side Abilities API, exactly
  * as a consumer would in the browser.
  *
  * Mirrors the plugin's own sequence in `src/utils/run-ability.ts`: importing
@@ -28,7 +28,7 @@ const {
  * @param {Object}                          input The ability input.
  * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
  */
-async function runCoreSettings( page, input ) {
+async function runCoreReadSettings( page, input ) {
 	return page.evaluate( async ( abilityInput ) => {
 		const { ready } = await import( '@wordpress/core-abilities' );
 		if ( ready ) {
@@ -39,7 +39,7 @@ async function runCoreSettings( page, input ) {
 
 		try {
 			const result = await executeAbility(
-				'core/settings',
+				'core/read-settings',
 				abilityInput
 			);
 			return { ok: true, result };
@@ -49,7 +49,7 @@ async function runCoreSettings( page, input ) {
 	}, input );
 }
 
-test.describe( 'core/settings ability (client-side Abilities API)', () => {
+test.describe( 'core/read-settings ability (client-side Abilities API)', () => {
 	test.beforeEach( async ( { admin, page } ) => {
 		// Enabling an experiment loads its block-editor script, which declares the
 		// `@wordpress/abilities` + `@wordpress/core-abilities` modules as dependencies
@@ -60,14 +60,14 @@ test.describe( 'core/settings ability (client-side Abilities API)', () => {
 		// Run from the block editor, where the abilities client modules are available.
 		await admin.createNewPost( {
 			postType: 'post',
-			title: 'core/settings ability test',
+			title: 'core/read-settings ability test',
 		} );
 	} );
 
 	test( 'returns a flat, correctly typed map of settings', async ( {
 		page,
 	} ) => {
-		const outcome = await runCoreSettings( page, {} );
+		const outcome = await runCoreReadSettings( page, {} );
 
 		expect( outcome.ok ).toBe( true );
 		// Flat map keyed by setting name (not grouped/nested).
@@ -77,7 +77,7 @@ test.describe( 'core/settings ability (client-side Abilities API)', () => {
 	} );
 
 	test( 'filters by group', async ( { page } ) => {
-		const outcome = await runCoreSettings( page, { group: 'reading' } );
+		const outcome = await runCoreReadSettings( page, { group: 'reading' } );
 
 		expect( outcome.ok ).toBe( true );
 		expect( outcome.result ).toHaveProperty( 'posts_per_page' );
@@ -87,7 +87,7 @@ test.describe( 'core/settings ability (client-side Abilities API)', () => {
 	} );
 
 	test( 'filters by fields', async ( { page } ) => {
-		const outcome = await runCoreSettings( page, {
+		const outcome = await runCoreReadSettings( page, {
 			fields: [ 'blogname', 'posts_per_page' ],
 		} );
 
@@ -103,7 +103,7 @@ test.describe( 'core/settings ability (client-side Abilities API)', () => {
 	} ) => {
 		// `blogname` is in the `general` group and `posts_per_page` in `reading`; only the
 		// latter satisfies both filters.
-		const outcome = await runCoreSettings( page, {
+		const outcome = await runCoreReadSettings( page, {
 			group: 'reading',
 			fields: [ 'blogname', 'posts_per_page' ],
 		} );
@@ -117,7 +117,7 @@ test.describe( 'core/settings ability (client-side Abilities API)', () => {
 	} ) => {
 		// Registered by the `e2e-testing` plugin (mapped in .wp-env.test.json)
 		// with `show_in_abilities` and a default of `sample-default`.
-		const outcome = await runCoreSettings( page, {
+		const outcome = await runCoreReadSettings( page, {
 			fields: [ 'ai_e2e_sample_setting' ],
 		} );
 


### PR DESCRIPTION
## What?
- Renames the read-only settings ability from `core/settings` to `core/read-settings`.
- Keeps behavior, schemas, permissions, and `show_in_abilities` exposure unchanged.
- Updates source comments and tests so the public ability name matches `core/read-content`.

## Commits
1. Start read settings ability rename
2. Abilities: Rename settings ability slug
3. Tests: Update settings ability integration coverage
4. Tests: Rename settings ability E2E spec

## Testing
- `git grep -n -E "core/settings|core-settings|Get Settings" -- .` returns no tracked matches.
- `npm run test:php -- --filter SettingsTest`
- `npm run test:e2e -- tests/e2e/specs/abilities/core-read-settings.spec.js`

Note: the first E2E attempt failed before reaching the spec because the local wp-env site had the AI plugin inactive (`Enable AI` missing / 403). Activating the expected `ai-1` mount fixed the environment, and the rerun passed.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-806-a8e755b5575a807c093aba96670876a933655d85.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->