### PR TITLE
feat: add success notice after saving developer feature settings

### DIFF
--- a/routes/ai-home/hooks/use-developer-feature-settings.ts
+++ b/routes/ai-home/hooks/use-developer-feature-settings.ts
@@ -48,7 +48,7 @@ export function useDeveloperFeatureSettings(
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { __experimentalSaveSpecifiedEntityEdits: saveSpecifiedEdits } =
 		useDispatch( coreStore ) as any;
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
 
 	const rawValue = editedRecord?.[ fieldKey ];
 	const settings: DeveloperFeatureSettings =
@@ -81,6 +81,11 @@ export function useDeveloperFeatureSettings(
 					undefined,
 					[ fieldKey ],
 					{ throwOnError: true }
+				);
+
+				createSuccessNotice(
+					__( 'Developer settings saved successfully.', 'ai' ),
+					{ type: 'snackbar' }
 				);
 			} catch {
 				createErrorNotice(

--- a/routes/ai-home/hooks/use-developer-feature-settings.ts
+++ b/routes/ai-home/hooks/use-developer-feature-settings.ts
@@ -48,7 +48,8 @@ export function useDeveloperFeatureSettings(
 	const { editEntityRecord } = useDispatch( coreStore );
 	const { __experimentalSaveSpecifiedEntityEdits: saveSpecifiedEdits } =
 		useDispatch( coreStore ) as any;
-	const { createErrorNotice, createSuccessNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
 
 	const rawValue = editedRecord?.[ fieldKey ];
 	const settings: DeveloperFeatureSettings =
@@ -94,7 +95,13 @@ export function useDeveloperFeatureSettings(
 				);
 			}
 		},
-		[ fieldKey, editEntityRecord, saveSpecifiedEdits, createErrorNotice ]
+		[
+			fieldKey,
+			editEntityRecord,
+			saveSpecifiedEdits,
+			createErrorNotice,
+			createSuccessNotice,
+		]
 	);
 
 	const update = useCallback(


### PR DESCRIPTION
## What?
Added visual confirmation (success snackbar) when saving or resetting AI developer settings.


## Why?
Previously, users only received an error notice if a settings update failed, but there was no immediate visual feedback upon a successful save, unlike other places in the interface where a success snackbar is shown.

## How?
* Updated the `useDeveloperFeatureSettings` hook to import `createSuccessNotice` alongside `createErrorNotice`.
* Inside the hook's `save` function, a success snackbar (`Developer settings saved successfully.`) is now dispatched.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
AI assistance: Yes
Tool(s): Claude 4.6 sonnet
Used for: Drafting this PR description.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Navigate to the AI Settings page (`/wp-admin/options-general.php?page=ai-wp-admin`).
2. Turn on Developer Mode.
3. Change the Provider and Model selection, then click **Save**. 
4. Verify that a success snackbar appears.
5. Click **Reset to default**.
6. Verify that the settings reset and the success snackbar appears again.

## Screenshots or screencast

https://github.com/user-attachments/assets/4e2fe89b-8dbc-4eac-b51f-22091917503b


## Changelog Entry
> Changed - Added success snackbar when saving or resetting AI developer settings.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-807-a9c427512d50d7aa319382c075b3f51a26e6ab0f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->