### PR TITLE
Limit comment moderation bulk analysis queue size

### DIFF
--- a/docs/experiments/alt-text-generation.md
+++ b/docs/experiments/alt-text-generation.md
@@ -266,7 +266,7 @@ add_filter( 'wpai_bulk_action_max_items', function ( int $max_items, string $fea
 }, 10, 2 );
 ```
 
-Values below 1 are clamped to 1. The same filter governs the bulk summarization cap, so check `$feature_id` when you only mean to change one.
+Values below 1 are clamped to 1. The same filter governs the bulk summarization and comment moderation caps, so check `$feature_id` when you only mean to change one.
 
 ### Adding Custom UI Elements
 

--- a/docs/experiments/comment-moderation.md
+++ b/docs/experiments/comment-moderation.md
@@ -130,6 +130,18 @@ add_filter( 'wpai_comment_moderation_should_moderate', function( $should_moderat
 }, 10, 3 );
 ```
 
+### Adjusting the Bulk Batch Cap
+
+Each comment queued by the **Analyze Sentiment and Toxicity** bulk action becomes one billed model call once it is analyzed, so `handle_bulk_action()` caps how many comments a single request will queue. The default is 100; comments beyond the cap are not queued, and the surplus is reported to the user in an admin notice.
+
+```php
+add_filter( 'wpai_bulk_action_max_items', function ( int $max_items, string $feature_id ): int {
+    return 'comment-moderation' === $feature_id ? 25 : $max_items;
+}, 10, 2 );
+```
+
+Values below 1 are clamped to 1. The same filter governs the alt text and summarization bulk caps, so check `$feature_id` when you only mean to change one.
+
 ## Testing
 
 ### Manual Testing
