### PR TITLE
CI: Do not run `build-plugin-zip` when PR metadata changes

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -2,7 +2,7 @@ name: Build Plugin Zip
 
 on:
   pull_request:
-    types: ['opened', 'synchronize', 'reopened', 'edited']
+    types: ['opened', 'synchronize', 'reopened']
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:


### PR DESCRIPTION
## What, Why, and How?

While working on other PRs, I noticed that build-plugin-zip reruns for PR metadata-only changes, such as title or description edits. Each run takes about three minutes, and since the generated artifact depends on the PR code rather than PR metadata, repeated edits can waste CI time. This change limits the workflow to code-relevant PR events (opened, synchronize, and reopened), matching [Gutenberg’s corresponding workflow](https://github.com/WordPress/gutenberg/blob/trunk/.github/workflows/build-plugin-zip.yml), which uses the default pull_request activity types.

P.S. edited also runs when the PR base branch changes. If we decide that base-branch changes should still rebuild the plugin ZIP (which I don't think is required), we can keep edited and add an if guard so only that specific edit path triggers the workflow.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review

## Testing Instructions
- CI should be green.
- Changing PR metadata should not trigger `build-plugin-zip`.

## Changelog Entry
> Fixed - Prevent unnecessary plugin ZIP rebuilds when a pull request metadata is edited

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-841-a5bcb0e8f9401085dee0a0020cfe920257da34dd.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->