### PR TITLE
Respect explicit and core-owned show_in_abilities setting values

### DIFF
--- a/includes/Abilities/Show_In_Abilities.php
+++ b/includes/Abilities/Show_In_Abilities.php
@@ -46,12 +46,33 @@ final class Show_In_Abilities {
 	}
 
 	/**
+	 * Checks whether WordPress core declares the setting flag natively.
+	 *
+	 * `register_setting()` applies the `register_setting_args` filter before merging the
+	 * caller's arguments over its defaults, so the defaults array is core's own statement of
+	 * which arguments it understands. Once `show_in_abilities` appears there, core owns the
+	 * flag: it picks the default and each setting opts in through `register_setting()`, the
+	 * way `show_in_rest` already works.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $defaults The default registration arguments.
+	 * @return bool True when core declares `show_in_abilities` as a setting argument.
+	 */
+	private function core_declares_setting_flag( $defaults ): bool {
+		return is_array( $defaults ) && array_key_exists( 'show_in_abilities', $defaults );
+	}
+
+	/**
 	 * Adds the `show_in_abilities` flag to curated core settings as they are registered.
 	 *
-	 * Respects an explicit `show_in_abilities` value already present on the setting (for
-	 * example once core ships it natively), only filling it in when absent.
+	 * Respects an explicit `show_in_abilities` value already present in the registration
+	 * arguments, including an explicit `false` opt-out, only filling it in when the key is
+	 * absent entirely. Does nothing once core declares the flag natively, so the polyfill
+	 * never overrides a default core chose.
 	 *
 	 * @since 1.1.0
+	 * @since x.x.x Respects an explicit falsy value, and stands down once core declares the flag.
 	 *
 	 * @param mixed                $args         The setting registration arguments.
 	 * @param array<string, mixed> $defaults     The default registration arguments.
@@ -60,13 +81,13 @@ final class Show_In_Abilities {
 	 * @return mixed The (possibly amended) registration arguments.
 	 */
 	public function mark_setting( $args, $defaults, $option_group, $option_name ) {
-		if ( ! is_array( $args ) ) {
+		if ( ! is_array( $args ) || $this->core_declares_setting_flag( $defaults ) ) {
 			return $args;
 		}
 
 		$settings = $this->settings_map();
 
-		if ( isset( $settings[ $option_name ] ) && empty( $args['show_in_abilities'] ) ) {
+		if ( isset( $settings[ $option_name ] ) && ! array_key_exists( 'show_in_abilities', $args ) ) {
 			$args['show_in_abilities'] = $settings[ $option_name ];
 		}
 

--- a/tests/Integration/Includes/Abilities/Show_In_AbilitiesTest.php
+++ b/tests/Integration/Includes/Abilities/Show_In_AbilitiesTest.php
@@ -173,4 +173,82 @@ class Show_In_AbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertSame( array( 'name' => 'custom_title' ), $settings['blogname']['show_in_abilities'] );
 	}
+
+	/**
+	 * An explicit `show_in_abilities => false` opt-out is preserved.
+	 *
+	 * A falsy value is still a value. The polyfill fills the flag in only when the key is
+	 * absent, so a site that deliberately opts a curated setting out keeps that choice.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_respects_explicit_false_setting_value(): void {
+		$args = $this->show_in_abilities->mark_setting(
+			array( 'show_in_abilities' => false ),
+			array(),
+			'general',
+			'blogname'
+		);
+
+		$this->assertFalse(
+			$args['show_in_abilities'],
+			'An explicit opt-out must not be treated as an absent value.'
+		);
+	}
+
+	/**
+	 * The polyfill stands down once core declares the flag among its defaults.
+	 *
+	 * `register_setting()` filters the caller's arguments before merging them over its
+	 * defaults, so the defaults array says which arguments core understands. Once
+	 * `show_in_abilities` is one of them, core picks the default and each setting opts in,
+	 * and the polyfill must not force a curated setting back on.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_stands_down_once_core_declares_the_flag(): void {
+		$args = $this->show_in_abilities->mark_setting(
+			array( 'type' => 'string' ),
+			array( 'show_in_abilities' => false ),
+			'general',
+			'blogname'
+		);
+
+		$this->assertArrayNotHasKey(
+			'show_in_abilities',
+			$args,
+			'Once core declares the flag it owns the default; the polyfill must not fill it in.'
+		);
+	}
+
+	/**
+	 * Core does not declare the setting flag yet, so the polyfill is still needed.
+	 *
+	 * A tripwire. It reads the defaults core actually passes to the `register_setting_args`
+	 * filter, so it fails when core starts shipping the argument.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_core_does_not_yet_declare_the_setting_flag(): void {
+		$captured = null;
+		$spy      = static function ( $args, $defaults ) use ( &$captured ) {
+			$captured = $defaults;
+			return $args;
+		};
+
+		add_filter( 'register_setting_args', $spy, 1, 2 );
+		try {
+			register_setting( 'wpai_probe_group', 'wpai_probe_setting', array( 'type' => 'string' ) );
+		} finally {
+			remove_filter( 'register_setting_args', $spy, 1 );
+			unregister_setting( 'wpai_probe_group', 'wpai_probe_setting' );
+		}
+
+		$this->assertIsArray( $captured, 'Precondition: the filter should receive the defaults from core.' );
+		$this->assertArrayNotHasKey(
+			'show_in_abilities',
+			$captured,
+			'Core now declares show_in_abilities as a setting argument; the polyfill must step aside.'
+		);
+	}
 }


### PR DESCRIPTION
## What?

Follow up to #739.

`Show_In_Abilities::mark_setting()` adds the `show_in_abilities` flag to a curated list of core settings, so the `core/read-settings` ability returns data on a stock site. Its docblock says it respects a value that is already there, and only fills the flag in when it is absent. Today it does neither reliably. This PR makes the code match that promise.

These two changes started inside #739, which is about `core/read-content`. They have nothing to do with post types, so they are moved here to keep both pull requests focused.

## Why?

There are two separate problems.

**An explicit opt-out is ignored.** The check uses `empty( $args['show_in_abilities'] )`. A value of `false` is empty, so a site that deliberately opts a curated setting out has that choice overwritten and the setting is exposed anyway. An empty array is treated the same way.

**Core's own default would be overridden.** `register_setting()` passes the filter the defaults it is about to merge in, and the method ignores them. That array is core's statement of which arguments it understands. It already lists `show_in_rest`. When core ships `show_in_abilities`, it will pick the default, and each setting will opt in through `register_setting()`, the way `blogname` opts in to `show_in_rest` today. Without a guard, this polyfill would keep forcing the curated settings on and override the default core chose. That list includes `admin_email` and `siteurl`.

## How?

Check for the key instead of for a truthy value, so `false` and `array()` are respected.

Read the `$defaults` argument the filter already receives, and return early when `show_in_abilities` is in it. Core then owns the flag. This matches what `mark_post_type()` and `mark_registered_post_types()` do for post types in #739.

Nothing changes on any WordPress that exists today, because core does not pass the argument yet. On a live site the same 18 curated settings are still flagged.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 4.8
Used for: Finding the two problems, writing the fix and the tests, and running the checks. Every change was reviewed and directed by me.

## Testing Instructions

1. Run the unit tests: `npm run test:php -- --filter Show_In_AbilitiesTest`. All tests should pass.
2. Confirm each fix is really covered. Change the guard back to `empty( $args['show_in_abilities'] )` and only `test_respects_explicit_false_setting_value` fails. Remove the `core_declares_setting_flag()` call and only `test_stands_down_once_core_declares_the_flag` fails.
3. Confirm there is no regression to `core/read-settings`. With the plugin active, run:

```
wp eval 'rest_get_server(); global $wp_registered_settings; echo count( array_filter( $wp_registered_settings, fn( $a ) => ! empty( $a["show_in_abilities"] ) ) );'
```

It should print `18`, the size of the curated list.

There is also a tripwire test, `test_core_does_not_yet_declare_the_setting_flag`. It reads the defaults core really passes to the filter. It will fail on the day core starts shipping the argument, which is when someone should come back and remove this polyfill.

## Changelog Entry

> Fixed - Respect an explicit `show_in_abilities` value on curated settings, and leave the flag to WordPress core once core declares it.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-852-ca8d66c6f4b9ad98306525a5fa1881a3fcbf8bf7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->