### PR TITLE
Ensure our IPv4-in-IPv6 address check works for PHP <8.3

### DIFF
--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -726,14 +726,14 @@ class Alt_Text_Generation extends Abstract_Ability {
 	protected function is_public_ip( string $ip ): bool {
 		/*
 		 * Rejects loopback, link-local, private, and reserved ranges
-		 * for both IPv4 and IPv6, along with IPv4-mapped IPv6 addresses.
+		 * for both IPv4 and IPv6.
 		 */
 		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) ) {
 			return false;
 		}
 
 		if ( ! filter_var( $ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 ) ) {
-			return true;
+			return ! $this->embeds_ipv4_address( $ip );
 		}
 
 		$parts = array_map( 'intval', explode( '.', $ip ) );
@@ -749,6 +749,26 @@ class Alt_Text_Generation extends Abstract_Ability {
 			( 198 === $parts[0] && 18 <= $parts[1] && 19 >= $parts[1] ) ||
 			224 <= $parts[0]
 		);
+	}
+
+	/**
+	 * Checks whether an IPv6 address embeds an IPv4 address.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $ip The IPv6 address to check.
+	 * @return bool True when the address embeds an IPv4 address.
+	 */
+	protected function embeds_ipv4_address( string $ip ): bool {
+		$packed = inet_pton( $ip );
+
+		if ( ! is_string( $packed ) || 16 !== strlen( $packed ) ) {
+			return false;
+		}
+
+		$prefix = substr( $packed, 0, 12 );
+
+		return str_repeat( "\0", 12 ) === $prefix || str_repeat( "\0", 10 ) . "\xff\xff" === $prefix;
 	}
 
 	/**

--- a/includes/Abilities/Image/Alt_Text_Generation.php
+++ b/includes/Abilities/Image/Alt_Text_Generation.php
@@ -762,7 +762,7 @@ class Alt_Text_Generation extends Abstract_Ability {
 	protected function embeds_ipv4_address( string $ip ): bool {
 		$packed = inet_pton( $ip );
 
-		if ( ! is_string( $packed ) || 16 !== strlen( $packed ) ) {
+		if ( false === $packed ) {
 			return false;
 		}
 

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -755,6 +755,9 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 			'ipv6 unique local' => array( 'fd00::1' ),
 			'ipv6 link local'   => array( 'fe80::1' ),
 			'ipv4 mapped ipv6'  => array( '::ffff:127.0.0.1' ),
+			'ipv4 mapped hex'   => array( '::ffff:7f00:1' ),
+			'ipv4 compatible'   => array( '::127.0.0.1' ),
+			'ipv4 mapped cgnat' => array( '::ffff:100.64.0.1' ),
 		);
 	}
 

--- a/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
+++ b/tests/Integration/Includes/Abilities/Alt_Text_GenerationTest.php
@@ -757,6 +757,7 @@ class Alt_Text_GenerationTest extends WP_UnitTestCase {
 			'ipv4 mapped ipv6'  => array( '::ffff:127.0.0.1' ),
 			'ipv4 mapped hex'   => array( '::ffff:7f00:1' ),
 			'ipv4 compatible'   => array( '::127.0.0.1' ),
+			'ipv4 compat hex'   => array( '::7f00:1' ),
 			'ipv4 mapped cgnat' => array( '::ffff:100.64.0.1' ),
 		);
 	}


### PR DESCRIPTION
## What?

Add in a new `embeds_ipv4_address` method to check if an IPv6 address embeds an IPv4 address.

## Why?

We recently added more robust URL checking before allowing an image to be downloaded and our IPv4-in-IPv6 address check works as expected on PHP 8.3+ but PHP versions lower than that weren't working without additional checks.

## How?

- Adds a new `embeds_ipv4_address` method that we run when checking an IP to ensure we support PHP 8.2 and lower the same as PHP 8.3+

## Use of AI Tools

AI assistance: Yes
Tool(s): Cursor
Model(s): Opus 5
Used for: Diagnosing the failing unit tests, figuring out the reason why and suggesting a fix. Review and testing by me

## Testing Instructions

Not really much to test here as this is meant to prevent private IP addresses from being used when someone directly calls the Alt Text Ability with a custom image URL, so hard to reproduce. If desired, can test that the Alt Text Generation experiment still works as expected

## Changelog Entry

n/a - This is just a fix that a different PR missed

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-952-c98daacacb6650bd9eb7d7524993097b1ca8bf61.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->