### PR TITLE
refactor: Update `alt-text-generation` e2e selectors to use ARIA roles

### DIFF
--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -197,7 +197,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 
 		// Ensure the generated alt text is not visible.
 		await expect(
-			page.getByLabel( 'Generated Alt Text' )
+			page.locator( '.ai-alt-text-controls textarea' )
 		).not.toBeVisible();
 
 		// Save the post.

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -196,7 +196,9 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await page.getByRole( 'button', { name: 'Dismiss' } ).click();
 
 		// Ensure the generated alt text is not visible.
-		await expect( page.getByLabel( 'Generated Alt Text' ) ).not.toBeVisible();
+		await expect(
+			page.getByLabel( 'Generated Alt Text' )
+		).not.toBeVisible();
 
 		// Save the post.
 		await editor.saveDraft();

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -53,25 +53,19 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=grid' );
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is visible and says Generate
 		await expect(
-			page.locator( '#ai-alt-text-generate-button', {
-				hasText: 'Generate',
-			} )
+			page.getByRole( 'button', { name: 'Generate' } )
 		).toBeVisible();
 
 		// Click the alt text generation button.
-		await page.locator( '#ai-alt-text-generate-button' ).click();
+		await page.getByRole( 'button', { name: 'Generate' } ).click();
 
 		// Ensure the alt text generation button now says Regenerate
 		await expect(
-			page.locator( '#ai-alt-text-generate-button', {
-				hasText: 'Regenerate',
-			} )
+			page.getByRole( 'button', { name: 'Regenerate' } )
 		).toBeVisible();
 
 		// Ensure the alt text textarea is visible.
@@ -120,30 +114,24 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		// Click the Media Library button in the image block.
 		const imageBlock = editor.canvas.locator( '.wp-block-image' ).first();
 		const mediaLibraryButton = imageBlock
-			.locator( 'button', { hasText: 'Media Library' } )
+			.getByRole( 'button', { name: 'Media Library' } )
 			.first();
 		await mediaLibraryButton.click();
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is visible and says Generate
 		await expect(
-			page.locator( '#ai-alt-text-generate-button', {
-				hasText: 'Generate',
-			} )
+			page.getByRole( 'button', { name: 'Generate' } )
 		).toBeVisible();
 
 		// Click the alt text generation button.
-		await page.locator( '#ai-alt-text-generate-button' ).click();
+		await page.getByRole( 'button', { name: 'Generate' } ).click();
 
 		// Ensure the alt text generation button now says Regenerate
 		await expect(
-			page.locator( '#ai-alt-text-generate-button', {
-				hasText: 'Regenerate',
-			} )
+			page.getByRole( 'button', { name: 'Regenerate' } )
 		).toBeVisible();
 
 		// Ensure the alt text textarea is visible.
