### PR TITLE
Playground preview: derive PR from the triggering run

### DIFF
--- a/.github/workflows/pr-playground-preview.yml
+++ b/.github/workflows/pr-playground-preview.yml
@@ -30,35 +30,43 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Extract PR metadata from artifact name
+      - name: Resolve trusted PR metadata
         id: pr-metadata
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+            // The build runs untrusted PR code; the run's head SHA is the
+            // only trusted value.
+            const trustedSha = context.payload.workflow_run.head_sha;
+
+            // Resolve the PR from the trusted head SHA, not the PR number in
+            // the artifact name.
+            const pulls = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
+              state: 'open',
+              per_page: 100,
             });
+            const pr = pulls.find(p => p.head.sha === trustedSha);
+            if (!pr) {
+              throw new Error(`Could not resolve an open pull request for head SHA ${trustedSha}`);
+            }
 
-            const artifact = artifacts.data.artifacts.find(a =>
-              a.name.startsWith("ai-plugin-zip-pr")
-            );
-
+            // Match the artifact by the name the trusted build derives, not by
+            // prefix.
+            const expectedName = `ai-plugin-zip-pr${pr.number}-${trustedSha}`;
+            const artifacts = await github.paginate(github.rest.actions.listWorkflowRunArtifacts, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            const artifact = artifacts.find(a => a.name === expectedName);
             if (!artifact) {
-              throw new Error('Could not find plugin artifact');
+              throw new Error(`Could not find plugin artifact named ${expectedName}`);
             }
 
-            // Parse: ai-plugin-zip-pr123-abc123def...
-            const match = artifact.name.match(/^ai-plugin-zip-pr(\d+)-(.+)$/);
-            if (!match) {
-              throw new Error(`Could not parse artifact name: ${artifact.name}`);
-            }
-
-            const [, prNumber, commitSha] = match;
-
-            core.setOutput('pr-number', prNumber);
-            core.setOutput('commit-sha', commitSha);
+            core.setOutput('pr-number', String(pr.number));
+            core.setOutput('commit-sha', trustedSha);
             core.setOutput('artifact-name', artifact.name);
 
       - name: Expose built artifact


### PR DESCRIPTION
## What

The privileged `pr-playground-preview.yml` publisher currently reads the PR number and commit SHA out of the build artifact's name (`ai-plugin-zip-pr<n>-<sha>`). This change instead:

- Takes the head SHA from the `workflow_run` event (`context.payload.workflow_run.head_sha`).
- Resolves the pull request by matching that SHA against open PRs' head SHAs.
- Locates the build artifact by the exact name the trusted build derives from that PR and SHA, rather than by prefix.

The published preview and the comment target now follow from the commit that was actually built, not from artifact-supplied values.

## Why

The build workflow runs on PR code with a read-only token; its artifacts (name and contents) are untrusted. Binding to the `workflow_run` head SHA keeps the publish step aligned with the triggering run.

## Testing

- `actionlint` clean; embedded `github-script` syntax-checked.
- No producer change: the build already runs PR code by design, and the fix is entirely on the trusted consumer side.
- Worth a check on a fork-originated PR to confirm the PR resolves in the runner.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-978-3cecd11ebfddb6ae47a8556dbb3199aaea18a7c4.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->