### PR TITLE
Solution (#425): Update placement of Alt Text generation buttons

### DIFF
--- a/path/to/includes/Abilities/Image/Alt_Text_Generation.js
+++ b/path/to/includes/Abilities/Image/Alt_Text_Generation.js
@@ -1,0 +1,8 @@
+# Update the HTML structure and CSS styles to reflect the new layout
+(function($) {
+  $(document).ready(function() {
+    // Update the HTML structure and CSS styles to reflect the new layout
+    $('.ai-alt-text-generation').append('<textarea id="ai-alt-text-generation-textarea" placeholder="Enter image description"></textarea>');
+    $('.ai-alt-text-generation').append('<button class="button button-primary" id="ai-alt-text-generation-button">Generate Alt Text</button>');
+  });
+})(jQuery);

--- a/path/to/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/path/to/includes/Abilities/Image/Alt_Text_Generation.php
@@ -1,0 +1,34 @@
+# Update the HTML structure and CSS styles to reflect the new layout
+<?php
+/**
+ * Alt Text Generation Ability
+ *
+ * @package WordPress\AI
+ */
+
+namespace WordPress\AI\Includes\Abilities\Image;
+
+use WordPress\AI\Includes\Abilities\Image\Image_Prompt_System_Instruction;
+
+class Alt_Text_Generation {
+  public function __construct() {
+    add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    add_action( 'admin_footer', array( $this, 'render_ability' ) );
+  }
+
+  public function enqueue_scripts() {
+    wp_enqueue_script( 'ai-alt-text-generation', AI_PLUGIN_URL . 'assets/js/ai-alt-text-generation.js', array( 'jquery' ) );
+  }
+
+  public function render_ability() {
+    ?>
+    <div class="ai-alt-text-generation">
+      <h2><?php _e( 'Alt Text Generation', 'ai' ); ?></h2>
+      <div class="ai-alt-text-generation__content">
+        <textarea id="ai-alt-text-generation-textarea" placeholder="<?php _e( 'Enter image description', 'ai' ); ?>"></textarea>
+        <button class="button button-primary" id="ai-alt-text-generation-button"><?php _e( 'Generate Alt Text', 'ai' ); ?></button>
+      </div>
+    </div>
+    <?php
+  }
+}

--- a/path/to/includes/Abilities/Image/image-prompt-system-instruction.js
+++ b/path/to/includes/Abilities/Image/image-prompt-system-instruction.js
@@ -1,0 +1,26 @@
+# Update the CSS styles to reflect the new layout
+(function($) {
+  $(document).ready(function() {
+    // Update the CSS styles to reflect the new layout
+    $('.ai-alt-text-generation').css({
+      'margin-top': '20px'
+    });
+    $('.ai-alt-text-generation__content').css({
+      'padding': '20px',
+      'background-color': '#f7f7f7',
+      'border': '1px solid #ddd',
+      'border-radius': '10px',
+      'box-shadow': '0 0 10px rgba(0, 0, 0, 0.1)'
+    });
+    $('#ai-alt-text-generation-textarea').css({
+      'width': '100%',
+      'height': '100px',
+      'padding': '10px',
+      'font-size': '16px',
+      'border': '1px solid #ccc'
+    });
+    $('#ai-alt-text-generation-button').css({
+      'margin-top': '10px'
+    });
+  });
+})(jQuery);

--- a/path/to/includes/Abilities/Image/image-prompt-system-instruction.php
+++ b/path/to/includes/Abilities/Image/image-prompt-system-instruction.php
@@ -1,0 +1,47 @@
+# Update the CSS styles to reflect the new layout
+<?php
+/**
+ * Image Prompt System Instruction
+ *
+ * @package WordPress\AI
+ */
+
+namespace WordPress\AI\Includes\Abilities\Image;
+
+class Image_Prompt_System_Instruction {
+  public function __construct() {
+    add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    add_action( 'admin_footer', array( $this, 'render_instruction' ) );
+  }
+
+  public function enqueue_scripts() {
+    wp_enqueue_script( 'ai-image-prompt-system-instruction', AI_PLUGIN_URL . 'assets/js/ai-image-prompt-system-instruction.js', array( 'jquery' ) );
+  }
+
+  public function render_instruction() {
+    ?>
+    <style>
+      .ai-alt-text-generation {
+        margin-top: 20px;
+      }
+      .ai-alt-text-generation__content {
+        padding: 20px;
+        background-color: #f7f7f7;
+        border: 1px solid #ddd;
+        border-radius: 10px;
+        box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      }
+      #ai-alt-text-generation-textarea {
+        width: 100%;
+        height: 100px;
+        padding: 10px;
+        font-size: 16px;
+        border: 1px solid #ccc;
+      }
+      #ai-alt-text-generation-button {
+        margin-top: 10px;
+      }
+    </style>
+    <?php
+  }
+}

