### PR TITLE
Update documentation around the encryption experiment and address a few bugs

### DIFF
--- a/docs/experiments/key-encryption.md
+++ b/docs/experiments/key-encryption.md
@@ -4,12 +4,34 @@ Opt-in experiment that encrypts AI connector API keys at rest.
 
 ## Summary
 
-- Extends `Abstract_Feature`.
-- While enabled, every `connectors_ai_*_api_key` option is transparently routed through a
-  **bundled** libsodium-based secrets API, so the `wp_options` table never contains a plaintext
-  key.
+- While enabled, every `connectors_ai_*_api_key` option is transparently routed through a **bundled** libsodium-based secrets API, so the `wp_options` table never contains a plaintext key.
 - Existing keys are encrypted on opt-in, restored on opt-out, and restored on plugin deactivation
   — users cannot get locked out of their own credentials.
+
+## Threat model
+
+Encrypting keys at rest raises the cost of **database-level** exposure. It is not a sandbox around the credentials, and it cannot be one.
+
+**Protects against** — anything that reveals the contents of `wp_options` without also revealing `wp-config.php`:
+
+- A stolen or leaked database dump or backup.
+- A SQL-injection read in an unrelated plugin.
+- Shared-host or third-party access scoped to the database: support tooling, analytics ETL, a read-only replica, a screenshot of phpMyAdmin.
+- Query logs, slow-query logs, or error output that echo option values.
+
+**Does not protect against** — anything executing inside the WordPress PHP process, or anything that can read the filesystem:
+
+- **Any active plugin, theme, mu-plugin, or drop-in.** WordPress has no privilege separation between them; code execution in any one of them is code execution as the whole site. While the experiment is enabled, `get_option( 'connectors_ai_openai_api_key' )` returns the decrypted key to any in-process caller. That is what "transparent" means, and every existing caller (`Connector_Key_Index`, REST dispatch, the AI client registry) depends on it.
+- **Filesystem read access.** The encryption key is `WP_SECRETS_KEY`, or `LOGGED_IN_KEY . LOGGED_IN_SALT` when that constant is not defined. Both live in `wp-config.php`, so anyone who can read that file can decrypt the `_secret_*` rows directly. Encryption at rest is worth much less against a full filesystem compromise than against a database-only one.
+- **Users who can already see the key.** Anyone able to manage AI settings can read it through the settings screen and the REST API, by design.
+
+### The `plugin` context value is not an authorization boundary
+
+Every call into the bundled SDK passes a caller-asserted context (`[ 'plugin' => 'ai' ]`). The namespace check this feeds is a **collision guard**: it keeps well-behaved plugins out of each other's namespaces and gives the `secrets_access` filter a sensible default to refine. It is not, and cannot be, a boundary between plugins:
+
+- The value is supplied by the caller, so in-process code can assert any namespace it likes.
+- Deriving the caller from a backtrace instead would not change that — in-process code can steer a backtrace, for example by invoking the SDK from a core hook so the nearest frame belongs to whichever file core dispatched from.
+- It would not matter if it could. The same code can read the decrypted value straight out of `get_option()`, decrypt the `_secret_*` row using the salts, or simply return `true` from the `secrets_access` filter.
 
 ## Bundled secrets backend
 
@@ -22,9 +44,17 @@ bootstrap, admin UI, and WP-CLI commands are intentionally omitted. See
 upstream commit and the list of modifications.
 
 Secrets are stored under the `ai/` namespace (e.g. `ai/openai_api_key`). The experiment calls the
