### PR TITLE
Content Resizing: Preserve inline HTML

### DIFF
--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -30,7 +30,7 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import { runAbility } from '../../../utils/run-ability';
-import { getBlockText } from '../../../utils/blocks';
+import { getBlockHTML } from '../../../utils/blocks';
 import type { ContentResizingAction, ContentResizingData } from '../types';
 import { ICON_SHORTEN, ICON_EXPAND, ICON_REPHRASE } from '../icons';
 import { ensureProvider } from '../../../utils/provider-status';
@@ -90,7 +90,7 @@ export default function ContentResizingToolbar( {
 			/* eslint-disable dot-notation */
 			const block = select( blockEditorStore )[ 'getBlock' ]( clientId );
 			return {
-				blockContent: block ? getBlockText( block ) : '',
+				blockContent: block ? getBlockHTML( block ) : '',
 				isResized:
 					( block?.attributes[ 'aiResized' ] as boolean ) ?? false,
 				postId: select( editorStore )[ 'getCurrentPostId' ]() as number,


### PR DESCRIPTION
## What, Why, and How?

This PR enables preserving inline HTML in content resizing, ensuring links, emphasis, code, and other inline formatting survive the AI transformation.

The documentation and system prompts indicate that the experiment preserves inline HTML; however, this did not happen because the toolbar used the `getBlockText` helper. This PR replaces it with the shared `getBlockHTML` utility so formatted content is sent to the content-resizing ability with its inline markup intact.

Ref:
https://github.com/WordPress/ai/blob/5599e9d255a0b6cc31b2c0dc31328a98d5bc519b/docs/experiments/content-resizing.md#L5

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code review

## Testing Instructions

1. Enable the `Content Resizing` experiment and configure an `AI provider`.
2. Create a post with a paragraph containing inline formatting, such as a link, bold, italic, and inline code.
3. Select the paragraph and choose Resize Content → Rephrase.
4. Verify the original and suggested content retain the inline formatting.
5. Accept the suggestion and confirm the formatting remains intact in the editor and after saving/reloading the post.

## Screencast

### Before

https://github.com/user-attachments/assets/3d3b671d-3b36-4831-af53-bf26530156b7


### After

https://github.com/user-attachments/assets/24605abc-9239-4a8f-bf34-4b6264ef304b


## Changelog Entry

> Fixed - Preserve inline HTML when resizing content.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-915-ffbf4b4f3b1daea8635b5129270bb0a210f9b2c9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->