### PR TITLE
Content Translation: Add user-triggered retry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 35
+    timeout-minutes: 30
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,7 +319,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 35
 
     steps:
       - name: Checkout repository

--- a/docs/experiments/content-translation.md
+++ b/docs/experiments/content-translation.md
@@ -18,6 +18,7 @@ When enabled, the Content Translation experiment adds a "Generate Translation" b
 - Block-by-block translation for `core/paragraph` and `core/heading`
 - Batch processing with progress shown in the button label
 - Partial success handling: failed blocks are counted and reported without discarding successful translations
+- User-initiated retries for failed title and block translations; only failed translations are retried
 - Blocks below the minimum content length are skipped before a request is made, and reported separately from failures
 
 ### For Developers
@@ -292,7 +293,7 @@ Note that this ability deliberately does not inject the site's editorial guideli
 4. **Test short and unsupported content:**
    - Add a heading shorter than the minimum length (for example `FAQ`) alongside a long paragraph, then translate; verify the heading is left untouched and reported as skipped rather than failed
    - Translate a post whose only content is an unsupported block type (a Code block, say); verify the "No translatable content found in the post." notice
-   - Translate with **Also translate the title** enabled on a post with a very short title; verify the title-specific warning
+   - Translate with **Also translate the title** enabled on a post with an empty or very short title; verify the title-specific error while eligible blocks continue translating
 
 5. **Test REST API:**
    - Use curl or Postman to test the REST endpoint

--- a/src/experiments/content-translation/components/ContentTranslationPlugin.tsx
+++ b/src/experiments/content-translation/components/ContentTranslationPlugin.tsx
@@ -35,13 +35,18 @@ export default function ContentTranslationPlugin() {
 		return null;
 	}
 
+	const translatingLabel =
+		total > 0
+			? sprintf(
+					/* translators: %1$d: number of translated blocks, %2$d: total number of blocks */
+					__( 'Translating blocks… (%1$d/%2$d)', 'ai' ),
+					progress,
+					total
+			  )
+			: __( 'Translating…', 'ai' );
+
 	const buttonLabel = isTranslating
-		? sprintf(
-				/* translators: %1$d: number of translated blocks, %2$d: total number of blocks */
-				__( 'Translating blocks… (%1$d/%2$d)', 'ai' ),
-				progress,
-				total
-		  )
+		? translatingLabel
 		: __( 'Generate Translation', 'ai' );
 
 	const buttonDescription = isContentTooShort

