### PR TITLE
Register initial settings before core/read-settings snapshots them

### DIFF
--- a/includes/Abilities/Settings/Settings.php
+++ b/includes/Abilities/Settings/Settings.php
@@ -22,6 +22,14 @@ defined( 'ABSPATH' ) || exit;
  * exposed. It is structured to also back a future write-oriented `core/manage-settings`
  * ability via the shared helpers (get_exposed_settings(), value_schema(), cast_value()).
  *
+ * The exposed settings are captured when the ability registers on `wp_abilities_api_init`.
+ * That hook fires lazily on first use of the abilities registry, which is not ordered
+ * relative to `rest_api_init` (where core registers its own settings) and can happen
+ * without it entirely, e.g. on cron or WP-CLI. register() therefore ensures core's
+ * initial settings are registered before the snapshot is computed. Other plugin settings
+ * flagged with `show_in_abilities` must be registered before the abilities registry is
+ * first used in a request; registering them on `init` is reliable.
+ *
  * This class is kept almost identical to the WordPress core class `WP_Settings_Abilities`
  * so the two implementations stay in sync. Differences from the core class are marked with
  * `// Plugin:` comments. Additionally, all user-facing strings use the 'ai' text domain.
@@ -71,8 +79,21 @@ final class Settings {
 	 * Must run on the `wp_abilities_api_init` hook.
 	 *
 	 * @since 1.1.0
+	 * @since x.x.x Ensures core's initial settings are registered before taking the snapshot.
 	 */
 	public function register(): void {
+		/*
+		 * Core's initial settings register on `rest_api_init`, which fires lazily and
+		 * independently of `wp_abilities_api_init`: on cron, WP-CLI, or any request where
+		 * abilities are used before the REST server loads, it may not have fired — or may
+		 * be mid-fire at a priority before register_initial_settings() runs. Ensure the
+		 * core settings exist before the exposed-settings snapshot below is computed;
+		 * re-registering them again later on `rest_api_init` is harmless.
+		 */
+		if ( ! did_action( 'rest_api_init' ) || doing_action( 'rest_api_init' ) ) {
+			register_initial_settings();
+		}
+
 		$this->register_get_settings();
 
 		/*

--- a/includes/Abilities/Show_In_Abilities.php
+++ b/includes/Abilities/Show_In_Abilities.php
@@ -25,10 +25,11 @@ defined( 'ABSPATH' ) || exit;
  * It is intentionally object-type-agnostic: today it marks settings; post types and
  * meta can be marked here the same way when those abilities land.
  *
- * Timing: the `core/read-settings` ability snapshots the exposed settings when it registers
- * on `wp_abilities_api_init`. A setting therefore has to be flagged with `show_in_abilities`
- * before that hook fires — i.e. its `register_setting()` call must run before abilities
- * init — for the ability to pick it up.
+ * Timing: the `core/read-settings` ability ensures core's initial settings are registered,
+ * then snapshots the exposed settings when it registers on `wp_abilities_api_init`. Any
+ * other setting therefore has to be flagged with `show_in_abilities` before that hook fires
+ * — i.e. its `register_setting()` call must run before abilities init — for the ability to
+ * pick it up.
  *
  * @internal This class should not be used outside the plugin and there is no guarantee of backwards compatibility.
  *

--- a/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
+++ b/tests/Integration/Includes/Abilities/Settings/SettingsTest.php
@@ -98,6 +98,46 @@ class SettingsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Core settings are exposed when abilities initialize before the REST API.
+	 *
+	 * Simulates cron, WP-CLI, or any request that uses the Abilities API before
+	 * `rest_api_init` registers core's initial settings.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_core_read_settings_registers_initial_settings_without_rest_api_init(): void {
+		global $wp_registered_settings, $wp_actions;
+
+		$registered_settings_backup = $wp_registered_settings;
+		$rest_api_init_count        = $wp_actions['rest_api_init'] ?? null;
+		$wp_registered_settings     = array(); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Simulating WordPress before its settings are registered.
+		unset( $wp_actions['rest_api_init'] );
+
+		try {
+			$this->register_ability();
+
+			$ability = wp_get_ability( 'core/read-settings' );
+			$this->assertArrayHasKey( 'blogname', $ability->get_output_schema()['properties'] );
+
+			$this->become_admin();
+			$result = $ability->execute( array( 'fields' => array( 'blogname' ) ) );
+
+			$this->assertArrayHasKey( 'blogname', $result );
+		} finally {
+			if ( wp_has_ability( 'core/read-settings' ) ) {
+				wp_unregister_ability( 'core/read-settings' );
+			}
+
+			$wp_registered_settings = $registered_settings_backup; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Restoring the WordPress test global.
+			if ( null === $rest_api_init_count ) {
+				unset( $wp_actions['rest_api_init'] );
+			} else {
+				$wp_actions['rest_api_init'] = $rest_api_init_count; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restoring the WordPress test global.
+			}
+		}
+	}
+
+	/**
 	 * The ability is registered in the `site` category and flagged read-only.
 	 *
 	 * @since 1.1.0


### PR DESCRIPTION
## What?

Follow up to WordPress/wordpress-develop#12141.

Ensure `core/read-settings` registers WordPress's initial settings before it snapshots the settings exposed through the Abilities API. Add regression coverage for an ability-first request where `rest_api_init` has not fired.

## Why?

The Abilities API registry initializes lazily on first use. Its `wp_abilities_api_init` hook is not ordered relative to `rest_api_init`, where WordPress registers its initial settings, and REST initialization may not run at all during cron or WP-CLI requests.

When `core/read-settings` registers first, it currently snapshots an empty settings registry. Because that snapshot supplies the input schema, output schema, and execution callback for the remainder of the request, the ability cannot expose normal Core settings such as `blogname`.

## How?

Before computing the exposed-settings snapshot, `Settings::register()` calls `register_initial_settings()` when `rest_api_init`:

- has not fired, or
- is currently firing and may not yet have reached Core's settings callback.

Once `rest_api_init` has completed, the guard does nothing. Re-registering settings later during the normal REST callback is harmless.

The regression test clears the registered-settings global and the `rest_api_init` action count, registers the ability under the previously broken ordering, and verifies that `blogname` is present in both the output schema and execution result.

This does not change the public ability name, schemas, filters, permissions, annotations, or exposed-settings list.

### Use of AI Tools

AI assistance: Yes  
Tool(s): Codex  
Model(s): GPT-5  
Used for: Plugin/Core parity auditing, implementation, regression testing, and verification. All changes and test results were reviewed.

## Testing Instructions

- `npm run build`
- `npm run test:php -- --filter SettingsTest` (10 tests, 35 assertions)
- `npm run test:php` (1010 tests, 2779 assertions, 34 skipped)
- `npm run lint:php`
- `vendor/bin/phpstan analyse --memory-limit=2G --debug`
- WP-CLI no-REST check:
  - `rest_api_init`: `0`
  - `core/read-settings` output schema contains `blogname`: `true`

The targeted browser E2E was not used for this regression because loading the REST/browser client initializes the path that the bug specifically bypasses.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-856-0c0e2c5c919f18cb36a142e4139354fec36137f1.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->