### PR TITLE
Refactor snackbar locators

### DIFF
--- a/tests/e2e/specs/admin/settings.spec.js
+++ b/tests/e2e/specs/admin/settings.spec.js
@@ -148,7 +148,7 @@ test.describe( 'Plugin settings', () => {
 		await expect( globalToggle ).toBeVisible( { timeout: 10000 } );
 		await globalToggle.click();
 
-		const snackbar = page.locator( '.components-snackbar' ).first();
+		const snackbar = page.getByTestId( 'snackbar' ).first();
 		await expect( snackbar ).toBeVisible();
 
 		// The snackbar must sit to the inline-start of the centered settings
@@ -205,7 +205,7 @@ test.describe( 'Plugin settings', () => {
 
 		// Wait for the auto-save snackbar to confirm siteSettings changed.
 		await expect(
-			page.locator( '.components-snackbar__content', {
+			page.getByTestId( 'snackbar' ).filter( {
 				hasText: 'Title Generation enabled.',
 			} )
 		).toBeVisible();
@@ -254,7 +254,7 @@ test.describe( 'Plugin settings', () => {
 		const count = experimentToggles.length;
 
 		await expect(
-			page.locator( '.components-snackbar__content', {
+			page.getByTestId( 'snackbar' ).filter( {
 				hasText: `${ count } experiments enabled`,
 			} )
 		).toBeVisible();
@@ -301,7 +301,7 @@ test.describe( 'Plugin settings', () => {
 		const count = experimentToggles.length;
 
 		await expect(
-			page.locator( '.components-snackbar__content', {
+			page.getByTestId( 'snackbar' ).filter( {
 				hasText: `${ count } experiments disabled`,
 			} )
 		).toBeVisible();

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -94,7 +94,7 @@ async function setStrategy( admin, page, strategy ) {
 	await saveButton.click();
 
 	await expect(
-		page.locator( '.components-snackbar__content', {
+		page.getByTestId( 'snackbar' ).filter( {
 			hasText: 'Content Classification settings saved.',
 		} )
 	).toBeVisible();

--- a/tests/e2e/specs/experiments/content-classification.spec.js
+++ b/tests/e2e/specs/experiments/content-classification.spec.js
@@ -94,7 +94,7 @@ async function setStrategy( admin, page, strategy ) {
 	await saveButton.click();
 
 	await expect(
-		page.getByTestId( 'snackbar' ).filter( {
+		page.locator( '.components-snackbar__content', {
 			hasText: 'Content Classification settings saved.',
 		} )
 	).toBeVisible();


### PR DESCRIPTION
## What?
Part of: #778

This PR standardizes the way we locate snackbar components in our E2E tests by migrating from CSS class selectors to the component's built-in `data-test-id`. 

## Why?
The Gutenberg snackbar component already provides `data-test-id="snackbar"`, but we weren't utilizing it consistently. Previously, we were querying `.components-snackbar__content`. Moving to `getByTestId` aligns with our testing best practices.
<img width="738" height="533" alt="Screenshot 2026-07-13 at 3 44 29 PM" src="https://github.com/user-attachments/assets/d5bc74d0-8711-4679-8b6b-9255ce6f0074" />

## How?
* Replaced instances of `page.locator( '.components-snackbar__content' )` with `page.getByTestId( 'snackbar' )`.
* Updated assertions in `settings.spec.js` to correctly filter and verify the snackbar visibility using the new test ID.

## Use of AI Tools

**AI assistance:** Yes
**Tool(s):** Claude Code
**Model(s):** Sonnet 4.6
**Used for:** Code review, PR description

## Testing Instructions

Verify that CI passes, or run the updated E2E test locally:

```bash
npm run test:e2e tests/e2e/specs/admin/settings.spec.js
```

## Changelog Entry
> Developer - Standardize E2E snackbar locators to use data-test-id.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-860-1ba23c318ae344e103779341805c10b28d13807d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->