### PR TITLE
CI: Add multisite PHPUnit test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -175,9 +175,21 @@ jobs:
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
         wp: ['7.0', latest, trunk]
-        multisite: [false, true]
+        multisite: [false]
         coverage: [false]
         include:
+          - php: '8.4'
+            wp: '7.0'
+            multisite: true
+            coverage: false
+          - php: '8.4'
+            wp: latest
+            multisite: true
+            coverage: false
+          - php: '8.4'
+            wp: trunk
+            multisite: true
+            coverage: false
           - php: '8.4'
             wp: latest
             multisite: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,7 +167,7 @@ jobs:
   # - Uploads code coverage report to Codecov.io (if coverage is enabled).
   # - Uploads HTML coverage report as an artifact (if coverage is enabled).
   phpunit:
-    name: Test PHP ${{ matrix.php }} WP ${{ matrix.wp }}${{ matrix.coverage && ' with coverage' || '' }}
+    name: Test PHP ${{ matrix.php }} WP ${{ matrix.wp }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.coverage && ' with coverage' || '' }}
     runs-on: ubuntu-24.04
     if: ${{ github.repository == 'WordPress/ai' || github.event_name == 'pull_request' }}
     strategy:
@@ -175,10 +175,12 @@ jobs:
       matrix:
         php: ['8.4', '8.3', '8.2', '8.1', '8.0', '7.4']
         wp: ['7.0', latest, trunk]
+        multisite: [false, true]
         coverage: [false]
         include:
           - php: '8.4'
             wp: latest
+            multisite: false
             coverage: true
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
@@ -244,7 +246,7 @@ jobs:
       - name: Run PHPUnit tests${{ matrix.coverage && ' with coverage report' || '' }}
         id: phpunit
         run: |
-          npm run test:php
+          npm run ${{ matrix.multisite && 'test:php:multisite' || 'test:php' }}
 
       - name: Upload code coverage report
         continue-on-error: true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"test:e2e:debug": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts --ui",
 		"test:e2e": "wp-scripts test-playwright --config tests/e2e/playwright.config.ts",
 		"test:php": "wp-env --config=.wp-env.test.json run cli --env-cwd=wp-content/plugins/ai vendor/bin/phpunit -c phpunit.xml.dist",
+		"test:php:multisite": "wp-env --config=.wp-env.test.json run cli --env-cwd=wp-content/plugins/ai env WP_MULTISITE=1 vendor/bin/phpunit -c phpunit.xml.dist",
 		"typecheck": "tsc --noEmit",
 		"wp-env": "wp-env",
 		"wp-env:cli": "wp-env run cli --env-cwd=wp-content/plugins/ai",

--- a/tests/Integration/Includes/Abilities/Users/UsersTest.php
+++ b/tests/Integration/Includes/Abilities/Users/UsersTest.php
@@ -129,6 +129,11 @@ class UsersTest extends WP_UnitTestCase {
 			)
 		);
 
+		// On multisite, only super admins can edit arbitrary network users.
+		if ( is_multisite() ) {
+			grant_super_admin( self::$fixture_ids['administrator'] );
+		}
+
 		self::$fixture_ids['public_post'] = $factory->post->create(
 			array(
 				'post_author' => self::$fixture_ids['public_author'],
@@ -145,6 +150,10 @@ class UsersTest extends WP_UnitTestCase {
 	 */
 	public static function wpTearDownAfterClass(): void {
 		wp_delete_post( self::$fixture_ids['public_post'], true );
+
+		if ( is_multisite() ) {
+			revoke_super_admin( self::$fixture_ids['administrator'] );
+		}
 
 		foreach ( array( 'administrator', 'editor', 'author', 'contributor', 'subscriber', 'public_author' ) as $fixture_name ) {
 			wp_delete_user( self::$fixture_ids[ $fixture_name ] );


### PR DESCRIPTION
## What?

Follow-up to #961.

This PR keeps the PHP test suite running in single-site mode across the existing PHP and WordPress version matrix, and adds multisite runs on PHP 8.4 for WordPress 7.0, latest, and trunk.

## Why?

PR #961 adds Agent Users behavior with meaningful multisite security boundaries and currently exercises that behavior with an ad hoc multisite PHPUnit command. The regular CI suite only runs as single site, so multisite-only branches and differences in WordPress capability mapping are not continuously covered.

WordPress core already exercises PHPUnit in both single-site and multisite configurations. Applying the same strategy here makes multisite a normal supported test mode instead of something feature branches need to opt into temporarily. Limiting multisite to PHP 8.4 retains coverage across every supported WordPress target without doubling the full PHP matrix.

Enabling the suite exposed six failures in the read-users tests. The implementation was behaving correctly: on multisite, a site administrator cannot edit arbitrary network users unless they are also a super admin, so sensitive email and roles fields were omitted. The tests expected a fully privileged administrator, so their shared fixture now receives and later relinquishes super-admin status when the suite runs in multisite mode.

## How?

- Add explicit PHP 8.4 multisite jobs for WordPress 7.0, latest, and trunk, preserving the existing single-site matrix and coverage job.
- Add a test:php:multisite npm script that passes WP_MULTISITE=1 to the wp-phpunit bootstrap.
- Select the matching npm script from each matrix job and label multisite jobs clearly.
- Grant the read-users administrator fixture super-admin status only under multisite, then revoke it during class cleanup.

### Use of AI Tools

- AI assistance: Yes
- Tool(s): OpenAI Codex
- Model(s): GPT-5
- Used for: comparing the WordPress core workflow, implementing the CI matrix, diagnosing multisite failures, updating the test fixture, running verification, and drafting this PR description. I directed the scope and reviewed the changes and results.

## Testing Instructions

Run both PHPUnit modes:

```sh
npm run test:php
npm run test:php:multisite
```

Both modes pass locally with 1,448 tests. Also verified with:

```sh
composer phpstan
composer lint -- tests/Integration/Includes/Abilities/Users/UsersTest.php
npm exec prettier -- --check .github/workflows/test.yml package.json
```

## Changelog Entry

> Developer - Add multisite PHPUnit coverage to CI.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-974-edd25a26a1d715b671aa46942c243e360b647370.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->