@@ -167,6 +179,7 @@ add_filter( 'wpai_comment_moderation_should_moderate', function( $should_moderat
 - Frontend processing is sequential by design to avoid sending many concurrent requests
 - Ability-level status locking prevents duplicate simultaneous analysis on the same comment
 - Failed comments are marked `failed` and are retried on subsequent scans because failed badges remain queryable
+- Bulk analysis is capped at 100 comments per request by default; see [Adjusting the Bulk Batch Cap](#adjusting-the-bulk-batch-cap)
 
 ### Limitations
 

--- a/includes/Experiments/Comment_Moderation/Comment_Moderation.php
+++ b/includes/Experiments/Comment_Moderation/Comment_Moderation.php
@@ -15,6 +15,7 @@ use WordPress\AI\Asset_Loader;
 use WordPress\AI\Experiments\Experiment_Category;
 use WordPress\AI\Settings\Settings_Registration;
 
+use function WordPress\AI\get_bulk_action_max_items;
 use function WordPress\AI\get_provider_availability_data;
 use function WordPress\AI\has_ai_credentials;
 
@@ -143,7 +144,7 @@ class Comment_Moderation extends Abstract_Feature {
 	 *
 	 * @var list<string>
 	 */
-	private const BULK_NOTICE_QUERY_ARGS = array( 'wpai_analysis_queued', 'wpai_no_provider' ); // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
+	private const BULK_NOTICE_QUERY_ARGS = array( 'wpai_analysis_queued', 'wpai_analysis_truncated', 'wpai_no_provider' ); // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
 
 	/**
 	 * Gets the configuration for sentiment levels.
@@ -918,21 +919,36 @@ class Comment_Moderation extends Abstract_Feature {
 			return add_query_arg( 'wpai_no_provider', 1, (string) $redirect_url );
 		}
 
-		// Mark selected comments as pending for analysis.
-		$queued = 0;
-		foreach ( (array) $comment_ids as $comment_id ) {
-			$comment_id = absint( $comment_id );
-			$comment    = get_comment( $comment_id );
+		$comment_ids       = array_values( array_unique( array_filter( array_map( 'absint', (array) $comment_ids ) ) ) );
+		$valid_comment_ids = array();
+		foreach ( $comment_ids as $comment_id ) {
+			$comment = get_comment( $comment_id );
 			if ( ! $comment || ! is_a( $comment, '\WP_Comment' ) ) {
 				continue;
 			}
 
+			$valid_comment_ids[] = $comment_id;
+		}
+
+		// Each queued comment becomes a billed model call once it is analyzed, so bound the batch.
+		$max_items       = get_bulk_action_max_items( $this->get_id() );
+		$truncated_count = max( 0, count( $valid_comment_ids ) - $max_items );
+		$comment_ids     = array_slice( $valid_comment_ids, 0, $max_items );
+
+		// Mark selected comments as pending for analysis.
+		$queued = 0;
+		foreach ( $comment_ids as $comment_id ) {
 			update_comment_meta( $comment_id, self::META_ANALYSIS_STATUS, self::STATUS_PENDING );
 			++$queued;
 		}
 
-		// Add query arg to show notice.
-		return add_query_arg( 'wpai_analysis_queued', $queued, (string) $redirect_url );
+		// Add query args to show notice.
+		$notice_args = array( 'wpai_analysis_queued' => $queued );
+		if ( $truncated_count > 0 ) {
+			$notice_args['wpai_analysis_truncated'] = $truncated_count;
+		}
+
+		return add_query_arg( $notice_args, (string) $redirect_url );
 	}
 
 	/**
@@ -950,26 +966,45 @@ class Comment_Moderation extends Abstract_Feature {
 			return;
 		}
 
-		$count = absint( wp_unslash( $_GET['wpai_analysis_queued'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$count     = absint( wp_unslash( $_GET['wpai_analysis_queued'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$truncated = isset( $_GET['wpai_analysis_truncated'] ) ? absint( wp_unslash( $_GET['wpai_analysis_truncated'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( $count <= 0 ) {
+		// Nothing queued and nothing dropped means there is nothing to report.
+		if ( $count <= 0 && $truncated <= 0 ) {
 			return;
 		}
 
+		$message = '';
+		if ( $count > 0 ) {
+			$message = sprintf(
+				/* translators: %d: Number of comments queued for analysis. */
+				_n(
+					'%d comment queued for analysis.',
+					'%d comments queued for analysis.',
+					$count,
+					'ai'
+				),
+				$count
+			);
+		}
+
+		if ( $truncated > 0 ) {
+			$message .= ( '' !== $message ? ' ' : '' ) . sprintf(
+				/* translators: %d: Number of comments that were not queued because the batch limit was reached. */
+				_n(
+					'%d comment was not queued because the batch limit was reached.',
+					'%d comments were not queued because the batch limit was reached.',
+					$truncated,
+					'ai'
+				),
+				$truncated
+			);
+		}
+
 		printf(
-			'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
-			esc_html(
-				sprintf(
-					/* translators: %d: Number of comments queued for analysis. */
-					_n(
-						'%d comment queued for analysis.',
-						'%d comments queued for analysis.',
-						$count,
-						'ai'
-					),
-					$count
-				)
-			)
+			'<div class="notice notice-%s is-dismissible"><p>%s</p></div>',
+			esc_attr( $truncated > 0 ? 'warning' : 'success' ),
+			esc_html( $message )
 		);
 	}
 

--- a/src/experiments/comment-moderation/components/LazyAnalysisController.tsx
+++ b/src/experiments/comment-moderation/components/LazyAnalysisController.tsx
@@ -142,16 +142,26 @@ function markBadgeProcessing( badge: HTMLElement ): void {
 }
 
 /**
- * Removes the queued-analysis query arg from the URL.
+ * Bulk analysis notice query args that should not linger in the URL.
+ */
+const BULK_NOTICE_QUERY_ARGS = [
+	'wpai_analysis_queued',
+	'wpai_analysis_truncated',
+];
+
+/**
+ * Removes the bulk analysis notice query args from the URL.
  */
 function clearQueuedAnalysisQueryArg(): void {
 	const url = new URL( window.location.href );
 
-	if ( ! url.searchParams.has( 'wpai_analysis_queued' ) ) {
+	if (
+		! BULK_NOTICE_QUERY_ARGS.some( ( arg ) => url.searchParams.has( arg ) )
+	) {
 		return;
 	}
 
-	url.searchParams.delete( 'wpai_analysis_queued' );
+	BULK_NOTICE_QUERY_ARGS.forEach( ( arg ) => url.searchParams.delete( arg ) );
 	window.history.replaceState(
 		null,
 		'',

--- a/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
+++ b/tests/Integration/Includes/Experiments/Comment_Moderation/Comment_ModerationTest.php
@@ -245,6 +245,156 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the bulk action bounds how many comments it queues.
+	 *
+	 * Each queued comment costs one billed model call once it is analyzed, so the
+	 * batch is bounded by the shared bulk action limit and the overflow is
+	 * reported back through the notice.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_handle_bulk_action_caps_batch_size() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$cap = static function (): int {
+			return 2;
+		};
+
+		add_filter( 'wpai_bulk_action_max_items', $cap );
+
+		try {
+			$comment_ids = array(
+				$this->create_comment_without_hooks(),
+				$this->create_comment_without_hooks(),
+				$this->create_comment_without_hooks(),
+			);
+
+			$experiment = new Comment_Moderation();
+			$result     = $experiment->handle_bulk_action(
+				'https://example.com/wp-admin/edit-comments.php',
+				'wpai_analyze',
+				$comment_ids
+			);
+
+			$this->assertStringContainsString( 'wpai_analysis_queued=2', $result );
+			$this->assertStringContainsString( 'wpai_analysis_truncated=1', $result );
+
+			$this->assertSame(
+				Comment_Moderation::STATUS_PENDING,
+				get_comment_meta( $comment_ids[0], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+			$this->assertSame(
+				Comment_Moderation::STATUS_PENDING,
+				get_comment_meta( $comment_ids[1], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+			$this->assertSame(
+				'',
+				get_comment_meta( $comment_ids[2], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+		} finally {
+			remove_filter( 'wpai_bulk_action_max_items', $cap );
+		}
+	}
+
+	/**
+	 * Test that duplicate comment IDs are only queued once.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_handle_bulk_action_deduplicates_comment_ids() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$comment_id = $this->create_comment_without_hooks();
+		$experiment = new Comment_Moderation();
+
+		$result = $experiment->handle_bulk_action(
+			'https://example.com/wp-admin/edit-comments.php',
+			'wpai_analyze',
+			array( $comment_id, $comment_id, $comment_id )
+		);
+
+		$this->assertStringContainsString( 'wpai_analysis_queued=1', $result );
+		$this->assertStringNotContainsString( 'wpai_analysis_truncated', $result );
+	}
+
+	/**
+	 * Test that invalid comment IDs do not consume queue slots before the cap applies.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_handle_bulk_action_ignores_invalid_ids_before_capping() {
+		wp_set_current_user( $this->admin_user_id );
+
+		$cap = static function (): int {
+			return 2;
+		};
+
+		add_filter( 'wpai_bulk_action_max_items', $cap );
+
+		try {
+			$invalid_comment_id = 999999;
+			$comment_ids        = array(
+				$invalid_comment_id,
+				$this->create_comment_without_hooks(),
+				$this->create_comment_without_hooks(),
+				$this->create_comment_without_hooks(),
+			);
+
+			$experiment = new Comment_Moderation();
+			$result     = $experiment->handle_bulk_action(
+				'https://example.com/wp-admin/edit-comments.php',
+				'wpai_analyze',
+				$comment_ids
+			);
+
+			$this->assertStringContainsString( 'wpai_analysis_queued=2', $result );
+			$this->assertStringContainsString( 'wpai_analysis_truncated=1', $result );
+			$this->assertSame(
+				Comment_Moderation::STATUS_PENDING,
+				get_comment_meta( $comment_ids[1], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+			$this->assertSame(
+				Comment_Moderation::STATUS_PENDING,
+				get_comment_meta( $comment_ids[2], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+			$this->assertSame(
+				'',
+				get_comment_meta( $comment_ids[3], Comment_Moderation::META_ANALYSIS_STATUS, true )
+			);
+		} finally {
+			remove_filter( 'wpai_bulk_action_max_items', $cap );
+		}
+	}
+
+	/**
+	 * Test that the notice reports dropped comments even when none were queued.
+	 *
+	 * The notice should not hide a truncation warning if no comments were queued.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_show_bulk_action_notice_reports_truncation_without_queued() {
+		$original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		try {
+			$_GET['wpai_analysis_queued']    = '0';
+			$_GET['wpai_analysis_truncated'] = '3';
+
+			$experiment = new Comment_Moderation();
+
+			ob_start();
+			$experiment->show_bulk_action_notice();
+			$output = ob_get_clean();
+
+			$this->assertStringContainsString( 'notice-warning', $output );
+			$this->assertStringNotContainsString( '0 comments queued for analysis.', $output );
+			$this->assertStringContainsString( 'batch limit was reached', $output );
+		} finally {
+			$_GET = $original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+	}
+
+	/**
 	 * Test that the bulk notice trigger params are registered as removable query args.
 	 *
 	 * Core cleans removable args out of the address bar, so a reload of the
@@ -259,6 +409,7 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 		$removable = wp_removable_query_args();
 
 		$this->assertContains( 'wpai_analysis_queued', $removable );
+		$this->assertContains( 'wpai_analysis_truncated', $removable );
 		$this->assertContains( 'wpai_no_provider', $removable );
 	}
 
@@ -275,13 +426,14 @@ class Comment_ModerationTest extends WP_UnitTestCase {
 		$original_request_uri = $_SERVER['REQUEST_URI'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		try {
-			$_SERVER['REQUEST_URI'] = '/wp-admin/edit-comments.php?paged=2&wpai_analysis_queued=3&wpai_no_provider=1&orderby=date'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$_SERVER['REQUEST_URI'] = '/wp-admin/edit-comments.php?paged=2&wpai_analysis_queued=3&wpai_analysis_truncated=1&wpai_no_provider=1&orderby=date'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			$experiment = new Comment_Moderation();
 			$experiment->remove_bulk_notice_query_args();
 
 			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Asserting on the raw value.
 			$this->assertStringNotContainsString( 'wpai_analysis_queued', $_SERVER['REQUEST_URI'] );
+			$this->assertStringNotContainsString( 'wpai_analysis_truncated', $_SERVER['REQUEST_URI'] );
 			$this->assertStringNotContainsString( 'wpai_no_provider', $_SERVER['REQUEST_URI'] );
 			$this->assertStringContainsString( 'paged=2', $_SERVER['REQUEST_URI'], 'Unrelated query args must survive the scrub.' );
 			$this->assertStringContainsString( 'orderby=date', $_SERVER['REQUEST_URI'], 'Unrelated query args must survive the scrub.' );


### PR DESCRIPTION
## Description

The plugin bounds AI bulk actions with `get_bulk_action_max_items()`, a filterable, feature-keyed limit that defaults to 100. Alt text generation and summarization both use it. Comment moderation registers a bulk action but does not, so it marks every selected comment as pending regardless of how many were selected.

Each pending comment becomes a model call once it is analyzed, which is the same reason the other two bulk actions are bounded.

## Changes

- Comment moderation now applies `get_bulk_action_max_items()` to its bulk action.
- Selected comments are validated before the limit is applied, so IDs for comments that no longer exist cannot consume slots and push out valid ones.
- Comment IDs are deduplicated, so the same comment selected twice counts once.
- Comments left out are reported in the admin notice, which switches to a warning when anything was left out.
- `wpai_analysis_truncated` is registered as a removable query arg and scrubbed from the request URI, matching the existing notice args.

## Testing

- `npm run test:php -- --filter Comment_ModerationTest` passes with 31 tests and 130 assertions. Three new tests cover the limit, deduplication, and invalid IDs not consuming slots, plus one covering the notice when comments were left out but none were queued.
- Full PHP test suite passes.
- PHPCS passes on both changed files.
- PHPStan passes on both changed files.

Manual wp-admin verification was performed with a temporary local filter that set the Comment Moderation bulk limit to 2 and satisfied the credential gate. Selecting 5 comments and running the real bulk action queued 2 comments, left 3 untouched, showed a warning notice for the truncated count, and scrubbed the notice query args after load.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-972-ef49eea1f51834af823564aa9a2b4689c59df308.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->