### PR TITLE
Content Translation: Disable title translation when the post title is too short

### DIFF
--- a/docs/experiments/content-translation.md
+++ b/docs/experiments/content-translation.md
@@ -293,7 +293,7 @@ Note that this ability deliberately does not inject the site's editorial guideli
 4. **Test short and unsupported content:**
    - Add a heading shorter than the minimum length (for example `FAQ`) alongside a long paragraph, then translate; verify the heading is left untouched and reported as skipped rather than failed
    - Translate a post whose only content is an unsupported block type (a Code block, say); verify the "No translatable content found in the post." notice
-   - Translate with **Also translate the title** enabled on a post with an empty or very short title; verify the title-specific error while eligible blocks continue translating
+   - Open the modal with an empty or short title; verify the informational notice appears and "Also translate the title" is disabled. Close the modal, lengthen the title, reopen it, and verify the notice is absent and the option is enabled.
 
 5. **Test REST API:**
    - Use curl or Postman to test the REST endpoint

--- a/src/experiments/content-translation/components/ContentTranslationPlugin.tsx
+++ b/src/experiments/content-translation/components/ContentTranslationPlugin.tsx
@@ -20,6 +20,7 @@ export default function ContentTranslationPlugin() {
 	const {
 		isLoading: isTranslating,
 		isContentTooShort,
+		isTitleTooShort,
 		progress,
 		total,
 		minContentLength,
@@ -88,7 +89,9 @@ export default function ContentTranslationPlugin() {
 
 				{ isOpen && (
 					<TranslationModal
-						canTranslate={ ! isContentTooShort }
+						canTranslateContent={ ! isContentTooShort }
+						canTranslateTitle={ ! isTitleTooShort }
+						minContentLength={ minContentLength }
 						closeModal={ () => setIsOpen( false ) }
 						translate={ translate }
 					/>

--- a/src/experiments/content-translation/components/TranslationModal.tsx
+++ b/src/experiments/content-translation/components/TranslationModal.tsx
@@ -4,11 +4,12 @@
 import {
 	Button,
 	Modal,
+	Notice,
 	SelectControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
 
 /**
@@ -17,7 +18,9 @@ import { Stack } from '@wordpress/ui';
 import { getSettings } from '../utils';
 
 type TranslationModalProps = {
-	canTranslate: boolean;
+	canTranslateContent: boolean;
+	canTranslateTitle: boolean;
+	minContentLength: number;
 	closeModal: () => void;
 	translate: (
 		languageCode: string,
@@ -28,13 +31,17 @@ type TranslationModalProps = {
 /**
  * TranslationModal component.
  *
- * @param props              Component props.
- * @param props.canTranslate Whether translation can be started.
- * @param props.closeModal   Callback to close the modal.
- * @param props.translate    Callback to translate content.
+ * @param props                     Component props.
+ * @param props.canTranslateContent Whether content translation can be started.
+ * @param props.canTranslateTitle   Whether title translation can be started.
+ * @param props.minContentLength    Minimum number of characters required for translation.
+ * @param props.closeModal          Callback to close the modal.
+ * @param props.translate           Callback to translate content.
  */
 export default function TranslationModal( {
-	canTranslate,
+	canTranslateContent,
+	canTranslateTitle,
+	minContentLength,
 	closeModal,
 	translate,
 }: TranslationModalProps ) {
@@ -68,15 +75,31 @@ export default function TranslationModal( {
 					__next40pxDefaultSize
 				/>
 
-				<ToggleControl
-					label={ __( 'Also translate the title', 'ai' ) }
-					help={ __(
-						'Translates the title along with the post content.',
-						'ai'
+				<Stack direction="column" gap="md">
+					{ ! canTranslateTitle && (
+						<Notice isDismissible={ false } status="info">
+							{ sprintf(
+								/* translators: %d: minimum number of characters required for translation. */
+								__(
+									'Title translation will be available when the title has at least %d characters.',
+									'ai'
+								),
+								minContentLength
+							) }
+						</Notice>
 					) }
-					onChange={ ( value ) => setTranslateTitle( value ) }
-					checked={ translateTitle }
-				/>
+
+					<ToggleControl
+						label={ __( 'Also translate the title', 'ai' ) }
+						help={ __(
+							'Translates the title along with the post content.',
+							'ai'
+						) }
+						onChange={ ( value ) => setTranslateTitle( value ) }
+						checked={ translateTitle }
+						disabled={ ! canTranslateTitle }
+					/>
+				</Stack>
 
 				<Stack direction="row" gap="sm" justify="flex-end">
 					<Button
@@ -85,10 +108,11 @@ export default function TranslationModal( {
 						onClick={ () => {
 							closeModal();
 							void translate( selectedLanguage, {
-								translateTitle,
+								translateTitle:
+									translateTitle && canTranslateTitle,
 							} );
 						} }
-						disabled={ ! canTranslate || ! selectedLanguage }
+						disabled={ ! canTranslateContent || ! selectedLanguage }
 					>
 						{ __( 'Translate', 'ai' ) }
 					</Button>

--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -25,6 +25,7 @@ import { TRANSLATION_BATCH_SIZE, TRANSLATION_NOTICE_ID } from '../constants';
 
 type UseContentTranslationReturn = {
 	isContentTooShort: boolean;
+	isTitleTooShort: boolean;
 	isLoading: boolean;
 	progress: number;
 	total: number;
@@ -74,15 +75,21 @@ export function useContentTranslation(): UseContentTranslationReturn {
 
 	const { minContentLength } = getSettings();
 
-	const { postId, content } = useSelect( ( sel ) => {
+	const { postId, content, currentTitle } = useSelect( ( sel ) => {
 		return {
 			postId: sel( editorStore ).getCurrentPostId() as number,
 			content: sel( editorStore ).getEditedPostContent(),
+			currentTitle: sel( editorStore ).getEditedPostAttribute( 'title' ),
 		};
 	}, [] );
 
 	const isContentTooShort = ! hasMinimumContent(
 		content || '',
+		minContentLength
+	);
+
+	const isTitleTooShort = ! hasMinimumContent(
+		currentTitle || '',
 		minContentLength
 	);
 
@@ -456,6 +463,7 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	return {
 		isLoading: isTranslating,
 		isContentTooShort,
+		isTitleTooShort,
 		progress,
 		total,
 		minContentLength,

--- a/tests/e2e/specs/experiments/content-translation.spec.js
+++ b/tests/e2e/specs/experiments/content-translation.spec.js
@@ -216,6 +216,7 @@ test.describe( 'Content Translation Experiment', () => {
 		const titleTranslationCheckbox = page.getByRole( 'checkbox', {
 			name: 'Also translate the title',
 		} );
+
 		await expect( titleTranslationCheckbox ).toBeVisible();
 		await expect( titleTranslationCheckbox ).toBeDisabled();
 

--- a/tests/e2e/specs/experiments/content-translation.spec.js
+++ b/tests/e2e/specs/experiments/content-translation.spec.js
@@ -173,6 +173,70 @@ test.describe( 'Content Translation Experiment', () => {
 		await expect( generateButton ).toBeDisabled();
 	} );
 
+	test( 'Translate title is disabled when the title is shorter than the minimum length', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		// Globally turn on Experiments.
+		await enableExperiments( admin, page );
+
+		// Enable the Content Translation Experiment.
+		await enableExperiment( admin, page, 'Content Translation' );
+
+		// Create a new post with a title shorter than the minimum length.
+		await admin.createNewPost( {
+			postType: 'post',
+			title: 'A',
+		} );
+
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: {
+				content:
+					'This is some test content for the Content Translation Experiment.',
+			},
+		} );
+
+		// Save the post.
+		await editor.saveDraft();
+
+		// Ensure the sidebar is visible.
+		await editor.openDocumentSettingsSidebar();
+
+		// Switch to the Post tab (if not already on it).
+		await page.getByRole( 'tab', { name: 'Post' } ).click();
+
+		// Open the translation modal.
+		await page
+			.getByRole( 'button', { name: 'Generate Translation' } )
+			.click();
+
+		// Ensure the title translation option is visible but disabled.
+		const titleTranslationCheckbox = page.getByRole( 'checkbox', {
+			name: 'Also translate the title',
+		} );
+		await expect( titleTranslationCheckbox ).toBeVisible();
+		await expect( titleTranslationCheckbox ).toBeDisabled();
+
+		// Close the modal.
+		await page.getByRole( 'button', { name: 'Cancel' } ).click();
+
+		// Lengthen the title.
+		await editor.canvas
+			.getByRole( 'textbox', { name: 'Add title' } )
+			.fill( 'Longer Title' );
+
+		// Open the translation modal again.
+		await page
+			.getByRole( 'button', { name: 'Generate Translation' } )
+			.click();
+
+		// Ensure the title translation option is visible and enabled.
+		await expect( titleTranslationCheckbox ).toBeVisible();
+		await expect( titleTranslationCheckbox ).toBeEnabled();
+	} );
+
 	test( 'Ensure the Content Translation Experiment UI is not visible when the experiment is disabled', async ( {
 		admin,
 		editor,


### PR DESCRIPTION
## What, Why, and How?

Previously, users could enable title translation even when the post title was empty or shorter than the required minimum length. The title would then be skipped during translation, with the reason shown only after the operation completed. This made the outcome feel delayed/unexpected.

This PR validates the title before translation begins. When the title does not meet the minimum-length requirement (or is empty), the modal displays an informational notice and disables the `Also translate the title` toggle beforehand. This sets expectations upfront while still allowing eligible post content to be translated. This should help improve the user-experience while using the content translation feature.

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Code review of the implementation.

## Testing Instructions

1. Enable the Content Translation experiment.
2. Create or edit a post with sufficient content and an empty or short title.
3. Open the translation modal and verify that an informational notice appears.
4. Verify that `Also translate the title` is disabled.
5. Close the modal and lengthen the title to meet the minimum requirement.
6. Reopen the modal and verify that the notice is absent and `Also translate the title` is enabled.
7. Start the translation and verify that both the title and eligible post content are translated.

## Screenshot

<img width="1362" height="1051" alt="image" src="https://github.com/user-attachments/assets/b3b39099-89e6-45f7-9067-9e906b2787e2" />

## Changelog Entry

> Changed - Show a notice and disable title translation when the post title is too short.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-967-289468fd6644efd62f03d1321ca3eacba2729ae6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->