### PR TITLE
Logging: add a public API for recording MCP tool and ability requests

### DIFF
--- a/docs/experiments/ai-request-logging.md
+++ b/docs/experiments/ai-request-logging.md
@@ -25,6 +25,41 @@ The logging system uses the decorator pattern to wrap the SDK's HTTP transporter
 
 This approach uses the SDK's public API rather than reflection or internal hacks, making it resilient to SDK updates.
 
+## Public API
+Consumers that surface abilities themselves — an MCP server, or code invoking an ability directly — can record their own requests instead of shipping a parallel log.
+
+### `WordPress\AI\log_ai_request()`
+Writes an entry to the same log the experiment populates. Returns the log identifier on success, or `false` when the experiment is disabled or the write failed, so it is safe to call unconditionally.
+
+```php
+\WordPress\AI\log_ai_request( array(
+    'type'        => 'mcp_tool',       // Required. One of AI_Request_Log_Manager::get_types().
+    'operation'   => 'example/tool',   // Required. Non-empty string.
+    'status'      => 'success',        // Required. Non-empty string.
+    'provider'    => 'openai',
+    'model'       => 'gpt-5-nano',
+    'duration_ms' => 120,
+    'context'     => array( 'input_preview' => '…' ),
+) );
+```
+
+`type`, `operation`, and `status` are validated: anything else triggers `_doing_it_wrong()` and no row is written. `type` must be one of the values `AI_Request_Log_Manager::get_types()` returns — `ai_client` (generations made through the AI Client SDK), `mcp_tool`, or `ability`. A row carrying an unlisted type could never be filtered through the REST API, and `operation` and `status` are stored in columns that cannot be null.
+
+The REST `type` filter enum is derived from `get_types()`, so the read and write sides cannot drift apart.
+
+## Action Hooks
+
+### `wpai_request_logged`
+Fires after an entry is written, with the log identifier and the stored row. Lets consumers react to logged requests without polling the REST endpoint.
+
+```php
+add_action( 'wpai_request_logged', function( $log_id, $data ) {
+    if ( 'error' === $data['status'] ) {
+        // Alert on failed AI requests.
+    }
+}, 10, 2 );
+```
+
 ## Filter Hooks
 The logging system exposes several filter hooks for extensibility:
 

--- a/includes/Logging/AI_Request_Log_Manager.php
+++ b/includes/Logging/AI_Request_Log_Manager.php
@@ -180,23 +180,6 @@ class AI_Request_Log_Manager {
 
 		$log_id = $this->repository->insert( $data );
 
-		if ( false === $log_id ) {
-			return false;
-		}
-
-		/**
-		 * Fires after an AI request has been written to the log.
-		 *
-		 * Lets consumers react to logged requests without polling the REST
-		 * endpoint.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param string              $log_id The identifier of the log entry.
-		 * @param array<string,mixed> $data   The logged data.
-		 */
-		do_action( 'wpai_ai_request_logged', $log_id, $data );
-
 		return $log_id;
 	}
 