@@ -159,72 +147,56 @@ test.describe( 'Alt Text Generation Experiment', () => {
 
 		// Click the Select button.
 		await page
-			.locator( '.media-frame-toolbar button', { hasText: 'Select' } )
+			.getByRole( 'button', { name: 'Select', exact: true } )
 			.click();
 
 		// Clear the alt text textarea.
-		await page
-			.locator( '.components-tools-panel textarea' )
-			.first()
-			.fill( '' );
+		await page.getByLabel( 'Alternative text' ).first().fill( '' );
 
 		// Ensure the Generate button is visible in the sidebar.
 		await expect(
-			page.locator( '.ai-alt-text-controls button', {
-				hasText: 'Generate Alt Text',
-			} )
+			page.getByRole( 'button', { name: 'Generate Alt Text' } )
 		).toBeVisible();
 
 		// Click the Generate button.
-		await page.locator( '.ai-alt-text-controls button' ).click();
+		await page.getByRole( 'button', { name: 'Generate Alt Text' } ).click();
 
 		// Ensure the generated alt text shows in the textarea.
-		await expect(
-			page.locator( '.ai-alt-text-controls textarea' )
-		).toHaveValue( /Edit or Delete Your First WordPress Post/ );
+		await expect( page.getByLabel( 'Generated Alt Text' ) ).toHaveValue(
+			/Edit or Delete Your First WordPress Post/
+		);
 
 		// Click the Apply button.
 		await page
-			.locator( '.ai-alt-text-controls button', { hasText: 'Apply' } )
+			.getByRole( 'button', { name: 'Apply', exact: true } )
 			.click();
 
 		// Ensure the generated alt text shows in the textarea.
 		await expect(
-			page.locator( '.components-tools-panel textarea' ).first()
+			page.getByLabel( 'Alternative text' ).first()
 		).toHaveValue( /Edit or Delete Your First WordPress Post/ );
 
 		// Ensure the generate button text is updated.
 		await expect(
-			page.locator( '.ai-alt-text-controls button', {
-				hasText: 'Regenerate Alt Text',
-			} )
+			page.getByRole( 'button', { name: 'Regenerate Alt Text' } )
 		).toBeVisible();
 
 		// Remove alt text.
-		await page
-			.locator( '.components-tools-panel textarea' )
-			.first()
-			.fill( '' );
+		await page.getByLabel( 'Alternative text' ).first().fill( '' );
 
 		// Ensure the generate button text is updated.
 		await expect(
-			page.locator( '.ai-alt-text-controls button', {
-				hasText: 'Generate Alt Text',
-			} )
+			page.getByRole( 'button', { name: 'Generate Alt Text' } )
 		).toBeVisible();
 
 		// Generate alt text again.
-		await page.locator( '.ai-alt-text-controls button' ).click();
+		await page.getByRole( 'button', { name: 'Generate Alt Text' } ).click();
 
 		// Click the Dismiss button.
-		await page
-			.locator( '.ai-alt-text-controls button', { hasText: 'Dismiss' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Dismiss' } ).click();
 
 		// Ensure the generated alt text is not visible.
-		await expect(
-			page.locator( '.ai-alt-text-controls textarea' )
-		).not.toBeVisible();
+		await expect( page.getByLabel( 'Generated Alt Text' ) ).toBeHidden();
 
 		// Save the post.
 		await editor.saveDraft();
@@ -249,14 +221,12 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=grid' );
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is not visible.
 		await expect(
-			page.locator( '#ai-alt-text-generate-button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate' } )
+		).toBeHidden();
 
 		// Create a new post.
 		await admin.createNewPost( {
@@ -277,29 +247,27 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		// Click the Media Library button in the image block.
 		const imageBlock = editor.canvas.locator( '.wp-block-image' ).first();
 		const mediaLibraryButton = imageBlock
-			.locator( 'button', { hasText: 'Media Library' } )
+			.getByRole( 'button', { name: 'Media Library' } )
 			.first();
 		await mediaLibraryButton.click();
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is not visible.
 		await expect(
-			page.locator( '#ai-alt-text-generate-button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate' } )
+		).toBeHidden();
 
 		// Click the Select button.
 		await page
-			.locator( '.media-frame-toolbar button', { hasText: 'Select' } )
+			.getByRole( 'button', { name: 'Select', exact: true } )
 			.click();
 
 		// Ensure the Generate button is not visible in the sidebar.
 		await expect(
-			page.locator( '.ai-alt-text-controls button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate Alt Text' } )
+		).toBeHidden();
 
 		await editor.saveDraft();
 	} );
@@ -323,14 +291,12 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=grid' );
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is not visible.
 		await expect(
-			page.locator( '#ai-alt-text-generate-button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate' } )
+		).toBeHidden();
 
 		// Create a new post.
 		await admin.createNewPost( {
@@ -351,29 +317,27 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		// Click the Media Library button in the image block.
 		const imageBlock = editor.canvas.locator( '.wp-block-image' ).first();
 		const mediaLibraryButton = imageBlock
-			.locator( 'button', { hasText: 'Media Library' } )
+			.getByRole( 'button', { name: 'Media Library' } )
 			.first();
 		await mediaLibraryButton.click();
 
 		// Click on the first image in the Media Library.
-		await page
-			.locator( '.media-frame-content ul.attachments li:first-child' )
-			.click();
+		await page.getByRole( 'checkbox' ).first().click();
 
 		// Ensure the alt text generation button is not visible.
 		await expect(
-			page.locator( '#ai-alt-text-generate-button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate' } )
+		).toBeHidden();
 
 		// Click the Select button.
 		await page
-			.locator( '.media-frame-toolbar button', { hasText: 'Select' } )
+			.getByRole( 'button', { name: 'Select', exact: true } )
 			.click();
 
 		// Ensure the Generate button is not visible in the sidebar.
 		await expect(
-			page.locator( '.ai-alt-text-controls button' )
-		).not.toBeVisible();
+			page.getByRole( 'button', { name: 'Generate Alt Text' } )
+		).toBeHidden();
 
 		await editor.saveDraft();
 	} );
@@ -396,7 +360,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=list' );
 
 		// Verify the bulk actions dropdown contains the Generate Alt Text option.
