### PR TITLE
Update our preferred models

### DIFF
--- a/docs/experiments/multi-provider-support.md
+++ b/docs/experiments/multi-provider-support.md
@@ -44,12 +44,6 @@ The AI plugin depends on registered `ai_provider` connectors. It does not ship p
 
 Default model preference arrays are ordered. The first supported and available provider/model pair is used by the AI Client prompt builder.
 
-Example default text preference sequence includes:
-
-- Anthropic `claude-sonnet-4-6`
-- Google `gemini-3-flash-preview`, `gemini-2.5-flash`
-- OpenAI `gpt-5.4-mini`, `gpt-4.1-mini`
-
 When earlier preferences are unavailable, lower-priority entries act as fallback candidates.
 
 ### Capability Validation

--- a/includes/Abilities/Content_Classification/Content_Classification.php
+++ b/includes/Abilities/Content_Classification/Content_Classification.php
@@ -501,7 +501,6 @@ class Content_Classification extends Abstract_Ability {
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() )
-			->using_temperature( 0.2 )
 			->as_json_response( $this->suggestions_schema() );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Content_Classification_Experiment::class, array(), $prompt );

--- a/includes/Abilities/Content_Resizing/Content_Resizing.php
+++ b/includes/Abilities/Content_Resizing/Content_Resizing.php
@@ -236,8 +236,7 @@ class Content_Resizing extends Abstract_Ability {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_system_instruction(
 				$this->get_system_instruction( 'system-instruction.php', array( 'action' => $action ) )
-			)
-			->using_temperature( 0.7 );
+			);
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Content_Resizing_Experiment::class, array(), $prompt, $action );
 

--- a/includes/Abilities/Content_Translation/Content_Translation.php
+++ b/includes/Abilities/Content_Translation/Content_Translation.php
@@ -239,8 +239,7 @@ class Content_Translation extends Abstract_Ability {
 						'target_language' => $language,
 					)
 				)
-			)
-			->using_temperature( 0.7 );
+			);
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Content_Translation_Experiment::class, array(), $prompt, $language );
 

--- a/includes/Abilities/Excerpt_Generation/Excerpt_Generation.php
+++ b/includes/Abilities/Excerpt_Generation/Excerpt_Generation.php
@@ -254,8 +254,7 @@ class Excerpt_Generation extends Abstract_Ability {
 	 */
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction() )
-			->using_temperature( 0.7 );
+			->using_system_instruction( $this->get_system_instruction() );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Excerpt_Generation_Experiment::class, array(), $prompt );
 

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -412,8 +412,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 	private function get_prompt_builder( string $prompt, string $reference ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->with_file( $reference )
-			->using_system_instruction( $this->get_system_instruction( 'alt-text-system-instruction.php' ) )
-			->using_temperature( 0.3 );
+			->using_system_instruction( $this->get_system_instruction( 'alt-text-system-instruction.php' ) );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Alt_Text_Generation_Experiment::class, get_preferred_vision_models(), $prompt, $reference );
 

--- a/includes/Abilities/Image/Generate_Image_Prompt.php
+++ b/includes/Abilities/Image/Generate_Image_Prompt.php
@@ -271,8 +271,7 @@ class Generate_Image_Prompt extends Abstract_Ability {
 	 */
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction( 'image-prompt-system-instruction.php' ) )
-			->using_temperature( 0.9 );
+			->using_system_instruction( $this->get_system_instruction( 'image-prompt-system-instruction.php' ) );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, null, get_preferred_models_for_text_generation(), $prompt );
 