--- a/includes/Logging/AI_Request_Log_Manager.php
+++ b/includes/Logging/AI_Request_Log_Manager.php
@@ -160,7 +160,59 @@ class AI_Request_Log_Manager {
 	 * @return string|false The log ID on success, false on failure.
 	 */
 	public function log( array $data ) {
-		return $this->repository->insert( $data );
+		$type  = $data['type'] ?? '';
+		$types = self::get_types();
+
+		if ( ! in_array( $type, $types, true ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: 1: the supplied log type, 2: comma-separated list of supported log types. */
+					esc_html__( 'Unsupported log type "%1$s". Supported types are: %2$s.', 'ai' ),
+					esc_html( is_scalar( $type ) ? (string) $type : gettype( $type ) ),
+					esc_html( implode( ', ', $types ) )
+				),
+				'x.x.x'
+			);
+
+			return false;
+		}
+
+		$log_id = $this->repository->insert( $data );
+
+		if ( false === $log_id ) {
+			return false;
+		}
+
+		/**
+		 * Fires after an AI request has been written to the log.
+		 *
+		 * Lets consumers react to logged requests without polling the REST
+		 * endpoint.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string              $log_id The identifier of the log entry.
+		 * @param array<string,mixed> $data   The logged data.
+		 */
+		do_action( 'wpai_ai_request_logged', $log_id, $data );
+
+		return $log_id;
+	}
+
+	/**
+	 * Gets the log types that may be recorded.
+	 *
+	 * `ai_client` covers generations made through the AI Client SDK. `mcp_tool`
+	 * and `ability` are for consumers that surface abilities themselves, such as
+	 * an MCP server or a direct ability invocation.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return list<string> Supported log types.
+	 */
+	public static function get_types(): array {
+		return array( 'ai_client', 'mcp_tool', 'ability' );
 	}
 
 	/**

--- a/includes/Logging/AI_Request_Log_Manager.php
+++ b/includes/Logging/AI_Request_Log_Manager.php
@@ -163,12 +163,13 @@ class AI_Request_Log_Manager {
 		$type  = $data['type'] ?? '';
 		$types = self::get_types();
 
+		// Ensure the data has a valid `type`.
 		if ( ! in_array( $type, $types, true ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				sprintf(
 					/* translators: 1: the supplied log type, 2: comma-separated list of supported log types. */
-					esc_html__( 'Unsupported log type "%1$s". Supported types are: %2$s.', 'ai' ),
+					esc_html__( 'Unsupported log type: %1$s. Supported types are: %2$s.', 'ai' ),
 					esc_html( is_scalar( $type ) ? (string) $type : gettype( $type ) ),
 					esc_html( implode( ', ', $types ) )
 				),
@@ -178,9 +179,24 @@ class AI_Request_Log_Manager {
 			return false;
 		}
 
-		$log_id = $this->repository->insert( $data );
+		// Ensure we have `operation` and `status`, since both are stored in columns that cannot be null.
+		foreach ( array( 'operation', 'status' ) as $field ) {
+			if ( ! isset( $data[ $field ] ) || ! is_string( $data[ $field ] ) || '' === $data[ $field ] ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: the name of the required log field. */
+						esc_html__( 'The %s log field is required and must be a non-empty string.', 'ai' ),
+						esc_html( $field )
+					),
+					'x.x.x'
+				);
 
-		return $log_id;
+				return false;
+			}
+		}
+
+		return $this->repository->insert( $data );
 	}
 
 	/**

--- a/includes/Logging/Logging_Integration.php
+++ b/includes/Logging/Logging_Integration.php
@@ -68,6 +68,20 @@ class Logging_Integration {
 	}
 
 	/**
+	 * Gets the shared log manager instance.
+	 *
+	 * Returns null when the AI Request Logging experiment is disabled, since
+	 * nothing has initialized the manager in that case.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WordPress\AI\Logging\AI_Request_Log_Manager|null The log manager, or null when logging is inactive.
+	 */
+	public static function get_log_manager(): ?AI_Request_Log_Manager {
+		return self::$log_manager;
+	}
+
+	/**
 	 * Wraps the SDK's HTTP transporter with logging.
 	 *
 	 * Uses the public setHttpTransporter() API to replace the transporter

--- a/includes/Logging/REST/AI_Request_Log_Controller.php
+++ b/includes/Logging/REST/AI_Request_Log_Controller.php
@@ -246,7 +246,7 @@ class AI_Request_Log_Controller extends WP_REST_Controller {
 			'type'             => array(
 				'description' => __( 'Filter by log type.', 'ai' ),
 				'type'        => 'string',
-				'enum'        => array( '', 'ai_client', 'mcp_tool', 'ability' ),
+				'enum'        => array_merge( array( '' ), AI_Request_Log_Manager::get_types() ),
 				'default'     => '',
 			),
 			'status'           => array(

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -11,6 +11,8 @@ namespace WordPress\AI;
 
 use Throwable;
 use WordPress\AI\Experiments\Summarization\Summarization;
+use WordPress\AI\Logging\AI_Request_Log_Manager;
+use WordPress\AI\Logging\Logging_Integration;
 use WordPress\AI\Services\AI_Service;
 use WordPress\AI\Services\Guidelines;
 use WordPress\AiClient\AiClient;
@@ -760,4 +762,41 @@ function post_type_supports_bulk_action( string $post_type, string $feature_id )
 		default:
 			return $base_supported;
 	}
+}
+
+/**
+ * Records an AI request in the request log.
+ *
+ * Lets consumers that surface abilities themselves — an MCP server, or code
+ * invoking an ability directly — write to the same log the AI Request Logging
+ * experiment populates, instead of constructing their own log manager.
+ *
+ * Does nothing when the experiment is disabled.
+ *
+ * @since x.x.x
+ *
+ * @param array{
+ *     type: string,
+ *     operation: string,
+ *     provider?: string,
+ *     model?: string,
+ *     duration_ms?: int,
+ *     tokens_input?: int,
+ *     tokens_output?: int,
+ *     status: string,
+ *     error_message?: string,
+ *     user_id?: int,
+ *     context?: array<string, mixed>
+ * } $data Log data. The `type` must be one of the values returned by
+ *         {@see AI_Request_Log_Manager::get_types()}.
+ * @return string|false The log identifier on success, false when logging is inactive or the write failed.
+ */
+function log_ai_request( array $data ) {
+	$log_manager = Logging_Integration::get_log_manager();
+
+	if ( ! $log_manager instanceof AI_Request_Log_Manager ) {
+		return false;
+	}
+
+	return $log_manager->log( $data );
 }

