### PR TITLE
Add some missing content sanitization

### DIFF
--- a/includes/Abilities/Editorial_Updates/Editorial_Updates.php
+++ b/includes/Abilities/Editorial_Updates/Editorial_Updates.php
@@ -130,7 +130,7 @@ class Editorial_Updates extends Abstract_Ability {
 			return $result;
 		}
 
-		return $result;
+		return wp_kses_post( $result );
 	}
 
 	/**

--- a/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
+++ b/src/experiments/content-resizing/components/ContentResizingToolbar.tsx
@@ -15,6 +15,7 @@ import {
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { safeHTML } from '@wordpress/dom';
 import {
 	useState,
 	useCallback,
@@ -161,7 +162,7 @@ export default function ContentResizingToolbar( {
 	const handleAccept = useCallback( () => {
 		if ( suggestedContent !== null ) {
 			blockEditorDispatch.updateBlockAttributes( clientId, {
-				content: suggestedContent,
+				content: safeHTML( suggestedContent ),
 				aiResized: true,
 			} );
 		}
@@ -307,7 +308,7 @@ export default function ContentResizingToolbar( {
 						<div
 							className="ai-content-resizing-modal__text ai-content-resizing-modal__text--original"
 							dangerouslySetInnerHTML={ {
-								__html: blockContent,
+								__html: safeHTML( blockContent ),
 							} }
 						/>
 					</section>
@@ -354,7 +355,7 @@ export default function ContentResizingToolbar( {
 							<div
 								className="ai-content-resizing-modal__text"
 								dangerouslySetInnerHTML={ {
-									__html: suggestedContent ?? '',
+									__html: safeHTML( suggestedContent ?? '' ),
 								} }
 							/>
 						) }

--- a/src/experiments/type-ahead/utils/text.ts
+++ b/src/experiments/type-ahead/utils/text.ts
@@ -18,13 +18,10 @@ export const htmlToPlainText = ( value?: string ): string => {
 		return '';
 	}
 
-	const temp = document.createElement( 'div' );
-	temp.innerHTML = value;
+	const inertDocument = document.implementation.createHTMLDocument( '' );
+	inertDocument.body.innerHTML = value;
 
-	return ( temp.textContent || temp.innerText || '' ).replaceAll(
-		'\u00A0',
-		' '
-	);
+	return ( inertDocument.body.textContent || '' ).replaceAll( '\u00A0', ' ' );
 };
 
 /**


### PR DESCRIPTION
## What?

Ensure content we render has been passed through sanitization functions

## Why?

In reviewing a separate PR, I was prompted to do some larger review of our codebase to ensure any content we pull from the editor to send to an LLM, or content we receive back from an LLM and render in the editor, has been passed through proper sanitization. For the most part that was already being done but there were a few areas that could be improved, which this PR does.

## How?

- For the Editorial Updates feature, ensure the content we receive from the LLM passes through `wp_kses_post`
- For the Content Resizing feature, ensure the content we render is passed through `safeHTML`
- For the Type Ahead feature, ensure the content we grab is passed through an inert element so it can never execute
 
## Use of AI Tools

AI assistance: Yes
Tool(s): Claude
Model(s): Opus 5
Used for: Reviewing our entire codebase for missing sanitization and adding those in. Review and testing by me

## Testing Instructions

The changes here touch Editorial Updates, Content Resizing and Type Ahead so turn those features on and ensure they all work as expected

## Changelog Entry

> Security - Ensure any content we render from the LLM or content we send to the LLM is properly sanitized.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-950-4d5a61022e51a238417015aeb53d4d3a8ab89dc9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->