### PR TITLE
Fix MutationObserver crash when editor iframe body isn't ready

### DIFF
--- a/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
+++ b/src/experiments/title-generation/components/TitleToolbarWrapper.tsx
@@ -369,35 +369,58 @@ function TitleToolbarWrapper(): React.JSX.Element {
 		// The observer stays connected for the editor's lifetime so the toolbar
 		// can be re-attached if the editor recreates the title input (e.g. when
 		// toggling "Show template" on and then off).
+		let observerRetryTimeout: NodeJS.Timeout | null = null;
+		let observerRetryCount = 0;
+		const MAX_OBSERVER_RETRIES = 20;
+
 		const setupObserver = () => {
-			const editorDoc = getEditorDocument();
-			if ( editorDoc && ! observer ) {
-				observer = new MutationObserver( () => {
-					const wrapperExists = !! editorDoc.querySelector(
-						'.ai-title-toolbar-wrapper'
-					);
-
-					// Our injected toolbar was removed from the DOM, but we
-					// still think it is attached. Reset so we can re-attach to
-					// the new title input.
-					if ( isAttached && ! wrapperExists ) {
-						resetAttachmentState();
-					}
-
-					if ( ! isAttached && ! wrapperExists ) {
-						findAndAttachToolbar();
-					}
-				} );
-
-				observer.observe( editorDoc.body, {
-					childList: true,
-					subtree: true,
-				} );
+			if ( observer ) {
+				return;
 			}
+
+			const editorDoc = getEditorDocument();
+
+			// The iframe (and its document) can exist before the document's
+			// body has been created, so keep retrying instead of assuming
+			// a fixed delay is enough for the canvas to be ready.
+			if ( ! editorDoc || ! editorDoc.body ) {
+				if ( observerRetryCount < MAX_OBSERVER_RETRIES ) {
+					observerRetryCount++;
+					observerRetryTimeout = setTimeout( setupObserver, 200 );
+				}
+				return;
+			}
+
+			const newObserver = new MutationObserver( () => {
+				const wrapperExists = !! editorDoc.querySelector(
+					'.ai-title-toolbar-wrapper'
+				);
+
+				// Our injected toolbar was removed from the DOM, but we
+				// still think it is attached. Reset so we can re-attach to
+				// the new title input.
+				if ( isAttached && ! wrapperExists ) {
+					resetAttachmentState();
+				}
+
+				if ( ! isAttached && ! wrapperExists ) {
+					findAndAttachToolbar();
+				}
+			} );
+
+			newObserver.observe( editorDoc.body, {
+				childList: true,
+				subtree: true,
+			} );
+
+			// Only assign once observe() has succeeded so a retry remains
+			// possible if this ever throws.
+			observer = newObserver;
 		};
 
-		// Try to set up observer after a delay to ensure iframe is loaded
-		const observerTimeout = setTimeout( setupObserver, 500 );
+		// Start trying to set up the observer; setupObserver retries on its
+		// own until the iframe's document body is ready.
+		const observerTimeout = setTimeout( setupObserver, 100 );
 
 		// Cleanup function
 		return () => {
@@ -406,6 +429,9 @@ function TitleToolbarWrapper(): React.JSX.Element {
 			}
 			clearTimeout( initialTimeout );
 			clearTimeout( observerTimeout );
+			if ( observerRetryTimeout ) {
+				clearTimeout( observerRetryTimeout );
+			}
 
 			// Remove event listeners
 			if ( removeTitleListeners ) {


### PR DESCRIPTION
## Summary

The title toolbar's MutationObserver setup waited a fixed 500ms before assuming the editor canvas iframe was ready, then called `observer.observe(editorDoc.body, ...)`. The iframe element (and its `contentDocument`) can exist before the document's `body` does, so on slower editor boots this threw an uncaught TypeError. Because `observer` was assigned before the throwing call, the setup never ran again, which also silently broke the toolbar re-attach behavior from #694 for that session.

## Fix

- Check that `editorDoc.body` actually exists before calling `observe()`.
- If it's not ready yet, retry every 200ms (capped at 20 tries) instead of relying on one fixed delay.
- Only assign the observer once `observe()` has succeeded, so retries stay possible.
- Clean up the retry timer on unmount.

Fixes #833

## Test plan

- [ ] Enable Title Generation experiment, open the block editor, confirm no console errors
- [ ] Verify toolbar still appears/hides correctly on title focus/blur
- [ ] Toggle "Show template" off and back on, confirm toolbar re-attaches (per #694)

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-849-f35684f28994ddae196dc45e845ba84899a94d1b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->