### PR TITLE
Content Translation: Improve loading effect

### DIFF
--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
+import {
+	store as blockEditorStore,
+	useBlockEditingMode,
+} from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { select, useDispatch, useSelect } from '@wordpress/data';
@@ -68,6 +71,16 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	const [ isTranslating, setIsTranslating ] = useState( false );
 	const [ progress, setProgress ] = useState( 0 );
 	const [ total, setTotal ] = useState( 0 );
+
+	/**
+	 * Keep all blocks read-only while translation is pending.
+	 *
+	 * Since this runs outside an individual block context, the editing mode applies
+	 * to the root block container and is inherited by every block. Changes to
+	 * `isTranslating` rerun the hook, applying `disabled` while true and cleaning
+	 * up the temporary restriction when false.
+	 */
+	useBlockEditingMode( isTranslating ? 'disabled' : undefined );
 
 	const noticeDispatch = useDispatch( noticesStore );
 	const blockEditorDispatch = useDispatch( blockEditorStore );

--- a/src/experiments/content-translation/hooks/useContentTranslation.ts
+++ b/src/experiments/content-translation/hooks/useContentTranslation.ts
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import {
-	store as blockEditorStore,
-	useBlockEditingMode,
-} from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { select, useDispatch, useSelect } from '@wordpress/data';
@@ -71,16 +68,6 @@ export function useContentTranslation(): UseContentTranslationReturn {
 	const [ isTranslating, setIsTranslating ] = useState( false );
 	const [ progress, setProgress ] = useState( 0 );
 	const [ total, setTotal ] = useState( 0 );
-
-	/**
-	 * Keep all blocks read-only while translation is pending.
-	 *
-	 * Since this runs outside an individual block context, the editing mode applies
-	 * to the root block container and is inherited by every block. Changes to
-	 * `isTranslating` rerun the hook, applying `disabled` while true and cleaning
-	 * up the temporary restriction when false.
-	 */
-	useBlockEditingMode( isTranslating ? 'disabled' : undefined );
 
 	const noticeDispatch = useDispatch( noticesStore );
 	const blockEditorDispatch = useDispatch( blockEditorStore );

--- a/src/experiments/content-translation/index.scss
+++ b/src/experiments/content-translation/index.scss
@@ -1,39 +1,25 @@
 @keyframes ai-content-translation-text-shimmer {
 	from {
-		background-position: 300% 0, 0 0;
+		mask-position: 300% 0;
 	}
 	to {
-		background-position: 0 0, 0 0;
+		mask-position: 0 0;
 	}
 }
-
 .ai-content-translation--is-title-loading .wp-block-post-title,
 .ai-content-translation--is-blocks-loading .block-editor-rich-text__editable {
-	opacity: 0.75;
-
+	opacity: 0.8;
 	@media (prefers-reduced-motion: no-preference) {
-		background-image:
-			linear-gradient(
-				90deg,
-				currentColor 42%,
-				color-mix(in srgb, currentColor 55%, transparent) 50%,
-				currentColor 58%
-			),
-			linear-gradient(transparent, transparent);
-		background-position: 300% 0, 0 0;
-		background-repeat: repeat, no-repeat;
-		background-size: 300% 100%, 100% 100%;
+		mask-image: linear-gradient(
+			90deg,
+			#000 42%,
+			rgba(0, 0, 0, 0.7) 50%,
+			#000 58%
+		);
+		mask-repeat: repeat;
+		mask-size: 300% 100%;
+		mask-position: 300% 0;
 		animation: ai-content-translation-text-shimmer 2.25s linear infinite;
-		background-clip: text, border-box;
-		-webkit-background-clip: text, border-box;
-		-webkit-text-fill-color: transparent;
-
-		// Blend inline highlight colors with the shimmer while keeping the effect
-		// isolated from backgrounds outside the editable element.
-		isolation: isolate;
-		& :is(mark, [style*="background-color"]) {
-			mix-blend-mode: multiply;
-		}
 	}
 }
 

--- a/src/experiments/content-translation/index.scss
+++ b/src/experiments/content-translation/index.scss
@@ -1,34 +1,32 @@
 @keyframes ai-content-translation-text-shimmer {
 	from {
-		background-position: 300% 0;
+		background-position: 300% 0, 0 0;
 	}
 	to {
-		background-position: 0 0;
+		background-position: 0 0, 0 0;
 	}
 }
 
 .ai-content-translation--is-title-loading .wp-block-post-title,
 .ai-content-translation--is-blocks-loading .block-editor-rich-text__editable {
-	color: var(--wpds-color-fg-content-neutral-weak, #707070);
+	opacity: 0.75;
 
 	@media (prefers-reduced-motion: no-preference) {
-		background: linear-gradient(
-			90deg,
-			var(--wpds-color-fg-content-neutral-weak, #707070) 42%,
-			color-mix(
-					in srgb,
-					var(--wpds-color-fg-content-neutral-weak, #707070) 55%,
-					#fff
-				)
-				50%,
-			var(--wpds-color-fg-content-neutral-weak, #707070) 58%
-		);
-		background-size: 300% 100%;
-		animation: ai-content-translation-text-shimmer 1.8s linear infinite;
-		background-clip: text;
-		-webkit-background-clip: text;
+		background-image:
+			linear-gradient(
+				90deg,
+				currentColor 42%,
+				color-mix(in srgb, currentColor 55%, transparent) 50%,
+				currentColor 58%
+			),
+			linear-gradient(transparent, transparent);
+		background-position: 300% 0, 0 0;
+		background-repeat: repeat, no-repeat;
+		background-size: 300% 100%, 100% 100%;
+		animation: ai-content-translation-text-shimmer 2.25s linear infinite;
+		background-clip: text, border-box;
+		-webkit-background-clip: text, border-box;
 		-webkit-text-fill-color: transparent;
-		will-change: background-position;
 
 		// Blend inline highlight colors with the shimmer while keeping the effect
 		// isolated from backgrounds outside the editable element.


### PR DESCRIPTION
## What, Why, and How?

The previous loading animation used a `background-clipping` technique with the hard-coded `content-neutral-weak` color. As a result, the loading state replaced the element’s existing text color with the default gray and required additional clipping and blend-mode workarounds to handle elements with their own backgrounds. It also had issues rendering the animation properly with text highlights + custom text colors.

This PR replaces that implementation with a simpler `mask-based` animation. Because the mask operates on the element’s existing rendering instead of supplying a new color, it retains the underlying text and background colors while removing the previous `background-clipping` and `blend-mode` workarounds.

`Mask-*` has [good support score](https://caniuse.com/?search=mask-image).

### Use of AI Tools

AI assistance: Yes
Tool(s): Codex
Model(s): GPT-5.6 Sol
Used for: Suggesting mask properties, and code review.

## Screencast

|Before|After|
|-|-|
|<img height="810" alt="Before-01" src="https://github.com/user-attachments/assets/cdc06165-b02a-4582-a4cd-04f14152de44" />|<img height="810" alt="after-latest" src="https://github.com/user-attachments/assets/08db942d-bb19-479d-a24d-954071b9de9e" />|

## Changelog Entry

> Fixed - Improves the Content Translation loading animation to preserve existing text and background colors.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-977-e2a6031c79b8296e5c07a0ef2bfb9546eb735833.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->