### PR TITLE
Fix: Meta Description: Issue with Yoast plugin for Meta Description experiment

### DIFF
--- a/src/experiments/meta-description/components/useMetaDescription.ts
+++ b/src/experiments/meta-description/components/useMetaDescription.ts
@@ -7,7 +7,7 @@
  */
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, useCallback } from '@wordpress/element';
+import { useState, useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -17,6 +17,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { runAbility } from '../../../utils/run-ability';
 import { ensureProvider } from '../../../utils/provider-status';
 import { hasMinimumContent } from '../../../utils/character-count';
+import { getAdapter } from '../seo-adapters';
 import type {
 	MetaDescriptionAbilityInput,
 	MetaDescriptionAbilityResponse,
@@ -52,7 +53,12 @@ interface UseMetaDescriptionReturn {
 export function useMetaDescription(): UseMetaDescriptionReturn {
 	const localized = getLocalized();
 	const metaKey = localized?.metaKey ?? 'wpai_meta_description';
-	const hasSeoPlugin = Boolean( localized?.seoPlugin );
+	const seoPlugin = localized?.seoPlugin ?? null;
+	const hasSeoPlugin = Boolean( seoPlugin );
+
+	// The active SEO plugin decides how the description is written to and read from the
+	// editor. The default adapter uses core/editor post meta; Yoast targets its own store.
+	const adapter = useMemo( () => getAdapter( seoPlugin ), [ seoPlugin ] );
 
 	const { editPost } = useDispatch( editorStore );
 	const { removeNotice, createErrorNotice } = dispatch( noticesStore );
@@ -66,19 +72,23 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 		[]
 	);
 
-	const { postId, content, title, meta } = useSelect( ( select ) => {
-		const editor = select( editorStore );
-		const currentMeta = editor.getEditedPostAttribute( 'meta' ) as
-			| Record< string, string >
-			| undefined;
+	const { postId, content, title, meta, currentDescription } = useSelect(
+		( select ) => {
+			const editor = select( editorStore );
+			const currentMeta = editor.getEditedPostAttribute( 'meta' ) as
+				| Record< string, string >
+				| undefined;
 
-		return {
-			postId: editor.getCurrentPostId() as number,
-			content: editor.getEditedPostContent(),
-			title: editor.getEditedPostAttribute( 'title' ) as string,
-			meta: currentMeta,
-		};
-	}, [] );
+			return {
+				postId: editor.getCurrentPostId() as number,
+				content: editor.getEditedPostContent(),
+				title: editor.getEditedPostAttribute( 'title' ) as string,
+				meta: currentMeta,
+				currentDescription: adapter.read( select, { metaKey } ),
+			};
+		},
+		[ adapter, metaKey ]
+	);
 
 	const minContentLength =
 		localized?.minContentLength ?? MINIMUM_CONTENT_COUNT_DEFAULT;
@@ -145,14 +155,9 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 
 	const applyDescription = useCallback(
 		( text: string ) => {
-			editPost( {
-				meta: {
-					...meta,
-					[ metaKey ]: text,
-				},
-			} );
+			adapter.apply( text, { metaKey, meta, editPost } );
 		},
-		[ editPost, metaKey, meta ]
+		[ adapter, editPost, metaKey, meta ]
 	);
 
 	const clearSuggestion = useCallback( () => {
@@ -162,7 +167,7 @@ export function useMetaDescription(): UseMetaDescriptionReturn {
 	return {
 		isGenerating,
 		suggestion,
-		currentDescription: meta?.[ metaKey ] ?? '',
+		currentDescription,
 		metaKey,
 		hasSeoPlugin,
 		isContentTooShort,

--- a/src/experiments/meta-description/seo-adapters.ts
+++ b/src/experiments/meta-description/seo-adapters.ts
@@ -1,0 +1,144 @@
+/**
+ * SEO plugin editor adapters for applying and reading the meta description.
+ *
+ * The active SEO plugin is detected server-side and passed to the client as
+ * `window.aiMetaDescriptionData.seoPlugin`. Adapter selection is keyed by that slug.
+ *
+ * The default adapter writes to core/editor post meta, which works for the fallback meta
+ * key (registered for all REST post types) and for any SEO plugin whose meta key is
+ * REST-registered for the current post type. Plugin-specific adapters instead target the
+ * plugin's own editor store so the value updates the plugin UI and persists on every post
+ * type — including pages and CPTs, where a plugin may expose its meta to REST only for the
+ * `post` post type.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import type { SelectFunction } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Context available when reading the current description.
+ */
+export interface ReadContext {
+	metaKey: string;
+}
+
+/**
+ * Context available when applying a description.
+ */
+export interface ApplyContext extends ReadContext {
+	meta: Record< string, string > | undefined;
+	editPost: ( edits: { meta: Record< string, string > } ) => unknown;
+}
+
+/**
+ * Encapsulates how to write and read a meta description for a given SEO plugin.
+ */
+export interface SeoEditorAdapter {
+	/**
+	 * Writes the description so the SEO plugin UI updates and the value persists on save.
+	 *
+	 * @param text Description to apply.
+	 * @param ctx  Apply context.
+	 */
+	apply: ( text: string, ctx: ApplyContext ) => void;
+
+	/**
+	 * Reads the currently stored description for display.
+	 *
+	 * @param select The `useSelect` select function.
+	 * @param ctx    Read context.
+	 * @return The current description, or an empty string.
+	 */
+	read: ( select: SelectFunction, ctx: ReadContext ) => string;
+}
+
+const YOAST_STORE = 'yoast-seo/editor';
+
+/**
+ * Default adapter: stores the description in core/editor post meta.
+ */
+export const defaultAdapter: SeoEditorAdapter = {
+	apply: ( text, { metaKey, meta, editPost } ) => {
+		editPost( { meta: { ...meta, [ metaKey ]: text } } );
+	},
+	read: ( select, { metaKey } ) => {
+		const meta = select( editorStore ).getEditedPostAttribute( 'meta' ) as
+			| Record< string, string >
+			| undefined;
+		return meta?.[ metaKey ] ?? '';
+	},
+};
+
+/**
+ * Yoast adapter: writes to the `yoast-seo/editor` store.
+ *
+ * Yoast exposes `_yoast_wpseo_metadesc` to REST only for the `post` post type, so core/editor
+ * meta cannot round-trip on pages or CPTs. Writing to Yoast's own store updates the snippet
+ * editor UI and persists via Yoast's metabox save on every post type. The extra `editPost`
+ * marks the editor dirty so the Save button enables (and persists via REST on `post`).
+ */
+export const yoastAdapter: SeoEditorAdapter = {
+	apply: ( text, { metaKey, meta, editPost } ) => {
+		try {
+			const yoast = dispatch( YOAST_STORE ) as unknown as
+				| { updateData?: ( data: { description: string } ) => void }
+				| undefined;
+			yoast?.updateData?.( { description: text } );
+		} catch {
+			// Yoast store not registered; the editPost below still applies the value.
+		}
+
+		// Mark the editor dirty on every post type; also persists via REST on `post`.
+		editPost( { meta: { ...meta, [ metaKey ]: text } } );
+	},
+	read: ( select, { metaKey } ) => {
+		try {
+			const yoast = select( YOAST_STORE ) as unknown as
+				| { getSnippetEditorDescription?: () => string }
+				| undefined;
+			if ( typeof yoast?.getSnippetEditorDescription === 'function' ) {
+				return yoast.getSnippetEditorDescription() ?? '';
+			}
+		} catch {
+			// Fall through to the core/editor meta fallback below.
+		}
+
+		return defaultAdapter.read( select, { metaKey } );
+	},
+};
+
+/**
+ * Registry of SEO plugin adapters, keyed by the plugin slug from `SEO_Integration`.
+ */
+const ADAPTERS: Record< string, SeoEditorAdapter > = {
+	'yoast-seo': yoastAdapter,
+};
+
+/**
+ * Returns the editor adapter for the active SEO plugin, or the default adapter.
+ *
+ * @param slug The active SEO plugin slug, or null when none is detected.
+ * @return The matching adapter.
+ */
+export function getAdapter( slug: string | null ): SeoEditorAdapter {
+	/**
+	 * Filters the SEO plugin editor adapters.
+	 *
+	 * Lets third parties register a store-based adapter for an SEO plugin. Plugins registered
+	 * only via the PHP `wpai_meta_description_seo_plugins` filter fall back to the default
+	 * (core/editor meta) adapter.
+	 *
+	 * @param {Record<string, SeoEditorAdapter>} adapters Map of plugin slug to adapter.
+	 */
+	const adapters = applyFilters(
+		'ai.metaDescription.seoAdapters',
+		ADAPTERS
+	) as Record< string, SeoEditorAdapter >;
+
+	return ( slug && adapters[ slug ] ) || defaultAdapter;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/874

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR resolves the issue where, Yoast meta description is only saved for posts and no other post types.
- It also resolves the issue where, `Yoast AI` is disable, still meta description is saved via yoast.
- Read more on issue mentioned.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds the `seo-adapter.ts` file, which register the adapter and use the required SEO adapters to work with.
- If the Yoast plugin is active, the adapter uses Yoast method and way to store/fetch the meta description, else fallback to default what's being performed.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 4.8
Used for: Initial code implementation and final implementation and testing was done by me.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Open both post and page.
2. Make sure to activate yoast plugin.
3. Use Meta Description experiment to generated meta description.
4. See both post and page stores the meta description correctly to Yoast meta and our custom meta description box.

## Screenshots or screencast

https://github.com/user-attachments/assets/8be352b0-e95c-4ee2-99d4-5ed4b1e140c3



## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Meta Description suggestions applied on pages and custom post types were lost on save when Yoast SEO was active.


---

# AI Summary

## What?

Routes the Meta Description **Apply** action through the active SEO plugin's own editor store instead of always writing to `core/editor` post meta. Introduces a small, slug-keyed adapter layer and ships a **Yoast** adapter, so an applied AI meta description updates the SEO plugin UI and persists on **all post types** (posts, pages, and CPTs).

## Why?

`useMetaDescription.applyDescription` wrote the suggestion via `editPost( { meta: { [ metaKey ]: text } } )` (the `core/editor` store). That only works when the meta key is REST-registered for the current post type:

- **No SEO plugin:** the plugin registers its fallback key for all REST post types, so this already works everywhere.
- **Yoast active:** Yoast exposes `_yoast_wpseo_metadesc` to REST **only for the `post` post type** (`register_meta( … 'object_subtype' => 'post' )`). On a **page or CPT** the key isn't REST-registered, so `editPost` is dropped on save and the Yoast snippet field (bound to the `yoast-seo/editor` store) never reflects it — the applied description is lost. It also only appeared to work on posts when Yoast's own AI feature happened to be enabled, because that feature mounts the hook that mirrors `core/editor` meta into the Yoast store.

The fix targets the SEO plugin's own store, which is the source of truth for its UI and its all-post-type save path.

## How?

- **New `src/experiments/meta-description/seo-adapters.ts`** — a `SeoEditorAdapter` abstraction (`apply` / `read`) selected by the active plugin slug (`window.aiMetaDescriptionData.seoPlugin`):
  - `defaultAdapter` — unchanged behaviour: `editPost` on the meta key; reads from `core/editor` meta. Used for the fallback key and any not-yet-adapted SEO plugin.
  - `yoastAdapter` — `apply` dispatches `updateData( { description } )` to `yoast-seo/editor` (drives the UI + Yoast's metabox save on every post type) **and** calls `editPost` to mark the editor dirty so the Save button enables (and to persist via REST on `post`). `read` uses `getSnippetEditorDescription()` with a fallback to core meta if the Yoast store isn't ready.
  - `getAdapter()` with an `ai.metaDescription.seoAdapters` JS filter, mirroring the existing PHP `wpai_meta_description_seo_plugins` filter for extensibility.
- **`components/useMetaDescription.ts`** — selects the adapter by slug, routes `applyDescription` through `adapter.apply()`, and derives `currentDescription` from `adapter.read()` (fixing the display / "already set" check on Yoast pages, where `core/editor` meta doesn't carry the key).
- **PHP unchanged** — `SEO_Integration` remains the single source of truth for detection and the meta key. Which plugin is active and its key stay server-side; *how* to write to the editor store is client-side, per-plugin behaviour.

**Scope:** ships the Yoast adapter only. Rank Math / All in One SEO / SEOPress continue to use the default (`editPost`) adapter until each is verified — dedicated adapters can be added incrementally (AIOSEO in particular uses a non-`@wordpress/data` store).

## Testing Instructions

Preconditions: an AI connector with a text-generation model configured, and the Meta Description experiment enabled.

1. **Yoast active — Page (the bug):** Activate Yoast SEO. Edit a **Page** with ≥250 characters of content. Open the **Meta Description** panel → **Generate** → **Apply**.
   - The Yoast "Meta description" field/snippet preview updates to the applied text.
   - The Save/Update button becomes enabled even with no other edit.
   - **Save → reload:** the value persists; the front end outputs `<meta name="description" …>` with the text.
2. **Yoast active — Post:** Repeat step 1 on a **Post**; confirm it still works.
3. **Yoast active — CPT:** Repeat on a public custom post type that shows the Yoast metabox.
4. **Yoast AI feature on/off:** Repeat step 1 with Yoast's own AI feature toggled both ways — behaviour should now be identical.
5. **No SEO plugin (regression):** Deactivate all SEO plugins. Generate → Apply on a Post and a Page; confirm the value persists in the fallback meta and renders in the head (default path unchanged).

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-886-bfba0be3cc66bc483224a1aba92803e763809d92.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->