--- a/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
@@ -11,6 +11,7 @@ use WP_UnitTestCase;
 use WordPress\AI\Logging\AI_Request_Log_Manager;
 use WordPress\AI\Logging\AI_Request_Log_Repository;
 use WordPress\AI\Logging\AI_Request_Log_Schema;
+use WordPress\AI\Logging\REST\AI_Request_Log_Controller;
 
 /**
  * AI_Request_Log_Manager test case.
@@ -69,7 +70,7 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 	public function test_log_persists_entry(): void {
 		$log_id = $this->manager->log(
 			array(
-				'type'          => 'ui',
+				'type'          => 'ai_client',
 				'operation'     => 'completion',
 				'provider'      => 'openai',
 				'model'         => 'gpt-5-nano',
@@ -313,5 +314,141 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 	public function test_accessors_return_correct_instances(): void {
 		$this->assertInstanceOf( AI_Request_Log_Schema::class, $this->manager->get_schema() );
 		$this->assertInstanceOf( AI_Request_Log_Repository::class, $this->manager->get_repository() );
+	}
+
+	/**
+	 * Tests that every supported type can be recorded.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_log_accepts_every_supported_type(): void {
+		foreach ( AI_Request_Log_Manager::get_types() as $type ) {
+			$log_id = $this->manager->log(
+				array(
+					'type'      => $type,
+					'operation' => 'example',
+					'status'    => 'success',
+				)
+			);
+
+			$this->assertIsString( $log_id, "Type \"{$type}\" should be accepted." );
+		}
+	}
+
+	/**
+	 * Tests that an unsupported type is rejected rather than written.
+	 *
+	 * A row carrying a type outside the supported set can never be filtered
+	 * through the REST API, so it is refused at the point of writing.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_log_rejects_unsupported_type(): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+
+		$log_id = $this->manager->log(
+			array(
+				'type'      => 'not-a-real-type',
+				'operation' => 'example',
+				'status'    => 'success',
+			)
+		);
+
+		$this->assertFalse( $log_id );
+	}
+
+	/**
+	 * Tests that a missing type is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_log_rejects_missing_type(): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+
+		$this->assertFalse(
+			$this->manager->log(
+				array(
+					'operation' => 'example',
+					'status'    => 'success',
+				)
+			)
+		);
+	}
+
+	/**
+	 * Tests that the write action fires with the log identifier and data.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_log_fires_action_on_write(): void {
+		$captured = array();
+
+		add_action(
+			'wpai_ai_request_logged',
+			static function ( $log_id, $data ) use ( &$captured ) {
+				$captured[] = array( $log_id, $data );
+			},
+			10,
+			2
+		);
+
+		$log_id = $this->manager->log(
+			array(
+				'type'      => 'mcp_tool',
+				'operation' => 'example',
+				'status'    => 'success',
+			)
+		);
+
+		remove_all_actions( 'wpai_ai_request_logged' );
+
+		$this->assertCount( 1, $captured );
+		$this->assertSame( $log_id, $captured[0][0] );
+		$this->assertSame( 'mcp_tool', $captured[0][1]['type'] );
+	}
+
+	/**
+	 * Tests that the action does not fire when the type is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_log_does_not_fire_action_when_rejected(): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+
+		$fired = false;
+
+		add_action(
+			'wpai_ai_request_logged',
+			static function () use ( &$fired ) {
+				$fired = true;
+			}
+		);
+
+		$this->manager->log(
+			array(
+				'type'      => 'nope',
+				'operation' => 'example',
+				'status'    => 'success',
+			)
+		);
+
+		remove_all_actions( 'wpai_ai_request_logged' );
+
+		$this->assertFalse( $fired );
+	}
+
+	/**
+	 * Tests that the supported types cover the values the REST API advertises.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_types_matches_rest_collection_enum(): void {
+		$controller = new AI_Request_Log_Controller( $this->manager );
+		$params     = $controller->get_collection_params();
+
+		$this->assertSame(
+			array_merge( array( '' ), AI_Request_Log_Manager::get_types() ),
+			$params['type']['enum']
+		);
 	}
 }

--- a/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
+++ b/tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php
@@ -376,21 +376,73 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the write action fires with the log identifier and data.
+	 * Tests that a missing required field is rejected.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_incomplete_log_entries
+	 *
+	 * @param array<string, mixed> $data Log data missing a required field.
+	 */
+	public function test_log_rejects_missing_required_field( array $data ): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+
+		$this->assertFalse( $this->manager->log( $data ) );
+	}
+
+	/**
+	 * Data provider for log entries missing a required field.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, array{array<string, mixed>}> Test data.
+	 */
+	public function data_incomplete_log_entries(): array {
+		return array(
+			'missing operation' => array(
+				array(
+					'type'   => 'mcp_tool',
+					'status' => 'success',
+				),
+			),
+			'empty operation'   => array(
+				array(
+					'type'      => 'mcp_tool',
+					'operation' => '',
+					'status'    => 'success',
+				),
+			),
+			'missing status'    => array(
+				array(
+					'type'      => 'mcp_tool',
+					'operation' => 'example',
+				),
+			),
+			'empty status'      => array(
+				array(
+					'type'      => 'mcp_tool',
+					'operation' => 'example',
+					'status'    => '',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Tests that the write action fires with the log identifier and stored row.
 	 *
 	 * @since x.x.x
 	 */
 	public function test_log_fires_action_on_write(): void {
 		$captured = array();
 
-		add_action(
-			'wpai_ai_request_logged',
-			static function ( $log_id, $data ) use ( &$captured ) {
-				$captured[] = array( $log_id, $data );
-			},
-			10,
-			2
-		);
+		// Removed by callback rather than with remove_all_actions(), since
+		// wpai_request_logged is a public hook other code may listen on.
+		$listener = static function ( $log_id, $data ) use ( &$captured ) {
+			$captured[] = array( $log_id, $data );
+		};
+
+		add_action( 'wpai_request_logged', $listener, 10, 2 );
 
 		$log_id = $this->manager->log(
 			array(
@@ -400,7 +452,7 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 			)
 		);
 
-		remove_all_actions( 'wpai_ai_request_logged' );
+		remove_action( 'wpai_request_logged', $listener, 10 );
 
 		$this->assertCount( 1, $captured );
 		$this->assertSame( $log_id, $captured[0][0] );
@@ -408,7 +460,7 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the action does not fire when the type is rejected.
+	 * Tests that the action does not fire when the entry is rejected.
 	 *
 	 * @since x.x.x
 	 */
@@ -417,12 +469,11 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 
 		$fired = false;
 
-		add_action(
-			'wpai_ai_request_logged',
-			static function () use ( &$fired ) {
-				$fired = true;
-			}
-		);
+		$listener = static function () use ( &$fired ) {
+			$fired = true;
+		};
+
+		add_action( 'wpai_request_logged', $listener );
 
 		$this->manager->log(
 			array(
@@ -432,7 +483,7 @@ class AI_Request_Log_ManagerTest extends WP_UnitTestCase {
 			)
 		);
 
-		remove_all_actions( 'wpai_ai_request_logged' );
+		remove_action( 'wpai_request_logged', $listener );
 
 		$this->assertFalse( $fired );
 	}

--- a/tests/Integration/Includes/Logging/Log_Ai_RequestTest.php
+++ b/tests/Integration/Includes/Logging/Log_Ai_RequestTest.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * Integration tests for the public request logging helper.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Logging
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Logging;
+
+use ReflectionProperty;
+use WP_UnitTestCase;
+use WordPress\AI\Logging\AI_Request_Log_Manager;
+use WordPress\AI\Logging\AI_Request_Log_Schema;
+use WordPress\AI\Logging\Logging_Integration;
+
+use function WordPress\AI\log_ai_request;
+
+/**
+ * log_ai_request() test case.
+ *
+ * @since x.x.x
+ *
+ * @covers \WordPress\AI\log_ai_request
+ */
+class Log_Ai_RequestTest extends WP_UnitTestCase {
+
+	/**
+	 * Manager instance shared with the integration.
+	 *
+	 * @var \WordPress\AI\Logging\AI_Request_Log_Manager
+	 */
+	private AI_Request_Log_Manager $manager;
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since x.x.x
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Force schema recreation in case a prior test's TRUNCATE broke the table state.
+		delete_option( 'wpai_request_logs_schema_version' );
+
+		$this->manager = new AI_Request_Log_Manager();
+		$this->manager->init();
+
+		global $wpdb;
+		$table = $wpdb->prefix . AI_Request_Log_Schema::TABLE_NAME;
+		$wpdb->query( "DELETE FROM {$table} WHERE 1=1" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since x.x.x
+	 */
+	protected function tearDown(): void {
+		$this->set_shared_manager( null );
+		delete_option( 'wpai_request_logs_schema_version' );
+		wp_clear_scheduled_hook( 'wpai_request_logs_cleanup' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Sets the manager the logging integration shares.
+	 *
+	 * Logging_Integration::init() is guarded against running twice, so the
+	 * shared manager is set directly to model both the active and inactive
+	 * states of the experiment.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WordPress\AI\Logging\AI_Request_Log_Manager|null $manager Manager instance, or null to model a disabled experiment.
+	 */
+	private function set_shared_manager( ?AI_Request_Log_Manager $manager ): void {
+		$property = new ReflectionProperty( Logging_Integration::class, 'log_manager' );
+		$property->setAccessible( true );
+		$property->setValue( null, $manager );
+	}
+
+	/**
+	 * Tests that the helper returns false when the experiment is inactive.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_returns_false_when_logging_is_inactive(): void {
+		$this->set_shared_manager( null );
+
+		$this->assertFalse( log_ai_request( array( 'type' => 'mcp_tool' ) ) );
+	}
+
+	/**
+	 * Tests that the helper writes a row when logging is active.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_writes_entry_when_logging_is_active(): void {
+		$this->set_shared_manager( $this->manager );
+
+		$log_id = log_ai_request(
+			array(
+				'type'      => 'mcp_tool',
+				'operation' => 'example-tool',
+				'status'    => 'success',
+			)
+		);
+
+		$this->assertIsString( $log_id );
+
+		$entry = $this->manager->get_log( $log_id );
+
+		$this->assertIsArray( $entry );
+		$this->assertSame( 'mcp_tool', $entry['type'] );
+		$this->assertSame( 'example-tool', $entry['operation'] );
+	}
+
+	/**
+	 * Tests that the helper rejects an unsupported type.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_rejects_unsupported_type(): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+		$this->set_shared_manager( $this->manager );
+
+		$this->assertFalse(
+			log_ai_request(
+				array(
+					'type'      => 'not-a-real-type',
+					'operation' => 'example',
+					'status'    => 'success',
+				)
+			)
+		);
+	}
+}

--- a/tests/Integration/Includes/Logging/Log_Ai_RequestTest.php
+++ b/tests/Integration/Includes/Logging/Log_Ai_RequestTest.php
@@ -32,12 +32,21 @@ class Log_Ai_RequestTest extends WP_UnitTestCase {
 	private AI_Request_Log_Manager $manager;
 
 	/**
+	 * Manager the logging integration held before this test replaced it.
+	 *
+	 * @var \WordPress\AI\Logging\AI_Request_Log_Manager|null
+	 */
+	private ?AI_Request_Log_Manager $original_shared_manager = null;
+
+	/**
 	 * Set up test case.
 	 *
 	 * @since x.x.x
 	 */
 	protected function setUp(): void {
 		parent::setUp();
+
+		$this->original_shared_manager = Logging_Integration::get_log_manager();
 
 		// Force schema recreation in case a prior test's TRUNCATE broke the table state.
 		delete_option( 'wpai_request_logs_schema_version' );
@@ -56,7 +65,9 @@ class Log_Ai_RequestTest extends WP_UnitTestCase {
 	 * @since x.x.x
 	 */
 	protected function tearDown(): void {
-		$this->set_shared_manager( null );
+		// Restore whatever the integration held, rather than assuming it was empty:
+		// Logging_Integration::init() will not run a second time to repopulate it.
+		$this->set_shared_manager( $this->original_shared_manager );
 		delete_option( 'wpai_request_logs_schema_version' );
 		wp_clear_scheduled_hook( 'wpai_request_logs_cleanup' );
 
@@ -88,7 +99,15 @@ class Log_Ai_RequestTest extends WP_UnitTestCase {
 	public function test_returns_false_when_logging_is_inactive(): void {
 		$this->set_shared_manager( null );
 
-		$this->assertFalse( log_ai_request( array( 'type' => 'mcp_tool' ) ) );
+		$this->assertFalse(
+			log_ai_request(
+				array(
+					'type'      => 'mcp_tool',
+					'operation' => 'example-tool',
+					'status'    => 'success',
+				)
+			)
+		);
 	}
 
 	/**
@@ -134,5 +153,20 @@ class Log_Ai_RequestTest extends WP_UnitTestCase {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Tests that the helper rejects data missing a required field.
+	 *
+	 * `operation` and `status` are stored in columns that cannot be null, so an
+	 * incomplete payload is refused instead of reaching the insert.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_rejects_missing_required_field(): void {
+		$this->setExpectedIncorrectUsage( 'WordPress\AI\Logging\AI_Request_Log_Manager::log' );
+		$this->set_shared_manager( $this->manager );
+
+		$this->assertFalse( log_ai_request( array( 'type' => 'mcp_tool' ) ) );
 	}
 }


### PR DESCRIPTION
## What?
Closes #906

Adds a public API so consumers that surface abilities themselves — an MCP server, or code invoking an ability directly — can record requests in the AI Request Logging experiment's log, instead of reaching into the experiment's internals or shipping a parallel log of their own.

- Adds `WordPress\AI\log_ai_request()`.
- Adds `AI_Request_Log_Manager::get_types()` as the single source of truth for the supported log types, and derives the REST `type` enum from it.
- `AI_Request_Log_Manager::log()` now rejects an unsupported `type`.
- Fires `wpai_ai_request_logged` after a successful write.

## Why?

The log's read contract already declares three types, but only one of them could ever exist:

- `AI_Request_Log_Controller::get_collection_params()` exposes `type` with `enum => array( '', 'ai_client', 'mcp_tool', 'ability' )`.
- The client mirrors it — `LogEntry.type` is typed `'ai_client' | 'mcp_tool' | 'ability'` in `src/admin/ai-request-logs/types.ts`.
- But the only writer is `Log_Data_Extractor::extract_request_data()`, which hardcodes `'type' => 'ai_client'`. Nothing ever produced an `mcp_tool` or `ability` row.

There was also no supported way for anything outside the experiment to write one: `AI_Request_Logging::$manager` and `::get_manager()` are private, and `Logging_Integration::$log_manager` is `private static` with no accessor. A consumer's only option was to construct its own `AI_Request_Log_Manager`, which bypasses the experiment-enabled check and re-runs `maybe_upgrade_table()` plus the cleanup cron negotiation on `init()`.

The practical consequence: an MCP tool call that publishes a post is exactly the kind of AI-initiated request a site owner expects to find in **Tools → AI Request Log**, and it was invisible. Left unsolved centrally, every MCP or ability surface ends up shipping its own logging table.

## How?

**`WordPress\AI\log_ai_request()`** in `includes/helpers.php` returns the log ID on success, or `false` when the experiment is disabled, so callers can invoke it unconditionally. It follows the namespaced convention used throughout that file (`has_ai_credentials()`, `get_post_context()`, …) rather than the `wpai_`-prefixed name sketched in the issue.

**`Logging_Integration::get_log_manager()`** exposes the shared manager, returning `null` when nothing has initialised it.

**`AI_Request_Log_Manager::get_types()`** returns the supported types, and `AI_Request_Log_Controller::get_collection_params()` now builds its enum from it, so the write and read sides cannot drift apart.

**`AI_Request_Log_Manager::log()`** validates `type` and refuses anything outside that set with `_doing_it_wrong()`. This is a behaviour change on a public method and worth calling out: a row carrying a type the REST API cannot filter is unreachable through the UI, so it is refused at the point of writing rather than stored where nothing can retrieve it. Any existing caller passing a custom type would begin losing rows.

**One existing test changed.** `AI_Request_Log_ManagerTest::test_log_persists_entry()` passed `'type' => 'ui'`, which was never one of the advertised values — a row typed `ui` can never be filtered through the REST API. It is updated to `ai_client`. Happy to revisit if `ui` was intentional.

**Not included:** validation is limited to `type`. Normalising other fields felt like scope creep for this issue.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Opus 5
Used for: Investigating the gap, drafting the implementation and the integration tests, and running the verification described below. I reviewed every line, decided the API shape and naming, and tested the change end-to-end on a local WordPress 7.1 site against a real MCP server before opening this PR.

## Testing Instructions

**Setup:** enable the **AI Request Logging** experiment (the API intentionally no-ops while it is off).

**1. A row can be recorded, and the reserved type is reachable**

Drop this in an mu-plugin and load any admin page:

```php
add_action( 'admin_init', function () {
	\WordPress\AI\log_ai_request( array(
		'type'      => 'mcp_tool',
		'operation' => 'example/tool-call',
		'status'    => 'success',
	) );
} );
```

Go to **Tools → AI Request Log** — the entry appears. Confirm the type by requesting `/wp-json/ai/v1/logs?type=mcp_tool`; before this change that filter could never match a row.

**2. An unsupported type is refused**

Change `'type'` to `'not-a-real-type'`. With `WP_DEBUG` on you get a `_doing_it_wrong()` notice, the call returns `false`, and no row is written.

**3. It no-ops when the experiment is disabled**

Turn the experiment off and reload. The call returns `false` and nothing is written — no fatal, no notice.

**4. The write action fires**

```php
add_action( 'wpai_ai_request_logged', function ( $log_id, $data ) {
	error_log( "logged {$log_id} as {$data['type']}" );
}, 10, 2 );
```

**Integration tests:** `tests/Integration/Includes/Logging/AI_Request_Log_ManagerTest.php` and `Log_Ai_RequestTest.php` cover every supported type, rejection of unsupported and missing types, the action firing (and not firing when rejected), the inactive-experiment path, and that `get_types()` matches the REST enum.

**Real-world check:** I verified this against an MCP server exposing abilities on WordPress 7.1. On unpatched `develop` the MCP tool call ran and left no trace; with this branch the same call recorded an `mcp_tool` entry with a real duration, and a failing call recorded `status: error` carrying the actual `WP_Error` message.

> **Note:** I could not run PHPUnit locally (no Docker on this machine), so the integration tests here have their first execution in CI. `vendor/bin/phpcs` and `vendor/bin/phpstan analyse` (level 8) both pass clean.

## Screenshots or screencast

No UI changes. Entries render through the existing AI Request Log screen.

## Changelog Entry

> Added - Public `WordPress\AI\log_ai_request()` API so MCP servers and ability consumers can record requests in the AI Request Log.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-914-772f1ebbec58996a2d62befa635f12b7ca3eb6b7.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->