### PR TITLE
Code Quality: Clean up unnecessary `any` type casts

### DIFF
--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -794,7 +794,7 @@ function AISettingsPage() {
 				createSuccessNotice( message, { type: 'snackbar' } );
 			} catch {
 				// Revert only the toggled keys to their server-side values.
-				const serverRecord = ( registry as any )
+				const serverRecord = registry
 					.select( coreStore )
 					.getEntityRecord( 'root', 'site' ) as
 					| Record< string, unknown >

--- a/src/experiments/content-classification/components/useContentClassification.ts
+++ b/src/experiments/content-classification/components/useContentClassification.ts
@@ -114,7 +114,7 @@ async function generateSuggestions(
  * @return A promise that resolves to an array of lowercase term names.
  */
 async function getAssignedTermNames( taxonomy: string ): Promise< string[] > {
-	const taxonomyObject: any = select( coreStore ).getTaxonomy( taxonomy );
+	const taxonomyObject = select( coreStore ).getTaxonomy( taxonomy );
 	const restBase = taxonomyObject?.rest_base ?? taxonomy;
 	const { getEditedPostAttribute } = select( editorStore );
 	const termIds: number[] = getEditedPostAttribute( restBase ) ?? [];
@@ -331,7 +331,7 @@ async function addTermToPost(
 	taxonomy: string,
 	suggestion: TagSuggestion
 ): Promise< boolean > {
-	const taxonomyObject: any = select( coreStore ).getTaxonomy( taxonomy );
+	const taxonomyObject = select( coreStore ).getTaxonomy( taxonomy );
 	const restBase = taxonomyObject?.rest_base ?? taxonomy;
 
 	// Resolve parent term ID for hierarchical taxonomies only.
@@ -349,7 +349,7 @@ async function addTermToPost(
 		}
 	}
 
-	const { editPost }: any = dispatch( editorStore );
+	const { editPost } = dispatch( editorStore );
 	const { getEditedPostAttribute } = select( editorStore );
 
 	const currentTerms: number[] = getEditedPostAttribute( restBase ) ?? [];
@@ -412,9 +412,11 @@ async function findOrCreateTerm(
 			data[ 'parent' ] = parentId; // eslint-disable-line dot-notation
 		}
 
-		const newTerm: any = await (
-			dispatch( coreStore ) as any
-		 ).saveEntityRecord( 'taxonomy', taxonomy, data );
+		const newTerm = await dispatch( coreStore ).saveEntityRecord(
+			'taxonomy',
+			taxonomy,
+			data
+		);
 
 		return newTerm?.id ?? null;
 	} catch ( error: any ) {

--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -100,7 +100,7 @@ export default function ContentResizingToolbar( {
 		[ clientId ]
 	);
 
-	const blockEditorDispatch = useDispatch( blockEditorStore ) as any;
+	const blockEditorDispatch = useDispatch( blockEditorStore );
 	const noticesDispatch = useDispatch( noticesStore );
 
 	const handleAction = useCallback(

--- a/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
+++ b/src/experiments/editorial-notes/hooks/useEditorialNotes.ts
@@ -84,7 +84,7 @@ function useEditorialNotesAvailability(): {
 } {
 	const content =
 		useSelect( ( selectStore ) => {
-			return ( selectStore( editorStore ) as any ).getEditedPostContent();
+			return selectStore( editorStore ).getEditedPostContent();
 		}, [] ) ?? '';
 	const minContentLength: number =
 		( window as any ).aiEditorialNotesData?.minContentLength ??
@@ -220,14 +220,10 @@ export function useEditorialNotes(): {
 		dispatch( noticesStore ).removeNotice( NOTICE_ID );
 
 		try {
-			const postId = (
-				select( editorStore ) as any
-			 ).getCurrentPostId() as number;
+			const postId = select( editorStore ).getCurrentPostId() as number;
 
 			// Get all blocks and flatten the tree.
-			const allBlocks = (
-				select( blockEditorStore ) as any
-			 ).getBlocks() as Block[];
+			const allBlocks = select( blockEditorStore ).getBlocks();
 			const flatBlocks = flattenBlocks( allBlocks );
 
 			// Filter to reviewable block types.
@@ -294,9 +290,9 @@ export function useEditorialNotes(): {
 			setLastRunCount( totalSuggestions );
 
 			if ( totalSuggestions > 0 ) {
-				(
-					dispatch( coreStore ) as any
-				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
+				dispatch( coreStore ).invalidateResolutionForStoreSelector(
+					'getEntityRecords'
+				);
 
 				dispatch( noticesStore ).createSuccessNotice(
 					sprintf(
@@ -364,17 +360,13 @@ export function useEditorialBlock(): {
 		dispatch( noticesStore ).removeNotice( 'ai_editorial_block_error' );
 
 		try {
-			const block = ( select( blockEditorStore ) as any ).getBlock(
-				clientId
-			) as Block | null;
+			const block = select( blockEditorStore ).getBlock( clientId );
 
 			if ( ! block ) {
 				return;
 			}
 
-			const postId = (
-				select( editorStore ) as any
-			 ).getCurrentPostId() as number;
+			const postId = select( editorStore ).getCurrentPostId() as number;
 
 			// Fetch fresh note state for this invocation.
 			const [ pendingNotes, approvedNotes ] = await Promise.all( [
@@ -400,9 +392,9 @@ export function useEditorialBlock(): {
 			);
 
 			if ( suggestionCount > 0 ) {
-				(
-					dispatch( coreStore ) as any
-				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
+				dispatch( coreStore ).invalidateResolutionForStoreSelector(
+					'getEntityRecords'
+				);
 				( dispatch( editPostStore ) as any ).openGeneralSidebar?.(
 					NOTES_SIDEBAR_ID
 				);
@@ -470,7 +462,7 @@ async function createNote(
 		.map( ( s ) => `[${ s.review_type.toUpperCase() }] ${ s.text }` )
 		.join( '\n\n' );
 
-	const note = ( await ( dispatch( coreStore ) as any ).saveEntityRecord(
+	const note = ( await dispatch( coreStore ).saveEntityRecord(
 		'root',
 		'comment',
 		{
@@ -490,11 +482,8 @@ async function createNote(
 				block.clientId
 			)?.metadata ?? {};
 
-		( dispatch( blockEditorStore ) as any ).updateBlockAttributes(
-			block.clientId,
-			{
-				metadata: { ...existingMeta, noteId: note.id },
-			}
-		);
+		dispatch( blockEditorStore ).updateBlockAttributes( block.clientId, {
+			metadata: { ...existingMeta, noteId: note.id },
+		} );
 	}
 }

--- a/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
+++ b/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
@@ -87,7 +87,7 @@ export function useEditorialUpdates(): {
 	const [ total, setTotal ] = useState< number >( 0 );
 
 	const postId = useSelect(
-		( sel ) => ( sel( editorStore ) as any ).getCurrentPostId() as number,
+		( sel ) => sel( editorStore ).getCurrentPostId() as number,
 		[]
 	);
 
@@ -119,7 +119,7 @@ export function useEditorialUpdates(): {
 				return false;
 			}
 
-			const notes = ( sel( coreStore ) as any ).getEntityRecords(
+			const notes = sel( coreStore ).getEntityRecords(
 				'root',
 				'comment',
 				{
@@ -149,14 +149,12 @@ export function useEditorialUpdates(): {
 		dispatch( noticesStore ).removeNotice( NOTICE_ID );
 
 		try {
-			const content = (
-				select( editorStore ) as any
-			 ).getEditedPostContent() as string;
+			const content = select(
+				editorStore
+			).getEditedPostContent() as string;
 
 			// Get all blocks and flatten the tree.
-			const allBlocks = (
-				select( blockEditorStore ) as any
-			 ).getBlocks() as Block[];
+			const allBlocks = select( blockEditorStore ).getBlocks() as Block[];
 			const flatBlocks = flattenBlocks( allBlocks );
 
 			// Fetch pending Notes for this post.
@@ -284,9 +282,9 @@ export function useEditorialUpdates(): {
 										? 'alt'
 										: 'content';
 
-								(
-									dispatch( blockEditorStore ) as any
-								 ).updateBlockAttributes( block.clientId, {
+								dispatch(
+									blockEditorStore
+								).updateBlockAttributes( block.clientId, {
 									[ attributeToUpdate ]: refinedContent,
 								} );
 
@@ -326,9 +324,9 @@ export function useEditorialUpdates(): {
 					)
 				);
 
-				(
-					dispatch( coreStore ) as any
-				 ).invalidateResolutionForStoreSelector( 'getEntityRecords' );
+				dispatch( coreStore ).invalidateResolutionForStoreSelector(
+					'getEntityRecords'
+				);
 			}
 
 			// If every block failed, surface an error notice.
@@ -348,7 +346,7 @@ export function useEditorialUpdates(): {
 				// Save the post so refinements are persisted and a revision is
 				// created. This keeps the editor state clean — no "unsaved
 				// changes" prompt when navigating to the revisions link.
-				await ( dispatch( editorStore ) as any ).savePost();
+				await dispatch( editorStore ).savePost();
 				const { aiEditorialUpdatesData } = window as any;
 				const restBase = aiEditorialUpdatesData?.rest_base as
 					| string
@@ -364,9 +362,8 @@ export function useEditorialUpdates(): {
 					);
 					lastRevisionId = revisions[ 0 ]?.id ?? null;
 				} catch {
-					lastRevisionId = (
-						select( editorStore ) as any
-					 ).getCurrentPostLastRevisionId() as number | null;
+					lastRevisionId =
+						select( editorStore ).getCurrentPostLastRevisionId();
 				}
 
 				const adminUrl = aiEditorialUpdatesData?.admin_url as

--- a/src/experiments/summarization/functions/useSummaryGeneration.ts
+++ b/src/experiments/summarization/functions/useSummaryGeneration.ts
@@ -93,8 +93,7 @@ export function useSummaryGeneration() {
 				const innerBlocks =
 					createSummaryInnerBlocks( generatedSummary );
 				// Replace inner blocks of the existing group to preserve its attributes.
-				// eslint-disable-next-line dot-notation
-				( dispatch( blockEditorStore ) as any )[ 'replaceInnerBlocks' ](
+				dispatch( blockEditorStore ).replaceInnerBlocks(
 					existingSummaryBlock.clientId,
 					innerBlocks,
 					false
@@ -102,11 +101,8 @@ export function useSummaryGeneration() {
 			} else {
 				// Insert a new summary group block at the top.
 				const summaryBlock = createSummaryBlock( generatedSummary );
-				// eslint-disable-next-line dot-notation
-				( dispatch( blockEditorStore ) as any )[ 'insertBlock' ](
-					summaryBlock,
-					0
-				);
+
+				dispatch( blockEditorStore ).insertBlock( summaryBlock, 0 );
 			}
 		} catch ( error: any ) {
 			const message =

--- a/src/features/image-generation/functions/insert-into-block.ts
+++ b/src/features/image-generation/functions/insert-into-block.ts
@@ -52,10 +52,8 @@ export function insertIntoBlock(
 		case 'core/gallery': {
 			const { getBlocks } = select( blockEditorStore );
 
-			const replaceInnerBlocks = ( dispatch( blockEditorStore ) as any )
-				?.replaceInnerBlocks as
-				| ( ( clientId: string, blocks: unknown[] ) => void )
-				| undefined;
+			const replaceInnerBlocks =
+				dispatch( blockEditorStore )?.replaceInnerBlocks;
 			if ( replaceInnerBlocks ) {
 				const existing = getBlocks( clientId );
 				replaceInnerBlocks( clientId, [

--- a/src/features/image-generation/functions/open-gallery-media-library.ts
+++ b/src/features/image-generation/functions/open-gallery-media-library.ts
@@ -71,9 +71,7 @@ function addSelectionToGallery(
 	selection: SelectionItem[]
 ): void {
 	const { getBlock } = select( blockEditorStore );
-	const { replaceInnerBlocks, selectBlock } = dispatch(
-		blockEditorStore
-	) as any;
+	const { replaceInnerBlocks, selectBlock } = dispatch( blockEditorStore );
 
 	const innerBlockImages = getBlock( clientId )?.innerBlocks ?? [];
 

--- a/src/features/image-generation/inline.tsx
+++ b/src/features/image-generation/inline.tsx
@@ -98,7 +98,7 @@ const insertAfterUploadButton = (
  */
 const useSelectedTargetBlock = (): SelectedTargetBlock | null =>
 	useSelect( ( select ) => {
-		const { getSelectedBlock } = select( blockEditorStore ) as any;
+		const { getSelectedBlock } = select( blockEditorStore );
 		const selectedBlock = getSelectedBlock();
 
 		if (
@@ -132,7 +132,7 @@ const withGenerateImageButton = createHigherOrderComponent( ( Component ) => {
 		}
 
 		const setAttributes = ( attrs: Record< string, unknown > ) =>
-			( dispatch( blockEditorStore ) as any ).updateBlockAttributes(
+			dispatch( blockEditorStore ).updateBlockAttributes(
 				selectedBlock.clientId,
 				attrs
 			);
@@ -210,7 +210,7 @@ const withGenerateImageReplaceFlowButton = createHigherOrderComponent(
 
 			const { children, ...rest } = props;
 			const setAttributes = ( attrs: Record< string, unknown > ) =>
-				( dispatch( blockEditorStore ) as any ).updateBlockAttributes(
+				dispatch( blockEditorStore ).updateBlockAttributes(
 					selectedBlock.clientId,
 					attrs
 				);


### PR DESCRIPTION
## What, Why, and How?

Builds on https://github.com/WordPress/ai/pull/725

This PR removes unnecessary `any` casts from TypeScript code. The current type definitions for multiple stores already cover these APIs, so the casts weaken type safety without providing value. 

> [!NOTE]
> A few `any` casts remain because removing them exposes type errors, primarily due to unexpected consumer signatures that require further review. These cases should be audited separately to ensure they can be corrected without affecting existing functionality.

---

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code Review

## Testing Instructions
- Run `npm run typecheck`
- CI should be green.

## Changelog Entry

> Developer - Removed unnecessary `any` casts to improve TypeScript type safety.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-878-389513054e684251664797f8a879424369b3baeb.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->