### PR TITLE
Refactor experiments to leverage ai service layer

### DIFF
--- a/includes/Abilities/Excerpt_Generation/Excerpt_Generation.php
+++ b/includes/Abilities/Excerpt_Generation/Excerpt_Generation.php
@@ -12,6 +12,7 @@ namespace WordPress\AI\Abilities\Excerpt_Generation;
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI\Experiments\Excerpt_Generation\Excerpt_Generation as Excerpt_Generation_Experiment;
+use WordPress\AI\Services\AI_Service;
 
 use function WordPress\AI\get_post_context;
 use function WordPress\AI\normalize_content;
@@ -253,7 +254,7 @@ class Excerpt_Generation extends Abstract_Ability {
 	 * @return \WP_AI_Client_Prompt_Builder|\WP_Error The prompt builder, or a WP_Error on failure.
 	 */
 	private function get_prompt_builder( string $prompt ) {
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_textgen_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() )
 			->using_temperature( 0.7 );
 

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -12,6 +12,7 @@ namespace WordPress\AI\Abilities\Image;
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI\Experiments\Alt_Text_Generation\Alt_Text_Generation as Alt_Text_Generation_Experiment;
+use WordPress\AI\Services\AI_Service;
 
 use function WordPress\AI\get_preferred_vision_models;
 use function WordPress\AI\normalize_content;
@@ -410,7 +411,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 	 * @return \WP_AI_Client_Prompt_Builder|\WP_Error The prompt builder, or a WP_Error on failure.
 	 */
 	private function get_prompt_builder( string $prompt, string $reference ) {
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_textgen_prompt( $prompt )
 			->with_file( $reference )
 			->using_system_instruction( $this->get_system_instruction( 'alt-text-system-instruction.php' ) )
 			->using_temperature( 0.3 );

--- a/includes/Abilities/Image/Generate_Image.php
+++ b/includes/Abilities/Image/Generate_Image.php
@@ -13,6 +13,7 @@ use Throwable;
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI\Features\Image_Generation\Image_Generation as Image_Generation_Feature;
+use WordPress\AI\Services\AI_Service;
 use WordPress\AiClient\Files\DTO\File;
 use WordPress\AiClient\Files\Enums\FileTypeEnum;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
@@ -261,7 +262,7 @@ class Generate_Image extends Abstract_Ability {
 			$prompt .= "\n\n" . $guidelines;
 		}
 
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_imagegen_prompt( $prompt )
 			->using_request_options( $request_options )
 			->as_output_file_type( FileTypeEnum::inline() );
 

--- a/includes/Abilities/Image/Generate_Image_Prompt.php
+++ b/includes/Abilities/Image/Generate_Image_Prompt.php
@@ -11,6 +11,7 @@ namespace WordPress\AI\Abilities\Image;
 
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
+use WordPress\AI\Services\AI_Service;
 
 use function WordPress\AI\get_post_context;
 use function WordPress\AI\get_preferred_models_for_text_generation;
@@ -270,7 +271,7 @@ class Generate_Image_Prompt extends Abstract_Ability {
 	 * @return \WP_AI_Client_Prompt_Builder|\WP_Error The prompt builder, or a WP_Error on failure.
 	 */
 	private function get_prompt_builder( string $prompt ) {
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_textgen_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction( 'image-prompt-system-instruction.php' ) )
 			->using_temperature( 0.9 );
 

--- a/includes/Abilities/Summarization/Summarization.php
+++ b/includes/Abilities/Summarization/Summarization.php
@@ -12,6 +12,7 @@ namespace WordPress\AI\Abilities\Summarization;
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI\Experiments\Summarization\Summarization as Summarization_Experiment;
+use WordPress\AI\Services\AI_Service;
 
 use function WordPress\AI\get_post_context;
 use function WordPress\AI\normalize_content;
@@ -271,7 +272,7 @@ class Summarization extends Abstract_Ability {
 	 * @return \WP_AI_Client_Prompt_Builder|\WP_Error The prompt builder, or a WP_Error on failure.
 	 */
 	private function get_prompt_builder( string $prompt, string $length ) {
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_textgen_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction( 'system-instruction.php', array( 'length' => $length ) ) )
 			->using_temperature( 0.9 );
 

--- a/includes/Abilities/Title_Generation/Title_Generation.php
+++ b/includes/Abilities/Title_Generation/Title_Generation.php
@@ -12,6 +12,7 @@ namespace WordPress\AI\Abilities\Title_Generation;
 use WP_Error;
 use WordPress\AI\Abstracts\Abstract_Ability;
 use WordPress\AI\Experiments\Title_Generation\Title_Generation as Title_Generation_Experiment;
+use WordPress\AI\Services\AI_Service;
 
 use function WordPress\AI\get_post_context;
 use function WordPress\AI\normalize_content;
@@ -260,7 +261,7 @@ class Title_Generation extends Abstract_Ability {
 	 * @return \WP_AI_Client_Prompt_Builder|\WP_Error The prompt builder, or a WP_Error on failure.
 	 */
 	private function get_prompt_builder( string $prompt ) {
-		$prompt_builder = wp_ai_client_prompt( $prompt )
+		$prompt_builder = AI_Service::get_instance()->create_textgen_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() )
 			->using_temperature( 0.7 );
 

--- a/includes/Services/AI_Service.php
+++ b/includes/Services/AI_Service.php
@@ -13,6 +13,7 @@ namespace WordPress\AI\Services;
 
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 
+use function WordPress\AI\get_preferred_image_models;
 use function WordPress\AI\get_preferred_models_for_text_generation;
 
 /**
@@ -126,6 +127,48 @@ class AI_Service {
 
 		// Apply default model preferences.
 		$models = get_preferred_models_for_text_generation();
+		if ( ! empty( $models ) ) {
+			$builder = $builder->using_model_preference( ...$models );
+		}
+
+		// Apply options via ModelConfig if any are provided.
+		if ( ! empty( $options ) ) {
+			$config_array = $this->map_options_to_config( $options );
+			if ( ! empty( $config_array ) ) {
+				$config  = ModelConfig::fromArray( $config_array );
+				$builder = $builder->using_model_config( $config );
+			}
+		}
+
+		return $builder;
+	}
+
+	/**
+	 * Creates an image generation prompt builder with default configuration applied.
+	 *
+	 * Mirrors {@see self::create_textgen_prompt()} but seeds the builder with the
+	 * plugin's preferred image generation models instead of the text generation
+	 * defaults, since the two capabilities are typically served by different models.
+	 *
+	 * Example usage:
+	 * ```php
+	 * $service = AI_Service::get_instance();
+	 *
+	 * $image_result = $service->create_imagegen_prompt( 'A watercolor mountain landscape' )->generate_image_result();
+	 * ```
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string|null          $prompt  Optional. Initial prompt content.
+	 * @param array<string, mixed> $options Optional. Configuration options. See
+	 *                                      {@see self::create_textgen_prompt()} for the supported keys.
+	 * @return \WP_AI_Client_Prompt_Builder The prompt builder instance.
+	 */
+	public function create_imagegen_prompt( ?string $prompt = null, array $options = array() ) {
+		$builder = wp_ai_client_prompt( $prompt );
+
+		// Apply default model preferences for image generation.
+		$models = get_preferred_image_models();
 		if ( ! empty( $models ) ) {
 			$builder = $builder->using_model_preference( ...$models );
 		}

--- a/tests/Integration/Includes/Services/AI_ServiceTest.php
+++ b/tests/Integration/Includes/Services/AI_ServiceTest.php
@@ -107,6 +107,42 @@ class AI_Service_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test create_imagegen_prompt returns prompt builder.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_imagegen_prompt_returns_builder(): void {
+		$builder = $this->service->create_imagegen_prompt( 'Test prompt' );
+
+		$this->assertInstanceOf(
+			\WP_AI_Client_Prompt_Builder::class,
+			$builder,
+			'Should return WP_AI_Client_Prompt_Builder instance'
+		);
+	}
+
+	/**
+	 * Test create_imagegen_prompt with options applies configuration.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_imagegen_prompt_with_options(): void {
+		$builder = $this->service->create_imagegen_prompt(
+			'Test prompt',
+			array(
+				'temperature' => 0.5,
+				'max_tokens'  => 100,
+			)
+		);
+
+		$this->assertInstanceOf(
+			\WP_AI_Client_Prompt_Builder::class,
+			$builder,
+			'Should return WP_AI_Client_Prompt_Builder instance with options applied'
+		);
+	}
+
+	/**
 	 * Test ai_experiments_service_initialized action can be hooked.
 	 *
 	 * @since 0.2.1


### PR DESCRIPTION
## What?
Closes #233

Refactors the Excerpt Generation, Title Generation, Content Summarization, Alt Text Generation, and Image Generation (Generate_Image + Generate_Image_Prompt) abilities to route their AI calls through the `AI_Service` layer introduced in #101, instead of calling `wp_ai_client_prompt()` directly.

## Why?
With #101 merged and part of the 0.2.1 release, the various experiments/abilities still constructed prompt builders by calling the global `wp_ai_client_prompt()` function directly and duplicated model-preference logic themselves. Centralizing that through `AI_Service` gives us one place to manage default model configuration and keeps each ability's prompt-builder setup consistent.

## How?
- Added `AI_Service::create_imagegen_prompt()`, mirroring the existing `create_textgen_prompt()`, but seeded with `get_preferred_image_models()` instead of the text-generation model list, since image generation needs a different default model preference.
- Updated the following abilities to call `AI_Service::get_instance()->create_textgen_prompt( $prompt )` instead of `wp_ai_client_prompt( $prompt )` as the first call in their private `get_prompt_builder()` method:
  - `Excerpt_Generation`
  - `Title_Generation`
  - `Summarization`
  - `Alt_Text_Generation`
  - `Generate_Image_Prompt`
- Updated `Generate_Image` to call the new `AI_Service::get_instance()->create_imagegen_prompt( $prompt )`.
- Left the rest of each ability's builder chain (`using_system_instruction()`, `using_temperature()`, `with_file()`, `filter_prompt_builder()`, etc.) untouched, since `Abstract_Ability::set_provider_model_preference()` already handles developer provider/model overrides and reapplies the correct fallback model list (text vs. vision vs. image) after `AI_Service` seeds the default — so behavior is unchanged, only the entry point moved to the service layer.
- `Abilities Explorer` required no change: `Ability_Handler` only invokes arbitrary registered abilities generically via `wp_get_ability()->execute()` and never calls the AI client directly, so there was nothing to migrate there.
- Other experiments not listed in #233 (Editorial Updates, Editorial Notes, Content Classification, Type Ahead, Content Resizing, Meta Description, Suggest Reply, Comment Moderation) still call `wp_ai_client_prompt()` directly and are intentionally out of scope for this PR.

## Testing Instructions
1. Confirm no regressions in behavior — model preference, developer overrides, and prompt filters are unchanged:
   - `composer test` / run the PHPUnit integration suite, in particular:
     - `tests/Integration/Includes/Services/AI_ServiceTest.php`
     - `tests/Integration/Includes/Abilities/Excerpt_GenerationTest.php`
     - `tests/Integration/Includes/Abilities/Title_GenerationTest.php`
     - `tests/Integration/Includes/Abilities/SummarizationTest.php`
     - `tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php`
     - `tests/Integration/Includes/Abilities/Image_GenerationTest.php`
     - `tests/Integration/Includes/Abilities/Image_Prompt_GenerationTest.php`
2. Manually verify each affected feature still works end-to-end with a connected provider:
   - Generate an excerpt suggestion on a post.
   - Generate a title suggestion on a post.
   - Generate a content summary on a post.
   - Generate alt text for an image in the Media Library.
   - Generate an image via the Generate Image admin page, and generate an image prompt from post content.


## Changelog Entry
> Developer - Refactored the Excerpt Generation, Title Generation, Content Summarization, Alt Text Generation, and Image Generation abilities to use the `AI_Service` layer instead of calling `wp_ai_client_prompt()` directly, and added `AI_Service::create_imagegen_prompt()` for image generation defaults.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-898-b920b992f0f8ff080c309f451bbc7b011a4f47fc.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->