### PR TITLE
Editorial Updates: Fix missed updates for Pullquote and other value-based blocks

### DIFF
--- a/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
+++ b/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
@@ -53,6 +53,26 @@ interface Block {
 }
 
 /**
+ * Returns the attribute Editorial Updates should use for a block's primary
+ * editable text. Most text blocks use `content`, while blocks such as
+ * Pullquote use `value` and Image uses `alt`.
+ *
+ * @param block The block to inspect.
+ * @return The editable text attribute.
+ */
+function getEditableTextAttribute( block: Block ) {
+	if ( block.name === 'core/image' ) {
+		return 'alt';
+	}
+
+	if ( Object.hasOwn( block.attributes, 'value' ) ) {
+		return 'value';
+	}
+
+	return 'content';
+}
+
+/**
  * Updates a Note status to approved.
  *
  * @param noteId Note ID.
@@ -407,11 +427,8 @@ export function useEditorialUpdates(): {
 								refinedContent &&
 								refinedContent !== blockText
 							) {
-								// For heading and paragraph it's content, image is alt
 								const attributeToUpdate =
-									block.name === 'core/image'
-										? 'alt'
-										: 'content';
+									getEditableTextAttribute( block );
 
 								dispatch(
 									blockEditorStore

--- a/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
+++ b/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
@@ -21,6 +21,7 @@ import {
 	flattenBlocks,
 	getBlockText,
 	replaceBlockWithPlaceholder,
+	getEditableTextAttribute,
 } from '../../../utils/blocks';
 import {
 	REVIEWABLE_BLOCK_TYPES,
@@ -50,26 +51,6 @@ interface Block {
 	name: string;
 	attributes: BlockAttributes;
 	innerBlocks: Block[];
-}
-
-/**
- * Returns the attribute Editorial Updates should use for a block's primary
- * editable text. Most text blocks use `content`, while blocks such as
- * Pullquote use `value` and Image uses `alt`.
- *
- * @param block The block to inspect.
- * @return The editable text attribute.
- */
-function getEditableTextAttribute( block: Block ) {
-	if ( block.name === 'core/image' ) {
-		return 'alt';
-	}
-
-	if ( Object.hasOwn( block.attributes, 'value' ) ) {
-		return 'value';
-	}
-
-	return 'content';
 }
 
 /**
@@ -429,6 +410,16 @@ export function useEditorialUpdates(): {
 							) {
 								const attributeToUpdate =
 									getEditableTextAttribute( block );
+
+								if ( ! attributeToUpdate ) {
+									// A missing editable attribute indicates an unexpected block schema.
+									throw new Error(
+										__(
+											'Unable to update a block because its editable text attribute could not be determined.',
+											'ai'
+										)
+									);
+								}
 
 								dispatch(
 									blockEditorStore

--- a/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
+++ b/src/experiments/editorial-updates/hooks/useEditorialUpdates.ts
@@ -415,7 +415,7 @@ export function useEditorialUpdates(): {
 									// A missing editable attribute indicates an unexpected block schema.
 									throw new Error(
 										__(
-											'Unable to update a block because its editable text attribute could not be determined.',
+											'Unable to update one or more blocks because their editable text attributes could not be determined.',
 											'ai'
 										)
 									);

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -213,3 +213,27 @@ export function getBlockHTML( block: BlockWithContent ): string {
 
 	return '';
 }
+
+/**
+ * Returns the attribute Editorial Updates should use for a block's primary
+ * editable text. Most text blocks use `content`, while blocks such as
+ * Pullquote use `value` and Image uses `alt`.
+ *
+ * @param block The block to inspect.
+ * @return The editable text attribute.
+ */
+export function getEditableTextAttribute( block: BlockWithContent ) {
+	if ( block.name === 'core/image' ) {
+		return 'alt';
+	}
+
+	if ( Object.hasOwn( block.attributes, 'content' ) ) {
+		return 'content';
+	}
+
+	if ( Object.hasOwn( block.attributes, 'value' ) ) {
+		return 'value';
+	}
+
+	return undefined;
+}

--- a/src/utils/blocks.ts
+++ b/src/utils/blocks.ts
@@ -215,14 +215,15 @@ export function getBlockHTML( block: BlockWithContent ): string {
 }
 
 /**
- * Returns the attribute Editorial Updates should use for a block's primary
- * editable text. Most text blocks use `content`, while blocks such as
- * Pullquote use `value` and Image uses `alt`.
+ * Returns the attribute that stores a block's primary editable text.
+ * Most text blocks use `content`; Pullquote uses `value`; and Image uses `alt`.
  *
- * @param block The block to inspect.
- * @return The editable text attribute.
+ * @param {BlockWithContent} block The block to inspect.
+ * @return {string | undefined} The editable text attribute.
  */
-export function getEditableTextAttribute( block: BlockWithContent ) {
+export function getEditableTextAttribute(
+	block: BlockWithContent
+): string | undefined {
 	if ( block.name === 'core/image' ) {
 		return 'alt';
 	}

--- a/tests/e2e/specs/experiments/editorial-updates.spec.js
+++ b/tests/e2e/specs/experiments/editorial-updates.spec.js
@@ -600,4 +600,176 @@ test.describe( 'Editorial Updates Experiment', () => {
 		} );
 		expect( blockContent ).toContain( 'Content that will fail refinement' );
 	} );
