### PR TITLE
E2E[Content Classification]:  Prefer user-facing attributes 

### DIFF
--- a/src/experiments/content-classification/components/SuggestionPanel.tsx
+++ b/src/experiments/content-classification/components/SuggestionPanel.tsx
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { close as closeIcon, update } from '@wordpress/icons';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -49,6 +50,17 @@ export default function SuggestionPanel( {
 		( selectFn ) => selectFn( coreStore ).getTaxonomy( taxonomy ),
 		[ taxonomy ]
 	);
+
+	const classificationHintId = useInstanceId(
+		SuggestionPanel,
+		'suggestion-panel-classification-hint'
+	);
+
+	const classificationSuggestionsId = useInstanceId(
+		SuggestionPanel,
+		'suggestion-panel-classification-suggestions'
+	);
+
 	const taxonomyLabel: string = taxonomyObject?.name ?? taxonomy;
 
 	const hasSuggestions = suggestions.length > 0;
@@ -65,6 +77,9 @@ export default function SuggestionPanel( {
 					isBusy={ isGenerating }
 					className="ai-content-classification__generate-button"
 					__next40pxDefaultSize
+					aria-describedby={
+						! hasEnoughContent ? classificationHintId : undefined
+					}
 				>
 					{ isGenerating
 						? __( 'Generating…', 'ai' )
@@ -78,6 +93,7 @@ export default function SuggestionPanel( {
 
 			{ ! hasEnoughContent && ! hasSuggestions && (
 				<p
+					id={ classificationHintId }
 					className="ai-content-classification__hint components-base-control__help"
 					style={ { color: '#757575' } }
 				>
@@ -94,14 +110,21 @@ export default function SuggestionPanel( {
 
 			{ hasSuggestions && (
 				<div className="ai-content-classification__suggestions">
-					<h3 className="ai-content-classification__suggestions-title">
+					<h3
+						id={ classificationSuggestionsId }
+						className="ai-content-classification__suggestions-title"
+					>
 						{ sprintf(
 							/* translators: %s: Taxonomy label (e.g., "Tags" or "Categories"). */
 							__( 'Suggested %s', 'ai' ),
 							taxonomyLabel
 						) }
 					</h3>
-					<div className="ai-content-classification__pills">
+					<div
+						className="ai-content-classification__pills"
+						aria-labelledby={ classificationSuggestionsId }
+						role="list"
+					>
 						{ suggestions.map( ( suggestion: TagSuggestion ) => (
 							<span
 								key={ suggestion.term }
@@ -110,6 +133,7 @@ export default function SuggestionPanel( {
 										? ' ai-content-classification__pill--new'
 										: ''
 								}` }
+								role="listitem"
 							>
 								<Button
 									className="ai-content-classification__pill-accept"

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -52,8 +52,9 @@ async function openTaxonomyPanel( editor, page, panelLabel ) {
 	}
 
 	// Expand the taxonomy panel if it is collapsed.
-	const panelToggle = page.locator( '.components-panel__body-toggle', {
-		hasText: panelLabel,
+	const panelToggle = page.getByRole( 'button', {
+		name: panelLabel,
+		exact: true,
 	} );
 
 	if ( ( await panelToggle.count() ) > 0 ) {
@@ -88,14 +89,14 @@ async function setStrategy( admin, page, strategy ) {
 
 	await strategySelect.selectOption( strategy );
 
-	const saveButton = page
-		.locator( '.ai-feature-settings-form' )
-		.getByRole( 'button', { name: 'Save' } );
+	const saveButton = page.getByRole( 'button', {
+		name: /Save Content Classification/,
+	} );
 	await saveButton.click();
 
 	await expect(
-		page.locator( '.components-snackbar__content', {
-			hasText: 'Content Classification settings saved.',
+		page.getByTestId( 'snackbar' ).filter( {
+			hasText: /Content Classification settings saved\./,
 		} )
 	).toBeVisible();
 }
@@ -133,9 +134,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// The suggest button should be visible within the Tags panel.
 		await expect(
-			page.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
+			page.getByRole( 'button', { name: 'Suggest Tags' } )
 		).toBeVisible();
 	} );
 
@@ -159,9 +158,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// The suggest button should be visible within the Categories panel.
 		await expect(
-			page.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Categories',
-			} )
+			page.getByRole( 'button', { name: 'Suggest Categories' } )
 		).toBeVisible();
 	} );
 
@@ -183,20 +180,17 @@ test.describe( 'Content Classification Experiment', () => {
 		// Open the Tags panel.
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
+		const suggestButton = page.getByRole( 'button', {
+			name: 'Suggest Tags',
+		} );
+
 		// The hint should be visible.
-		await expect(
-			page.locator( '.ai-content-classification__hint', {
-				hasText:
-					'Content Classification will be available when the post content has at least 250 characters.',
-			} )
-		).toBeVisible();
+		await expect( suggestButton ).toHaveAccessibleDescription(
+			/Content Classification will be available when the post content has at least 250 characters/
+		);
 
 		// The suggest button should be disabled.
-		await expect(
-			page
-				.locator( '.ai-content-classification__generate-button' )
-				.first()
-		).toBeDisabled();
+		await expect( suggestButton ).toBeDisabled();
 	} );
 
 	test( 'Enables suggestions once content reaches the minimum length', async ( {
@@ -217,18 +211,16 @@ test.describe( 'Content Classification Experiment', () => {
 		// Open the Tags panel.
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
+		const suggestButton = page.getByRole( 'button', {
+			name: 'Suggest Tags',
+		} );
+
 		// The hint surfaces the configured minimum content length, and the
 		// suggest button is disabled.
-		await expect(
-			page.locator( '.ai-content-classification__hint' ).first()
-		).toHaveText(
-			'Content Classification will be available when the post content has at least 250 characters.'
+		await expect( suggestButton ).toHaveAccessibleDescription(
+			/Content Classification will be available when the post content has at least 250 characters/
 		);
-		await expect(
-			page
-				.locator( '.ai-content-classification__generate-button' )
-				.first()
-		).toBeDisabled();
+		await expect( suggestButton ).toBeDisabled();
 
 		// Add enough content to cross the minimum threshold.
 		await editor.insertBlock( {
@@ -237,14 +229,10 @@ test.describe( 'Content Classification Experiment', () => {
 		} );
 
 		// The hint disappears and the suggest button becomes enabled.
-		await expect(
-			page.locator( '.ai-content-classification__hint' )
-		).toHaveCount( 0 );
-		await expect(
-			page
-				.locator( '.ai-content-classification__generate-button' )
-				.first()
-		).toBeEnabled();
+		await expect( suggestButton ).not.toHaveAccessibleDescription(
+			/Content Classification will be available when the post content has at least 250 characters/
+		);
+		await expect( suggestButton ).toBeEnabled();
 	} );
 
 	test( 'Generates and displays suggestion pills', async ( {
@@ -272,37 +260,25 @@ test.describe( 'Content Classification Experiment', () => {
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
 		// Click the Suggest Tags button.
-		await page
-			.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
-			.first()
-			.click();
-
-		// Wait for suggestions to appear.
-		await expect(
-			page.locator( '.ai-content-classification__suggestions' ).first()
-		).toBeVisible();
+		await page.getByRole( 'button', { name: 'Suggest Tags' } ).click();
 
 		// Verify suggestion pills are rendered.
-		await expect(
-			page.locator( '.ai-content-classification__pill' ).first()
-		).toBeVisible();
+		const suggestions = page
+			.getByRole( 'list', { name: 'Suggested Tags' } )
+			.getByRole( 'listitem' );
+
+		await expect( suggestions ).not.toHaveCount( 0 );
 
 		// Verify the "Suggest again" and "Dismiss all" actions are visible.
 		await expect(
 			page
-				.locator( '.ai-content-classification__actions button', {
-					hasText: 'Suggest again',
-				} )
+				.getByRole( 'button', { name: 'Suggest again', exact: true } )
 				.first()
 		).toBeVisible();
 
 		await expect(
 			page
-				.locator( '.ai-content-classification__actions button', {
-					hasText: 'Dismiss all',
-				} )
+				.getByRole( 'button', { name: 'Dismiss all', exact: true } )
 				.first()
 		).toBeVisible();
 	} );
@@ -332,37 +308,27 @@ test.describe( 'Content Classification Experiment', () => {
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
 		// Generate suggestions.
-		await page
-			.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: 'Suggest Tags' } ).click();
 
 		// Wait for suggestions to appear.
-		await expect(
-			page.locator( '.ai-content-classification__suggestions' ).first()
-		).toBeVisible();
+		const suggestions = page
+			.getByRole( 'list', { name: 'Suggested Tags' } )
+			.getByRole( 'listitem' );
+
+		await expect( suggestions ).not.toHaveCount( 0 );
 
 		// Click "Dismiss all".
 		await page
-			.locator( '.ai-content-classification__actions button', {
-				hasText: 'Dismiss all',
-			} )
-			.first()
+			.getByRole( 'button', { name: 'Dismiss all', exact: true } )
 			.click();
 
 		// Suggestions should be cleared and the generate button should reappear.
 		await expect(
-			page.locator( '.ai-content-classification__suggestions' ).first()
-		).not.toBeVisible();
+			page.getByRole( 'list', { name: 'Suggested Tags' } )
+		).toHaveCount( 0 );
 
 		await expect(
-			page
-				.locator( '.ai-content-classification button', {
-					hasText: 'Suggest Tags',
-				} )
-				.first()
+			page.getByRole( 'button', { name: 'Suggest Tags' } )
 		).toBeVisible();
 	} );
 
@@ -389,7 +355,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// The content classification UI should not be present.
 		await expect(
-			page.locator( '.ai-content-classification' )
+			page.getByRole( 'button', { name: 'Suggest Tags' } )
 		).toHaveCount( 0 );
 	} );
 
@@ -416,7 +382,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// The content classification UI should not be present.
 		await expect(
-			page.locator( '.ai-content-classification' )
+			page.getByRole( 'button', { name: 'Suggest Tags' } )
 		).toHaveCount( 0 );
 	} );
 
@@ -441,22 +407,14 @@ test.describe( 'Content Classification Experiment', () => {
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
 		// Click the Suggest Tags button.
-		await page
-			.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
-			.first()
-			.click();
-
-		// Wait for suggestions to appear.
-		await expect(
-			page.locator( '.ai-content-classification__suggestions' ).first()
-		).toBeVisible();
+		await page.getByRole( 'button', { name: 'Suggest Tags' } ).click();
 
 		// Verify suggestion pills are rendered.
-		await expect(
-			page.locator( '.ai-content-classification__pill' ).first()
-		).toBeVisible();
+		const suggestions = page
+			.getByRole( 'list', { name: 'Suggested Tags' } )
+			.getByRole( 'listitem' );
+
+		await expect( suggestions ).not.toHaveCount( 0 );
 
 		// Switch to the Block tab.
 		const blockTab = page.getByRole( 'tab', { name: 'Block' } );
@@ -466,9 +424,7 @@ test.describe( 'Content Classification Experiment', () => {
 		await openTaxonomyPanel( editor, page, 'Tags' );
 
 		// Verify suggestion pills are STILL rendered and visible.
-		await expect(
-			page.locator( '.ai-content-classification__pill' ).first()
-		).toBeVisible();
+		await expect( suggestions ).not.toHaveCount( 0 );
 	} );
 
 	test( 'Restores suggestion pill to original position if tag addition fails', async ( {
@@ -489,15 +445,13 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// Open the Tags panel and suggest.
 		await openTaxonomyPanel( editor, page, 'Tags' );
-		await page
-			.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: 'Suggest Tags' } ).click();
 
 		await expect(
-			page.locator( '.ai-content-classification__pill' ).first()
+			page
+				.getByRole( 'list', { name: 'Suggested Tags' } )
+				.getByRole( 'listitem' )
+				.first()
 		).toBeVisible();
 
 		let resolveRoute;
@@ -519,20 +473,19 @@ test.describe( 'Content Classification Experiment', () => {
 		} );
 
 		const firstPill = page
-			.locator( '.ai-content-classification__pill' )
+			.getByRole( 'list', { name: 'Suggested Tags' } )
+			.getByRole( 'listitem' )
 			.first();
 		const pillText = await firstPill
-			.locator( '.ai-content-classification__pill-accept' )
+			.getByRole( 'button', { name: /^Add ".+"$/ } )
 			.textContent();
 
 		// Click to accept a term.
-		await firstPill
-			.locator( '.ai-content-classification__pill-accept' )
-			.click();
+		await firstPill.getByRole( 'button', { name: /^Add ".+"$/ } ).click();
 
 		// Pill should disappear immediately.
 		await expect(
-			page.locator( '.ai-content-classification__pill-accept' ).first()
+			firstPill.getByRole( 'button', { name: /^Add ".+"$/ } )
 		).not.toHaveText( pillText );
 
 		// Resolve the promise to return the failure response.
@@ -540,7 +493,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// Since request fails, the pill should be restored to its original (first) position.
 		await expect(
-			page.locator( '.ai-content-classification__pill-accept' ).first()
+			firstPill.getByRole( 'button', { name: /^Add ".+"$/ } )
 		).toHaveText( pillText );
 	} );
 
@@ -562,15 +515,13 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// Open the Tags panel and suggest.
 		await openTaxonomyPanel( editor, page, 'Tags' );
-		await page
-			.locator( '.ai-content-classification button', {
-				hasText: 'Suggest Tags',
-			} )
-			.first()
-			.click();
+		await page.getByRole( 'button', { name: 'Suggest Tags' } ).click();
 
 		await expect(
-			page.locator( '.ai-content-classification__pill' ).first()
+			page
+				.getByRole( 'list', { name: 'Suggested Tags' } )
+				.getByRole( 'listitem' )
+				.first()
 		).toBeVisible();
 
 		let resolveRoute;
@@ -592,28 +543,24 @@ test.describe( 'Content Classification Experiment', () => {
 		} );
 
 		const firstPill = page
-			.locator( '.ai-content-classification__pill' )
+			.getByRole( 'list', { name: 'Suggested Tags' } )
+			.getByRole( 'listitem' )
 			.first();
 		const pillText = await firstPill
-			.locator( '.ai-content-classification__pill-accept' )
+			.getByRole( 'button', { name: /^Add ".+"$/ } )
 			.textContent();
 
 		// Click to accept a term.
-		await firstPill
-			.locator( '.ai-content-classification__pill-accept' )
-			.click();
+		await firstPill.getByRole( 'button', { name: /^Add ".+"$/ } ).click();
 
 		// Pill should disappear immediately.
 		await expect(
-			page.locator( '.ai-content-classification__pill-accept' ).first()
+			firstPill.getByRole( 'button', { name: /^Add ".+"$/ } )
 		).not.toHaveText( pillText );
 
 		// While API call is pending, click "Dismiss all" to clear suggestions and increment session count.
 		await page
-			.locator( '.ai-content-classification__actions button', {
-				hasText: 'Dismiss all',
-			} )
-			.first()
+			.getByRole( 'button', { name: 'Dismiss all', exact: true } )
 			.click();
 
 		// Resolve the promise to return the failure response.
@@ -621,7 +568,7 @@ test.describe( 'Content Classification Experiment', () => {
 
 		// Since the session is now stale, the suggestions UI should remain cleared/empty.
 		await expect(
-			page.locator( '.ai-content-classification__suggestions' ).first()
-		).not.toBeVisible();
+			page.getByRole( 'list', { name: 'Suggested Tags' } )
+		).toHaveCount( 0 );
 	} );
 } );


### PR DESCRIPTION
## What, Why, and How?

Closes https://github.com/WordPress/ai/issues/778

Playwright recommends using user-facing locators (example, `getByRole`) instead of CSS classes or DOM-structure selectors wherever possible. This is because CSS classes and markup structure are implementation details that can change during design or refactoring without changing the actual user experience, which can make tests fail even though the feature still works ([Docs](https://playwright.dev/docs/best-practices#prefer-user-facing-attributes-to-xpath-or-css-selectors)).

This PR updates the Content Classification E2E spec to follow the Playwright best practices by replacing hard-coded `page.locator(...)` calls with role-based locators. This should make the test less brittle because it now targets the UI the way a user, or assistive technology, understands it rather than depending on implementation details.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code review

## Testing Instructions
- CI should be green.

## Changelog Entry

> Changed - Updated Content Classification E2E selectors to use Playwright user-facing attributes

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-859-6a31fef2c526f2e5483e71404bbda359dd8b555c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->