### PR TITLE
refactor: migrate excerpt generation e2e tests to use Playwright loca…

### DIFF
--- a/tests/e2e/specs/experiments/excerpt-generation.spec.js
+++ b/tests/e2e/specs/experiments/excerpt-generation.spec.js
@@ -66,7 +66,10 @@ test.describe( 'Excerpt Generation Experiment', () => {
 		).toBeVisible();
 
 		// Click the generate excerpt button.
-		await page.getByRole( 'button', { name: 'Generate excerpt' } ).last().click();
+		await page
+			.getByRole( 'button', { name: 'Generate excerpt' } )
+			.last()
+			.click();
 
 		// Ensure the excerpt is updated.
 		await expect(
@@ -86,7 +89,9 @@ test.describe( 'Excerpt Generation Experiment', () => {
 			.fill( '' );
 
 		// Close the modal.
-		await page.getByRole( 'button', { name: 'Close', exact: true } ).click();
+		await page
+			.getByRole( 'button', { name: 'Close', exact: true } )
+			.click();
 
 		// Click the generate excerpt inline button.
 		await page
@@ -126,14 +131,22 @@ test.describe( 'Excerpt Generation Experiment', () => {
 		// Ensure the sidebar is visible.
 		await editor.openDocumentSettingsSidebar();
 
-		const inlineButton = page.getByRole( 'button', { name: /Excerpt generation will be available when the post content has at least/i } ).first();
+		const inlineButton = page
+			.getByRole( 'button', {
+				name: /Excerpt generation will be available when the post content has at least/i,
+			} )
+			.first();
 		await expect( inlineButton ).toBeVisible();
 		await expect( inlineButton ).toBeDisabled();
 
 		// The panel button inside the excerpt dropdown is also disabled.
 		await page.getByRole( 'button', { name: /Add an excerpt/i } ).click();
 		await expect(
-			page.getByRole( 'button', { name: /Excerpt generation will be available when the post content has at least/i } ).last()
+			page
+				.getByRole( 'button', {
+					name: /Excerpt generation will be available when the post content has at least/i,
+				} )
+				.last()
 		).toBeDisabled();
 	} );
 

--- a/tests/e2e/specs/experiments/excerpt-generation.spec.js
+++ b/tests/e2e/specs/experiments/excerpt-generation.spec.js
@@ -54,75 +54,52 @@ test.describe( 'Excerpt Generation Experiment', () => {
 
 		// Ensure the generate excerpt inline button exists.
 		await expect(
-			page.locator(
-				'.editor-post-excerpt__dropdown .ai-excerpt-inline-wrapper .ai-excerpt-inline-button'
-			)
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).first()
 		).toBeVisible();
 
 		// Click the Add excerpt button.
-		await page
-			.locator( '.editor-post-excerpt__dropdown button' )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: /Add an excerpt/i } ).click();
 
 		// Ensure the generate excerpt button shows in the modal.
 		await expect(
-			page.locator( '.ai-excerpt-generation button' )
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).last()
 		).toBeVisible();
 
 		// Click the generate excerpt button.
-		await page.locator( '.ai-excerpt-generation button' ).click();
+		await page.getByRole( 'button', { name: 'Generate excerpt' } ).last().click();
 
 		// Ensure the excerpt is updated.
 		await expect(
-			page.locator(
-				'.editor-post-excerpt .editor-post-excerpt__textarea textarea'
-			)
+			page.getByRole( 'textbox', { name: 'Write an excerpt (optional)' } )
 		).toHaveValue(
 			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure'
 		);
 
 		// Ensure the excerpt button text is updated.
 		await expect(
-			page.locator( '.ai-excerpt-generation button' )
-		).toHaveText( 'Regenerate excerpt' );
+			page.getByRole( 'button', { name: 'Regenerate excerpt' } ).last()
+		).toBeVisible();
 
 		// Delete the excerpt.
 		await page
-			.locator(
-				'.editor-post-excerpt .editor-post-excerpt__textarea textarea'
-			)
+			.getByRole( 'textbox', { name: 'Write an excerpt (optional)' } )
 			.fill( '' );
 
 		// Close the modal.
-		await page
-			.locator(
-				'.editor-post-excerpt__dropdown__content .block-editor-inspector-popover-header button'
-			)
-			.click();
+		await page.getByRole( 'button', { name: 'Close', exact: true } ).click();
 
 		// Click the generate excerpt inline button.
 		await page
-			.locator(
-				'.editor-post-excerpt__dropdown .ai-excerpt-inline-wrapper .ai-excerpt-inline-button'
-			)
+			.getByRole( 'button', { name: 'Generate excerpt' } )
+			.first()
 			.click();
 
 		// Ensure the excerpt is updated.
-		const excerptDropdownLocator = page.locator(
-			'.editor-post-excerpt__dropdown'
-		);
-		const excerptParentLocator = page
-			.locator(
-				'.editor-post-panel__section .components-h-stack .components-h-stack'
-			)
-			.filter( { has: excerptDropdownLocator } );
-
 		await expect(
-			excerptParentLocator.locator( '.components-text' ).first()
-		).toHaveText(
-			'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure'
-		);
+			page.getByText(
+				'Edit or Delete Your First WordPress Post to Begin Your Blogging Adventure'
+			)
+		).toBeVisible();
 
 		// Save the post.
 		await editor.saveDraft();