--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -5,7 +5,7 @@ import { useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, useDispatch, useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
@@ -37,6 +37,7 @@ type UseContentTranslationReturn = {
 
 type TranslateOptions = {
 	translateTitle?: boolean;
+	targetClientIds?: readonly string[] | undefined;
 };
 
 // Notice IDs for the content translation process.
@@ -59,13 +60,9 @@ export function useContentTranslation(): UseContentTranslationReturn {
 
 	const { minContentLength } = getSettings();
 
-	const { postId, allBlocks, title, content } = useSelect( ( sel ) => {
+	const { postId, content } = useSelect( ( sel ) => {
 		return {
 			postId: sel( editorStore ).getCurrentPostId() as number,
-			allBlocks: sel( blockEditorStore ).getBlocks(),
-			title: sel( editorStore ).getEditedPostAttribute(
-				'title'
-			) as string,
 			content: sel( editorStore ).getEditedPostContent(),
 		};
 	}, [] );
@@ -78,20 +75,24 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	/**
 	 * Translates the content of a post.
 	 *
-	 * @param languageCode The code of the language to translate the post to.
-	 * @param options      The options for the translation.
+	 * @param languageCode            The code of the language to translate the post to.
+	 * @param options                 The options for the translation.
+	 * @param options.translateTitle  Whether to translate the post title. Defaults to false.
+	 * @param options.targetClientIds Optional client IDs used to restrict translation.
+	 *                                When undefined, all eligible blocks are considered.
+	 *                                When empty, no blocks are considered.
+	 *                                When provided, only blocks with matching client IDs are considered.
 	 * @return A promise that resolves when the translation is complete.
 	 */
 	const translate = async (
 		languageCode: string,
 		options?: TranslateOptions
 	) => {
-		const { translateTitle = false } = options || {};
+		const { translateTitle = false, targetClientIds = undefined } =
+			options || {};
 
 		// Remove any existing error notices.
 		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID );
-		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_TITLE );
-		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_CONTENT );
 
 		if ( ! ensureProvider( TRANSLATION_NOTICE_ID ) ) {
 			return;
@@ -102,16 +103,16 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		}
 
 		setIsTranslating( true );
-		setTranslationLoadingClass( 'BLOCKS', true );
 
 		try {
 			if ( translateTitle ) {
-				// Title translation is optional. If it fails, continue translating the post
-				// content and show a warning so the user can retry the title separately.
+				// Translate the title independently so failures can be reported and retried
+				// without affecting block translation.
 				await translatePostTitle( languageCode );
 			}
 
-			await translateBlocksContent( languageCode );
+			setTranslationLoadingClass( 'BLOCKS', true );
+			await translateBlocksContent( languageCode, targetClientIds );
 		} catch ( error ) {
 			noticeDispatch.createErrorNotice( getErrorMessage( error ), {
 				id: TRANSLATION_NOTICE_ID_CONTENT,
@@ -131,6 +132,15 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	 * @return A promise that resolves when the translation and updates are complete.
 	 */
 	const translatePostTitle = async ( languageCode: string ) => {
+		// Remove any existing warning notices for title translation.
+		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_TITLE );
+
+		const title = select( editorStore ).getEditedPostAttribute( 'title' );
+
+		if ( typeof title !== 'string' ) {
+			return;
+		}
+
 		if ( title.trim().length === 0 ) {
 			noticeDispatch.createWarningNotice(
 				__( 'Cannot translate an empty post title.', 'ai' ),
@@ -177,6 +187,18 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		} catch ( error ) {
 			noticeDispatch.createWarningNotice( getErrorMessage( error ), {
 				id: TRANSLATION_NOTICE_ID_TITLE,
+				actions: [
+					{
+						label: __( 'Retry title translation', 'ai' ),
+						onClick: () => {
+							if ( ! ensureProvider( TRANSLATION_NOTICE_ID ) ) {
+								return;
+							}
+
+							translatePostTitle( languageCode );
+						},
+					},
+				],
 			} );
 		} finally {
 			setTranslationLoadingClass( 'TITLE', false );
@@ -186,27 +208,53 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	/**
 	 * Translates and updates the content of the blocks in the post.
 	 *
-	 * @param languageCode The code of the language to translate the post to.
+	 * @param languageCode    The code of the language to translate the post to.
+	 * @param targetClientIds Optional client IDs used to restrict translation.
+	 *                        When undefined, all eligible blocks are considered.
+	 *                        When empty, no blocks are considered.
+	 *                        When provided, only blocks with matching client IDs are considered.
 	 * @return A promise that resolves when the translation and updates are complete.
 	 */
-	const translateBlocksContent = async ( languageCode: string ) => {
+	const translateBlocksContent = async (
+		languageCode: string,
+		targetClientIds?: readonly string[]
+	) => {
+		// If an empty target list is explicitly provided, do not translate any blocks.
+		if ( targetClientIds && targetClientIds.length === 0 ) {
+			return;
+		}
+
+		// Remove any existing block translation notice.
+		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_CONTENT );
+
 		setProgress( 0 );
 		setTotal( 0 );
+
+		const allBlocks = select( blockEditorStore ).getBlocks();
 
 		const supportedBlocks = flattenBlocks( allBlocks )
 			.map( ( block ) => getTranslatableBlock( block ) )
 			.filter( ( block ) => block !== null );
 
+		// Restrict translation when a non-empty target list is provided.
+		// Otherwise, consider every eligible block.
+		const targetedBlocks =
+			targetClientIds && targetClientIds.length > 0
+				? supportedBlocks.filter( ( block ) =>
+						targetClientIds.includes( block.clientId )
+				  )
+				: supportedBlocks;
+
 		// The ability rejects content below the minimum length, so filter those
 		// blocks out up front rather than spending a request to be told no. The
 		// post-level gate measures the whole post, which can pass while short
 		// individual blocks (a "FAQ" heading, say) would not.
-		const translatableBlocks = supportedBlocks.filter( ( block ) =>
+		const translatableBlocks = targetedBlocks.filter( ( block ) =>
 			hasMinimumContent( block.content, minContentLength )
 		);
 
 		const skippedBlocksCount =
-			supportedBlocks.length - translatableBlocks.length;
+			targetedBlocks.length - translatableBlocks.length;
 
 		if ( translatableBlocks.length === 0 ) {
 			noticeDispatch.createErrorNotice(
@@ -232,7 +280,7 @@ export function useContentTranslation(): UseContentTranslationReturn {
 
 		// Count the blocks that were translated and applied, and those that failed.
 		let translatedBlocksCount = 0;
-		let failedBlocksCount = 0;
+		const failedBlockClientIds: string[] = [];
 
 		// Process blocks in batches.
 		for (
@@ -255,26 +303,25 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			);
 
 			results.forEach( ( result, index ) => {
-				if ( result.status === 'rejected' ) {
-					failedBlocksCount++;
-					return;
-				}
-
-				// This should not happen, but keep the index access guarded in case the
-				// result list and batch ever diverge.
+				// Promise.allSettled() preserves input order, but TypeScript cannot infer
+				// that each result has a corresponding block.
 				if ( ! batch[ index ] ) {
-					failedBlocksCount++;
 					return;
 				}
 
-				// If the translation is empty, failedBlocksCount is incremented and the
-				// block is skipped.
+				if ( result.status === 'rejected' ) {
+					failedBlockClientIds.push( batch[ index ].clientId );
+					return;
+				}
+
+				// Treat missing, non-string, or blank translations as failures and skip
+				// updating the block.
 				if (
 					! result.value ||
 					typeof result.value !== 'string' ||
 					! result.value.trim().length
 				) {
-					failedBlocksCount++;
+					failedBlockClientIds.push( batch[ index ].clientId );
 					return;
 				}
 
@@ -292,6 +339,7 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		}
 
 		const warnings: string[] = [];
+		const failedBlocksCount = failedBlockClientIds.length;
 
 		if ( failedBlocksCount > 0 ) {
 			warnings.push(
@@ -327,6 +375,26 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		if ( warnings.length > 0 ) {
 			noticeDispatch.createWarningNotice( warnings.join( ' ' ), {
 				id: TRANSLATION_NOTICE_ID_CONTENT,
+				...( failedBlocksCount > 0
+					? {
+							actions: [
+								{
+									label: _n(
+										'Retry failed block',
+										'Retry failed blocks',
+										failedBlocksCount,
+										'ai'
+									),
+									onClick: () => {
+										translate( languageCode, {
+											targetClientIds:
+												failedBlockClientIds,
+										} );
+									},
+								},
+							],
+					  }
+					: undefined ),
 			} );
 		}
 	};

--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -261,6 +261,17 @@ export function useContentTranslation(): UseContentTranslationReturn {
 				postId
 			);
 
+			if (
+				! translatedTitle ||
+				typeof translatedTitle !== 'string' ||
+				! translatedTitle.trim().length
+			) {
+				return {
+					notice: __( 'Failed to translate the post title.', 'ai' ),
+					shouldRetry: true,
+				};
+			}
+
 			editorDispatch.editPost( {
 				title: translatedTitle,
 			} );

--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -35,17 +35,31 @@ type UseContentTranslationReturn = {
 	) => Promise< void >;
 };
 
+type BlockTranslationTarget =
+	| { kind: 'all' }
+	| { kind: 'none' }
+	| { kind: 'specific'; clientIds: readonly string[] };
+
 type TranslateOptions = {
 	translateTitle?: boolean;
-	targetClientIds?: readonly string[] | undefined;
+	blockTarget?: BlockTranslationTarget;
 };
 
-// Notice IDs for the content translation process.
-const TRANSLATION_NOTICE_ID_TITLE = `${ TRANSLATION_NOTICE_ID }_title`;
-const TRANSLATION_NOTICE_ID_CONTENT = `${ TRANSLATION_NOTICE_ID }_content`;
+type TranslateTitleResult = {
+	notice?: string;
+	shouldRetry: boolean;
+};
+
+type TranslateBlocksContentResult = {
+	notices: string[];
+	failedBlockClientIds: string[];
+};
+
+const ERRORS_NOTICE_ID = `${ TRANSLATION_NOTICE_ID }_errors`;
+const WARNING_NOTICE_ID = `${ TRANSLATION_NOTICE_ID }_warnings`;
 
 /**
- * Handles the content translation process, including managing loading state, progress, and error handling.
+ * Handles content translation, including loading state, progress, partial failures, and user-initiated retries.
  *
  * @return An object with the translation state and functions.
  */
@@ -73,28 +87,27 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	);
 
 	/**
-	 * Translates the content of a post.
+	 * Translates the requested title and block content of a post.
 	 *
-	 * @param languageCode            The code of the language to translate the post to.
-	 * @param options                 The options for the translation.
-	 * @param options.translateTitle  Whether to translate the post title. Defaults to false.
-	 * @param options.targetClientIds Optional client IDs used to restrict translation.
-	 *                                When undefined, all eligible blocks are considered.
-	 *                                When empty, no blocks are considered.
-	 *                                When provided, only blocks with matching client IDs are considered.
+	 * @param languageCode           The code of the language to translate the post to.
+	 * @param options                The options for the translation.
+	 * @param options.translateTitle Whether to translate the post title. Defaults to false.
+	 * @param options.blockTarget    The block translation scope. Defaults to all eligible blocks;
+	 *                               use `none` to skip blocks or `specific` to target client IDs.
 	 * @return A promise that resolves when the translation is complete.
 	 */
 	const translate = async (
 		languageCode: string,
 		options?: TranslateOptions
 	) => {
-		const { translateTitle = false, targetClientIds = undefined } =
+		const { translateTitle = false, blockTarget = { kind: 'all' } } =
 			options || {};
 
-		// Remove any existing error notices.
-		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID );
+		// Remove any existing notices.
+		noticeDispatch.removeNotice( ERRORS_NOTICE_ID );
+		noticeDispatch.removeNotice( WARNING_NOTICE_ID );
 
-		if ( ! ensureProvider( TRANSLATION_NOTICE_ID ) ) {
+		if ( ! ensureProvider( ERRORS_NOTICE_ID ) ) {
 			return;
 		}
 
@@ -105,21 +118,104 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		setIsTranslating( true );
 
 		try {
+			let titleResult: TranslateTitleResult = {
+				shouldRetry: false,
+			};
+
+			let blocksResult: TranslateBlocksContentResult = {
+				notices: [],
+				failedBlockClientIds: [],
+			};
+
+			const errors: string[] = [];
+
 			if ( translateTitle ) {
-				// Translate the title independently so failures can be reported and retried
-				// without affecting block translation.
-				await translatePostTitle( languageCode );
+				setTranslationLoadingClass( 'TITLE', true );
+
+				try {
+					titleResult = await translatePostTitle( languageCode );
+				} catch ( error ) {
+					errors.push( getErrorMessage( error ) );
+				} finally {
+					setTranslationLoadingClass( 'TITLE', false );
+				}
 			}
 
-			setTranslationLoadingClass( 'BLOCKS', true );
-			await translateBlocksContent( languageCode, targetClientIds );
+			if ( blockTarget.kind !== 'none' ) {
+				setTranslationLoadingClass( 'BLOCKS', true );
+
+				try {
+					blocksResult = await translateBlocksContent(
+						languageCode,
+						blockTarget
+					);
+				} catch ( error ) {
+					errors.push( getErrorMessage( error ) );
+				} finally {
+					setTranslationLoadingClass( 'BLOCKS', false );
+				}
+			}
+
+			if ( errors.length > 0 ) {
+				noticeDispatch.createErrorNotice( errors.join( ' ' ), {
+					id: ERRORS_NOTICE_ID,
+				} );
+			}
+
+			const warningNotices = [
+				titleResult.notice,
+				...blocksResult.notices,
+			].filter( ( notice ): notice is string => notice !== undefined );
+
+			// Total retryable failures include both block content failures and title failures.
+			const retryableFailuresCount =
+				blocksResult.failedBlockClientIds.length +
+				( titleResult.shouldRetry ? 1 : 0 );
+
+			const retryBlockTarget: BlockTranslationTarget =
+				blocksResult.failedBlockClientIds.length === 0
+					? { kind: 'none' }
+					: {
+							kind: 'specific',
+							clientIds: blocksResult.failedBlockClientIds,
+					  };
+
+			if ( warningNotices.length > 0 ) {
+				noticeDispatch.createWarningNotice(
+					warningNotices.join( ' ' ),
+					{
+						id: WARNING_NOTICE_ID,
+						...( retryableFailuresCount > 0
+							? {
+									actions: [
+										{
+											label: _n(
+												'Retry failed translation',
+												'Retry failed translations',
+												retryableFailuresCount,
+												'ai'
+											),
+											onClick: () => {
+												translate( languageCode, {
+													translateTitle:
+														titleResult.shouldRetry,
+													blockTarget:
+														retryBlockTarget,
+												} );
+											},
+										},
+									],
+							  }
+							: undefined ),
+					}
+				);
+			}
 		} catch ( error ) {
 			noticeDispatch.createErrorNotice( getErrorMessage( error ), {
-				id: TRANSLATION_NOTICE_ID_CONTENT,
+				id: ERRORS_NOTICE_ID,
 			} );
 		} finally {
 			setIsTranslating( false );
-			setTranslationLoadingClass( 'BLOCKS', false );
 			setProgress( 0 );
 			setTotal( 0 );
 		}
@@ -129,33 +225,24 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	 * Translates and updates the title of a post.
 	 *
 	 * @param languageCode The code of the language to translate the post to.
-	 * @return A promise that resolves when the translation and updates are complete.
+	 * @return A promise that resolves with the translation result and rejects if
+	 *         the title is empty or is too short.
 	 */
-	const translatePostTitle = async ( languageCode: string ) => {
-		// Remove any existing warning notices for title translation.
-		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_TITLE );
-
+	const translatePostTitle = async (
+		languageCode: string
+	): Promise< TranslateTitleResult > => {
 		const title = select( editorStore ).getEditedPostAttribute( 'title' );
 
-		if ( typeof title !== 'string' ) {
-			return;
-		}
-
-		if ( title.trim().length === 0 ) {
-			noticeDispatch.createWarningNotice(
-				__( 'Cannot translate an empty post title.', 'ai' ),
-				{
-					id: TRANSLATION_NOTICE_ID_TITLE,
-				}
+		if ( typeof title !== 'string' || title.trim().length === 0 ) {
+			throw new Error(
+				__( 'Cannot translate an empty post title.', 'ai' )
 			);
-
-			return;
 		}
 
 		// The ability enforces the same minimum, so check it here to warn with a
 		// clear reason instead of surfacing a generic request failure.
 		if ( ! hasMinimumContent( title, minContentLength ) ) {
-			noticeDispatch.createWarningNotice(
+			throw new Error(
 				sprintf(
 					/* translators: %d: minimum number of characters required for translation. */
 					__(
@@ -163,18 +250,11 @@ export function useContentTranslation(): UseContentTranslationReturn {
 						'ai'
 					),
 					minContentLength
-				),
-				{
-					id: TRANSLATION_NOTICE_ID_TITLE,
-				}
+				)
 			);
-
-			return;
 		}
 
 		try {
-			setTranslationLoadingClass( 'TITLE', true );
-
 			const translatedTitle = await translateContent(
 				title,
 				languageCode,
@@ -184,48 +264,39 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			editorDispatch.editPost( {
 				title: translatedTitle,
 			} );
-		} catch ( error ) {
-			noticeDispatch.createWarningNotice( getErrorMessage( error ), {
-				id: TRANSLATION_NOTICE_ID_TITLE,
-				actions: [
-					{
-						label: __( 'Retry title translation', 'ai' ),
-						onClick: () => {
-							if ( ! ensureProvider( TRANSLATION_NOTICE_ID ) ) {
-								return;
-							}
 
-							translatePostTitle( languageCode );
-						},
-					},
-				],
-			} );
-		} finally {
-			setTranslationLoadingClass( 'TITLE', false );
+			return { shouldRetry: false };
+		} catch ( error ) {
+			return {
+				notice: getErrorMessage( error ),
+				shouldRetry: true,
+			};
 		}
 	};
 
 	/**
 	 * Translates and updates the content of the blocks in the post.
 	 *
-	 * @param languageCode    The code of the language to translate the post to.
-	 * @param targetClientIds Optional client IDs used to restrict translation.
-	 *                        When undefined, all eligible blocks are considered.
-	 *                        When empty, no blocks are considered.
-	 *                        When provided, only blocks with matching client IDs are considered.
-	 * @return A promise that resolves when the translation and updates are complete.
+	 * @param languageCode The code of the language to translate the post to.
+	 * @param target       The block translation scope: all eligible blocks, no blocks,
+	 *                     or only blocks matching specific client IDs.
+	 * @return A promise that resolves with notices and failed block client IDs. A `none`
+	 *         target resolves without translating; other targets reject when no blocks are eligible.
 	 */
 	const translateBlocksContent = async (
 		languageCode: string,
-		targetClientIds?: readonly string[]
-	) => {
-		// If an empty target list is explicitly provided, do not translate any blocks.
-		if ( targetClientIds && targetClientIds.length === 0 ) {
-			return;
-		}
+		target: BlockTranslationTarget
+	): Promise< TranslateBlocksContentResult > => {
+		const notices: string[] = [];
+		const failedBlockClientIds: string[] = [];
 
-		// Remove any existing block translation notice.
-		noticeDispatch.removeNotice( TRANSLATION_NOTICE_ID_CONTENT );
+		// A `none` target explicitly requests that block translation be skipped.
+		if ( target.kind === 'none' ) {
+			return {
+				notices,
+				failedBlockClientIds,
+			};
+		}
 
 		setProgress( 0 );
 		setTotal( 0 );
@@ -236,12 +307,12 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			.map( ( block ) => getTranslatableBlock( block ) )
 			.filter( ( block ) => block !== null );
 
-		// Restrict translation when a non-empty target list is provided.
-		// Otherwise, consider every eligible block.
+		// A `specific` target restricts translation to matching client IDs;
+		// an `all` target considers every eligible block.
 		const targetedBlocks =
-			targetClientIds && targetClientIds.length > 0
+			target.kind === 'specific'
 				? supportedBlocks.filter( ( block ) =>
-						targetClientIds.includes( block.clientId )
+						target.clientIds.includes( block.clientId )
 				  )
 				: supportedBlocks;
 
@@ -257,7 +328,7 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			targetedBlocks.length - translatableBlocks.length;
 
 		if ( translatableBlocks.length === 0 ) {
-			noticeDispatch.createErrorNotice(
+			throw new Error(
 				skippedBlocksCount > 0
 					? sprintf(
 							/* translators: %d: minimum number of characters required for translation. */
@@ -267,20 +338,14 @@ export function useContentTranslation(): UseContentTranslationReturn {
 							),
 							minContentLength
 					  )
-					: __( 'No translatable content found in the post.', 'ai' ),
-				{
-					id: TRANSLATION_NOTICE_ID_CONTENT,
-				}
+					: __( 'No translatable content found in the post.', 'ai' )
 			);
-
-			return;
 		}
 
 		setTotal( translatableBlocks.length );
 
 		// Count the blocks that were translated and applied, and those that failed.
 		let translatedBlocksCount = 0;
-		const failedBlockClientIds: string[] = [];
 
 		// Process blocks in batches.
 		for (
@@ -338,11 +403,10 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			setProgress( translatedBlocksCount );
 		}
 
-		const warnings: string[] = [];
 		const failedBlocksCount = failedBlockClientIds.length;
 
 		if ( failedBlocksCount > 0 ) {
-			warnings.push(
+			notices.push(
 				sprintf(
 					/* translators: %d: number of blocks that failed to be translated. */
 					_n(
@@ -357,7 +421,7 @@ export function useContentTranslation(): UseContentTranslationReturn {
 		}
 
 		if ( skippedBlocksCount > 0 ) {
-			warnings.push(
+			notices.push(
 				sprintf(
 					/* translators: %1$d: number of blocks skipped, %2$d: minimum number of characters required for translation. */
 					_n(
@@ -372,31 +436,10 @@ export function useContentTranslation(): UseContentTranslationReturn {
 			);
 		}
 
-		if ( warnings.length > 0 ) {
-			noticeDispatch.createWarningNotice( warnings.join( ' ' ), {
-				id: TRANSLATION_NOTICE_ID_CONTENT,
-				...( failedBlocksCount > 0
-					? {
-							actions: [
-								{
-									label: _n(
-										'Retry failed block',
-										'Retry failed blocks',
-										failedBlocksCount,
-										'ai'
-									),
-									onClick: () => {
-										translate( languageCode, {
-											targetClientIds:
-												failedBlockClientIds,
-										} );
-									},
-								},
-							],
-					  }
-					: undefined ),
-			} );
-		}
+		return {
+			notices,
+			failedBlockClientIds,
+		};
 	};
 
 	return {

--- a/tests/e2e/specs/experiments/content-translation.spec.js
+++ b/tests/e2e/specs/experiments/content-translation.spec.js
@@ -325,4 +325,78 @@ test.describe( 'Content Translation Experiment', () => {
 		await expect( notice ).toBeVisible();
 		await expect( notice ).not.toContainText( 'Failed to translate' );
 	} );
+
+	test( 'Shows a retry button when the translation fails', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Content Translation Experiment.
+		await enableExperiment( admin, page, 'Content Translation' );
+
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'Test Content Translation Retry Button',
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'This paragraph is comfortably longer than the minimum content length required for translation, so it should be translated and replaced with the generated content.',
+			},
+		} );
+
+		await editor.saveDraft();
+
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Post' } ).click();
+
+		await page
+			.getByRole( 'button', { name: 'Generate Translation' } )
+			.click();
+
+		await page.getByLabel( 'Translate to' ).selectOption( {
+			label: 'French',
+		} );
+
+		// Mock the translation failure by returning a 500 error.
+		await page.route(
+			( url ) =>
+				url.href.includes( 'wp-abilities' ) &&
+				url.href.includes( 'content-translation' ),
+			async ( route ) => {
+				await route.fulfill( {
+					status: 500,
+					contentType: 'application/json',
+					body: JSON.stringify( {
+						code: 'translation_failed',
+						message: 'Simulated translation failure',
+						data: { status: 500 },
+					} ),
+				} );
+			},
+			{ times: 1 }
+		);
+
+		await page.getByRole( 'button', { name: 'Translate' } ).click();
+
+		// Ensure the retry button is visible and clickable.
+		const retryButton = page.getByRole( 'button', {
+			name: 'Retry failed translation',
+		} );
+
+		await expect( retryButton ).toBeVisible();
+		await retryButton.click();
+
+		// The retry reaches the normal E2E mock and applies its successful response.
+		await expect(
+			editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+		).toHaveText( MOCKED_RESPONSE );
+	} );
 } );


### PR DESCRIPTION
## What, Why, and How?

This PR adds a “Retry” action to the warning notice shown when a title or block translation fails.

For example, if 2 out of 10 blocks fail, the user can retry only those failed blocks instead of translating the entire post again. The PR tracks the client IDs of failed blocks and uses them to retry only the affected translations.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code reviews and implementation suggestions.

## Testing Instructions

1. Create a post with a title and several paragraphs, then generate a translation.
2. Simulate one or more block translation failures and verify a "Retry" action appears.
3. Click "Retry" and confirm only the failed blocks are translated.
4. Simulate a title translation failure and confirm Retry title translation retries only the title.

## Screencast

https://github.com/user-attachments/assets/e4968fef-a60d-4345-93f5-b0a311f6b4da

## Changelog Entry

> Added - User-triggered retry for Content Translation.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-941-ff9b0dd3c7dba0195bafc56df939b96e5b22783b.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->