### PR TITLE
Fix[Settings]: Improve focus restoration after AI settings saves

### DIFF
--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -56,6 +56,20 @@ export function DeveloperSettings( {
 		useState< DeveloperSelection | null >( null );
 	const [ isSavingThis, setIsSavingThis ] = useState( false );
 
+	const focusResetButtonRef = useRef( false );
+
+	const moveFocusToResetButton = ( node: HTMLButtonElement | null ) => {
+		if (
+			focusResetButtonRef.current &&
+			node &&
+			! isSavingThis &&
+			! hasUnsavedChanges
+		) {
+			node.focus();
+			focusResetButtonRef.current = false;
+		}
+	};
+
 	useEffect( () => {
 		if ( ! isSaving ) {
 			setIsSavingThis( false );
@@ -212,7 +226,10 @@ export function DeveloperSettings( {
 						{ ( hasUnsavedChanges || isSavingThis ) && (
 							<Button
 								variant="primary"
-								onClick={ handleSave }
+								onClick={ () => {
+									handleSave();
+									focusResetButtonRef.current = true;
+								} }
 								disabled={ isSavingThis || ! hasUnsavedChanges }
 								isBusy={ isSavingThis }
 								accessibleWhenDisabled
@@ -236,6 +253,7 @@ export function DeveloperSettings( {
 								} }
 								disabled={ isSavingThis }
 								accessibleWhenDisabled
+								ref={ moveFocusToResetButton }
 							>
 								{ __( 'Reset to default', 'ai' ) }
 							</Button>

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -23,7 +23,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
 import { DataForm } from '@wordpress/dataviews';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	check as checkIcon,
@@ -486,6 +486,16 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 	const { createSuccessNotice, createErrorNotice } =
 		useDispatch( noticesStore );
 
+	const dataFormRef = useRef< HTMLDivElement >( null );
+
+	const moveFocusToLastFormElement = () => {
+		const elements =
+			dataFormRef.current?.querySelectorAll< HTMLElement >(
+				'select, input, textarea'
+			) ?? [];
+		elements[ elements.length - 1 ]?.focus();
+	};
+
 	const data = useMemo( () => {
 		const base: Record< string, unknown > = {};
 		for ( const field of feature.settingsFields ) {
@@ -532,6 +542,8 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 				),
 				{ type: 'snackbar' }
 			);
+
+			moveFocusToLastFormElement();
 		} catch {
 			// Edits remain in the store — user can retry or adjust values.
 			createErrorNotice( __( 'Failed to save settings.', 'ai' ), {
@@ -550,12 +562,14 @@ function InlineFeatureSettings( { feature }: { feature: FeatureData } ) {
 
 	return (
 		<Stack direction="column" gap="md" className="ai-feature-settings-form">
-			<DataForm< Record< string, unknown > >
-				data={ data }
-				fields={ fields }
-				form={ form }
-				onChange={ handleChange }
-			/>
+			<div ref={ dataFormRef }>
+				<DataForm< Record< string, unknown > >
+					data={ data }
+					fields={ fields }
+					form={ form }
+					onChange={ handleChange }
+				/>
+			</div>
 			{ isDirty && (
 				<Stack align="flex-end" direction="row">
 					<Button


### PR DESCRIPTION
## What, Why, and How?

Similar to https://github.com/WordPress/ai/pull/532

This PR adds an interim focus-management fix for AI settings flows where the Save button disappears after saving. It restores keyboard focus to a related remaining control: the last inline settings field for inline feature settings, and “Reset to default” for developer model selection when that button is available. This avoids leaving keyboard and assistive technology users focused on an unmounted Save button.

This is not the ideal long-term UX. Disappearing action UI is inherently less predictable, and the settings page currently mixes save models: feature toggles and “Reset to default” save immediately, while developer settings and inline feature settings use explicit Save buttons. A better follow-up would be to unify settings changes through a shared store and provide one persistent Save action in the header, so all updates follow the same interaction model.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Reviewing the code.

## Testing Instructions
1. In the AI settings page, change an inline feature setting and click Save. 
2. Confirm focus returns to the last field in that settings form.
3. Enable model selection, choose a provider/model, and click Save. 
4. Confirm focus moves to “Reset to default” after Save disappears.

## Screencast

https://github.com/user-attachments/assets/b069093d-e29c-4e89-8892-a00c1fdaf744

## Changelog Entry

> Fixed - focus restoration after AI settings saves.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-812-fde2a7f6d2dde8052d45d47e577ad29d021d613f.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->