### PR TITLE
Fix image ALT text issue

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -656,7 +656,7 @@ function VisualCardToggle( {
 			}` }
 		>
 			{ feature?.image && (
-				<img alt="" loading="lazy" src={ feature.image } />
+				<img alt={ feature.label } loading="lazy" src={ feature.image } />
 			) }
 			<Card.Content>
 				<ToggleControl

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -656,7 +656,11 @@ function VisualCardToggle( {
 			}` }
 		>
 			{ feature?.image && (
-				<img alt={ feature.label } loading="lazy" src={ feature.image } />
+				<img
+					alt={ feature.label }
+					loading="lazy"
+					src={ feature.image }
+				/>
 			) }
 			<Card.Content>
 				<ToggleControl


### PR DESCRIPTION
## What?
Fixed: #818

## Why?
The feature card image on the AI Home stage rendered with an empty `alt` attribute (`alt=""`), which marks the image as decorative. Since the image illustrates the feature the card represents, it carries meaningful content and should expose an accessible name. As written, screen reader users get no information about the image, failing WCAG 1.1.1 (Non-text Content).

## How?
Set the image's `alt` attribute to the feature's label so it exposes a meaningful, human-readable description instead of an empty string:

```diff
- <img alt="" loading="lazy" src={ feature.image } />
+ <img alt={ feature.label } loading="lazy" src={ feature.image } />
```

`feature.label` is already the user-facing name for the card's feature, so it stays in sync with the displayed content and is localized alongside the rest of the card.

### Use of AI Tools
No

## Testing Instructions
1. Open the AI Home settings screen where the feature/showcase cards are displayed.
2. Inspect a feature card image in the browser DevTools.
3. Confirm the `<img>` now has a non-empty `alt` attribute matching the feature's label (e.g. `alt="<Feature name>"`).
4. Optionally, verify with a screen reader (VoiceOver / NVDA) that the image announces the feature label rather than being skipped or read as an empty/decorative image.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| `<img alt="">` | `<img alt="<Feature label>">` |

## Changelog Entry

> Fixed - Added descriptive alt text to AI Home feature card images for improved screen reader accessibility.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-819-66e50d3396246482f4240526bfe4c6238df6fb74.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->