### PR TITLE
Fix: Meta Description: SEO plugin detection cache never expires and skips the "no plugin" case

### DIFF
--- a/includes/Abilities/Meta_Description/SEO_Integration.php
+++ b/includes/Abilities/Meta_Description/SEO_Integration.php
@@ -29,6 +29,22 @@ class SEO_Integration {
 	public const FALLBACK_META_KEY = 'wpai_meta_description';
 
 	/**
+	 * Transient key caching the detected SEO plugin.
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	public const CACHE_KEY = 'wpai_active_seo_plugin';
+
+	/**
+	 * Cached value meaning "no supported SEO plugin is active".
+	 *
+	 * @since x.x.x
+	 * @var string
+	 */
+	private const CACHE_NONE = 'none';
+
+	/**
 	 * Returns the list of supported SEO plugins and their meta keys.
 	 *
 	 * @since 0.7.0
@@ -69,16 +85,22 @@ class SEO_Integration {
 
 	/**
 	 * Detects the currently active SEO plugin.
-	 * Cache is flushed when a plugin is deactivated.
+	 *
+	 * Result is cached with a TTL and flushed on plugin activation/deactivation.
 	 *
 	 * @since 0.7.0
 	 *
 	 * @return string|null The slug of the active SEO plugin, or null if none detected.
 	 */
 	public static function detect_active_plugin(): ?string {
-		$active_plugin = get_transient( 'wpai_active_seo_plugin' );
-		if ( ! empty( $active_plugin ) ) {
-			return $active_plugin;
+		$cached = get_transient( self::CACHE_KEY );
+
+		if ( self::CACHE_NONE === $cached ) {
+			return null;
+		}
+
+		if ( ! empty( $cached ) ) {
+			return $cached;
 		}
 
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -87,12 +109,36 @@ class SEO_Integration {
 
 		foreach ( self::get_supported_plugins() as $slug => $info ) {
 			if ( is_plugin_active( $info['file'] ) ) {
-				set_transient( 'wpai_active_seo_plugin', $slug );
+				set_transient( self::CACHE_KEY, $slug, DAY_IN_SECONDS );
 				return $slug;
 			}
 		}
 
+		// Cache the "none active" result so the scan is not repeated every call.
+		set_transient( self::CACHE_KEY, self::CACHE_NONE, DAY_IN_SECONDS );
 		return null;
+	}
+
+	/**
+	 * Registers cache invalidation on plugin activation and deactivation.
+	 *
+	 * Runs regardless of the Meta Description experiment state so the cache is
+	 * never left stale when a plugin changes while the experiment is disabled.
+	 *
+	 * @since x.x.x
+	 */
+	public static function register_cache_invalidation(): void {
+		add_action( 'activated_plugin', array( self::class, 'clear_cache' ) );
+		add_action( 'deactivated_plugin', array( self::class, 'clear_cache' ) );
+	}
+
+	/**
+	 * Clears the detected SEO plugin cache.
+	 *
+	 * @since x.x.x
+	 */
+	public static function clear_cache(): void {
+		delete_transient( self::CACHE_KEY );
 	}
 
 	/**

--- a/includes/Abilities/Meta_Description/SEO_Integration.php
+++ b/includes/Abilities/Meta_Description/SEO_Integration.php
@@ -128,17 +128,55 @@ class SEO_Integration {
 	 * @since x.x.x
 	 */
 	public static function register_cache_invalidation(): void {
-		add_action( 'activated_plugin', array( self::class, 'clear_cache' ) );
-		add_action( 'deactivated_plugin', array( self::class, 'clear_cache' ) );
+		add_action( 'activated_plugin', array( self::class, 'clear_cache_on_plugin_change' ), 10, 2 );
+		add_action( 'deactivated_plugin', array( self::class, 'clear_cache_on_plugin_change' ), 10, 2 );
 	}
 
 	/**
-	 * Clears the detected SEO plugin cache.
+	 * Clears the cache when a plugin is activated or deactivated. Also
+	 * supports multisite and network activated/deactivated plugins.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $plugin       Path to the plugin file, relative to the plugins directory.
+	 * @param bool   $network_wide Whether the change applied network-wide.
+	 */
+	public static function clear_cache_on_plugin_change( string $plugin, bool $network_wide = false ): void {
+		if ( $network_wide && is_multisite() ) {
+			self::clear_cache_for_network();
+			return;
+		}
+
+		self::clear_cache();
+	}
+
+	/**
+	 * Clears the detected SEO plugin cache for the current site.
 	 *
 	 * @since x.x.x
 	 */
 	public static function clear_cache(): void {
 		delete_transient( self::CACHE_KEY );
+	}
+
+	/**
+	 * Clears the detected SEO plugin cache for every site on the network.
+	 *
+	 * @since x.x.x
+	 */
+	private static function clear_cache_for_network(): void {
+		$site_ids = get_sites(
+			array(
+				'fields' => 'ids',
+				'number' => 0,
+			)
+		);
+
+		foreach ( $site_ids as $site_id ) {
+			switch_to_blog( (int) $site_id ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.switch_to_blog_switch_to_blog
+			self::clear_cache();
+			restore_current_blog();
+		}
 	}
 
 	/**

--- a/includes/Admin/Upgrades.php
+++ b/includes/Admin/Upgrades.php
@@ -14,6 +14,7 @@ use WordPress\AI\Admin\Upgrades\V0_5_0;
 use WordPress\AI\Admin\Upgrades\V0_6_0;
 use WordPress\AI\Admin\Upgrades\V1_0_0;
 use WordPress\AI\Admin\Upgrades\V1_3_0;
+use WordPress\AI\Admin\Upgrades\V1_4_0;
 
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
@@ -54,6 +55,7 @@ final class Upgrades {
 		V0_6_0::class,
 		V1_0_0::class,
 		V1_3_0::class,
+		V1_4_0::class,
 	);
 
 	/**

--- a/includes/Admin/Upgrades/V1_4_0.php
+++ b/includes/Admin/Upgrades/V1_4_0.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Upgrade routines for version x.x.x
+ *
+ * @package WordPress\AI\Admin\Upgrades
+ * @since x.x.x
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Admin\Upgrades;
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Upgrade routine for clearing the legacy SEO plugin detection cache.
+ *
+ * Earlier versions cached the detected SEO plugin in a transient with no
+ * expiration, so on existing sites it could persist indefinitely. Deleting it
+ * once lets the new TTL-based caching repopulate it cleanly.
+ *
+ * @since x.x.x
+ * @internal
+ */
+class V1_4_0 extends Abstract_Upgrade {
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @since x.x.x
+	 */
+	public static string $version = '1.4.0';
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * Clears the previously non-expiring SEO plugin detection cache.
+	 *
+	 * @since x.x.x
+	 */
+	protected function upgrade(): void {
+		if ( '' === $this->db_version ) {
+			return;
+		}
+
+		// Keeping the literal here, because if key changed in future,
+		// this upgrade routine should target this key only.
+		delete_transient( 'wpai_active_seo_plugin' );
+	}
+}

--- a/includes/Experiments/Meta_Description/Meta_Description.php
+++ b/includes/Experiments/Meta_Description/Meta_Description.php
@@ -57,7 +57,6 @@ class Meta_Description extends Abstract_Feature {
 	public function register(): void {
 		add_action( 'wp_abilities_api_init', array( $this, 'register_abilities' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
-		add_action( 'deactivated_plugin', array( $this, 'clear_active_plugin_cache' ) );
 
 		$this->maybe_output_meta_description();
 		$this->register_post_meta();
@@ -154,15 +153,6 @@ class Meta_Description extends Abstract_Feature {
 				'minContentLength' => get_min_content_length( 'meta-description', 250 ),
 			)
 		);
-	}
-
-	/**
-	 * Clears the active SEO plugin cache when a plugin is deactivated.
-	 *
-	 * @since 0.7.0
-	 */
-	public function clear_active_plugin_cache(): void {
-		delete_transient( 'wpai_active_seo_plugin' );
 	}
 
 	/**

--- a/includes/Main.php
+++ b/includes/Main.php
@@ -11,6 +11,7 @@ declare( strict_types=1 );
 
 namespace WordPress\AI;
 
+use WordPress\AI\Abilities\Meta_Description\SEO_Integration;
 use WordPress\AI\Admin\Activation;
 use WordPress\AI\Admin\Dashboard\Dashboard_Widgets;
 use WordPress\AI\Admin\Deactivation;
@@ -89,6 +90,9 @@ final class Main {
 
 		// Handle deprecated code.
 		( new Deprecated() )->init();
+
+		// Keep the detected SEO plugin cache fresh regardless of experiment state.
+		SEO_Integration::register_cache_invalidation();
 
 		// Add plugin action links to plugins screen.
 		add_filter( 'plugin_action_links_' . plugin_basename( WPAI_PLUGIN_FILE ), array( $this, 'plugin_action_links' ) );

--- a/tests/Integration/Includes/Abilities/Meta_Description/SEO_IntegrationTest.php
+++ b/tests/Integration/Includes/Abilities/Meta_Description/SEO_IntegrationTest.php
@@ -36,8 +36,8 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 		remove_all_filters( 'wpai_meta_description_seo_plugins' );
 		remove_all_filters( 'wpai_meta_description_meta_key' );
 		SEO_Integration::clear_cache();
-		remove_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache' ) );
-		remove_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache' ) );
+		remove_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache_on_plugin_change' ) );
+		remove_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache_on_plugin_change' ) );
 		parent::tearDown();
 	}
 
@@ -237,7 +237,7 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_cache_invalidation() hooks clear_cache onto plugin activation and deactivation.
+	 * Test that register_cache_invalidation() hooks clear_cache_on_plugin_change onto plugin activation and deactivation.
 	 *
 	 * @since x.x.x
 	 */
@@ -245,12 +245,12 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 		SEO_Integration::register_cache_invalidation();
 
 		$this->assertNotFalse(
-			has_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache' ) ),
-			'register_cache_invalidation() should hook clear_cache onto activated_plugin.'
+			has_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache_on_plugin_change' ) ),
+			'register_cache_invalidation() should hook clear_cache_on_plugin_change onto activated_plugin.'
 		);
 		$this->assertNotFalse(
-			has_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache' ) ),
-			'register_cache_invalidation() should hook clear_cache onto deactivated_plugin.'
+			has_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache_on_plugin_change' ) ),
+			'register_cache_invalidation() should hook clear_cache_on_plugin_change onto deactivated_plugin.'
 		);
 	}
 
@@ -280,5 +280,77 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 		do_action( 'deactivated_plugin', 'some-plugin/some-plugin.php', false );
 
 		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'Deactivating a plugin should clear the cache.' );
+	}
+
+	/**
+	 * Test that a network-wide plugin change clears the per-site cache on every site.
+	 *
+	 * @group ms-required
+	 *
+	 * @since x.x.x
+	 */
+	public function test_network_wide_change_clears_cache_on_all_sites() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires a multisite installation.' );
+		}
+
+		$second_blog_id = self::factory()->blog->create();
+
+		SEO_Integration::register_cache_invalidation();
+
+		// Cache a value on both sites.
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+		switch_to_blog( $second_blog_id );
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+		restore_current_blog();
+
+		// Fire a network-wide activation from the main site.
+		do_action( 'activated_plugin', 'wordpress-seo/wp-seo.php', true );
+
+		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'The main site cache should be cleared.' );
+
+		switch_to_blog( $second_blog_id );
+		$second_site_cache = get_transient( SEO_Integration::CACHE_KEY );
+		restore_current_blog();
+
+		$this->assertFalse( $second_site_cache, 'The other site cache should be cleared for a network-wide change.' );
+
+		wp_delete_site( get_site( $second_blog_id ) );
+	}
+
+	/**
+	 * Test that a single-site plugin change only clears the current site's cache.
+	 *
+	 * @group ms-required
+	 *
+	 * @since x.x.x
+	 */
+	public function test_single_site_change_only_clears_current_site() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'This test requires a multisite installation.' );
+		}
+
+		$second_blog_id = self::factory()->blog->create();
+
+		SEO_Integration::register_cache_invalidation();
+
+		// Cache a value on both sites.
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+		switch_to_blog( $second_blog_id );
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+		restore_current_blog();
+
+		// Fire a single-site activation from the main site.
+		do_action( 'activated_plugin', 'wordpress-seo/wp-seo.php', false );
+
+		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'The main site cache should be cleared.' );
+
+		switch_to_blog( $second_blog_id );
+		$second_site_cache = get_transient( SEO_Integration::CACHE_KEY );
+		restore_current_blog();
+
+		$this->assertSame( 'yoast-seo', $second_site_cache, 'The other site cache should be untouched by a single-site change.' );
+
+		wp_delete_site( get_site( $second_blog_id ) );
 	}
 }