--- a/path/to/includes/Admin/Dashboard/AI_Capabilities_Widget.js
+++ b/path/to/includes/Admin/Dashboard/AI_Capabilities_Widget.js
@@ -1,0 +1,15 @@
+# Update the layout of the Alt Text generation button on the Edit Media page
+# Remove the standalone Alt Text metabox on the Edit Media page
+# Update the layout of the Alt Text generation button on the Attachment details view
+(function($) {
+  $(document).ready(function() {
+    // Update the layout of the Alt Text generation button on the Edit Media page
+    $('#ai-alt-text-generation-button').appendTo('.ai-capabilities-widget__content');
+
+    // Remove the standalone Alt Text metabox on the Edit Media page
+    $('#ai-alt-text-metabox').remove();
+
+    // Update the layout of the Alt Text generation button on the Attachment details view
+    $('#ai-attachment-details-button').appendTo('.ai-capabilities-widget__content');
+  });
+})(jQuery);

--- a/path/to/includes/Admin/Dashboard/AI_Capabilities_Widget.php
+++ b/path/to/includes/Admin/Dashboard/AI_Capabilities_Widget.php
@@ -1,0 +1,42 @@
+# Update the layout of the Alt Text generation button on the Edit Media page
+# Remove the standalone Alt Text metabox on the Edit Media page
+# Update the layout of the Alt Text generation button on the Attachment details view
+<?php
+/**
+ * AI Capabilities Widget
+ *
+ * @package WordPress\AI
+ */
+
+namespace WordPress\AI\Includes\Admin\Dashboard;
+
+use WordPress\AI\Includes\Abilities\Image\Alt_Text_Generation;
+
+class AI_Capabilities_Widget {
+  public function __construct() {
+    add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+    add_action( 'admin_footer', array( $this, 'render_widget' ) );
+  }
+
+  public function enqueue_scripts() {
+    wp_enqueue_script( 'ai-capabilities-widget', AI_PLUGIN_URL . 'assets/js/ai-capabilities-widget.js', array( 'jquery' ) );
+  }
+
+  public function render_widget() {
+    ?>
+    <div class="ai-capabilities-widget">
+      <h2><?php _e( 'AI Capabilities', 'ai' ); ?></h2>
+      <div class="ai-capabilities-widget__content">
+        <div class="ai-capabilities-widget__section">
+          <h3><?php _e( 'Alt Text Generation', 'ai' ); ?></h3>
+          <button class="button button-primary" id="ai-alt-text-generation-button"><?php _e( 'Generate Alt Text', 'ai' ); ?></button>
+        </div>
+        <div class="ai-capabilities-widget__section">
+          <h3><?php _e( 'Attachment Details', 'ai' ); ?></h3>
+          <button class="button button-primary" id="ai-attachment-details-button"><?php _e( 'View Attachment Details', 'ai' ); ?></button>
+        </div>
+      </div>
+    </div>
+    <?php
+  }
+}


### PR DESCRIPTION
This pull request updates the placement of the Alt Text generation buttons on the Edit Media page and Attachment details view. To test this update, please follow these steps:

1. Clone the WordPress/ai repository
2. Run `composer install` to install dependencies
3. Run `wp plugin install ai` to install the AI plugin
4. Go to the Edit Media page or Attachment details view
5. Verify that the Alt Text generation button is in a more prominent position
6. Verify that the CSS styles have been updated correctly

Please review the changes and let me know if you have any questions or concerns.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-885-cf20925e61a5d8e918de914fc90c7053d2d5d4fd.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->