### PR TITLE
Slug Generation: fix silent no-op and stale applied state for edited slugs

### DIFF
--- a/docs/experiments/slug-generation.md
+++ b/docs/experiments/slug-generation.md
@@ -19,7 +19,7 @@ When enabled, the experiment adds two entry points for permalink suggestions:
 - Multiple suggestions per request (3 by default, configurable from 1 to 10)
 - Every suggestion is sanitized with `sanitize_title()` so it is always a valid WordPress slug
 - Suggestions are checked against existing content, so a suggestion that is already taken comes back with a numeric suffix
-- Hand-editable before insertion; edits are normalized with `cleanForSlug()`
+- Hand-editable before insertion; edits are normalized with `cleanForSlug()`, a help text below the field previews the normalized form, and input that normalizes to an empty slug cannot be applied
 - Gated behind a minimum content length (250 characters by default) so the model has something to work with
 - Language-aware — slugs use the language of the supplied title/content
 
@@ -318,12 +318,15 @@ add_filter( 'wpai_preferred_text_models', function ( array $models ): array {
    - Create a post with a title and at least 250 characters of content, then save a draft
    - Open the URL / permalink field in the post settings sidebar
    - Click **Generate Slug**; verify the popover closes and the modal opens with suggestions
-   - Edit a suggestion in **Selected slug**, click **Insert**, and verify the permalink updates
+   - Edit a suggestion in **Selected slug**, click **Apply**, and verify the permalink updates
+   - Edit the slug to text that needs normalizing (e.g. `My Cool Slug`); verify the help text previews the normalized form before applying
+   - Edit the slug to text that cannot become a slug (e.g. `!!!`); verify **Apply** is disabled, the help text explains why, and the modal stays open
    - Reopen the popover and verify the button now reads **Regenerate Slug**
 
 3. **Test the pre-publish panel:**
    - Click **Publish** and expand **Suggest Slugs**
    - Generate, select, and **Apply** a suggestion; verify the permalink updates
+   - Apply an edited slug that needs normalizing; verify the normalized form is what gets applied and **Apply** becomes **Applied**
    - Verify **Apply** becomes **Applied** and is disabled once the selected slug matches the current one
 
 4. **Test the content-length gate:**
@@ -355,3 +358,4 @@ add_filter( 'wpai_preferred_text_models', function ( array $models ): array {
 - The **Generate Slug** button is attached by DOM injection and assumes the standard `.editor-post-url` markup; heavily customized editors may need additional selectors.
 - The modal is given an explicit `z-index` so it renders above the permalink popover, which relies on the popover's current stacking values.
 - Suggestions are generated in real time and are not cached.
+- Non-Latin suggestions are stored percent-encoded (via `sanitize_title()`), and `cleanForSlug()` does not account for octets, so applying such a suggestion re-normalizes the encoded form rather than the original text. The normalization preview is suppressed for percent-encoded slugs so it does not advertise that form, but the underlying apply behavior is a known limitation.

--- a/src/experiments/slug-generation/components/SlugGenerationModal.tsx
+++ b/src/experiments/slug-generation/components/SlugGenerationModal.tsx
@@ -13,6 +13,11 @@ import {
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { describeSlugApplication } from '../hooks/useSlugGeneration';
+
 interface SlugGenerationModalProps {
 	suggestions: string[];
 	onClose: () => void;
@@ -41,6 +46,10 @@ export default function SlugGenerationModal( {
 }: SlugGenerationModalProps ): React.JSX.Element {
 	const [ selectedSlug, setSelectedSlug ] = useState( '' );
 	const applyButtonRef = useRef< HTMLButtonElement >( null );
+
+	// Edits are normalized on apply; surface the normalized form, and block
+	// applying input that normalizes to nothing.
+	const { cleanedSlug, help } = describeSlugApplication( selectedSlug );
 
 	/*
 	 * Select the first suggestion whenever a new list is received, and move focus to
@@ -100,6 +109,7 @@ export default function SlugGenerationModal( {
 				value={ selectedSlug }
 				onChange={ setSelectedSlug }
 				disabled={ isRegenerating }
+				help={ help }
 			/>
 
 			<Flex
@@ -126,7 +136,7 @@ export default function SlugGenerationModal( {
 						ref={ applyButtonRef }
 						variant="primary"
 						onClick={ () => onSelect( selectedSlug ) }
-						disabled={ isRegenerating || ! selectedSlug }
+						disabled={ isRegenerating || ! cleanedSlug }
 						accessibleWhenDisabled
 						__next40pxDefaultSize
 					>

--- a/src/experiments/slug-generation/components/SlugPrePublishPanel.tsx
+++ b/src/experiments/slug-generation/components/SlugPrePublishPanel.tsx
@@ -19,6 +19,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { hasMinimumContent } from '../../../utils/character-count';
 import {
 	applySlug,
+	describeSlugApplication,
 	useSlugGeneration,
 	useSlugSource,
 } from '../hooks/useSlugGeneration';
@@ -56,6 +57,14 @@ export default function SlugPrePublishPanel(): React.JSX.Element {
 
 	const { minContentLength } = getSettings();
 	const isContentTooShort = ! hasMinimumContent( content, minContentLength );
+
+	/*
+	 * Edits are normalized on apply, so the applied state is derived from the
+	 * normalized form. Comparing the raw text against the stored slug would
+	 * keep the button on "Apply" forever after applying an edited value.
+	 */
+	const { cleanedSlug, help } = describeSlugApplication( selectedSlug );
+	const isApplied = !! cleanedSlug && cleanedSlug === currentSlug;
 
 	const handleGenerate = () => {
 		if ( isGenerating ) {
@@ -119,6 +128,7 @@ export default function SlugPrePublishPanel(): React.JSX.Element {
 							value={ selectedSlug }
 							onChange={ setSelectedSlug }
 							disabled={ isGenerating }
+							help={ isApplied ? undefined : help }
 						/>
 					</div>
 				)
@@ -150,14 +160,12 @@ export default function SlugPrePublishPanel(): React.JSX.Element {
 							icon={ check }
 							onClick={ () => applySlug( selectedSlug ) }
 							disabled={
-								isGenerating ||
-								! selectedSlug ||
-								selectedSlug === currentSlug
+								isGenerating || ! cleanedSlug || isApplied
 							}
 							accessibleWhenDisabled
 							__next40pxDefaultSize
 						>
-							{ selectedSlug === currentSlug
+							{ isApplied
 								? __( 'Applied', 'ai' )
 								: __( 'Apply', 'ai' ) }
 						</Button>

--- a/src/experiments/slug-generation/hooks/useSlugGeneration.ts
+++ b/src/experiments/slug-generation/hooks/useSlugGeneration.ts
@@ -8,9 +8,9 @@
 import { dispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { cleanForSlug } from '@wordpress/url';
+import { cleanForSlug, safeDecodeURIComponent } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -54,15 +54,64 @@ export function useSlugSource(): SlugSource & { currentSlug: string } {
  * `cleanForSlug()` the same way the core permalink field does.
  *
  * @param slug The slug to apply.
+ * @return The normalized slug that was applied, or an empty string when the
+ *         input normalizes to an empty string and nothing was applied.
  */
-export function applySlug( slug: string ): void {
+export function applySlug( slug: string ): string {
 	const cleanSlug = cleanForSlug( slug );
 
 	if ( ! cleanSlug ) {
-		return;
+		return '';
 	}
 
 	dispatch( editorStore ).editPost( { slug: cleanSlug } );
+
+	return cleanSlug;
+}
+
+/**
+ * Describes how a hand-edited slug will be applied.
+ *
+ * Edits are normalized with `cleanForSlug()` on apply, so the value in the
+ * text control and the value that ends up on the post can differ. This helper
+ * exposes the normalized form together with a help text for the text control,
+ * so both the modal and the pre-publish panel explain the normalization the
+ * same way instead of silently applying something else — or, for input that
+ * normalizes to nothing, silently applying nothing at all.
+ *
+ * Percent-encoded slugs (how non-Latin suggestions are stored after
+ * `sanitize_title()`) are excluded from the preview: `cleanForSlug()` does not
+ * account for octets, so previewing its output would advertise a garbled slug
+ * for a suggestion the user never edited.
+ *
+ * @param slug The current value of the slug text control.
+ * @return The normalized slug and, when it differs from the input, a help text.
+ */
+export function describeSlugApplication( slug: string ): {
+	cleanedSlug: string;
+	help?: string;
+} {
+	const cleanedSlug = cleanForSlug( slug );
+
+	if ( cleanedSlug === slug || safeDecodeURIComponent( slug ) !== slug ) {
+		return { cleanedSlug };
+	}
+
+	if ( ! cleanedSlug ) {
+		return {
+			cleanedSlug,
+			help: __( 'This text cannot be used as a slug.', 'ai' ),
+		};
+	}
+
+	return {
+		cleanedSlug,
+		help: sprintf(
+			/* translators: %s: The normalized slug. */
+			__( 'Will be applied as “%s”.', 'ai' ),
+			cleanedSlug
+		),
+	};
 }
 
 interface UseSlugGenerationOptions {

--- a/src/experiments/slug-generation/hooks/useSlugGeneration.ts
+++ b/src/experiments/slug-generation/hooks/useSlugGeneration.ts
@@ -80,9 +80,10 @@ export function applySlug( slug: string ): string {
  * normalizes to nothing, silently applying nothing at all.
  *
  * Percent-encoded slugs (how non-Latin suggestions are stored after
- * `sanitize_title()`) are excluded from the preview: `cleanForSlug()` does not
- * account for octets, so previewing its output would advertise a garbled slug
- * for a suggestion the user never edited.
+ * `sanitize_title()`) are excluded from the normalization preview:
+ * `cleanForSlug()` does not account for octets, so previewing its output would
+ * advertise a garbled slug for a suggestion the user never edited. Input that
+ * cannot become a slug at all is still explained, encoded or not.
  *
  * @param slug The current value of the slug text control.
  * @return The normalized slug and, when it differs from the input, a help text.
@@ -93,15 +94,24 @@ export function describeSlugApplication( slug: string ): {
 } {
 	const cleanedSlug = cleanForSlug( slug );
 
-	if ( cleanedSlug === slug || safeDecodeURIComponent( slug ) !== slug ) {
+	if ( cleanedSlug === slug ) {
 		return { cleanedSlug };
 	}
 
+	/*
+	 * Checked before the percent-encoded exclusion below, so input that cannot
+	 * be applied is always explained rather than leaving Apply disabled with no
+	 * reason given.
+	 */
 	if ( ! cleanedSlug ) {
 		return {
 			cleanedSlug,
 			help: __( 'This text cannot be used as a slug.', 'ai' ),
 		};
+	}
+
+	if ( safeDecodeURIComponent( slug ) !== slug ) {
+		return { cleanedSlug };
 	}
 
 	return {

--- a/src/experiments/slug-generation/index.tsx
+++ b/src/experiments/slug-generation/index.tsx
@@ -215,8 +215,12 @@ function SlugGenerationWrapper(): React.JSX.Element {
 					suggestions={ suggestions }
 					onClose={ closeModal }
 					onSelect={ ( selectedSlug ) => {
-						applySlug( selectedSlug );
-						closeModal();
+						// The modal's disabled Apply button is the primary
+						// gate; this is defense in depth so the modal can
+						// never close without something having been applied.
+						if ( applySlug( selectedSlug ) ) {
+							closeModal();
+						}
 					} }
 					onRegenerate={ () => generate( modalSource ) }
 					isRegenerating={ isGenerating }

--- a/tests/e2e/specs/experiments/slug-generation.spec.js
+++ b/tests/e2e/specs/experiments/slug-generation.spec.js
@@ -234,4 +234,185 @@ test.describe( 'Slug Generation Experiment', () => {
 			page.locator( '.ai-slug-generation-container' )
 		).not.toBeVisible();
 	} );
+
+	test( 'Apply is blocked with an explanation when the edited slug cannot become a slug', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Slug Generation Experiment.
+		await enableExperiment( admin, page, 'Slug Generation' );
+
+		// Create a new post with sufficient content.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'Test Slug Invalid Input',
+			content: LONG_CONTENT,
+		} );
+
+		// Save the post so a permalink / slug section is generated.
+		await editor.saveDraft();
+
+		// Open the permalink popover and the suggestions modal.
+		await openPermalinkPopover( editor, page );
+		await page
+			.getByRole( 'button', { name: /Generate Slug|Regenerate Slug/i } )
+			.first()
+			.click();
+
+		const modal = page.getByRole( 'dialog', {
+			name: 'Slug suggestions',
+		} );
+		await expect( modal ).toBeVisible( { timeout: 10000 } );
+
+		// Wait for suggestions to load.
+		const selectedSlugInput = modal.getByLabel( 'Selected slug' );
+		await expect( selectedSlugInput ).not.toHaveValue( '', {
+			timeout: 15000,
+		} );
+
+		// Edit the slug to text that normalizes to an empty slug.
+		await selectedSlugInput.fill( '!!!' );
+
+		// Apply must be blocked, with an explanation.
+		const applyButton = modal.getByRole( 'button', { name: 'Apply' } );
+		await expect( applyButton ).toBeDisabled();
+		await expect(
+			modal.getByText( 'This text cannot be used as a slug.' )
+		).toBeVisible();
+
+		// Even if the disabled state is bypassed, nothing may be applied and
+		// the modal may not close as if something had been.
+		await applyButton.click( { force: true } );
+		await expect( modal ).toBeVisible();
+
+		// The post slug must be untouched by the whole exercise.
+		await modal.getByRole( 'button', { name: 'Close' } ).click();
+		await openPermalinkPopover( editor, page );
+		await expect(
+			page.locator( '.editor-post-url input[type="text"]' ).first()
+		).not.toHaveValue( /!/ );
+	} );
+
+	test( 'An edited slug is normalized when applied from the modal', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Slug Generation Experiment.
+		await enableExperiment( admin, page, 'Slug Generation' );
+
+		// Create a new post with sufficient content.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'Test Slug Normalized Input',
+			content: LONG_CONTENT,
+		} );
+
+		// Save the post so a permalink / slug section is generated.
+		await editor.saveDraft();
+
+		// Open the permalink popover and the suggestions modal.
+		await openPermalinkPopover( editor, page );
+		await page
+			.getByRole( 'button', { name: /Generate Slug|Regenerate Slug/i } )
+			.first()
+			.click();
+
+		const modal = page.getByRole( 'dialog', {
+			name: 'Slug suggestions',
+		} );
+		await expect( modal ).toBeVisible( { timeout: 10000 } );
+
+		// Wait for suggestions to load.
+		const selectedSlugInput = modal.getByLabel( 'Selected slug' );
+		await expect( selectedSlugInput ).not.toHaveValue( '', {
+			timeout: 15000,
+		} );
+
+		// Edit the slug to text that needs normalizing, and verify the
+		// normalized form is announced before applying.
+		await selectedSlugInput.fill( 'My Custom Slug' );
+		await expect( modal.getByText( /Will be applied as/ ) ).toBeVisible();
+
+		// Apply and verify the normalized slug ended up on the post.
+		await modal.getByRole( 'button', { name: 'Apply' } ).click();
+		await expect( modal ).not.toBeVisible();
+
+		await openPermalinkPopover( editor, page );
+		await expect(
+			page.locator( '.editor-post-url input[type="text"]' ).first()
+		).toHaveValue( /my-custom-slug/ );
+	} );
+
+	test( 'Pre-publish panel shows Applied after applying an edited slug', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Slug Generation Experiment.
+		await enableExperiment( admin, page, 'Slug Generation' );
+
+		// Create a new post with sufficient content.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'Test Slug Prepublish Panel',
+			content: LONG_CONTENT,
+		} );
+
+		// Save the post, then open the pre-publish panel.
+		await editor.saveDraft();
+		await page
+			.getByRole( 'button', { name: 'Publish', exact: true } )
+			.first()
+			.click();
+
+		// Expand the Suggest Slugs panel and generate suggestions.
+		await page.getByRole( 'button', { name: /Suggest Slugs/i } ).click();
+		await page
+			.getByRole( 'button', { name: 'Generate Suggestions' } )
+			.click();
+
+		// Wait for suggestions to load. Scope all queries to the panel so
+		// other sidebar buttons can never make the locators ambiguous.
+		const panel = page.locator( '.ai-slug-prepublish-content' );
+		const customizeInput = panel.getByLabel( 'Customize slug' );
+		await expect( customizeInput ).toBeVisible( { timeout: 15000 } );
+
+		// Input that cannot become a slug blocks Apply with an explanation.
+		await customizeInput.fill( '!!!' );
+		await expect(
+			panel.getByRole( 'button', { name: 'Apply', exact: true } )
+		).toBeDisabled();
+		await expect(
+			panel.getByText( 'This text cannot be used as a slug.' )
+		).toBeVisible();
+
+		// Apply an edited slug that needs normalizing.
+		await customizeInput.fill( 'My Custom Slug' );
+		await panel
+			.getByRole( 'button', { name: 'Apply', exact: true } )
+			.click();
+
+		// The button must reflect that the normalized slug is now applied,
+		// rather than staying on an enabled "Apply" forever.
+		const appliedButton = panel.getByRole( 'button', {
+			name: 'Applied',
+			exact: true,
+		} );
+		await expect( appliedButton ).toBeVisible();
+		await expect( appliedButton ).toBeDisabled();
+
+		// And the normalized form is what ended up on the post.
+		await expect( panel.getByText( 'my-custom-slug' ) ).toBeVisible();
+	} );
 } );


### PR DESCRIPTION
## Description

The Slug Generation experiment lets users hand-edit a suggested slug before applying it, in both the permalink modal and the pre-publish panel. Edits are normalized with `cleanForSlug()` on apply, and two problems came out of that:

1. Input that normalizes to an empty slug (for example `!!!`) was silently dropped. The modal still closed as if the slug had been applied, with no feedback anywhere, and the panel button did nothing on click.
2. The pre-publish panel compared the raw input against the stored slug. After applying an edited value like `My Cool Slug` the post correctly received `my-cool-slug`, but the button stayed on an enabled Apply forever and the Applied state was unreachable.

### Before

Modal, input that cannot become a slug, Apply closes the modal with nothing applied and no feedback:


<img width="1280" height="720" alt="before-modal-invalid" src="https://github.com/user-attachments/assets/6fb00ea5-09c5-4d49-96b0-1815fcca9ad8" />


Panel, edited slug is applied but the button never reflects it:


<img width="1280" height="720" alt="before-panel-custom" src="https://github.com/user-attachments/assets/3baaab1b-1664-4b9d-ac0b-26ef34780db2" />


### After

Modal stays open with the Apply button disabled and an explanation:


<img width="1280" height="720" alt="after-modal-invalid" src="https://github.com/user-attachments/assets/3ba52e12-28ad-47e5-ac1e-152e2b9cab8c" />


Panel previews the normalized form and flips to a disabled Applied:


<img width="1280" height="720" alt="after-panel-custom" src="https://github.com/user-attachments/assets/6f8ea12c-9974-42d9-aeaf-29559dcca669" />



### How it is fixed

Everything rides on existing core pieces. `applySlug()` now returns the slug it applied, or an empty string when nothing was applied. A small shared helper describes how the current input will be applied, and both surfaces use it the same way:

- A help text under the field (the `help` prop of `TextControl`) previews the normalized form when it differs from the input, for example `Will be applied as "my-cool-slug".`
- When the input cannot become a slug, the help explains why and Apply is disabled.
- The Applied state in the panel is derived from the normalized form, so it is reachable for edited input, and the modal only closes when something was actually applied.

Percent-encoded slugs (how non-Latin suggestions are stored after `sanitize_title()`) are excluded from the preview, since `cleanForSlug()` does not account for octets and the preview would show a garbled form for a suggestion the user never edited. The underlying apply behaviour for those slugs is pre-existing and is now noted in the doc's Limitations section.

## Testing

- Three new e2e tests: blocked input keeps the modal open and the slug untouched even on a forced click, an edited slug shows the preview and applies the normalized form, and the panel blocks unusable input and flips to a disabled Applied. Full slug spec passes (8 tests).
- Verified by mutation: reverting either fix makes the matching test fail.
- Manually verified both surfaces in wp-env, including edge cases: empty input, spaces only, emoji only, script tags, percent-encoded input, literal percent text, Hindi text, re-editing after apply, selecting a radio after a custom edit, and regenerating with custom text typed.
- `npm run lint:js` and the TypeScript check pass. No PHP changes.

The docs page is updated to match, including the Manual Testing steps and a Limitations entry.

## Use of AI Tools

This PR was developed with the assistance of AI tools for local testing, code review and drafting, with all changes reviewed and verified by me.

## Changelog Entry

> Fixed - Slug Generation: applying a hand-edited slug now previews the normalized form, blocks input that cannot become a slug, and correctly shows the Applied state.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-932-4bbdf7079fbbc695d9306059ef658968e1fe3f2a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->