### PR TITLE
Improve focus handling in the Suggest Reply tone dropdown

### DIFF
--- a/src/experiments/suggest-reply/components/SuggestReply.ts
+++ b/src/experiments/suggest-reply/components/SuggestReply.ts
@@ -251,6 +251,7 @@ function createSplitButtonControls(): HTMLElement {
 			updateSelectionUI();
 			dropdownMenu.hidden = true;
 			toggleBtn.setAttribute( 'aria-expanded', 'false' );
+			toggleBtn.focus();
 		} );
 
 		dropdownMenu.appendChild( itemBtn );
@@ -267,6 +268,17 @@ function createSplitButtonControls(): HTMLElement {
 		);
 
 		dropdownMenu.hidden = isExpanded;
+	} );
+
+	// Close the dropdown on Escape and return focus to its trigger.
+	container.addEventListener( 'keydown', ( event ) => {
+		if ( event.key !== 'Escape' || dropdownMenu.hidden ) {
+			return;
+		}
+
+		dropdownMenu.hidden = true;
+		toggleBtn.setAttribute( 'aria-expanded', 'false' );
+		toggleBtn.focus();
 	} );
 
 	// Close dropdown when clicking outside


### PR DESCRIPTION
## What?

This PR implements the following:
- Close the tone dropdown when Escape is pressed.
- Restore focus to the dropdown toggle after selecting an option or pressing Escape.

## Why?

The tone dropdown is custom, so Escape dismissal and focus restoration are not provided natively. Closing it while an option has focus can otherwise cause focus to be lost or feel unstable.

## How?

The PR adds a keydown listener to handle Escape, updates the dropdown’s hidden and expanded states, and focus the toggle when focus needs to be restored.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code reviews

## Screencast

https://github.com/user-attachments/assets/7f61e6df-1c78-4039-9849-3285dc43183c

## Changelog Entry

> Fixed - Improved keyboard and focus handling for the Suggest Reply tone dropdown.

### Note:

At the moment, focus is also lost while generation is in progress. This is outside the scope of the current PR and will be addressed in a follow-up.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-907-42c41fbd5ca673b025a7551e202f00f77614b7ef.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->