-vendored `Secrets::get()` / `Secrets::set()` / `Secrets::delete()` facade directly — it never
-defines the global `get_secret()` / `set_secret()` functions, so it will not collide if a site also
-installs the real Displace Secrets Manager plugin.
+vendored `Secrets::get()` / `Secrets::set()` / `Secrets::delete()` facade directly and never defines
+the global `get_secret()` / `set_secret()` functions, so the PHP *symbols* do not collide if a site
+also installs the real Displace Secrets Manager plugin.
+
+**Storage is shared with that plugin, though.** The vendored provider is byte-identical to upstream,
+so both write to `_secret_{namespace}/{key}` options, share the `_secrets_master_key` option, and
+derive the same key from `WP_SECRETS_KEY` (or the salts). Running both is interoperable rather than
+conflicting — each reads what the other wrote, and rotating `WP_SECRETS_KEY` covers both. The
+consequence worth knowing: on such a site the store holds other plugins' secrets alongside `ai/*`,
+and the namespace check does not isolate them from in-process code (see
+[Threat model](#threat-model)).
 
 ## Requirements
 
@@ -67,11 +97,12 @@ While enabled, the experiment registers two transparent option filters per conne
 - `option_{setting_name}` — decrypts and returns the secret on read via `Secrets::get()`; passes
   through to the stored value if no secret exists (handles partially-migrated state).
 
-Each call passes an explicit `[ 'plugin' => 'ai' ]` context. The bundled secrets manager enforces
-access control on every operation, granting "self-namespace" access when the caller's plugin slug
+Each call passes an explicit `[ 'plugin' => 'ai' ]` context. The bundled secrets manager runs a
+namespace check on every operation, granting "self-namespace" access when the caller's plugin slug
 matches the key's namespace. Passing the context explicitly guarantees that match — these filters
 run in unauthenticated request contexts (cron, front-end, REST) where no user holds the
-`manage_secrets` capability, so relying on automatic caller detection would be fragile.
+`manage_secrets` capability and backtrace-based caller detection is unreliable. That check is a
+collision guard, not an isolation boundary; see [Threat model](#threat-model).
 
 All existing callers — `Connector_Key_Index`, REST dispatch, the AI client registry — keep
 working because `get_option()` transparently returns the decrypted value through the read

--- a/includes/Vendor/Secrets/README.md
+++ b/includes/Vendor/Secrets/README.md
@@ -31,8 +31,16 @@ Kept byte-for-byte identical to upstream **except**:
 
 1. A `namespace WordPress\AI\Vendor\Secrets;` declaration was inserted after the file docblock (so the classes are isolated from the global namespace and resolved by the plugin's PSR-4 autoloader).
 2. References to global classes that are not in this namespace were fully qualified: in `Secrets_Exception.php`, `RuntimeException` → `\RuntimeException` and `Throwable` → `\Throwable`. (Other global classes — `\WP_Error`, `\Exception`, `\SodiumException` — were already qualified upstream.)
+3. `Secrets_Context::detect_calling_plugin()` also skips backtrace frames originating in this directory (matched against `__DIR__`). Upstream recognises its own frames by the `displace-secrets-manager/` plugin directory, which never matches a copy vendored inside a *different* plugin — so before this change the nearest frame was always an SDK file and every lookup returned the host plugin's slug (`ai`) regardless of the real caller. Regression tests live in `tests/Integration/Includes/Vendor/Secrets/`.
+4. `Secrets_Context::detect_calling_plugin()` changed from `private static` to `public static`, so the audit logger (below) and tests can reach it.
+5. `Secrets_Audit::log()` adds a `detected_plugin` entry to the context passed to the `secrets_accessed` and `secrets_{$operation}` actions, so audit consumers see the backtrace-derived caller next to the caller-asserted `plugin` value and can flag a mismatch. Computed only when a listener is registered, since detection walks a backtrace.
+6. Docblocks on `Secrets_Context::__construct()`, `Secrets_Context::can_access_namespace()`, `Secrets_Manager::check_access()`, and the `Secrets` facade were expanded to state that the namespace check is a collision guard rather than an isolation boundary between plugins. No behaviour change. See the [threat model](../../../docs/experiments/key-encryption.md#threat-model) for why.
 
 WordPress and PHP global *functions* and *constants* are left unqualified; PHP resolves them against the global namespace automatically.
+
+## Storage compatibility
+
+The provider writes secrets to `_secret_{namespace}/{key}` options and keeps its encrypted master key in `_secrets_master_key`, both inherited unchanged from upstream. A site running the real Displace Secrets Manager plugin alongside this one therefore **shares that storage and master key** with it: each side reads what the other wrote, and a `WP_SECRETS_KEY` rotation covers both. Interoperable, not conflicting — but do not assume the store only ever holds `ai/*` keys.
 
 ## Updating
 

--- a/includes/Vendor/Secrets/Secrets.php
+++ b/includes/Vendor/Secrets/Secrets.php
@@ -20,6 +20,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Usage:
  *   $key = Secrets::get( 'my-plugin/api_key' );
  *   Secrets::set( 'my-plugin/api_key', $value );
+ *
+ * The `$context` array on every method is caller-asserted metadata, and the namespace check it
+ * feeds is a collision guard rather than an isolation boundary between plugins. See
+ * {@see Secrets_Context::can_access_namespace()} for what it can and cannot enforce.
  */
 final class Secrets {
 

--- a/includes/Vendor/Secrets/Secrets_Audit.php
+++ b/includes/Vendor/Secrets/Secrets_Audit.php
@@ -37,12 +37,23 @@ final class Secrets_Audit {
 			$context['user_id'] = get_current_user_id();
 		}
 
+		// `plugin` is whatever the caller asserted, so on its own it would attribute every
+		// operation to a slug the caller chose. Record the backtrace-derived caller alongside it
+		// so audit consumers can log both and flag a mismatch. Detection walks a backtrace, so
+		// only pay for it when something is actually listening.
+		if ( has_action( 'secrets_accessed' ) || has_action( "secrets_{$operation}" ) ) {
+			$context['detected_plugin'] = Secrets_Context::detect_calling_plugin();
+		}
+
 		/**
 		 * Fires on every secret operation.
 		 *
 		 * @param string $key       The secret key.
 		 * @param string $operation The operation performed.
-		 * @param array  $context   Caller context (never contains the secret value).
+		 * @param array  $context   Caller context (never contains the secret value). The `plugin`
+		 *                          entry is asserted by the caller; `detected_plugin` is derived
+		 *                          from the backtrace. Neither is an authenticated identity, but a
+		 *                          mismatch between them is worth surfacing.
 		 */
 		do_action( 'secrets_accessed', $key, $operation, $context );
 
@@ -57,7 +68,8 @@ final class Secrets_Audit {
 		 *   - secrets_list
 		 *
 		 * @param string $key     The secret key.
-		 * @param array  $context Caller context.
+		 * @param array  $context Caller context. See the `secrets_accessed` hook above for the
+		 *                        difference between `plugin` and `detected_plugin`.
 		 */
 		do_action( "secrets_{$operation}", $key, $context );
 	}

--- a/includes/Vendor/Secrets/Secrets_Context.php
+++ b/includes/Vendor/Secrets/Secrets_Context.php
@@ -53,10 +53,13 @@ final class Secrets_Context {
 	/**
 	 * Constructor.
 	 *
+	 * Every field is asserted by the caller and used as given. None of them are verified, and
+	 * they are not an authenticated identity — see can_access_namespace() for what that means.
+	 *
 	 * @param array $context {
 	 *     Optional. Context overrides.
 	 *
-	 *     @type string $plugin  Plugin slug. Auto-detected if omitted.
+	 *     @type string $plugin  Plugin slug asserted by the caller. Auto-detected if omitted.
 	 *     @type int    $user_id WordPress user ID. Defaults to current user.
 	 *     @type bool   $is_cli  Whether running under WP-CLI.
 	 * }
@@ -112,7 +115,22 @@ final class Secrets_Context {
 	}
 
 	/**
-	 * Check whether the caller has cross-namespace access.
+	 * Check whether the caller may use the given namespace.
+	 *
+	 * This is a namespace-collision guard, not a security boundary, and it cannot isolate
+	 * secrets from other code running inside WordPress. Every value it consults is asserted by
+	 * the caller: `$plugin_slug`, `$user_id`, and `$is_cli` all come from the context array
+	 * when one is supplied, and the automatic fallback for `$plugin_slug` is a backtrace walk
+	 * that hostile code can influence. That is by design rather than an oversight — WordPress
+	 * grants every active plugin, theme, mu-plugin, and drop-in the same privileges as this
+	 * SDK, so a caller that wanted a secret it does not own could equally read the underlying
+	 * `_secret_*` option and derive the key from `WP_SECRETS_KEY` or the WordPress salts, or
+	 * simply short-circuit the `secrets_access` filter. There is no check that could be added
+	 * here to prevent that.
+	 *
+	 * What it does do is keep well-behaved callers out of each other's namespaces by accident
+	 * and give the `secrets_access` filter a sensible default to refine. Sites that need a
+	 * stricter policy should implement it on that filter.
 	 *
 	 * @param string $target_namespace The namespace being accessed.
 	 * @return bool
@@ -136,14 +154,25 @@ final class Secrets_Context {
 	/**
 	 * Detect the calling plugin by walking the backtrace.
 	 *
-	 * Looks for the first file path outside displace-secrets-manager that
-	 * lives within wp-content/plugins/{slug}/.
+	 * Skips frames belonging to the secrets SDK itself and returns the first plugin or theme
+	 * directory found above them.
+	 *
+	 * Best-effort attribution only. The result is useful as diagnostic metadata (which plugin
+	 * touched which secret) but it is not an authenticated identity: any in-process caller can
+	 * steer the backtrace, for instance by invoking the SDK from a core hook so the nearest
+	 * frame belongs to whichever file core dispatched from. See can_access_namespace().
 	 *
 	 * @return string The detected plugin slug, or 'unknown'.
 	 */
-	private static function detect_calling_plugin(): string {
+	public static function detect_calling_plugin(): string {
 		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace -- intentional for caller detection.
 		$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 15 );
+
+		// Frames inside the SDK are never the caller. Upstream recognises its own files by the
+		// `displace-secrets-manager/` plugin directory, which never matches a vendored copy
+		// living inside some other plugin — so match this directory as well. Without this, the
+		// nearest frame is always an SDK file and every lookup returns the host plugin's slug.
+		$sdk_dir = wp_normalize_path( __DIR__ ) . '/';
 
 		foreach ( $trace as $frame ) {
 			if ( empty( $frame['file'] ) ) {
@@ -153,6 +182,10 @@ final class Secrets_Context {
 			$file = wp_normalize_path( $frame['file'] );
 
 			if ( false !== strpos( $file, 'displace-secrets-manager/' ) ) {
+				continue;
+			}
+
+			if ( 0 === strpos( $file, $sdk_dir ) ) {
 				continue;
 			}
 

--- a/includes/Vendor/Secrets/Secrets_Manager.php
+++ b/includes/Vendor/Secrets/Secrets_Manager.php
@@ -251,6 +251,11 @@ final class Secrets_Manager {
 	/**
 	 * Check access control for a secrets operation.
 	 *
+	 * Delegates to {@see Secrets_Context::can_access_namespace()}, which is a namespace-collision
+	 * guard rather than an isolation boundary between plugins — read that method before relying
+	 * on this for anything security-sensitive. The `secrets_access` filter below is the
+	 * extension point for sites that need a stricter policy.
+	 *
 	 * @param string $key       The secret key.
 	 * @param string $operation The operation ('get', 'set', 'delete', 'exists', 'list').
 	 * @param array  $context   Caller context.

--- a/tests/Integration/Includes/Vendor/Secrets/Fixture_Plugin_Trait.php
+++ b/tests/Integration/Includes/Vendor/Secrets/Fixture_Plugin_Trait.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Helper for running code from inside a throwaway plugin directory.
+ *
+ * The vendored secrets SDK attributes callers by inspecting backtrace file paths, so testing that
+ * attribution needs a caller whose file genuinely lives under a different
+ * `wp-content/plugins/{slug}/` path. This writes one to a temporary tree and runs it.
+ *
+ * @package WordPress\AI\Tests\Integration\Vendor
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Tests\Integration\Vendor\Secrets;
+
+/**
+ * Creates, invokes, and cleans up a fixture plugin file.
+ *
+ * @since x.x.x
+ */
+trait Fixture_Plugin_Trait {
+
+	/**
+	 * Root of the throwaway plugin tree, or '' when none has been created.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	private string $fixture_root = '';
+
+	/**
+	 * Writes a caller into a temporary `wp-content/plugins/{$slug}/` tree and includes it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $slug Plugin directory name to impersonate.
+	 * @param string $body PHP source for the caller, without the opening tag. Whatever it returns
+	 *                     is returned from here.
+	 * @return mixed The fixture's return value.
+	 */
+	private function run_in_fixture_plugin( string $slug, string $body ) {
+		$this->fixture_root = untrailingslashit( get_temp_dir() ) . '/wpai-secrets-fixture';
+		$directory          = $this->fixture_root . '/wp-content/plugins/' . $slug;
+
+		$this->assertTrue( wp_mkdir_p( $directory ), 'Could not create the fixture plugin directory.' );
+
+		$file = $directory . '/caller.php';
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture outside the WP tree.
+		$this->assertNotFalse( file_put_contents( $file, "<?php\n" . $body ), 'Could not write the fixture caller.' );
+
+		return include $file;
+	}
+
+	/**
+	 * Removes the fixture tree, if one was created.
+	 *
+	 * @since x.x.x
+	 */
+	private function delete_fixture_plugin(): void {
+		if ( '' === $this->fixture_root ) {
+			return;
+		}
+
+		$this->delete_tree( $this->fixture_root );
+		$this->fixture_root = '';
+	}
+
+	/**
+	 * Recursively removes a directory tree.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $path Absolute path to remove.
+	 */
+	private function delete_tree( string $path ): void {
+		if ( is_dir( $path ) ) {
+			foreach ( array_diff( (array) scandir( $path ), array( '.', '..' ) ) as $entry ) {
+				$this->delete_tree( $path . '/' . $entry );
+			}
+
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.directory_operations_rmdir -- test fixture outside the WP tree.
+			rmdir( $path );
+			return;
+		}
+
+		if ( file_exists( $path ) ) {
+			wp_delete_file( $path );
+		}
+	}
+}

--- a/tests/Integration/Includes/Vendor/Secrets/Secrets_AuditTest.php
+++ b/tests/Integration/Includes/Vendor/Secrets/Secrets_AuditTest.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Integration tests for audit attribution in the vendored secrets SDK.
+ *
+ * The `plugin` entry in an audit context is asserted by the caller, so on its own it would record
+ * whatever slug the caller chose. These tests cover the `detected_plugin` entry added alongside it,
+ * which lets an audit consumer see the backtrace-derived caller and flag a mismatch.
+ *
+ * Neither value is an authenticated identity — hostile in-process code can steer both, and would
+ * more likely bypass the SDK altogether. This is attribution for well-behaved callers and a signal
+ * for auditors, not an enforcement mechanism. See the Key Encryption threat model.
+ *
+ * @package WordPress\AI\Tests\Integration\Vendor
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Tests\Integration\Vendor\Secrets;
+
+use WP_UnitTestCase;
+
+/**
+ * Test case for Secrets_Audit caller attribution.
+ *
+ * @since x.x.x
+ */
+class Secrets_AuditTest extends WP_UnitTestCase {
+
+	use Fixture_Plugin_Trait;
+
+	/**
+	 * PHP run inside the fixture plugin: reads an `ai/` secret while claiming to be the AI plugin,
+	 * exactly as the proof-of-concept in the security reports did.
+	 *
+	 * @since x.x.x
+	 */
+	private const SPOOFED_READ = <<<'PHP'
+use WordPress\AI\Vendor\Secrets\Secrets;
+
+return Secrets::get( 'ai/fixture_key', array( 'plugin' => 'ai', 'user_id' => 0, 'is_cli' => false ) );
+PHP;
+
+	/**
+	 * Contexts captured from the audit hooks during a test.
+	 *
+	 * @since x.x.x
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $captured = array();
+
+	/**
+	 * @since x.x.x
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->captured = array();
+
+		// Short-circuit the read so these tests need no provider, no keyring, and no stored value:
+		// Secrets_Manager::get() logs the operation and returns as soon as this filter answers.
+		add_filter( 'secrets_pre_get', array( $this, 'short_circuit_get' ) );
+	}
+
+	/**
+	 * @since x.x.x
+	 */
+	public function tearDown(): void {
+		remove_filter( 'secrets_pre_get', array( $this, 'short_circuit_get' ) );
+		remove_action( 'secrets_accessed', array( $this, 'capture' ) );
+		remove_action( 'secrets_get', array( $this, 'capture' ) );
+
+		$this->delete_fixture_plugin();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Supplies a value for any secret read so no provider is required.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string The stand-in secret value.
+	 */
+	public function short_circuit_get(): string {
+		return 'stand-in-value';
+	}
+
+	/**
+	 * Records an audit context.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string               $key     The secret key. Unused.
+	 * @param string|array<mixed>  $second  Operation name (`secrets_accessed`) or context.
+	 * @param array<string, mixed> $context Context, when the hook passes an operation first.
+	 */
+	public function capture( string $key, $second, array $context = array() ): void {
+		unset( $key );
+
+		$this->captured[] = is_array( $second ) ? $second : $context;
+	}
+
+	/**
+	 * A forged `plugin` value is still recorded as given — but the audit context also carries the
+	 * real calling plugin, so the two can be compared.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_records_the_detected_caller_next_to_a_forged_plugin_value() {
+		add_action( 'secrets_accessed', array( $this, 'capture' ), 10, 3 );
+
+		$this->run_in_fixture_plugin( 'unrelated-fixture-plugin', self::SPOOFED_READ );
+
+		$this->assertCount( 1, $this->captured );
+		$this->assertSame( 'ai', $this->captured[0]['plugin'], 'The caller-asserted value should be recorded verbatim.' );
+		$this->assertSame(
+			'unrelated-fixture-plugin',
+			$this->captured[0]['detected_plugin'],
+			'The audit context should expose the real calling plugin.'
+		);
+	}
+
+	/**
+	 * The operation-specific hook gets the same attribution as the catch-all hook.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_operation_specific_hook_also_receives_the_detected_caller() {
+		add_action( 'secrets_get', array( $this, 'capture' ), 10, 2 );
+
+		$this->run_in_fixture_plugin( 'unrelated-fixture-plugin', self::SPOOFED_READ );
+
+		$this->assertCount( 1, $this->captured );
+		$this->assertSame( 'unrelated-fixture-plugin', $this->captured[0]['detected_plugin'] );
+	}
+
+	/**
+	 * A caller that asserts nothing is still attributed.
+	 *
+	 * Audit contexts are the caller's own array rather than the resolved Secrets_Context, so
+	 * `plugin` is absent entirely when the caller supplies no context — meaning these records
+	 * previously carried no attribution at all. `detected_plugin` closes that gap.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_detected_caller_is_recorded_when_the_caller_asserts_nothing() {
+		add_action( 'secrets_accessed', array( $this, 'capture' ), 10, 3 );
+
+		$body = <<<'PHP'
+use WordPress\AI\Vendor\Secrets\Secrets;
+
+return Secrets::get( 'unrelated-fixture-plugin/key', array( 'user_id' => 0, 'is_cli' => false ) );
+PHP;
+
+		$this->run_in_fixture_plugin( 'unrelated-fixture-plugin', $body );
+
+		$this->assertCount( 1, $this->captured );
+		$this->assertArrayNotHasKey( 'plugin', $this->captured[0] );
+		$this->assertSame( 'unrelated-fixture-plugin', $this->captured[0]['detected_plugin'] );
+	}
+}

--- a/tests/Integration/Includes/Vendor/Secrets/Secrets_ContextTest.php
+++ b/tests/Integration/Includes/Vendor/Secrets/Secrets_ContextTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Integration tests for caller detection in the vendored secrets context.
+ *
+ * These lock in the one behaviour that vendoring broke. Upstream's caller detection skips its own
+ * frames by matching the `displace-secrets-manager/` plugin directory, which never matches a copy
+ * vendored inside a different plugin — so before the fix the nearest frame was always an SDK file
+ * and every lookup attributed the call to the host plugin (`ai`), whoever the real caller was.
+ *
+ * Caller detection is diagnostic metadata, not an authenticated identity: see
+ * {@see \WordPress\AI\Vendor\Secrets\Secrets_Context::can_access_namespace()}. These tests assert
+ * that it reports the truth, not that it constitutes a boundary against hostile in-process code.
+ *
+ * @package WordPress\AI\Tests\Integration\Vendor
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Tests\Integration\Vendor\Secrets;
+
+use WP_UnitTestCase;
+use WordPress\AI\Vendor\Secrets\Secrets_Context;
+
+/**
+ * Test case for Secrets_Context caller detection.
+ *
+ * @since x.x.x
+ */
+class Secrets_ContextTest extends WP_UnitTestCase {
+
+	use Fixture_Plugin_Trait;
+
+	/**
+	 * PHP run inside the fixture plugin: reports how the SDK identifies it.
+	 *
+	 * @since x.x.x
+	 */
+	private const PROBE = <<<'PHP'
+use WordPress\AI\Vendor\Secrets\Secrets_Context;
+
+$context = new Secrets_Context( array( 'user_id' => 0, 'is_cli' => false ) );
+
+return array(
+	'detected'             => Secrets_Context::detect_calling_plugin(),
+	'slug_via_constructor' => $context->get_plugin_slug(),
+	'can_access_ai'        => $context->can_access_namespace( 'ai' ),
+);
+PHP;
+
+	/**
+	 * @since x.x.x
+	 */
+	public function tearDown(): void {
+		$this->delete_fixture_plugin();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A caller in another plugin directory must be reported as that plugin, not as the host plugin
+	 * whose tree the SDK happens to be vendored into.
+	 *
+	 * Asserted through the constructor rather than the bare helper on purpose: that is the path
+	 * every real caller takes (`Secrets_Manager::check_access()` builds a context per operation),
+	 * and it is the path the broken frame-skipping affected. A direct call to the helper was never
+	 * affected, because then the caller's own file is already the nearest frame.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_detects_the_calling_plugin_not_the_host_plugin() {
+		$result = $this->run_in_fixture_plugin( 'unrelated-fixture-plugin', self::PROBE );
+
+		$this->assertSame( 'unrelated-fixture-plugin', $result['slug_via_constructor'] );
+		$this->assertSame( 'unrelated-fixture-plugin', $result['detected'] );
+	}
+
+	/**
+	 * With no explicit context supplied, a caller from an unrelated plugin does not get
+	 * self-namespace access to `ai/`.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_foreign_caller_does_not_get_the_ai_namespace_by_default() {
+		$result = $this->run_in_fixture_plugin( 'unrelated-fixture-plugin', self::PROBE );
+
+		$this->assertFalse( $result['can_access_ai'] );
+	}
+
+	/**
+	 * SDK frames are skipped, but not the real caller above them: a context built from this
+	 * plugin's own code still resolves to this plugin's directory, so Secrets_Bridge keeps its
+	 * self-namespace access even on the automatic path.
+	 *
+	 * Cannot distinguish the fixed code from the broken code — for callers inside this plugin both
+	 * answer `ai`. It guards the opposite failure: skipping too far and reporting `unknown` or some
+	 * unrelated directory.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_detects_this_plugin_when_called_from_plugin_code() {
+		$expected = basename( untrailingslashit( WPAI_PLUGIN_DIR ) );
+
+		$context = new Secrets_Context(
+			array(
+				'user_id' => 0,
+				'is_cli'  => false,
+			)
+		);
+
+		$this->assertSame( $expected, $context->get_plugin_slug() );
+		$this->assertSame( $expected, Secrets_Context::detect_calling_plugin() );
+	}
+
+	/**
+	 * An explicitly supplied `plugin` context is still honoured.
+	 *
+	 * This is deliberate, not an oversight. Secrets_Bridge passes `[ 'plugin' => 'ai' ]` because
+	 * its option filters run in cron, front-end, and REST contexts where no user holds
+	 * `manage_secrets` and backtrace detection is unreliable. Removing caller-supplied context
+	 * would lock the site out of its own credentials in exactly those contexts without denying a
+	 * hostile in-process caller anything, so this test exists to stop a future refactor from
+	 * "hardening" it away.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_explicit_context_overrides_detection_and_grants_self_namespace() {
+		$context = new Secrets_Context(
+			array(
+				'plugin'  => 'ai',
+				'user_id' => 0,
+				'is_cli'  => false,
+			)
+		);
+
+		$this->assertSame( 'ai', $context->get_plugin_slug() );
+		$this->assertTrue( $context->can_access_namespace( 'ai' ) );
+	}
+}


### PR DESCRIPTION
## What?

Update our documentation to make it more clear what the encryption experiment does and does not do. Make a few refinements / bug fixes along the way.

## Why?

We've had some reports that seem to misunderstand the encryption experiment, most importantly they seem to think that encrypted data is locked down to the AI plugin only and shouldn't be accessible by other plugins. This is not how that experiment was built and honestly not sure there's a way to achieve this within WordPress, since WordPress allows plugins to do basically anything.

This PR updates the documentation around this experiment to make it more clear about what it is doing and things it won't help with, like preventing other plugins from accessing API keys.

In addition, a few modifications/fixes have been done based on these reports, namely ensuring we better detect the calling plugin instead of always attributing everything to the AI plugin and passing the calling plugin into our logging methods.

## How?

- Updates our main documentation as well as the README that lives with our vendored secrets manager code and some inline documentation
- Ensure caller attribution skips any frames that come from the vendored code so we properly match the calling plugin name
- Pass the detected plugin into our log hooks

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 5
Used for: Reviewing some reports and helping verify what actually needs fixing. Once a plan was settled on, it executed the plan with final review and testing by me

## Testing Instructions

Ensure the encryption experiment still works as expected. Easiest to follow instructions in the original PR, #560

## Changelog Entry

> Fixed - Ensure caller detection in the encryption experiment properly matches the calling plugin, not the host plugin.

> Developer - Documented the Key Encryption threat model: what encrypting API keys at rest does and does not protect against, and why the caller-supplied `plugin` context is a namespace-collision guard rather than an isolation boundary between plugins.

> Developer - The `secrets_accessed` and `secrets_{$operation}` actions now receive a backtrace-derived `detected_plugin` alongside the caller-asserted `plugin` value, so audit consumers can attribute operations and flag a mismatch.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-909-6a162f8d21b48c811b0eac3fb8eef7c220afdc1c.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->