### PR TITLE
Abilities Explorer: support custom providers in the filter dropdown and statistics

### DIFF
--- a/includes/Experiments/Abilities_Explorer/Ability_Handler.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Handler.php
@@ -95,6 +95,7 @@ class Ability_Handler {
 			'name'          => $ability->get_label(),
 			'description'   => $ability->get_description(),
 			'provider'      => self::detect_provider( $name, $meta ),
+			'origin'        => self::detect_origin( $name ),
 			'category'      => self::get_ability_category( $ability ),
 			'input_schema'  => $ability->get_input_schema(),
 			'output_schema' => $ability->get_output_schema(),
@@ -193,6 +194,22 @@ class Ability_Handler {
 			return $meta['provider'];
 		}
 
+		return self::detect_origin( $name );
+	}
+
+	/**
+	 * Detects the origin (Core, Plugin, or Theme) of an ability from its name.
+	 *
+	 * Unlike the provider, which can be overridden with a custom label via the
+	 * ability's `meta['provider']`, the origin always resolves to one of the
+	 * three known buckets, so it is suitable for aggregate statistics.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $name Ability name (slug).
+	 * @return string Origin type: 'Core', 'Plugin', or 'Theme'.
+	 */
+	private static function detect_origin( string $name ): string {
 		// Detect based on name prefix (namespace/ability format).
 		$parts = explode( '/', $name );
 		if ( count( $parts ) === 2 ) {
@@ -415,16 +432,13 @@ class Ability_Handler {
 		);
 
 		foreach ( $abilities as $ability ) {
-			// Count by provider.
-			if ( ! isset( $ability['provider'] ) ) {
+			// Count by origin so abilities with a custom provider label still
+			// land in their Core/Plugin/Theme bucket.
+			if ( ! isset( $ability['origin'], $stats['by_provider'][ $ability['origin'] ] ) ) {
 				continue;
 			}
 
-			if ( ! isset( $stats['by_provider'][ $ability['provider'] ] ) ) {
-				continue;
-			}
-
-			++$stats['by_provider'][ $ability['provider'] ];
+			++$stats['by_provider'][ $ability['origin'] ];
 		}
 
 		return $stats;

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -110,9 +110,17 @@ class Ability_Table extends \WP_List_Table {
 		// Apply provider filter.
 		$provider_filter = isset( $_REQUEST['provider'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['provider'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $provider_filter ) && 'all' !== $provider_filter ) {
-			$abilities = array_filter(
+			// Known origins filter by origin, so abilities carrying a custom
+			// provider label still appear under their Core/Plugin/Theme bucket
+			// (consistent with the statistics); custom providers filter by
+			// their exact label.
+			$known_origins = array( 'Core', 'Plugin', 'Theme' );
+			$abilities     = array_filter(
 				$abilities,
-				static function ( $ability ) use ( $provider_filter ) {
+				static function ( $ability ) use ( $provider_filter, $known_origins ) {
+					if ( in_array( $provider_filter, $known_origins, true ) ) {
+						return ( $ability['origin'] ?? '' ) === $provider_filter;
+					}
 					return $ability['provider'] === $provider_filter;
 				}
 			);
@@ -265,7 +273,7 @@ class Ability_Table extends \WP_List_Table {
 	 */
 	public function column_provider( $item ): string {
 		$provider = $item['provider'];
-		$class    = 'ability-provider ability-provider-' . strtolower( $provider );
+		$class    = 'ability-provider ability-provider-' . sanitize_title( $provider );
 
 		return sprintf(
 			'<span class="%s">%s</span>',

--- a/includes/Experiments/Abilities_Explorer/Ability_Table.php
+++ b/includes/Experiments/Abilities_Explorer/Ability_Table.php
@@ -187,6 +187,35 @@ class Ability_Table extends \WP_List_Table {
 	}
 
 	/**
+	 * Gets sorted unique providers derived from the already-fetched ability list.
+	 *
+	 * Known origins (Core, Plugin, Theme) come first in their canonical order;
+	 * any custom providers (set via an ability's `meta['provider']`) follow
+	 * alphabetically.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return list<string> Known provider origins followed by custom providers sorted alphabetically.
+	 */
+	public function get_unique_providers(): array {
+		$known  = array( 'Core', 'Plugin', 'Theme' );
+		$custom = array();
+
+		foreach ( $this->all_abilities as $ability ) {
+			if ( empty( $ability['provider'] ) || in_array( $ability['provider'], $known, true ) ) {
+				continue;
+			}
+
+			$custom[] = $ability['provider'];
+		}
+
+		$custom = array_unique( $custom );
+		sort( $custom );
+
+		return array_merge( $known, $custom );
+	}
+
+	/**
 	 * {@inheritDoc}
 	 *
 	 * @param array<string,mixed> $item Item data.
@@ -294,9 +323,9 @@ class Ability_Table extends \WP_List_Table {
 			<label for="filter-by-provider" class="screen-reader-text"><?php esc_html_e( 'Filter by provider', 'ai' ); ?></label>
 			<select name="provider" id="filter-by-provider">
 				<option value="all" <?php selected( $provider_filter, 'all' ); ?>><?php esc_html_e( 'All Providers', 'ai' ); ?></option>
-				<option value="Core" <?php selected( $provider_filter, 'Core' ); ?>><?php esc_html_e( 'Core', 'ai' ); ?></option>
-				<option value="Plugin" <?php selected( $provider_filter, 'Plugin' ); ?>><?php esc_html_e( 'Plugins', 'ai' ); ?></option>
-				<option value="Theme" <?php selected( $provider_filter, 'Theme' ); ?>><?php esc_html_e( 'Theme', 'ai' ); ?></option>
+				<?php foreach ( $this->get_unique_providers() as $provider ) : ?>
+					<option value="<?php echo esc_attr( $provider ); ?>" <?php selected( $provider_filter, $provider ); ?>><?php echo esc_html( Ability_Handler::get_provider_label( $provider ) ); ?></option>
+				<?php endforeach; ?>
 			</select>
 
 			<label for="filter-by-category" class="screen-reader-text"><?php esc_html_e( 'Filter by category', 'ai' ); ?></label>

--- a/includes/Experiments/Abilities_Explorer/Admin_Page.php
+++ b/includes/Experiments/Abilities_Explorer/Admin_Page.php
@@ -199,7 +199,7 @@ class Admin_Page {
 				<table class="ability-detail-table">
 					<tr>
 						<th><?php esc_html_e( 'Provider', 'ai' ); ?></th>
-						<td><span class="ability-provider ability-provider-<?php echo esc_attr( strtolower( $ability['provider'] ) ); ?>"><?php echo esc_html( Ability_Handler::get_provider_label( $ability['provider'] ) ); ?></span></td>
+						<td><span class="ability-provider ability-provider-<?php echo esc_attr( sanitize_title( $ability['provider'] ) ); ?>"><?php echo esc_html( Ability_Handler::get_provider_label( $ability['provider'] ) ); ?></span></td>
 					</tr>
 				</table>
 			</div>

--- a/src/experiments/abilities-explorer/index.scss
+++ b/src/experiments/abilities-explorer/index.scss
@@ -61,6 +61,7 @@
 }
 
 /* Provider Badges - Using WordPress notice colors */
+/* Base styles double as the pill for custom providers (set via meta['provider']). */
 .ability-provider {
 	display: inline-flex;
 	align-items: center;
@@ -69,6 +70,9 @@
 	border-radius: 2px;
 	font-size: 12px;
 	font-weight: 500;
+	background: #f0f6fc;
+	color: var(--wp--preset--color--foreground, #1e1e1e);
+	border: 1px solid var(--wp-admin-border-color, #c3c4c7);
 }
 
 .ability-provider-core {

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_HandlerTest.php
@@ -349,6 +349,48 @@ class Ability_HandlerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test get_statistics counts custom-provider abilities in their origin bucket.
+	 *
+	 * An ability with a custom provider label in `meta['provider']` must still
+	 * be counted in its Core/Plugin/Theme origin bucket instead of disappearing
+	 * from the statistics.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_statistics_counts_custom_provider_in_origin_bucket() {
+		global $wp_current_filter;
+
+		$slug = 'custom-provider-plugin/stats-ability';
+
+		$before = Ability_Handler::get_statistics();
+
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+
+		try {
+			wp_register_ability(
+				$slug,
+				array(
+					'label'               => 'Custom Provider Ability',
+					'description'         => 'Test ability with a custom provider label.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'meta'                => array( 'provider' => 'My Custom Plugin' ),
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$after = Ability_Handler::get_statistics();
+
+		wp_unregister_ability( $slug );
+
+		$this->assertSame( $before['total'] + 1, $after['total'] );
+		$this->assertSame( $before['by_provider']['Plugin'] + 1, $after['by_provider']['Plugin'] );
+	}
+
+	/**
 	 * Test invoke_ability accepts a scalar input value.
 	 *
 	 * Abilities may declare a non-object input schema (e.g. a bare integer),

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_TableTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_TableTest.php
@@ -87,4 +87,55 @@ class Ability_TableTest extends WP_UnitTestCase {
 
 		$this->assertSame( array( 'Core', 'Plugin', 'Theme', 'My Custom Plugin' ), $table->get_unique_providers() );
 	}
+
+	/**
+	 * Test the provider filter matches by origin for known providers and by label for custom ones.
+	 *
+	 * Filtering by "Plugin" must include abilities that carry a custom provider
+	 * label but originate from a plugin (consistent with the statistics), while
+	 * filtering by the custom label must return only those abilities.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_provider_filter_matches_origin_for_known_providers() {
+		global $wp_current_filter;
+
+		$slug = 'custom-provider-plugin/filter-ability';
+
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+
+		try {
+			wp_register_ability(
+				$slug,
+				array(
+					'label'               => 'AAA Custom Provider Filter Ability',
+					'description'         => 'Test ability with a custom provider label for filtering.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'meta'                => array( 'provider' => 'My Custom Plugin' ),
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		// Known origin: the custom-labeled ability still appears under "Plugin".
+		$_REQUEST['provider'] = 'Plugin';
+		$table                = new Ability_Table();
+		$table->prepare_items();
+		$plugin_slugs = wp_list_pluck( $table->items, 'slug' );
+		$this->assertContains( $slug, $plugin_slugs );
+
+		// Custom label: filtering by it returns exactly the custom-labeled ability.
+		$_REQUEST['provider'] = 'My Custom Plugin';
+		$table                = new Ability_Table();
+		$table->prepare_items();
+		$custom_slugs = wp_list_pluck( $table->items, 'slug' );
+
+		unset( $_REQUEST['provider'] );
+		wp_unregister_ability( $slug );
+
+		$this->assertSame( array( $slug ), $custom_slugs );
+	}
 }

--- a/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_TableTest.php
+++ b/tests/Integration/Includes/Experiments/Abilities_Explorer/Ability_TableTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Integration tests for the Ability_Table class.
+ *
+ * @package WordPress\AI\Tests\Integration\Experiments\Abilities_Explorer
+ */
+
+namespace WordPress\AI\Tests\Integration\Experiments\Abilities_Explorer;
+
+use WP_UnitTestCase;
+use WordPress\AI\Experiments\Abilities_Explorer\Ability_Table;
+
+/**
+ * Ability_Table test case.
+ *
+ * @since x.x.x
+ */
+class Ability_TableTest extends WP_UnitTestCase {
+	/**
+	 * Set up test case.
+	 *
+	 * @since x.x.x
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Create admin user for tests.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+		set_current_screen( 'tools_page_ai-abilities-explorer' );
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since x.x.x
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test get_unique_providers returns only the known origins by default.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_unique_providers_returns_known_origins() {
+		$table = new Ability_Table();
+		$table->prepare_items();
+
+		$this->assertSame( array( 'Core', 'Plugin', 'Theme' ), $table->get_unique_providers() );
+	}
+
+	/**
+	 * Test get_unique_providers appends custom providers after the known origins.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_unique_providers_includes_custom_providers() {
+		global $wp_current_filter;
+
+		$slug = 'custom-provider-plugin/table-ability';
+
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+
+		try {
+			wp_register_ability(
+				$slug,
+				array(
+					'label'               => 'Custom Provider Table Ability',
+					'description'         => 'Test ability with a custom provider label.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'meta'                => array( 'provider' => 'My Custom Plugin' ),
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$table = new Ability_Table();
+		$table->prepare_items();
+
+		wp_unregister_ability( $slug );
+
+		$this->assertSame( array( 'Core', 'Plugin', 'Theme', 'My Custom Plugin' ), $table->get_unique_providers() );
+	}
+}


### PR DESCRIPTION
## What?

Closes #883

Makes the Abilities Explorer treat custom providers (set via an ability's `meta['provider']`) as first-class citizens:

1. The provider filter dropdown is built dynamically, so custom providers become selectable filter options.
2. The overview statistics count abilities by their **origin** (Core/Plugin/Theme), so an ability with a custom provider label still counts in its origin bucket instead of disappearing from the stat cards.

## Why?

`Ability_Handler::detect_provider()` already supports custom providers via `meta['provider']`, and `get_provider_label()` deliberately passes unknown provider names through — the Provider column shows them and the `?provider=` query arg filters correctly. But the provider `<select>` in `Ability_Table::extra_tablenav()` was hardcoded to all/Core/Plugins/Theme, so custom providers could never be selected in the UI. See #883.

The stat cards had the mirrored problem: `get_statistics()` only counted the three hardcoded buckets, so any ability with a custom provider label silently vanished from every card (only Total stayed correct). Rendering a card per custom provider would not scale — a site with ten such plugins would get ten extra cards — so the cards stay Core/Plugins/Theme and the counting becomes origin-based instead.

## How?

Follows the same approach as the dynamic category filter added in #355 (`get_unique_categories()`):

- New `Ability_Table::get_unique_providers()` — known origins (Core, Plugin, Theme) first in canonical order, custom providers appended alphabetically.
- The three hardcoded `<option>` tags become a loop, labelled via the existing `Ability_Handler::get_provider_label()`. This also makes the dropdown label ("Plugin") consistent with the Provider column, which used the singular while the old dropdown said "Plugins".
- New `Ability_Handler::detect_origin()` holds the prefix-based Core/Plugin/Theme detection; `detect_provider()` returns `meta['provider']` when set and falls back to the origin. Formatted abilities expose a new `origin` field and `get_statistics()` counts by it — the `by_provider` array keys are unchanged, so `Admin_Page` needs no changes.
- Integration tests: new `Ability_TableTest` covers `get_unique_providers()` with and without a custom provider (this also covers the line the Codecov report flagged), and a new `Ability_HandlerTest` case asserts a custom-provider ability still increments its origin bucket in the statistics.

Sites without custom providers see no change anywhere (same four dropdown options, same counts). The accessible label added in #642 is preserved.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: drafting the implementation and this PR description under my direction; I reviewed the code and tested it on a live site before submitting.

## Testing Instructions

1. On a site with the plugin active, visit Tools → Abilities Explorer: the provider dropdown shows all/Core/Plugin/Theme and the stat cards show the same counts as before.
2. Register an ability whose meta includes `'provider' => 'My Plugin'` (e.g. via `wp_register_ability()`).
3. Reload the Explorer: the dropdown now contains a "My Plugin" option; selecting it and clicking Filter lists exactly the abilities with that provider.
4. The stat cards are unchanged by the custom label: the ability still counts under Plugins (previously it dropped out of all three cards).

Tested on WordPress 7.1-beta1 with 112 registered abilities, 82 of them carrying a custom provider: the dropdown gains the custom option and filters to exactly those 82, and the stat cards read Core 6 / Plugins 106 / Theme 0 — identical to the counts before the custom labels were applied.

## Changelog Entry

> Changed - The Abilities Explorer provider filter dropdown is now built dynamically and includes custom providers, and the overview statistics count abilities by origin so custom-provider abilities remain in their Core/Plugins/Theme bucket.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-884-40d0a75a105645dc36915a9c0d7236752307e0fa.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->