### PR TITLE
Increase gh actions runner timeout for E2E tests completion

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,6 +357,9 @@ jobs:
           command: |
             npm run wp-env:test start
 
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps
+
       - name: Run E2E tests
         run: npm run test:e2e
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,9 +357,6 @@ jobs:
           command: |
             npm run wp-env:test start
 
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps
-
       - name: Run E2E tests
         run: npm run test:e2e
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Developer: Increases GH action runner timeout from 20 minutes to 30 minutes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Presently any new PR that aims to add more E2E tests will fail to run all tests.
- This is because the gh-actions runner takes a total of `19m 43s` to completely run. (From last identified successful action run completion)
- As this is very close to the `20m` timeout, new PR jobs will fail when adding additional E2E tests.
  - https://github.com/WordPress/ai/actions/runs/28453990663/job/84324826069?pr=739 (cancelled in 20m 16s)
  - https://github.com/WordPress/ai/actions/runs/28508379230/job/84502348297?pr=810 (cancelled in 20m 17s)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Increased the `timeout-minutes` in `test.yml` to **30 minutes** (from 20m).
- Identified root cause with the assistance of @yogeshbhutkar 

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: No

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
Rerun existing cancelled jobs in PRs such as #810  

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Developer - Increased test timeout from 20m to 30m.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-811-bc428feac6f6b9c4ed512c9cf1a2ee9bfc5ecea0.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->