### PR TITLE
Fix: Focus inline reply textarea after generating suggestion

### DIFF
--- a/src/experiments/suggest-reply/components/SuggestReply.ts
+++ b/src/experiments/suggest-reply/components/SuggestReply.ts
@@ -37,7 +37,7 @@ const TONE_OPTIONS: { label: string; value: Tone }[] = [
 	{ label: __( 'Casual', 'ai' ), value: 'casual' },
 ];
 
-/** Writes text into the inline reply textarea and focuses it. */
+/** Writes text into the inline reply textarea. */
 function populateReplyTextarea( text: string ): void {
 	const textarea = document.querySelector< HTMLTextAreaElement >(
 		'#replycontainer #replycontent'
@@ -48,7 +48,6 @@ function populateReplyTextarea( text: string ): void {
 	}
 
 	textarea.value = text;
-	textarea.focus();
 	textarea.dispatchEvent( new Event( 'input', { bubbles: true } ) );
 }
 
@@ -347,6 +346,13 @@ async function runGeneration( commentId: number, tone: Tone ): Promise< void > {
 		setReplyFormDisabled( false );
 		setLinkLoading( commentId, false );
 		setSuggestBtnLoading( false );
+
+		// Focus the textarea after the form controls are re-enabled,
+		// so that focus is not lost due to the element being disabled.
+		const textarea = document.querySelector< HTMLTextAreaElement >(
+			'#replycontainer #replycontent'
+		);
+		textarea?.focus();
 	}
 }
 


### PR DESCRIPTION
## What?
Fixes an issue where the inline reply textarea fails to retain focus after an AI-suggested reply is generated.

## Why?
Previously, when a reply suggestion was generated, the code attempted to focus the textarea while the reply form was still disabled. Because of this the focus was lost. 

## How?
- Removed the `textarea.focus()` call from the `populateReplyTextarea` function.
- Moved the `textarea.focus()` call to the `runGeneration` function. This ensures the textarea is re-enabled and interactive before attempting to set focus to it.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude
Model(s): Sonnet 4.6
Used for: Code review, PR description

## Testing Instructions
1. Go to the Comments screen in the WordPress admin.
2. Find a comment and click the "Suggest reply" action link (or click "Reply", then click the "Suggest Reply" button).
3. Wait for the AI reply to be generated.
4. Verify that once the generation is complete and the text is inserted, the cursor focus is automatically placed inside the textarea so you can immediately start typing or editing.

## Changelog Entry
> Fixed - Inline reply textarea not receiving focus after generating a suggested reply.

### Before

https://github.com/user-attachments/assets/0de175f2-0715-4a03-8339-1ffa19049233

### After

https://github.com/user-attachments/assets/e22f0cb5-6973-4d95-b75f-0294916610ce

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-877-8e8cddab70248928f6f39dff1ed0d9d1287995ca.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->