### PR TITLE
Excerpt Generation: Synchronize generating state across inline and modal buttons

### DIFF
--- a/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
+++ b/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
@@ -7,7 +7,7 @@
  */
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -24,6 +24,14 @@ import type {
 
 const NOTICE_ID = 'ai_excerpt_generation_error';
 const MINIMUM_CONTENT_COUNT_DEFAULT = 250;
+
+let globalIsGenerating = false;
+const listeners = new Set< ( isGenerating: boolean ) => void >();
+
+function setGlobalIsGenerating( isGenerating: boolean ): void {
+	globalIsGenerating = isGenerating;
+	listeners.forEach( ( listener ) => listener( isGenerating ) );
+}
 
 const getSettings = (): ExcerptGenerationData => {
 	const settings = ( window as any ).aiExcerptGenerationData ?? {};
@@ -84,7 +92,19 @@ export function useExcerptGeneration(): {
 		};
 	} );
 	const { editPost } = useDispatch( editorStore );
-	const [ isGenerating, setIsGenerating ] = useState< boolean >( false );
+	const [ isGenerating, setIsGenerating ] =
+		useState< boolean >( globalIsGenerating );
+
+	useEffect( () => {
+		const listener = ( state: boolean ) => {
+			setIsGenerating( state );
+		};
+		listeners.add( listener );
+		setIsGenerating( globalIsGenerating );
+		return () => {
+			listeners.delete( listener );
+		};
+	}, [] );
 
 	const { minContentLength } = getSettings();
 	const isContentTooShort = ! hasMinimumContent( content, minContentLength );
@@ -101,11 +121,15 @@ export function useExcerptGeneration(): {
 	);
 
 	const handleGenerate = async () => {
+		if ( globalIsGenerating ) {
+			return;
+		}
+
 		if ( ! ensureProvider( NOTICE_ID ) ) {
 			return;
 		}
 
-		setIsGenerating( true );
+		setGlobalIsGenerating( true );
 		dispatch( noticesStore ).removeNotice( NOTICE_ID );
 
 		try {
@@ -158,7 +182,7 @@ export function useExcerptGeneration(): {
 				isDismissible: true,
 			} );
 		} finally {
-			setIsGenerating( false );
+			setGlobalIsGenerating( false );
 		}
 	};
 

--- a/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
+++ b/src/experiments/excerpt-generation/components/useExcerptGeneration.ts
@@ -7,7 +7,7 @@
  */
 import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useEffect, useState } from '@wordpress/element';
+import { useSyncExternalStore } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -26,11 +26,22 @@ const NOTICE_ID = 'ai_excerpt_generation_error';
 const MINIMUM_CONTENT_COUNT_DEFAULT = 250;
 
 let globalIsGenerating = false;
-const listeners = new Set< ( isGenerating: boolean ) => void >();
+const listeners = new Set< () => void >();
+
+function subscribe( callback: () => void ): () => void {
+	listeners.add( callback );
+	return () => {
+		listeners.delete( callback );
+	};
+}
+
+function getSnapshot(): boolean {
+	return globalIsGenerating;
+}
 
 function setGlobalIsGenerating( isGenerating: boolean ): void {
 	globalIsGenerating = isGenerating;
-	listeners.forEach( ( listener ) => listener( isGenerating ) );
+	listeners.forEach( ( listener ) => listener() );
 }
 
 const getSettings = (): ExcerptGenerationData => {
@@ -92,19 +103,7 @@ export function useExcerptGeneration(): {
 		};
 	} );
 	const { editPost } = useDispatch( editorStore );
-	const [ isGenerating, setIsGenerating ] =
-		useState< boolean >( globalIsGenerating );
-
-	useEffect( () => {
-		const listener = ( state: boolean ) => {
-			setIsGenerating( state );
-		};
-		listeners.add( listener );
-		setIsGenerating( globalIsGenerating );
-		return () => {
-			listeners.delete( listener );
-		};
-	}, [] );
+	const isGenerating = useSyncExternalStore( subscribe, getSnapshot );
 
 	const { minContentLength } = getSettings();
 	const isContentTooShort = ! hasMinimumContent( content, minContentLength );


### PR DESCRIPTION
## What?
Consolidates the excerpt generation status across the inline and modal excerpt generation buttons so that both UI elements reflect the generating state simultaneously.

## Why?
Previously, the inline button and modal/panel button each maintained independent `isGenerating` local component states. If a user clicked the inline button and then opened the modal, the modal button remained enabled, allowing parallel duplicate API generation requests to be triggered. Now, when generation is active from either button, both buttons are disabled and show loading state.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Validating bug, suggesting a fix.

## Testing Instructions
1. Enable the **Excerpt Generation** experiment in the plugin settings.
2. Create or edit a post with content longer than 250 characters.
3. Open the sidebar in the post editor.
4. Click the inline **Generate excerpt** button next to the Excerpt link.
5. Open the Excerpt panel/modal while generation is in progress.
6. Verify that both the inline button and modal **Generate excerpt** button display **"Generating…"**, are disabled, and show busy indicators.
7. Confirm that once generation finishes, both buttons return to normal state and the excerpt is updated.

## Screencast

### Before

https://github.com/user-attachments/assets/31ba347d-5e99-4513-ad60-3c866a9c8dd7

### After

 https://github.com/user-attachments/assets/5b2e5843-ad7c-4ada-a987-ec65e6930fcd

## Changelog Entry

> Fixed - Synchronized generating state across inline and modal excerpt generation buttons.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-908-3e5a3abde07740007e151467d482b464a767baaf.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->