### PR TITLE
Type Ahead: Fix ghost text placement and empty-block placeholder overlap

### DIFF
--- a/src/experiments/type-ahead/components/TypeAheadOverlay.tsx
+++ b/src/experiments/type-ahead/components/TypeAheadOverlay.tsx
@@ -20,6 +20,25 @@ type TypeAheadOverlayProps = {
 };
 
 /**
+ * Check whether a rect is inside a container rect.
+ *
+ * @param {DOMRect} innerRect     Inner rect.
+ * @param {DOMRect} containerRect Container rect.
+ * @return {boolean} True if the inner rect is inside the container.
+ */
+const isRectInsideContainer = (
+	innerRect: DOMRect,
+	containerRect: DOMRect
+): boolean => {
+	return (
+		innerRect.top >= containerRect.top &&
+		innerRect.bottom <= containerRect.bottom &&
+		innerRect.left >= containerRect.left &&
+		innerRect.right <= containerRect.right
+	);
+};
+
+/**
  * Portal-rendered ghost text anchored to the caret line.
  *
  * @param {Object}      props               Overlay display state.
@@ -48,13 +67,21 @@ const TypeAheadOverlay = ( {
 		const scrollX = win?.scrollX ?? win?.pageXOffset ?? 0;
 		const scrollY = win?.scrollY ?? win?.pageYOffset ?? 0;
 		const containerRect = container?.getBoundingClientRect() ?? null;
-		const containerLeft = containerRect?.left ?? rect.left;
-		const indent = Math.max( 0, rect.left - containerLeft );
+
+		// If the caret rect falls outside the editable area, anchor to the container
+		// so the overlay stays aligned with the visible block bounds.
+		const anchorRect =
+			containerRect && ! isRectInsideContainer( rect, containerRect )
+				? containerRect
+				: rect;
+
+		const containerLeft = containerRect?.left ?? anchorRect.left;
+		const indent = Math.max( 0, anchorRect.left - containerLeft );
 
 		setStyle( {
 			position: 'absolute',
 			zIndex: 1,
-			top: rect.top + scrollY,
+			top: anchorRect.top + scrollY,
 			left: containerLeft + scrollX,
 			width: containerRect?.width ?? 'auto',
 			textIndent: indent ? `${ indent }px` : undefined,

--- a/src/experiments/type-ahead/hooks/useTypeAheadSuggestion.ts
+++ b/src/experiments/type-ahead/hooks/useTypeAheadSuggestion.ts
@@ -117,6 +117,11 @@ export const useTypeAheadSuggestion = (
 	}, [] );
 
 	const cancelPendingRequest = useCallback( () => {
+		// `runAbility()` defers to `executeAbility()` when available, which does not accept
+		// AbortSignal options at the moment. Increment the token so stale results from in-flight
+		// responses that settle later are invalidated.
+		requestRef.current += 1;
+
 		if ( debounceTimerRef.current !== null ) {
 			window.clearTimeout( debounceTimerRef.current );
 			debounceTimerRef.current = null;


### PR DESCRIPTION
## What, Why, and How?

Closes https://github.com/WordPress/ai/issues/846

- Prevents ghost text from anchoring above the title or outside the active editable block.
- Prevents Gutenberg’s empty-block placeholder from overlapping with type-ahead ghost text.
- Invalidates stale in-flight suggestions when a pending request is cancelled.

Type Ahead depends on the current caret position and block focus to decide where a suggestion should appear. When the first empty paragraph is focused while a request is still resolving, Gutenberg can briefly report a caret rectangle outside the editable block. The overlay then trusts that stale or invalid geometry, causing ghost text to render above the title instead of inside the paragraph.

`cancelPendingRequest()` aborts the active request, but the `abilitiesModule.executeAbility()` path does not currently honor the `AbortController` signal. That means a cancelled request can still resolve later and apply a stale suggestion after focus has moved, causing ghost text to appear alongside Gutenberg’s placeholder. `cancelPendingRequest()` needs to also invalidate stale in-flight responses.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.5
Used for: Code review and PR metadata. The changes are tested and reviewed by me.

## Testing Instructions

1. Enable the Type Ahead experiment.
2. Open the block editor and create a post with an empty first paragraph below the title.
3. Click into the first empty paragraph and wait for a type-ahead suggestion to resolve.
4. Confirm the ghost text appears inside the paragraph, not above the title.
5. Click into an empty paragraph so a type-ahead request starts.
6. Before the request finishes, click outside the paragraph.
7. Wait for the request to finish, then click back into the same empty paragraph.
8. Confirm the ghost text does not overlap Gutenberg’s placeholder.
9. Confirm accepting the suggestion with Tab still inserts the full suggestion.
10. Confirm dismissing the suggestion with Escape still removes the ghost text.

## Screencast

https://github.com/user-attachments/assets/e2bd571a-b258-46bf-9337-ce7641eeac95

## Changelog Entry

> Fixed - Type-ahead ghost text placement and stale suggestions overlapping empty-block placeholders.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-847-214c48630e6af6350933263059206e91e13fa74b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->