### PR TITLE
feat: add "Copy" button to Title Generation modal

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbar.tsx
+++ b/src/experiments/title-generation/components/TitleToolbar.tsx
@@ -24,6 +24,7 @@ import { store as noticesStore } from '@wordpress/notices';
 /**
  * Internal dependencies
  */
+import { useCopyToClipboardFeedback } from '../../../hooks/use-copy-to-clipboard-feedback';
 import { runAbility } from '../../../utils/run-ability';
 import { ensureProvider } from '../../../utils/provider-status';
 import { hasMinimumContent } from '../../../utils/character-count';
@@ -111,6 +112,12 @@ export default function TitleToolbar( {
 	const [ isRegenerating, setIsRegenerating ] = useState< boolean >( false );
 	const [ isOpen, setOpen ] = useState< boolean >( false );
 	const [ generatedTitle, setGeneratedTitle ] = useState< string >( '' );
+
+	const { ref: copyButtonRef, hasCopied } =
+		useCopyToClipboardFeedback< HTMLButtonElement >( {
+			text: generatedTitle,
+			announcement: __( 'Title copied to clipboard.', 'ai' ),
+		} );
 
 	const generateButtonRef = useRef< HTMLButtonElement | null >( null );
 
@@ -308,6 +315,18 @@ export default function TitleToolbar( {
 						gap="3"
 						className="ai-title-generation-actions"
 					>
+						<FlexItem>
+							<Button
+								ref={ copyButtonRef }
+								variant="tertiary"
+								disabled={ isRegenerating || ! generatedTitle }
+								__next40pxDefaultSize
+							>
+								{ hasCopied
+									? __( 'Copied!', 'ai' )
+									: __( 'Copy', 'ai' ) }
+							</Button>
+						</FlexItem>
 						<FlexItem>
 							<Button
 								accessibleWhenDisabled


### PR DESCRIPTION
### Description

This PR introduces a **"Copy"** button to the AI Title Generation modal, utilizing the `useCopyToClipboardFeedback` hook. 

The primary motivation for this enhancement is to bring the UX of the Title Generation feature close to the **Generate Meta Description** feature, ensuring a more unified and consistent experience across the AI tooling suite.

### Why?

* **Improved UX Consistency:** Aligns the Title Generation interface with the Meta Description generator.
* **Enhanced Workflow Flexibility:** Users can now easily copy a generated title to use elsewhere.

### Changes Made

* **`TitleToolbar.tsx`**: 
  * Imported and implemented the `useCopyToClipboardFeedback` hook.
  * Added a new tertiary `<Button>` to the modal's action flex container to handle the copy action.
  * Bound the generated title state to the clipboard hook.
  
### Screenshots or screencast

https://github.com/user-attachments/assets/f431f2b6-e60b-481d-bdb0-b3065f5949b7

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Model(s):** Sonnet 4.6
**Used for:** Code review, PR description

## Changelog Entry

> **Enhancement**: Added a "Copy" button to the Title Generation modal.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-829-d1d4d9d6b32d47d9e0b036c4a2540f3e9076eac1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->