### PR TITLE
Tests: register core ability categories once in the bootstrap

### DIFF
--- a/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
+++ b/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
@@ -54,8 +54,6 @@ class SettingsTest extends WP_UnitTestCase {
 				'default'           => 42,
 			)
 		);
-
-		$this->ensure_site_category();
 	}
 
 	/**
@@ -73,31 +71,6 @@ class SettingsTest extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		parent::tearDown();
-	}
-
-	/**
-	 * Ensures the `site` ability category exists for the ability to attach to.
-	 *
-	 * @since 1.1.0
-	 */
-	private function ensure_site_category(): void {
-		if ( wp_has_ability_category( 'site' ) ) {
-			return;
-		}
-
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			wp_register_ability_category(
-				'site',
-				array(
-					'label'       => 'Site',
-					'description' => 'Site.',
-				)
-			);
-		} finally {
-			array_pop( $wp_current_filter );
-		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -168,9 +168,6 @@ class UsersTest extends WP_UnitTestCase {
 		$this->subscriber_id    = self::$fixture_ids['subscriber'];
 		$this->public_author_id = self::$fixture_ids['public_author'];
 		$this->public_post_id   = self::$fixture_ids['public_post'];
-
-		$this->ensure_user_category();
-		$this->ensure_site_category();
 	}
 
 	/**
@@ -187,57 +184,6 @@ class UsersTest extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 
 		parent::tearDown();
-	}
-
-	/**
-	 * Ensures the `user` ability category exists for the ability to attach to.
-	 *
-	 * @since x.x.x
-	 */
-	private function ensure_user_category(): void {
-		if ( wp_has_ability_category( 'user' ) ) {
-			return;
-		}
-
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			wp_register_ability_category(
-				'user',
-				array(
-					'label'       => 'Users',
-					'description' => 'Users.',
-				)
-			);
-		} finally {
-			array_pop( $wp_current_filter );
-		}
-	}
-
-	/**
-	 * Ensures the `site` ability category exists, used by the plugin's `core/settings`
-	 * ability which registers on the same hook as `core/read-users`.
-	 *
-	 * @since x.x.x
-	 */
-	private function ensure_site_category(): void {
-		if ( wp_has_ability_category( 'site' ) ) {
-			return;
-		}
-
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			wp_register_ability_category(
-				'site',
-				array(
-					'label'       => 'Site',
-					'description' => 'Site.',
-				)
-			);
-		} finally {
-			array_pop( $wp_current_filter );
-		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
@@ -360,10 +360,6 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	public function test_invoke_ability_accepts_scalar_input() {
 		global $wp_current_filter;
 
-		// Built-in plugin abilities registered during init use the "site"
-		// category; ensure it exists so triggering init stays quiet.
-		$this->ensure_site_category();
-
 		$slug = 'ai/scalar-input-ability';
 
 		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
@@ -397,35 +393,6 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 42, $result['data'] );
-	}
-
-	/**
-	 * Ensures the "site" ability category is registered.
-	 *
-	 * Built-in plugin abilities declare the "site" category. When a test
-	 * triggers the abilities API init those abilities register, so the
-	 * category must exist first to avoid an incorrect-usage notice.
-	 *
-	 * @since 1.1.0
-	 */
-	private function ensure_site_category(): void {
-		if ( wp_has_ability_category( 'site' ) ) {
-			return;
-		}
-
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			wp_register_ability_category(
-				'site',
-				array(
-					'label'       => 'Site',
-					'description' => 'Site.',
-				)
-			);
-		} finally {
-			array_pop( $wp_current_filter );
-		}
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,5 +41,29 @@ tests_add_filter(
 	}
 );
 