--- a/includes/Abilities/Meta_Description/Meta_Description.php
+++ b/includes/Abilities/Meta_Description/Meta_Description.php
@@ -301,14 +301,14 @@ class Meta_Description extends Abstract_Ability {
 		 * Filters the temperature for the result of the meta description generation.
 		 *
 		 * @since 0.7.0
+		 * @deprecated x.x.x No longer used.
 		 *
 		 * @param float $result_temperature The temperature for the result of the meta description generation.
 		 */
-		$result_temperature = (float) apply_filters( 'wpai_meta_description_result_temperature', 0.7 );
+		$result_temperature = (float) apply_filters_deprecated( 'wpai_meta_description_result_temperature', array( 0.7 ), 'x.x.x' );
 
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction() )
-			->using_temperature( $result_temperature );
+			->using_system_instruction( $this->get_system_instruction() );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Meta_Description_Experiment::class, array(), $prompt );
 

--- a/includes/Abilities/Meta_Description/Meta_Description.php
+++ b/includes/Abilities/Meta_Description/Meta_Description.php
@@ -305,7 +305,7 @@ class Meta_Description extends Abstract_Ability {
 		 *
 		 * @param float $result_temperature The temperature for the result of the meta description generation.
 		 */
-		$result_temperature = (float) apply_filters_deprecated( 'wpai_meta_description_result_temperature', array( 0.7 ), 'x.x.x' );
+		$result_temperature = (float) apply_filters_deprecated( 'wpai_meta_description_result_temperature', array( 0.7 ), 'x.x.x' ); // phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
 
 		$prompt_builder = wp_ai_client_prompt( $prompt )
 			->using_system_instruction( $this->get_system_instruction() );

--- a/includes/Abilities/Summarization/Summarization.php
+++ b/includes/Abilities/Summarization/Summarization.php
@@ -272,8 +272,7 @@ class Summarization extends Abstract_Ability {
 	 */
 	private function get_prompt_builder( string $prompt, string $length ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction( 'system-instruction.php', array( 'length' => $length ) ) )
-			->using_temperature( 0.9 );
+			->using_system_instruction( $this->get_system_instruction( 'system-instruction.php', array( 'length' => $length ) ) );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Summarization_Experiment::class, array(), $prompt, $length );
 

--- a/includes/Abilities/Title_Generation/Title_Generation.php
+++ b/includes/Abilities/Title_Generation/Title_Generation.php
@@ -261,8 +261,7 @@ class Title_Generation extends Abstract_Ability {
 	 */
 	private function get_prompt_builder( string $prompt ) {
 		$prompt_builder = wp_ai_client_prompt( $prompt )
-			->using_system_instruction( $this->get_system_instruction() )
-			->using_temperature( 0.7 );
+			->using_system_instruction( $this->get_system_instruction() );
 
 		$prompt_builder = $this->filter_prompt_builder( $prompt_builder, Title_Generation_Experiment::class, array(), $prompt );
 

--- a/includes/Abilities/Type_Ahead/Type_Ahead.php
+++ b/includes/Abilities/Type_Ahead/Type_Ahead.php
@@ -341,7 +341,7 @@ class Type_Ahead extends Abstract_Ability {
 			Type_Ahead_Experiment::class,
 			array(
 				array( 'anthropic', 'claude-haiku-4-5' ),
-				array( 'google', 'gemini-2.5-flash' ),
+				array( 'google', 'gemini-3.5-flash-lite' ),
 				array( 'openai', 'gpt-4.1-nano' ),
 			),
 			$prompt

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -202,11 +202,11 @@ function get_preferred_models_for_text_generation(): array {
 		),
 		array(
 			'openai',
-			'gpt-5.4-mini',
+			'gpt-5.6-luna',
 		),
 		array(
 			'openai',
-			'gpt-4.1-mini',
+			'gpt-5.4-mini',
 		),
 	);
 
@@ -326,11 +326,11 @@ function get_preferred_vision_models(): array {
 		),
 		array(
 			'openai',
-			'gpt-5.4-mini',
+			'gpt-5.6-luna',
 		),
 		array(
 			'openai',
-			'gpt-4.1-mini',
+			'gpt-5.4-mini',
 		),
 	);
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -190,15 +190,15 @@ function get_preferred_models_for_text_generation(): array {
 	$preferred_models = array(
 		array(
 			'anthropic',
-			'claude-sonnet-4-6',
+			'claude-sonnet-5',
 		),
 		array(
 			'google',
-			'gemini-3-flash-preview',
+			'gemini-3.6-flash',
 		),
 		array(
 			'google',
-			'gemini-2.5-flash',
+			'gemini-3.5-flash-lite',
 		),
 		array(
 			'openai',
@@ -314,15 +314,15 @@ function get_preferred_vision_models(): array {
 	$preferred_models = array(
 		array(
 			'anthropic',
-			'claude-sonnet-4-6',
+			'claude-sonnet-5',
 		),
 		array(
 			'google',
-			'gemini-3-flash-preview',
+			'gemini-3.6-flash',
 		),
 		array(
 			'google',
-			'gemini-2.5-flash',
+			'gemini-3.5-flash-lite',
 		),
 		array(
 			'openai',

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -710,19 +710,19 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[0], 'First model should be an array' );
 		$this->assertCount( 2, $result[0], 'First model should have 2 elements' );
 		$this->assertEquals( 'anthropic', $result[0][0], 'First model provider should be anthropic' );
-		$this->assertEquals( 'claude-sonnet-4-6', $result[0][1], 'First model name should be claude-sonnet-4-6' );
+		$this->assertEquals( 'claude-sonnet-5', $result[0][1], 'First model name should be claude-sonnet-5' );
 
 		// Check second model (google).
 		$this->assertIsArray( $result[1], 'Second model should be an array' );
 		$this->assertCount( 2, $result[1], 'Second model should have 2 elements' );
 		$this->assertEquals( 'google', $result[1][0], 'Second model provider should be google' );
-		$this->assertEquals( 'gemini-3-flash-preview', $result[1][1], 'Second model name should be gemini-3-flash-preview' );
+		$this->assertEquals( 'gemini-3.6-flash', $result[1][1], 'Second model name should be gemini-3.6-flash' );
 
 		// Check third model (google).
 		$this->assertIsArray( $result[2], 'Third model should be an array' );
 		$this->assertCount( 2, $result[2], 'Third model should have 2 elements' );
 		$this->assertEquals( 'google', $result[2][0], 'Third model provider should be google' );
-		$this->assertEquals( 'gemini-2.5-flash', $result[2][1], 'Third model name should be gemini-2.5-flash' );
+		$this->assertEquals( 'gemini-3.5-flash-lite', $result[2][1], 'Third model name should be gemini-3.5-flash-lite' );
 
 		// Check fourth model (openai).
 		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
@@ -931,17 +931,17 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[0], 'First model should be an array' );
 		$this->assertCount( 2, $result[0], 'First model should have 2 elements' );
 		$this->assertEquals( 'anthropic', $result[0][0], 'First model provider should be anthropic' );
-		$this->assertEquals( 'claude-sonnet-4-6', $result[0][1], 'First model name should be claude-sonnet-4-6' );
+		$this->assertEquals( 'claude-sonnet-5', $result[0][1], 'First model name should be claude-sonnet-5' );
 
 		$this->assertIsArray( $result[1], 'Second model should be an array' );
 		$this->assertCount( 2, $result[1], 'Second model should have 2 elements' );
 		$this->assertEquals( 'google', $result[1][0], 'Second model provider should be google' );
-		$this->assertEquals( 'gemini-3-flash-preview', $result[1][1], 'Second model name should be gemini-3-flash-preview' );
+		$this->assertEquals( 'gemini-3.6-flash', $result[1][1], 'Second model name should be gemini-3.6-flash' );
 
 		$this->assertIsArray( $result[2], 'Third model should be an array' );
 		$this->assertCount( 2, $result[2], 'Third model should have 2 elements' );
 		$this->assertEquals( 'google', $result[2][0], 'Third model provider should be google' );
-		$this->assertEquals( 'gemini-2.5-flash', $result[2][1], 'Third model name should be gemini-2.5-flash' );
+		$this->assertEquals( 'gemini-3.5-flash-lite', $result[2][1], 'Third model name should be gemini-3.5-flash-lite' );
 
 		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
 		$this->assertCount( 2, $result[3], 'Fourth model should have 2 elements' );

--- a/tests/Integration/Includes/HelpersTest.php
+++ b/tests/Integration/Includes/HelpersTest.php
@@ -728,13 +728,13 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
 		$this->assertCount( 2, $result[3], 'Fourth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[3][0], 'Fourth model provider should be openai' );
-		$this->assertEquals( 'gpt-5.4-mini', $result[3][1], 'Fourth model name should be gpt-5.4-mini' );
+		$this->assertEquals( 'gpt-5.6-luna', $result[3][1], 'Fourth model name should be gpt-5.6-luna' );
 
 		// Check fifth model (openai).
 		$this->assertIsArray( $result[4], 'Fifth model should be an array' );
 		$this->assertCount( 2, $result[4], 'Fifth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[4][0], 'Fifth model provider should be openai' );
-		$this->assertEquals( 'gpt-4.1-mini', $result[4][1], 'Fifth model name should be gpt-4.1-mini' );
+		$this->assertEquals( 'gpt-5.4-mini', $result[4][1], 'Fifth model name should be gpt-5.4-mini' );
 	}
 
 	/**
@@ -946,12 +946,12 @@ class HelpersTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result[3], 'Fourth model should be an array' );
 		$this->assertCount( 2, $result[3], 'Fourth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[3][0], 'Fourth model provider should be openai' );
-		$this->assertEquals( 'gpt-5.4-mini', $result[3][1], 'Fourth model name should be gpt-5.4-mini' );
+		$this->assertEquals( 'gpt-5.6-luna', $result[3][1], 'Fourth model name should be gpt-5.6-luna' );
 
 		$this->assertIsArray( $result[4], 'Fifth model should be an array' );
 		$this->assertCount( 2, $result[4], 'Fifth model should have 2 elements' );
 		$this->assertEquals( 'openai', $result[4][0], 'Fifth model provider should be openai' );
-		$this->assertEquals( 'gpt-4.1-mini', $result[4][1], 'Fifth model name should be gpt-4.1-mini' );
+		$this->assertEquals( 'gpt-5.4-mini', $result[4][1], 'Fifth model name should be gpt-5.4-mini' );
 	}
 
 	/**


### PR DESCRIPTION
## What?

Updates the preferred Anthropic text and vision model from `claude-sonnet-4-6` to `claude-sonnet-5`, the preferred Google text and vision model from `gemini-3-flash-preview` to `gemini-3.6-flash` and the preferred OpenAI text and vision model from `gpt-5.4-mini` to `gpt-5.6-luna` and removes the setting of custom temperature parameters.

## Why?

We want to ensure the default models we recommend are using the latest versions of models. In addition, the OpenAI GPT-5.5+ models don't support setting temperature values unless reasoning mode is turned off. There are a few different approaches we could take here:

1. Remove the setting of temperature values (what this PR does)
2. Set reasoning effort to none but will need to ensure we only apply this to OpenAI models
3. Update the OpenAI provider to ignore temperature values if the model doesn't support it

For now I've gone with option 1 in this PR as I don't think setting temperature really provides any value but open to thoughts there.

## How?

Updates our preferred models for Anthropic, Google and OpenAI to be the latest versions and removes anywhere we were using `using_temperature` on the prompt builder

### Use of AI Tools

None

## Testing Instructions

One by one, configure Anthropic, Google and OpenAI and test all features to ensure they still work

## Changelog Entry

> Changed - Updated preferred models to more recent ones for the three default providers.
> Deprecated - Filter `wpai_meta_description_result_temperature` is no longer being used and will be removed in the next release.
> Removed - No longer set custom temperature values on any of our requests.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-913-4b0e875ae2ab2b756d8d2c5be07f08f43fcd15f5.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->