--- a/tests/Integration/Includes/Abilities/Meta_Description/SEO_IntegrationTest.php
+++ b/tests/Integration/Includes/Abilities/Meta_Description/SEO_IntegrationTest.php
@@ -18,6 +18,16 @@ use WordPress\AI\Abilities\Meta_Description\SEO_Integration;
 class SEO_IntegrationTest extends WP_UnitTestCase {
 
 	/**
+	 * Set up test case.
+	 *
+	 * @since x.x.x
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		SEO_Integration::clear_cache();
+	}
+
+	/**
 	 * Tear down test case.
 	 *
 	 * @since 0.7.0
@@ -25,6 +35,9 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 	public function tearDown(): void {
 		remove_all_filters( 'wpai_meta_description_seo_plugins' );
 		remove_all_filters( 'wpai_meta_description_meta_key' );
+		SEO_Integration::clear_cache();
+		remove_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache' ) );
+		remove_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache' ) );
 		parent::tearDown();
 	}
 
@@ -168,5 +181,104 @@ class SEO_IntegrationTest extends WP_UnitTestCase {
 
 		// Restore.
 		update_option( 'active_plugins', $active );
+	}
+
+	/**
+	 * Test that detect_active_plugin() caches the detected slug.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_detect_active_plugin_caches_detected_slug() {
+		$active = get_option( 'active_plugins', array() );
+		update_option( 'active_plugins', array_merge( $active, array( 'wordpress-seo/wp-seo.php' ) ) );
+
+		// First call scans and caches the detected slug.
+		$this->assertEquals( 'yoast-seo', SEO_Integration::detect_active_plugin() );
+		$this->assertEquals( 'yoast-seo', get_transient( SEO_Integration::CACHE_KEY ), 'The detected slug should be cached.' );
+
+		// Deactivating without clearing the cache still returns the cached slug.
+		update_option( 'active_plugins', $active );
+		$this->assertEquals( 'yoast-seo', SEO_Integration::detect_active_plugin(), 'Should return the cached slug until the cache is cleared.' );
+	}
+
+	/**
+	 * Test that detect_active_plugin() caches the "none active" result.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_detect_active_plugin_caches_none_result() {
+		// With no SEO plugin active, the "none" result is cached.
+		$this->assertNull( SEO_Integration::detect_active_plugin() );
+		$this->assertNotFalse( get_transient( SEO_Integration::CACHE_KEY ), 'The "none active" result should be cached.' );
+
+		// Activating a plugin afterwards still returns null until the cache is cleared.
+		$active = get_option( 'active_plugins', array() );
+		update_option( 'active_plugins', array_merge( $active, array( 'wordpress-seo/wp-seo.php' ) ) );
+		$this->assertNull( SEO_Integration::detect_active_plugin(), 'Should return the cached "none" result until cleared.' );
+
+		// Clearing the cache lets a fresh scan pick up the newly active plugin.
+		SEO_Integration::clear_cache();
+		$this->assertEquals( 'yoast-seo', SEO_Integration::detect_active_plugin() );
+
+		update_option( 'active_plugins', $active );
+	}
+
+	/**
+	 * Test that clear_cache() removes the cached value.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_clear_cache_removes_cached_value() {
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+
+		SEO_Integration::clear_cache();
+
+		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'clear_cache() should delete the cached value.' );
+	}
+
+	/**
+	 * Test that register_cache_invalidation() hooks clear_cache onto plugin activation and deactivation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_register_cache_invalidation_hooks_actions() {
+		SEO_Integration::register_cache_invalidation();
+
+		$this->assertNotFalse(
+			has_action( 'activated_plugin', array( SEO_Integration::class, 'clear_cache' ) ),
+			'register_cache_invalidation() should hook clear_cache onto activated_plugin.'
+		);
+		$this->assertNotFalse(
+			has_action( 'deactivated_plugin', array( SEO_Integration::class, 'clear_cache' ) ),
+			'register_cache_invalidation() should hook clear_cache onto deactivated_plugin.'
+		);
+	}
+
+	/**
+	 * Test that the cache is cleared when a plugin is activated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_cache_is_cleared_on_plugin_activation() {
+		SEO_Integration::register_cache_invalidation();
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+
+		do_action( 'activated_plugin', 'some-plugin/some-plugin.php', false );
+
+		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'Activating a plugin should clear the cache.' );
+	}
+
+	/**
+	 * Test that the cache is cleared when a plugin is deactivated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_cache_is_cleared_on_plugin_deactivation() {
+		SEO_Integration::register_cache_invalidation();
+		set_transient( SEO_Integration::CACHE_KEY, 'yoast-seo', DAY_IN_SECONDS );
+
+		do_action( 'deactivated_plugin', 'some-plugin/some-plugin.php', false );
+
+		$this->assertFalse( get_transient( SEO_Integration::CACHE_KEY ), 'Deactivating a plugin should clear the cache.' );
 	}
 }

--- a/tests/Integration/Includes/Admin/Upgrades/V1_4_0Test.php
+++ b/tests/Integration/Includes/Admin/Upgrades/V1_4_0Test.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Integration tests for V1_4_0.
+ *
+ * @package WordPress\AI\Tests\Integration\Admin\Upgrades
+ */
+
+namespace WordPress\AI\Tests\Integration\Admin\Upgrades;
+
+use WP_UnitTestCase;
+use WordPress\AI\Admin\Upgrades\V1_4_0;
+
+/**
+ * V1_4_0 test case.
+ *
+ * @covers \WordPress\AI\Admin\Upgrades\V1_4_0
+ *
+ * @since x.x.x
+ */
+class V1_4_0Test extends WP_UnitTestCase {
+
+	/**
+	 * The historical transient key the migration clears.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const CACHE_KEY = 'wpai_active_seo_plugin';
+
+	/**
+	 * Tests that run() clears the legacy SEO plugin detection cache.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_run_clears_seo_plugin_cache(): void {
+		set_transient( self::CACHE_KEY, 'yoast-seo' );
+
+		( new V1_4_0( '1.3.0' ) )->run();
+
+		$this->assertFalse( get_transient( self::CACHE_KEY ), 'The legacy SEO plugin cache should be cleared.' );
+	}
+
+	/**
+	 * Tests that run() returns true on success.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_run_returns_success(): void {
+		$this->assertTrue( ( new V1_4_0( '1.3.0' ) )->run() );
+	}
+
+	/**
+	 * Tests that run() leaves the cache alone when the version is already current.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_run_skips_when_version_already_current(): void {
+		set_transient( self::CACHE_KEY, 'yoast-seo' );
+
+		( new V1_4_0( '1.4.0' ) )->run();
+
+		$this->assertSame( 'yoast-seo', get_transient( self::CACHE_KEY ), 'The cache should be untouched when the upgrade is skipped.' );
+	}
+
+	/**
+	 * Tests that run() leaves the cache alone on a new install, where an empty
+	 * database version means the plugin has never stored the legacy cache.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_run_skips_on_a_new_install(): void {
+		set_transient( self::CACHE_KEY, 'yoast-seo' );
+
+		$this->assertTrue( ( new V1_4_0( '' ) )->run() );
+
+		$this->assertSame( 'yoast-seo', get_transient( self::CACHE_KEY ), 'No transient should be deleted on a new install.' );
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->
Closes https://github.com/WordPress/ai/issues/970

<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. The positive result is stored with no expiry and is only cleared on deactivated_plugin - a hook that's registered only while the Meta Description experiment is enabled. So the cache can go stale and never self-heal.
2. The "no SEO plugin active" result is never cached, so a full plugin scan runs on every call, including the front-end output_meta_description() path.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Updates the transient to cache it for a day.
- Update the activated, deactivated hook outside of experiment, so a cache would invalidate regardless of experiment is enabled or not.

### Use of AI Tools
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.

Example disclosure:

AI assistance: Yes
Tool(s): GitHub Copilot, ChatGPT
Model(s): GPT-5.1
Used for: Initial code skeleton and test suggestions; final implementation and tests were reviewed and edited by me.
-->
AI assistance: Yes
Tool(s): Claude Code
Model(s): Opus 5
Used for: Code, Unit Test under the direction provided by me. Implementation reviwed by me.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Activate a supported SEO plugin (e.g. Yoast) + enable the Meta Description experiment; trigger meta handling once to cache the slug.
2. Disable the Meta Description experiment.
3. Deactivate the SEO plugin.
4. Re-enable the experiment, This should use the plugin's meta key, i.e wpai_meta_description.

## Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

> Fixed - Cached the active SEO plugin detection - with a TTL and immediate invalidation on any plugin activation/deactivation - so meta description meta-key lookups no longer re-scan active plugins on every request.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-973-b482d0bd1f34675dc2c1b0ba67420399795c3c10.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->