### PR TITLE
Fix[Content Classification]: Improve focus management

### DIFF
--- a/src/experiments/content-classification/components/SuggestionPanel.tsx
+++ b/src/experiments/content-classification/components/SuggestionPanel.tsx
@@ -11,6 +11,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { close as closeIcon, update } from '@wordpress/icons';
 import { useInstanceId } from '@wordpress/compose';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -46,7 +47,7 @@ export default function SuggestionPanel( {
 		minContentLength,
 	} = useContentClassification( taxonomy );
 
-	const taxonomyObject: any = useSelect(
+	const taxonomyObject = useSelect(
 		( selectFn ) => selectFn( coreStore ).getTaxonomy( taxonomy ),
 		[ taxonomy ]
 	);
@@ -61,9 +62,69 @@ export default function SuggestionPanel( {
 		'suggestion-panel-classification-suggestions'
 	);
 
+	const shouldFocusFirstAcceptButton = useRef( false );
+	const shouldFocusGenerateButton = useRef( false );
+
 	const taxonomyLabel: string = taxonomyObject?.name ?? taxonomy;
 
 	const hasSuggestions = suggestions.length > 0;
+
+	/**
+	 * Focuses the generate button when focus has been requested.
+	 *
+	 * @param node The mounted generate button element.
+	 */
+	const focusGenerateButtonOnMount = ( node: HTMLButtonElement | null ) => {
+		if ( shouldFocusGenerateButton.current && node ) {
+			node.focus();
+			shouldFocusGenerateButton.current = false;
+		}
+	};
+
+	/**
+	 * Focuses the first suggestion's accept button when requested.
+	 *
+	 * @param node The mounted accept button element.
+	 */
+	const focusFirstAcceptButtonOnMount = (
+		node: HTMLButtonElement | null
+	) => {
+		if ( shouldFocusFirstAcceptButton.current && node ) {
+			node.focus();
+			shouldFocusFirstAcceptButton.current = false;
+		}
+	};
+
+	/**
+	 * Generates suggestions and schedules the related focus transitions.
+	 *
+	 * @param focusGenerateButton Whether to focus the generate button first.
+	 */
+	const generateAndMoveFocus = ( focusGenerateButton: boolean ) => {
+		shouldFocusGenerateButton.current = focusGenerateButton;
+		shouldFocusFirstAcceptButton.current = true;
+		handleGenerate();
+	};
+
+	/**
+	 * Dismisses all suggestions and returns focus to the generate button.
+	 */
+	const dismissAllAndMoveFocus = () => {
+		shouldFocusFirstAcceptButton.current = false;
+		shouldFocusGenerateButton.current = true;
+		handleDismissAll();
+	};
+
+	/**
+	 * Schedules focus after removing a suggestion.
+	 *
+	 * @param mayRestoreSuggestion Whether the suggestion may be restored.
+	 */
+	const prepareFocusAfterRemoval = ( mayRestoreSuggestion: boolean ) => {
+		shouldFocusFirstAcceptButton.current =
+			suggestions.length > 1 || mayRestoreSuggestion;
+		shouldFocusGenerateButton.current = suggestions.length === 1;
+	};
 
 	return (
 		<div className="ai-content-classification">
@@ -72,9 +133,10 @@ export default function SuggestionPanel( {
 					accessibleWhenDisabled
 					icon={ update }
 					variant="secondary"
-					onClick={ handleGenerate }
+					onClick={ () => generateAndMoveFocus( false ) }
 					disabled={ isGenerating || ! hasEnoughContent }
 					isBusy={ isGenerating }
+					ref={ focusGenerateButtonOnMount }
 					className="ai-content-classification__generate-button"
 					__next40pxDefaultSize
 					aria-describedby={
@@ -137,7 +199,15 @@ export default function SuggestionPanel( {
 							>
 								<Button
 									className="ai-content-classification__pill-accept"
-									onClick={ () => handleAccept( suggestion ) }
+									onClick={ () => {
+										prepareFocusAfterRemoval( true );
+										handleAccept( suggestion );
+									} }
+									ref={
+										suggestion === suggestions[ 0 ]
+											? focusFirstAcceptButtonOnMount
+											: undefined
+									}
 									label={ sprintf(
 										/* translators: %s: Term name. */
 										__( 'Add "%s"', 'ai' ),
@@ -162,9 +232,10 @@ export default function SuggestionPanel( {
 									className="ai-content-classification__pill-dismiss"
 									icon={ closeIcon }
 									iconSize={ 16 }
-									onClick={ () =>
-										handleDismiss( suggestion )
-									}
+									onClick={ () => {
+										prepareFocusAfterRemoval( false );
+										handleDismiss( suggestion );
+									} }
 									label={ sprintf(
 										/* translators: %s: Term name. */
 										__( 'Dismiss "%s"', 'ai' ),
@@ -180,14 +251,17 @@ export default function SuggestionPanel( {
 						className="ai-content-classification__actions"
 					>
 						<FlexItem>
-							<Button variant="link" onClick={ handleGenerate }>
+							<Button
+								variant="link"
+								onClick={ () => generateAndMoveFocus( true ) }
+							>
 								{ __( 'Suggest again', 'ai' ) }
 							</Button>
 						</FlexItem>
 						<FlexItem>
 							<Button
 								variant="link"
-								onClick={ handleDismissAll }
+								onClick={ dismissAllAndMoveFocus }
 								isDestructive
 							>
 								{ __( 'Dismiss all', 'ai' ) }

--- a/src/experiments/content-classification/components/SuggestionPanel.tsx
+++ b/src/experiments/content-classification/components/SuggestionPanel.tsx
@@ -65,7 +65,7 @@ export default function SuggestionPanel( {
 	const shouldFocusFirstAcceptButton = useRef( false );
 	const shouldFocusGenerateButton = useRef( false );
 
-	const taxonomyLabel: string = taxonomyObject?.name ?? taxonomy;
+	const taxonomyLabel = taxonomyObject?.name ?? taxonomy;
 
 	const hasSuggestions = suggestions.length > 0;
 


### PR DESCRIPTION
## What, Why, and How?

Closes https://github.com/WordPress/ai/issues/872

This PR improves keyboard focus management in the content classification suggestion panel because dynamically replacing the generate button or removing a focused suggestion caused focus loss. It tracks pending focus with refs and moves focus to the generating button, the first available suggestion, or the generate button as the interface updates.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Initial code skeleton, code review, and PR metadata.

## Testing Instructions

1. Create a new post and add enough content to enable category/tag suggestions.
2. Select "Suggest Categories/Tags" and wait for the suggestions to appear.
3. Verify that focus moves to the first suggestion.
4. Accept or dismiss a suggestion, then verify that focus moves to the first remaining suggestion.
5. Select Suggest again and verify that focus is preserved while suggestions regenerate.
6. Select Dismiss all and verify that focus returns to the "Suggest Categories/Tags" button.

## Screencast

https://github.com/user-attachments/assets/f10723c2-0236-4592-9b65-753b5f81e77d

## Changelog Entry

> Changed - Improved keyboard focus handling when generating, accepting, or dismissing classification suggestions.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-873-0d616eb91a0037a8a9b9844316e2e9867986fa47.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->