### PR TITLE
Fix[Type-ahead]: Prevent suggestions from restarting right after `Escape` dismissal

### DIFF
--- a/src/experiments/type-ahead/hooks/useCaretData.ts
+++ b/src/experiments/type-ahead/hooks/useCaretData.ts
@@ -33,7 +33,19 @@ export const useCaretData = (
 		const win = doc.defaultView || window;
 		const viewport = win?.visualViewport;
 
-		const update = () => {
+		const update = ( event?: Event ) => {
+			// Escape is handled on keydown to dismiss suggestions and should not change
+			// caret data; ignore its keyup so dismissing does not immediately restart the
+			// caret-driven suggestion flow.
+			if (
+				event &&
+				event.type === 'keyup' &&
+				'key' in event &&
+				event.key === 'Escape'
+			) {
+				return;
+			}
+
 			const selection = doc.getSelection();
 			if ( ! selection || selection.rangeCount === 0 ) {
 				setCaret( null );


### PR DESCRIPTION
## What?

Closes https://github.com/WordPress/ai/issues/839

This PR prevents dismissed type-ahead suggestions from immediately restarting after pressing `Escape` to honour the user's intent.

## Why?

`Escape` means the user is rejecting the current suggestion. It should dismiss the ghost text without triggering another suggestion request on `Escape`'s keyup, until the user provides new writing input.

## How?

Ignores the Escape keyup event in caret tracking, since Escape is already handled on keydown for dismissal and does not change caret data.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review.

## Testing Instructions

1. Enable the Type-ahead Text experiment.
2. Create or edit a post.
3. Type in a paragraph block until a type-ahead suggestion appears.
4. Press Escape.
5. Confirm the suggestion is dismissed and does not immediately reappear.
6. Type another character at the end of the paragraph or press `Ctrl + Space` for a manual trigger.
7. Confirm type-ahead suggestions can be generated again after the new input.

## Screencast

https://github.com/user-attachments/assets/ea919b1d-1276-4806-951b-f4c72dba88bf

## Changelog Entry

> Fixed - Dismissing a type-ahead suggestion with `Escape` should not trigger a new suggestion request

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-840-d0eddd98e4a035058021b883fd0154537feca347.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->