+
+	test( 'Updates the correct text attribute for different block types', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost( {
+			title: 'Editorial Updates Attribute Test',
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content: 'This paragraph needs refinement.',
+			},
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/pullquote',
+			attributes: {
+				value: 'This pullquote needs refinement.',
+			},
+		} );
+
+		const noteIds = await page.evaluate( async () => {
+			const postId = window.wp.data
+				.select( 'core/editor' )
+				.getCurrentPostId();
+
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+
+			// Verify the post is open for comments.
+			await window.wp.apiFetch( {
+				path: `/wp/v2/posts/${ postId }`,
+				method: 'POST',
+				data: { comment_status: 'open' },
+			} );
+
+			return Promise.all(
+				blocks.map( async ( block ) => {
+					// Add a note for the block.
+					const note = await window.wp.apiFetch( {
+						path: '/wp/v2/comments',
+						method: 'POST',
+						data: {
+							post: postId,
+							content: `Improve this ${ block.name }.`,
+							type: 'note',
+							status: 'hold',
+							meta: { ai_note: true },
+						},
+					} );
+
+					// Link the note to the block.
+					window.wp.data
+						.dispatch( 'core/block-editor' )
+						.updateBlockAttributes( block.clientId, {
+							metadata: { noteId: note.id },
+						} );
+
+					return note.id;
+				} )
+			);
+		} );
+
+		await editor.saveDraft();
+
+		const mockNotes = noteIds.map( ( noteId ) => ( {
+			id: noteId,
+			parent: 0,
+			content: { rendered: '<p>Improve this block.</p>' },
+			meta: { ai_note: true },
+		} ) );
+
+		// Track the notes that have been resolved.
+		const resolvedNoteIds = new Set();
+
+		// Intercept note queries — always return the note so the button stays visible.
+		await page.route( /\/wp\/v2\/comments/, async ( route ) => {
+			const url = route.request().url();
+			const method = route.request().method();
+			const hasTypeNote =
+				url.includes( 'type=note' ) || url.includes( 'type%3Dnote' );
+			const resolvedNoteMatch =
+				method === 'PUT' && url.match( /\/wp\/v2\/comments\/(\d+)/ );
+
+			if ( hasTypeNote ) {
+				const pendingNotes = mockNotes.filter(
+					( note ) => ! resolvedNoteIds.has( note.id )
+				);
+
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( pendingNotes ),
+					headers: {
+						'X-WP-Total': String( pendingNotes.length ),
+						'X-WP-TotalPages': pendingNotes.length ? '1' : '0',
+					},
+				} );
+			} else if ( resolvedNoteMatch ) {
+				const resolvedNoteId = Number( resolvedNoteMatch[ 1 ] );
+
+				// Mark the note as resolved.
+				resolvedNoteIds.add( resolvedNoteId );
+
+				// Mock the note update response.
+				await route.fulfill( {
+					status: 200,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						id: resolvedNoteId,
+						status: 'approve',
+					} ),
+				} );
+			} else {
+				await route.continue();
+			}
+		} );
+
+		await page.reload();
+		await editor.openDocumentSettingsSidebar();
+
+		// Re-inject noteIds after reload.
+		await page.evaluate( ( ids ) => {
+			const blocks = window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+
+			blocks.forEach( ( block, index ) => {
+				window.wp.data
+					.dispatch( 'core/block-editor' )
+					.updateBlockAttributes( block.clientId, {
+						metadata: { noteId: ids[ index ] },
+					} );
+			} );
+		}, noteIds );
+
+		const refineButton = page.getByRole( 'button', {
+			name: 'Apply Editorial Updates',
+		} );
+
+		await expect( refineButton ).toBeVisible();
+		await refineButton.click();
+
+		await expect(
+			page.getByTestId( 'snackbar' ).filter( {
+				hasText: '2 blocks refined with AI.',
+			} )
+		).toBeVisible();
+
+		const attributes = await page.evaluate( () =>
+			window.wp.data
+				.select( 'core/block-editor' )
+				.getBlocks()
+				.map( ( block ) => block.attributes )
+		);
+
+		// Verify the paragraph content was updated.
+		expect( attributes[ 0 ].content ).toBe(
+			'This is the refined block content.'
+		);
+		expect( attributes[ 0 ].value ).toBeUndefined();
+
+		// Verify the pullquote content was updated.
+		expect( attributes[ 1 ].value ).toBe(
+			'This is the refined block content.'
+		);
+		expect( attributes[ 1 ].content ).toBeUndefined();
+	} );
 } );


### PR DESCRIPTION
## What, Why, and How?

The `Pullquote` block can receive notes through the `Generate Editorial Notes` flow, but clicking `Apply Editorial Updates` generates a successful response without updating the block.

This happens because `Pullquote` stores its primary text in the `value` attribute ([Ref](https://github.com/WordPress/gutenberg/blob/cc8e2c958b252da7eec9ef8c91c3e982cff060a4/packages/block-library/src/pullquote/block.json#L10)). Editorial Updates previously handled Image blocks through `alt` and defaulted all other supported blocks to `content`, causing updates for Pullquote blocks to be written to the wrong attribute.

This PR detects whether a block uses `value` and writes the generated update to that attribute when present. This fixes Pullquote updates and supports other value-based blocks in the future.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6
Used for: Code reviews and drafting the e2e test.

## Testing Instructions

1. Enable the Editorial Notes and Editorial Updates experiments.
2. Create or edit a post.
3. Add a Pullquote block containing some text.
4. Generate an editorial note for the Pullquote.
5. Apply Editorial Updates.
6. Confirm that the Pullquote text is updated.
7. Save and reload the post.
8. Confirm that the updated Pullquote content persists.

## Screencast

### Before

https://github.com/user-attachments/assets/9e4e0770-8033-424d-9652-3d3917a045cb

### After

https://github.com/user-attachments/assets/f810bb53-b9c9-4342-be1a-b78749f19692

## Changelog Entry

> Fixed - Apply editorial updates to blocks that store editable text in the value attribute.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-930-b62b2bba05b50c5ba3e1672d35180f2ec6c25db9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->