@@ -149,20 +126,15 @@ test.describe( 'Excerpt Generation Experiment', () => {
 		// Ensure the sidebar is visible.
 		await editor.openDocumentSettingsSidebar();
 
-		const inlineButton = page.locator(
-			'.editor-post-excerpt__dropdown .ai-excerpt-inline-wrapper .ai-excerpt-inline-button'
-		);
+		const inlineButton = page.getByRole( 'button', { name: /Excerpt generation will be available when the post content has at least/i } ).first();
 		await expect( inlineButton ).toBeVisible();
-		await expect( inlineButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		await expect( inlineButton ).toBeDisabled();
 
 		// The panel button inside the excerpt dropdown is also disabled.
-		await page
-			.locator( '.editor-post-excerpt__dropdown button' )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: /Add an excerpt/i } ).click();
 		await expect(
-			page.locator( '.ai-excerpt-generation button' )
-		).toHaveAttribute( 'aria-disabled', 'true' );
+			page.getByRole( 'button', { name: /Excerpt generation will be available when the post content has at least/i } ).last()
+		).toBeDisabled();
 	} );
 
 	test( 'Ensure the Excerpt Generation Experiment UI is not visible when Experiments are globally disabled', async ( {
@@ -192,20 +164,15 @@ test.describe( 'Excerpt Generation Experiment', () => {
 
 		// Ensure the generate excerpt inline button doesn't exist.
 		await expect(
-			page.locator(
-				'.editor-post-excerpt__dropdown .ai-excerpt-inline-wrapper .ai-excerpt-inline-button'
-			)
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).first()
 		).not.toBeVisible();
 
 		// Click the Add excerpt button.
-		await page
-			.locator( '.editor-post-excerpt__dropdown button' )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: /Add an excerpt/i } ).click();
 
 		// Ensure the generate excerpt button doesn't show in the modal.
 		await expect(
-			page.locator( '.ai-excerpt-generation button' )
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).last()
 		).not.toBeVisible();
 	} );
 
@@ -236,20 +203,15 @@ test.describe( 'Excerpt Generation Experiment', () => {
 
 		// Ensure the generate excerpt inline button doesn't exist.
 		await expect(
-			page.locator(
-				'.editor-post-excerpt__dropdown .ai-excerpt-inline-wrapper .ai-excerpt-inline-button'
-			)
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).first()
 		).not.toBeVisible();
 
 		// Click the Add excerpt button.
-		await page
-			.locator( '.editor-post-excerpt__dropdown button' )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: /Add an excerpt/i } ).click();
 
 		// Ensure the generate excerpt button doesn't show in the modal.
 		await expect(
-			page.locator( '.ai-excerpt-generation button' )
+			page.getByRole( 'button', { name: 'Generate excerpt' } ).last()
 		).not.toBeVisible();
 	} );
 } );


### PR DESCRIPTION
## What, Why, and How?

Part of https://github.com/WordPress/ai/issues/778

This PR updates the Excerpt Generation E2E tests (`tests/e2e/specs/experiments/excerpt-generation.spec.js`) to follow Playwright's recommended best practices. It replaces brittle CSS selectors and DOM structure-dependent locators with resilient, user-facing locators such as `getByRole`, `getByText`, and other accessibility-based queries.

### Changes

- Replaced CSS and DOM structure-dependent selectors with Playwright user-facing attributes.

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Model(s):** Sonnet 4.6
**Used for:** Code review, PR description

## Testing Instructions

Verify that CI passes, or run the updated E2E test locally:

```bash
npm run test:e2e tests/e2e/specs/experiments/excerpt-generation.spec.js
```

## Changelog Entry

> Developer: Updated Excerpt Generation E2E selectors to use Playwright user-facing attributes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-813-f4b207e1c9ce774fc964eb2f2652549c298bc82e.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->