+/*
+ * Register the core ability categories that the WordPress test suite removes.
+ *
+ * The suite unhooks `wp_register_core_ability_categories()` at priority 1, so that core
+ * abilities do not register during tests. The categories go with them. The plugin's own
+ * abilities still declare core categories such as `site` and `user`, and
+ * `wp_register_ability()` refuses a category that is not registered, so every plugin
+ * ability would emit an "incorrect usage" notice as soon as the registry boots.
+ *
+ * Put the categories back for tests only. This runs after the suite has unhooked core, and
+ * before the plugin registers the categories it owns.
+ *
+ * @see _unhook_core_ability_categories_registration() in the WordPress test suite.
+ */
+tests_add_filter(
+	'wp_abilities_api_categories_init',
+	static function (): void {
+		if ( function_exists( 'wp_register_core_ability_categories' ) ) {
+			wp_register_core_ability_categories();
+		}
+	},
+	5
+);
+
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,14 +53,27 @@ tests_add_filter(
  * Put the categories back for tests only. This runs after the suite has unhooked core, and
  * before the plugin registers the categories it owns.
  *
+ * Core owns `site` and `user`. The plugin owns the categories it registers itself, and those
+ * arrive through the plugin's own callbacks on this hook, so they need nothing here.
+ *
  * @see _unhook_core_ability_categories_registration() in the WordPress test suite.
  */
 tests_add_filter(
 	'wp_abilities_api_categories_init',
 	static function (): void {
-		if ( function_exists( 'wp_register_core_ability_categories' ) ) {
-			wp_register_core_ability_categories();
+		if ( ! function_exists( 'wp_register_core_ability_categories' ) ) {
+			return;
 		}
+
+		/*
+		 * Should the suite ever stop unhooking core, its callback still runs at priority 10.
+		 * Standing down keeps this from registering the same categories twice.
+		 */
+		if ( has_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' ) ) {
+			return;
+		}
+
+		wp_register_core_ability_categories();
 	},
 	5
 );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -66,10 +66,13 @@ tests_add_filter(
 		}
 
 		/*
-		 * Should the suite ever stop unhooking core, its callback still runs at priority 10.
-		 * Standing down keeps this from registering the same categories twice.
+		 * Should the suite ever stop unhooking core, its callback still runs later on this
+		 * hook. Standing down keeps this from registering the same categories twice.
+		 *
+		 * `has_action()` returns the priority, so a callback hooked at priority 0 is falsy.
+		 * Compare against `false` rather than testing for truth.
 		 */
-		if ( has_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' ) ) {
+		if ( false !== has_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' ) ) {
 			return;
 		}
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -44,17 +44,13 @@ tests_add_filter(
 /*
  * Register the core ability categories that the WordPress test suite removes.
  *
- * The suite unhooks `wp_register_core_ability_categories()` at priority 1, so that core
- * abilities do not register during tests. The categories go with them. The plugin's own
- * abilities still declare core categories such as `site` and `user`, and
- * `wp_register_ability()` refuses a category that is not registered, so every plugin
- * ability would emit an "incorrect usage" notice as soon as the registry boots.
+ * The suite unhooks `wp_register_core_ability_categories()`, so `site` and `user` do not
+ * exist during tests. Booting the abilities registry registers every plugin ability at once,
+ * and `wp_register_ability()` refuses a category that is not registered. A single missing
+ * category therefore breaks any test that touches abilities, whichever test that happens to
+ * be. Without this, every new ability test class had to register the categories again.
  *
- * Put the categories back for tests only. This runs after the suite has unhooked core, and
- * before the plugin registers the categories it owns.
- *
- * Core owns `site` and `user`. The plugin owns the categories it registers itself, and those
- * arrive through the plugin's own callbacks on this hook, so they need nothing here.
+ * Categories the plugin owns arrive through its own callbacks on this hook.
  *
  * @see _unhook_core_ability_categories_registration() in the WordPress test suite.
  */
@@ -66,11 +62,8 @@ tests_add_filter(
 		}
 
 		/*
-		 * Should the suite ever stop unhooking core, its callback still runs later on this
-		 * hook. Standing down keeps this from registering the same categories twice.
-		 *
-		 * `has_action()` returns the priority, so a callback hooked at priority 0 is falsy.
-		 * Compare against `false` rather than testing for truth.
+		 * Stand down once core registers them itself. `has_action()` returns the priority,
+		 * which is falsy at priority 0, so compare against `false`.
 		 */
 		if ( false !== has_action( 'wp_abilities_api_categories_init', 'wp_register_core_ability_categories' ) ) {
 			return;


### PR DESCRIPTION
## What

Register the core ability categories once in the PHPUnit bootstrap, and delete the three copies of `ensure_*_category()` that test classes carried to work around their absence.

## Why

The WordPress test suite unhooks `wp_register_core_ability_categories()`, so the `site` and `user` categories do not exist during tests. Plugin abilities declare those categories, and `wp_register_ability()` refuses a category that is not registered.

The catch is that booting the abilities registry registers **every** plugin ability at once. So one missing category breaks whichever test happens to touch abilities first, even a test that has nothing to do with settings or users. That is why `UsersTest` had to register `site` as well as `user`. It was paying for `core/read-settings`.

This gets worse with every ability we add. Each new ability test class copied the same setup, and each new core category meant editing all the copies. We are at three copies on this branch, and [#739](https://github.com/WordPress/ai/pull/739) adds a fourth while it waits for review.

It also makes the suite order dependent. Run everything and an earlier class has already registered the categories, so a later class passes without its own copy. Run one class alone and it fails. On `develop` today:

```
$ phpunit --filter 'Abilities\Settings\SettingsTest'
ERRORS! Tests: 9, Errors: 8, Failures: 1.
   Ability category 'site' is not registered ... core/read-settings

$ phpunit --filter 'Abilities_Explorer\Ability_HandlerTest'
ERRORS!
   Ability category 'site' is not registered ... core/read-settings
```

## How

`tests/bootstrap.php` registers the categories on `wp_abilities_api_categories_init` at priority 5. That runs after the suite has unhooked core, and before the plugin registers the categories it owns. Categories the plugin owns, such as `ai-experiments`, keep arriving through the plugin's own callbacks, so they need nothing here.

The filter stands down if core's callback is still hooked, so it turns into a no-op the day the suite stops unhooking it.

Deleting the three helpers is what makes CI protect this. With the helpers gone and the bootstrap filter reverted, the full suite reports **50 errors**. Before this change it passed either way.

## Testing

Each class now passes on its own, and the full suite still passes with `Tests: 986, Assertions: 2706`.

| Class | Before (alone) | After (alone) |
| --- | --- | --- |
| `Abilities\Settings\SettingsTest` | ERRORS | OK (9 tests) |
| `Abilities\Users\UsersTest` | OK (43 tests) | OK (43 tests) |
| `Abilities_Explorer\Ability_HandlerTest` | ERRORS | OK (17 tests) |

Two more checks. Simulating a future WordPress that no longer unhooks core, the filter stands down and registers nothing twice. Stacking this branch on [#739](https://github.com/WordPress/ai/pull/739) and deleting all three of `ContentTest`'s stubs, including the one for the plugin-owned `content` category, gives `OK (89 tests, 312 assertions)` alone and 1082 tests green for the full suite.

PHPCS and PHPStan are clean.

## Follow-up

Once this lands, `ContentTest::ensure_ability_category()` and its three `setUp()` calls can be removed from #739.

A test that wants a category **it owns** still has to fake the hook context, because the categories hook fires only once, when the registry boots. No test needs that today. If one does, it deserves a shared helper rather than a fourth copy.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-854-62be73e7adb4598da6e11ef1e20c592b5a551d90.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->