-		const bulkSelect = page.locator( '#bulk-action-selector-top' );
+		const bulkSelect = page.getByLabel( 'Select bulk action' ).first();
 		await expect( bulkSelect ).toBeVisible();
 		await expect(
 			bulkSelect.locator( 'option[value="wpai_generate_alt_text"]' )
@@ -422,15 +386,19 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=list' );
 
 		// Select all items via the header checkbox.
-		await page.locator( '#cb-select-all-1' ).check();
+		await page
+			.getByRole( 'checkbox', { name: 'Select All' } )
+			.first()
+			.check();
 
 		// Choose the bulk action.
 		await page
-			.locator( '#bulk-action-selector-top' )
+			.getByLabel( 'Select bulk action' )
+			.first()
 			.selectOption( 'wpai_generate_alt_text' );
 
 		// Click Apply.
-		await page.locator( '#doaction' ).click();
+		await page.getByRole( 'button', { name: 'Apply' } ).first().click();
 
 		// After redirect, the progress notice should appear.
 		await expect(
@@ -472,15 +440,19 @@ test.describe( 'Alt Text Generation Experiment', () => {
 			await admin.visitAdminPage( 'upload.php', 'mode=list' );
 
 			// Select all items via the header checkbox.
-			await page.locator( '#cb-select-all-1' ).check();
+			await page
+				.getByRole( 'checkbox', { name: 'Select All' } )
+				.first()
+				.check();
 
 			// Choose the bulk action.
 			await page
-				.locator( '#bulk-action-selector-top' )
+				.getByLabel( 'Select bulk action' )
+				.first()
 				.selectOption( 'wpai_generate_alt_text' );
 
 			// Click Apply.
-			await page.locator( '#doaction' ).click();
+			await page.getByRole( 'button', { name: 'Apply' } ).first().click();
 
 			await expect(
 				page.locator( '.notice-error p', {
@@ -515,13 +487,17 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=list' );
 
 		// Select all items.
-		await page.locator( '#cb-select-all-1' ).check();
+		await page
+			.getByRole( 'checkbox', { name: 'Select All' } )
+			.first()
+			.check();
 
 		// Choose the bulk action and apply.
 		await page
-			.locator( '#bulk-action-selector-top' )
+			.getByLabel( 'Select bulk action' )
+			.first()
 			.selectOption( 'wpai_generate_alt_text' );
-		await page.locator( '#doaction' ).click();
+		await page.getByRole( 'button', { name: 'Apply' } ).first().click();
 
 		// Wait for completion.
 		await expect(
@@ -554,7 +530,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await admin.visitAdminPage( 'upload.php', 'mode=list' );
 
 		// Verify the bulk actions dropdown does NOT contain the Generate Alt Text option.
-		const bulkSelect = page.locator( '#bulk-action-selector-top' );
+		const bulkSelect = page.getByLabel( 'Select bulk action' ).first();
 		await expect( bulkSelect ).toBeVisible();
 		await expect(
 			bulkSelect.locator( 'option[value="wpai_generate_alt_text"]' )

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -193,7 +193,9 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await page.getByRole( 'button', { name: 'Generate Alt Text' } ).click();
 
 		// Click the Dismiss button.
-		await page.getByRole( 'button', { name: 'Dismiss' } ).click();
+		await page
+			.locator( '.ai-alt-text-controls button', { hasText: 'Dismiss' } )
+			.click();
 
 		// Ensure the generated alt text is not visible.
 		await expect(

--- a/tests/e2e/specs/experiments/alt-text-generation.spec.js
+++ b/tests/e2e/specs/experiments/alt-text-generation.spec.js
@@ -196,7 +196,7 @@ test.describe( 'Alt Text Generation Experiment', () => {
 		await page.getByRole( 'button', { name: 'Dismiss' } ).click();
 
 		// Ensure the generated alt text is not visible.
-		await expect( page.getByLabel( 'Generated Alt Text' ) ).toBeHidden();
+		await expect( page.getByLabel( 'Generated Alt Text' ) ).not.toBeVisible();
 
 		// Save the post.
 		await editor.saveDraft();


### PR DESCRIPTION
## What, Why, and How?

Part of https://github.com/WordPress/ai/issues/778

This PR updates the alt-text-generation E2E tests (`tests/e2e/specs/experiments/alt-text-generation.spec.js`) to follow Playwright's recommended best practices. It replaces brittle CSS selectors and DOM structure-dependent locators with resilient, user-facing locators such as `getByRole`, `getByText`, and other accessibility-based queries.

### Changes

- Replaced CSS and DOM structure-dependent selectors with Playwright user-facing attributes.

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Model(s):** Sonnet 4.6
**Used for:** Code review, PR description

## Testing Instructions

Verify that CI passes, or run the updated E2E test locally:

```bash
npm run test:e2e tests/e2e/specs/experiments/alt-text-generation.spec.js
```

## Changelog Entry

> Developer: Updated `alt-text-generation` E2E selectors to use Playwright user-facing attributes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-828-91bfcb680216ffa0fb4e497d308e8ee60afe4472.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->