### PR TITLE
refactor: Update `connector-approval` e2e selectors to use ARIA roles

### DIFF
--- a/tests/e2e/specs/experiments/connector-approval.spec.js
+++ b/tests/e2e/specs/experiments/connector-approval.spec.js
@@ -86,7 +86,7 @@ test.describe( 'Connector Approval Experiment', () => {
 		);
 
 		if ( await aiOpenAiToggle.isChecked() ) {
-			await aiOpenAiToggle.uncheck();
+			await aiOpenAiToggle.click( { force: true } );
 			await expect( aiOpenAiToggle ).not.toBeChecked();
 		}
 

--- a/tests/e2e/specs/experiments/connector-approval.spec.js
+++ b/tests/e2e/specs/experiments/connector-approval.spec.js
@@ -39,9 +39,10 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's a page under Tools.
 		await expect(
-			page
-				.locator( '#adminmenu' )
-				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
+			page.locator( '#adminmenu' ).getByRole( 'link', {
+				name: 'Connector Approvals',
+				exact: true,
+			} )
 		).toBeVisible();
 
 		// Visit the Connector Approval page.
@@ -49,7 +50,10 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure the Connector Approval page is visible.
 		await expect(
-			page.getByRole( 'heading', { name: 'Connector Approvals', exact: true } )
+			page.getByRole( 'heading', {
+				name: 'Connector Approvals',
+				exact: true,
+			} )
 		).toBeVisible();
 
 		// Ensure the Approval matrix table is visible.
@@ -147,9 +151,10 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's not a page under Tools.
 		await expect(
-			page
-				.locator( '#adminmenu' )
-				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
+			page.locator( '#adminmenu' ).getByRole( 'link', {
+				name: 'Connector Approvals',
+				exact: true,
+			} )
 		).not.toBeVisible();
 	} );
 
@@ -167,9 +172,10 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's not a page under Tools.
 		await expect(
-			page
-				.locator( '#adminmenu' )
-				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
+			page.locator( '#adminmenu' ).getByRole( 'link', {
+				name: 'Connector Approvals',
+				exact: true,
+			} )
 		).not.toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/experiments/connector-approval.spec.js
+++ b/tests/e2e/specs/experiments/connector-approval.spec.js
@@ -39,9 +39,9 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's a page under Tools.
 		await expect(
-			page.locator( '#adminmenu .wp-menu-open .wp-submenu a', {
-				hasText: 'Connector Approvals',
-			} )
+			page
+				.locator( '#adminmenu' )
+				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
 		).toBeVisible();
 
 		// Visit the Connector Approval page.
@@ -49,12 +49,14 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure the Connector Approval page is visible.
 		await expect(
-			page.locator( '#ai-connector-approval-root' )
+			page.getByRole( 'heading', { name: 'Connector Approvals', exact: true } )
 		).toBeVisible();
 
 		// Ensure the Approval matrix table is visible.
 		await expect(
-			page.locator( '.ai-connector-approval__matrix table' )
+			page
+				.locator( '.ai-connector-approval__matrix' )
+				.getByRole( 'table' )
 		).toBeVisible();
 
 		// Remove any previous approvals.
@@ -86,7 +88,9 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Trigger a fresh request if no pending row exists yet.
 		const pendingRow = page
-			.locator( 'table.widefat.striped tbody tr' )
+			.locator( '.ai-connector-approval' )
+			.first()
+			.locator( 'tbody tr' )
 			.filter( {
 				has: page.locator( 'code', { hasText: 'ai/ai.php' } ),
 			} )
@@ -111,7 +115,9 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure we can approve the pending request.
 		await expect( pendingRow ).toHaveCount( 1 );
-		await pendingRow.getByRole( 'button', { name: 'Approve' } ).click();
+		await pendingRow
+			.getByRole( 'button', { name: 'Approve', exact: true } )
+			.click();
 
 		await expect(
 			page
@@ -123,11 +129,7 @@ test.describe( 'Connector Approval Experiment', () => {
 		).toHaveCount( 0 );
 
 		await expect(
-			aiMatrixRow.locator(
-				`td:nth-child(${
-					openAiColumnIndex + 1
-				}) input.components-form-toggle__input`
-			)
+			page.getByLabel( 'Allow AI to use OpenAI', { exact: true } )
 		).toBeChecked();
 	} );
 
@@ -145,9 +147,9 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's not a page under Tools.
 		await expect(
-			page.locator( '#adminmenu .wp-menu-open .wp-submenu a', {
-				hasText: 'Connector Approvals',
-			} )
+			page
+				.locator( '#adminmenu' )
+				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
 		).not.toBeVisible();
 	} );
 
@@ -165,9 +167,9 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure there's not a page under Tools.
 		await expect(
-			page.locator( '#adminmenu .wp-menu-open .wp-submenu a', {
-				hasText: 'Connector Approvals',
-			} )
+			page
+				.locator( '#adminmenu' )
+				.getByRole( 'link', { name: 'Connector Approvals', exact: true } )
 		).not.toBeVisible();
 	} );
 } );

--- a/tests/e2e/specs/experiments/connector-approval.spec.js
+++ b/tests/e2e/specs/experiments/connector-approval.spec.js
@@ -92,9 +92,7 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Trigger a fresh request if no pending row exists yet.
 		const pendingRow = page
-			.locator( '.ai-connector-approval' )
-			.first()
-			.locator( 'tbody tr' )
+			.locator( 'table.widefat.striped tbody tr' )
 			.filter( {
 				has: page.locator( 'code', { hasText: 'ai/ai.php' } ),
 			} )
@@ -119,9 +117,7 @@ test.describe( 'Connector Approval Experiment', () => {
 
 		// Ensure we can approve the pending request.
 		await expect( pendingRow ).toHaveCount( 1 );
-		await pendingRow
-			.getByRole( 'button', { name: 'Approve', exact: true } )
-			.click();
+		await pendingRow.getByRole( 'button', { name: 'Approve' } ).click();
 
 		await expect(
 			page


### PR DESCRIPTION
## What, Why, and How?

Part of https://github.com/WordPress/ai/issues/778

This PR updates the `connector-approval` E2E tests (`tests/e2e/specs/experiments/connector-approval.spec.js`) to follow Playwright's recommended best practices. It replaces brittle CSS selectors and DOM structure-dependent locators with resilient, user-facing locators such as `getByRole`, `getByText`, and other accessibility-based queries.

### Changes

- Replaced CSS and DOM structure-dependent selectors with Playwright user-facing attributes.

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Model(s):** Sonnet 4.6
**Used for:** Code review, PR description

## Testing Instructions

Verify that CI passes, or run the updated E2E test locally:

```bash
npm run test:e2e tests/e2e/specs/experiments/connector-approval.spec.js
```

## Changelog Entry

> Developer: Updated `connector-approval` E2E selectors to use Playwright user-facing attributes.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-850-c714f2c7f0524a5e6bd5691e7c22bab6c4b9b7d6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->