### PR TITLE
Fix: Update DataViews to fix settings page breakage in Gutenberg trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file, per [the Ke
 
 ## [Unreleased] - TBD
 
+### Fixed
+
+- Fixed AI settings page failing to render on Gutenberg 23.9+ after `@wordpress/dataviews` was removed from the private-apis allowlist.
+
 ## [1.3.0] - 2026-08-18
 ### Added
 - New Experiment: Content Translation; translates Paragraph and Heading blocks—and optionally the post title—into a selected language directly from the post editor ([#747](https://github.com/WordPress/ai/pull/747)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@wordpress/core-abilities": "0.10.0",
 				"@wordpress/core-data": "7.44.0",
 				"@wordpress/data": "10.44.0",
-				"@wordpress/dataviews": "14.1.0",
+				"@wordpress/dataviews": "18.1.0",
 				"@wordpress/date": "5.44.0",
 				"@wordpress/dom": "4.47.0",
 				"@wordpress/dom-ready": "4.44.0",
@@ -32,7 +32,7 @@
 				"@wordpress/notices": "5.44.0",
 				"@wordpress/plugins": "7.44.0",
 				"@wordpress/primitives": "4.45.0",
-				"@wordpress/ui": "0.20.0",
+				"@wordpress/ui": "0.21.0",
 				"@wordpress/url": "4.44.0",
 				"@wordpress/wordcount": "4.44.0",
 				"react": "18.3.1"
@@ -10198,6 +10198,66 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/admin-ui/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/admin-ui/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/admin-ui/node_modules/@floating-ui/react-dom": {
 			"version": "2.1.9",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
@@ -10355,19 +10415,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/deprecated": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
-			"integrity": "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/hooks": "^4.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/dom": {
 			"version": "4.53.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.53.0.tgz",
@@ -10474,27 +10521,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/keycodes": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
-			"integrity": "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/i18n": "^6.26.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@types/react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/primitives": {
 			"version": "4.53.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.53.0.tgz",
@@ -10518,19 +10544,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/priority-queue": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.53.0.tgz",
-			"integrity": "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"requestidlecallback": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/style-runtime": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.9.0.tgz",
@@ -10541,17 +10554,96 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/undo-manager": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.53.0.tgz",
-			"integrity": "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==",
+		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/theme": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.2.0.tgz",
+			"integrity": "sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.53.0"
+				"@wordpress/compose": "^8.6.0",
+				"@wordpress/deprecated": "^4.53.0",
+				"@wordpress/element": "^8.5.0",
+				"@wordpress/private-apis": "^1.53.0",
+				"@wordpress/style-runtime": "^0.9.0",
+				"colorjs.io": "^0.7.1",
+				"memize": "^2.1.1"
 			},
 			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
+				"node": "^20.19.0 || >=22.13.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"esbuild": ">=0.27.2 <1.0.0",
+				"postcss": "^8.0.0",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
+				"stylelint": "^16 || ^17",
+				"vite": "^7 || ^8"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"stylelint": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/admin-ui/node_modules/@wordpress/ui": {
+			"version": "0.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.20.0.tgz",
+			"integrity": "sha512-otLrXwHKekMy9RX3z/vlTWDwvtQlZW18niCOWcd7FtzSWZYRk4Nu7wwRLEv4oq3HyuTCbL+oOOOBPeQrN9IyeQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.6.0",
+				"@daypicker/react": "^10.0.1",
+				"@wordpress/a11y": "^4.53.0",
+				"@wordpress/compose": "^8.6.0",
+				"@wordpress/element": "^8.5.0",
+				"@wordpress/i18n": "^6.26.0",
+				"@wordpress/icons": "^15.4.0",
+				"@wordpress/keycodes": "^4.53.0",
+				"@wordpress/primitives": "^4.53.0",
+				"@wordpress/private-apis": "^1.53.0",
+				"@wordpress/style-runtime": "^0.9.0",
+				"@wordpress/theme": "^1.2.0",
+				"clsx": "^2.1.1",
+				"date-fns": "^4.4.0",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.13.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/admin-ui/node_modules/colorjs.io": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
+			"integrity": "sha512-LY7OHnJZxHwT5UlzNa9bbhHHDbzB6yE5+3MIPwJEQKRvSCt/T4G7epsj+9j2BExUIIfXFIJGsIXUKdfrK9Q5tA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
 			}
 		},
 		"node_modules/@wordpress/admin-ui/node_modules/date-fns": {
@@ -10697,6 +10789,641 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/@wordpress/ui/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/block-editor/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/block-library": {
@@ -12794,30 +13521,32 @@
 			}
 		},
 		"node_modules/@wordpress/dataviews": {
-			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.1.0.tgz",
-			"integrity": "sha512-RDnCbbgNEcTJiLscqn7pN0r9toEI3Pt3L2mvLHrMjMYR8aqdouYwPldM96Sa4j+DZLf+122hQ7wBvYwyn9C4Kw==",
+			"version": "18.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-18.1.0.tgz",
+			"integrity": "sha512-vV3wvSnqxjGqsUj9fnRmVVzXVCy/N+pRGYx+WyyXZUslbLX9xn1JfI2Z8uXFptKZJ5vGJ3BnLkfE4r2HdvG0Zg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.21",
-				"@wordpress/base-styles": "^6.20.0",
-				"@wordpress/components": "^32.6.0",
-				"@wordpress/compose": "^7.44.0",
-				"@wordpress/data": "^10.44.0",
-				"@wordpress/date": "^5.44.0",
-				"@wordpress/deprecated": "^4.44.0",
-				"@wordpress/element": "^6.44.0",
-				"@wordpress/i18n": "^6.17.0",
-				"@wordpress/icons": "^12.2.0",
-				"@wordpress/keycodes": "^4.44.0",
-				"@wordpress/primitives": "^4.44.0",
-				"@wordpress/private-apis": "^1.44.0",
-				"@wordpress/ui": "^0.11.0",
-				"@wordpress/warning": "^3.44.0",
+				"@ariakit/react": "^0.4.37",
+				"@date-fns/tz": "^1.5.0",
+				"@wordpress/a11y": "^4.54.0",
+				"@wordpress/base-styles": "^13.0.0",
+				"@wordpress/components": "^40.0.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/data": "^10.54.0",
+				"@wordpress/date": "^5.54.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/i18n": "^6.27.0",
+				"@wordpress/icons": "^15.5.0",
+				"@wordpress/kebab-case": "^1.1.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/primitives": "^4.54.0",
+				"@wordpress/ui": "^0.21.0",
+				"@wordpress/warning": "^3.54.0",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"date-fns": "^4.1.0",
-				"deepmerge": "4.3.1",
+				"colord": "^2.9.3",
+				"date-fns": "^4.4.0",
+				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"remove-accents": "^0.5.0"
 			},
@@ -12826,44 +13555,12 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@base-ui/react": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.3.1",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
-				"use-sync-external-store": "^1.6.0"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/mui-org"
-			},
-			"peerDependencies": {
-				"@date-fns/tz": "^1.2.0",
-				"@types/react": "^17 || ^18 || ^19",
-				"date-fns": "^4.0.0",
-				"react": "^17 || ^18 || ^19",
-				"react-dom": "^17 || ^18 || ^19"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
 			},
 			"peerDependenciesMeta": {
-				"@date-fns/tz": {
-					"optional": true
-				},
 				"@types/react": {
-					"optional": true
-				},
-				"date-fns": {
 					"optional": true
 				}
 			}
@@ -12881,58 +13578,322 @@
 				"react-dom": ">=16.8.0"
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/theme": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.11.0.tgz",
-			"integrity": "sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==",
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.44.0",
-				"@wordpress/private-apis": "^1.44.0",
-				"colorjs.io": "^0.6.0",
-				"memize": "^2.1.0"
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "13.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-13.0.0.tgz",
+			"integrity": "sha512-IBDH2iG+U373NiY8l6UVNvjMXKVtYN/iFaLpavt1vO/I/S2aOE+m693+iMJv9ELC5oYQZSXzTWh+p/1RjmmC6w==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "40.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-40.0.0.tgz",
+			"integrity": "sha512-QbMVLab+oDTpUECo9TAXn8J6g8zI5zjvHmL/pnloqc/ALujnHb+fLW5zaHjr9IBQ2qq1U5BXarbOnRCIktVuCA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.37",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.54.0",
+				"@wordpress/base-styles": "^13.0.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/date": "^5.54.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"@wordpress/hooks": "^4.54.0",
+				"@wordpress/html-entities": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0",
+				"@wordpress/icons": "^15.5.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/kebab-case": "^1.1.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/primitives": "^4.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/rich-text": "^7.54.0",
+				"@wordpress/style-runtime": "^0.10.0",
+				"@wordpress/ui": "^0.21.0",
+				"@wordpress/warning": "^3.54.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.9.3",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.4.0",
+				"deepmerge": "^4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "^1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.1.0",
+				"memize": "^2.1.1",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0",
-				"stylelint": "^16.8.2"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
 			},
 			"peerDependenciesMeta": {
-				"stylelint": {
+				"@types/react": {
 					"optional": true
 				}
 			}
 		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/ui": {
-			"version": "0.11.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.11.0.tgz",
-			"integrity": "sha512-V1R3CTQ8MltuajZ53PCHGe9mmRwyx1RpjHA2wWOv+79dV0qQ1Y/psL0YTMY4eteL4SNAlBcjJVP66zD5O6yF8Q==",
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.4.0",
-				"@wordpress/a11y": "^4.44.0",
-				"@wordpress/compose": "^7.44.0",
-				"@wordpress/element": "^6.44.0",
-				"@wordpress/i18n": "^6.17.0",
-				"@wordpress/icons": "^12.2.0",
-				"@wordpress/keycodes": "^4.44.0",
-				"@wordpress/primitives": "^4.44.0",
-				"@wordpress/private-apis": "^1.44.0",
-				"@wordpress/theme": "^0.11.0",
-				"clsx": "^2.1.1",
-				"tabbable": "^6.4.0"
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
 			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "15.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.5.0.tgz",
+			"integrity": "sha512-ES/PmxhDyBvx5Z+SqMXJCO1hLJ6XLs4L6FZNQLfqhFDn/xppjkFtFw6B0EnfumpdcZX/tSYDU3PfcicFilIGKQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/primitives": "^4.54.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/dataviews/node_modules/@wordpress/style-runtime": {
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.10.0.tgz",
+			"integrity": "sha512-yZm2r8qzt++oW+4X2UEHl2FBuO/9O+BazXsQbSjGxcabA2g4apjBH2pEZqKbdbNqlArkj5KZm0LCxY1p6DKYTQ==",
+			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
 			}
 		},
 		"node_modules/@wordpress/dataviews/node_modules/date-fns": {
@@ -12978,12 +13939,12 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.50.0.tgz",
-			"integrity": "sha512-TVJavTbunFoCSo2g64EKtGwmDVJhvlSqsc4T1EM4aBwsYGIJPjHcAzh6KS8Z171QXFnBxZ7We8CCDAvOFU9iaA==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.54.0.tgz",
+			"integrity": "sha512-CpTcvBtDLStxslBm2HvMrQVbZ8cS0iYjKQvaW2vJcJxf+C0CDO0bS86juBnjcxtSRXFPGtBhxx6DKVP6L3pntw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.50.0"
+				"@wordpress/hooks": "^4.54.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -12991,9 +13952,9 @@
 			}
 		},
 		"node_modules/@wordpress/deprecated/node_modules/@wordpress/hooks": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
-			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13323,6 +14284,666 @@
 				"react-dom": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/editor/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dataviews/node_modules/uuid": {
+			"version": "14.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.2.tgz",
+			"integrity": "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/editor/node_modules/@wordpress/ui/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/@wordpress/editor/node_modules/uuid": {
 			"version": "11.1.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
@@ -13385,9 +15006,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.53.0.tgz",
-			"integrity": "sha512-6EE4hOsd0kUp4bO9voTsIeK0oa80FYMbxvJkjN9Vitnf0ZTRVB7Iz2IviaYorhGUDemlRy3kOPEZdP9DA/CoCA==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.54.0.tgz",
+			"integrity": "sha512-dbXSgUZgJ4KcZF9OLO+suayc7PxptZ0qhSE1bgJraD8bnk/jkaCohp5J7WQKzTWw1OSiJtQFZLw2T+BnyqQOpA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -13475,20 +15096,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/deprecated": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
-			"integrity": "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/hooks": "^4.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/dom": {
 			"version": "4.53.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.53.0.tgz",
@@ -13532,73 +15139,6 @@
 				"@types/react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/hooks": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.53.0.tgz",
-			"integrity": "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/i18n": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.26.0.tgz",
-			"integrity": "sha512-v/LzeB7T5YKIfBgmLM0jYG8zOuu81biZ90j8RY9pHIVu+jdRE+DSmt55S3FvtXRo5J2X9FoigFRzYPKXLbitWA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.53.0",
-				"gettext-parser": "^1.3.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/keycodes": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
-			"integrity": "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/i18n": "^6.26.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@types/react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/priority-queue": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.53.0.tgz",
-			"integrity": "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"requestidlecallback": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/style-runtime": {
@@ -13656,20 +15196,6 @@
 				"vite": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/eslint-plugin/node_modules/@wordpress/undo-manager": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.53.0.tgz",
-			"integrity": "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin/node_modules/colorjs.io": {
@@ -13752,6 +15278,641 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/@wordpress/ui/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/fields/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/global-styles-engine": {
@@ -14745,9 +16906,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.53.0.tgz",
-			"integrity": "sha512-ACj7S5XnXtyWy6NZ4sFh+7haaZ6DFxCNXoTSCk/sEpw9nNN6ISUzTgVXmXXocTA/+ioU6bQYIISSkYXWE1TrWw==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.54.0.tgz",
+			"integrity": "sha512-swIbZ1n6OvmerwQylZxatB9QQ2vtAvD4vQaVxPLTf53BxLI9kpdjHr6ujcZnd9Q7vY+n23kVRIETZO+BBsau1g==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -15788,9 +17949,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.53.0.tgz",
-			"integrity": "sha512-NHhvEnqi82Vzon458Jz6nzmbAPWM1zy9k6rBXQTc+9PsRiWHWpqXqldKAeTFVrl0vspZf4PwmLlsxqP3ckCLWw==",
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.54.0.tgz",
+			"integrity": "sha512-j5mskkhAD3jWrgNSdoSsexos1dxI9EQftfAZAbI2GZwFi6I20cgSrktgCewAUSZDqJ+vPwaJs0bTDhtUDMHXLg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -15836,9 +17997,9 @@
 			}
 		},
 		"node_modules/@wordpress/kebab-case": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/kebab-case/-/kebab-case-1.0.0.tgz",
-			"integrity": "sha512-Ep7dCpM9B1PiP2WZyjI5dFnJJbTZA6melU/hu5tnvYBtzOdywqSjH4mtOsBY3CtQ0uJ5fQvFAP3tHuh6Si7Bsw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/kebab-case/-/kebab-case-1.1.0.tgz",
+			"integrity": "sha512-wsm3aFXYSZL9T0dQZr6rmeDzDUGHz48NRtje18XpyJUgfhvRq5A0UC3/CgKg2UftwxGamkpJ89G/MB2CrO/ELQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"change-case": "^4.1.2"
@@ -15974,19 +18135,19 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.50.0.tgz",
-			"integrity": "sha512-BtyCkA7pk5pMMx+dVjT10OuhQwr9ZjYY1LLcXJcYJjhhFsP16be2BiytrBnKDZj/479/icvEYwlooawZCPrxYQ==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.54.0.tgz",
+			"integrity": "sha512-WeaKup+THfx62hGOOVZpeK0AvEA0d3xwWo2P44pUbUKaBFydTXWqmm7HNsZ7bX9lDdk7JshuLSwhpHfwFPOQEw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.23.0"
+				"@wordpress/i18n": "^6.27.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@types/react": "^18.3.27"
+				"@types/react": "^18 || ^19"
 			},
 			"peerDependenciesMeta": {
 				"@types/react": {
@@ -15995,9 +18156,9 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes/node_modules/@wordpress/hooks": {
-			"version": "4.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.50.0.tgz",
-			"integrity": "sha512-dV/AeP9iH1UydVWoUoCPuM8FUx2XvL1i65dhiwRHmZxK/zz8nR5Rq75WISpwFzRYfsyRThjl4LwUxhFAQnHrDw==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -16005,15 +18166,14 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.23.0.tgz",
-			"integrity": "sha512-avuywVdBpOeHm9cghFcNXCKi/VlJhbJ6KN6LydQOy/NqdRbqyRc59/XlKk1Ks+Vb+dWTGKr5gjiSzm9QJETGmA==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.50.0",
+				"@wordpress/hooks": "^4.54.0",
 				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -16057,6 +18217,593 @@
 				"react": "^18.0.0"
 			}
 		},
+		"node_modules/@wordpress/media-editor/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-editor/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
+			}
+		},
 		"node_modules/@wordpress/media-fields": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/media-fields/-/media-fields-0.9.0.tgz",
@@ -16083,6 +18830,641 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@base-ui/react": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.8.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/a11y": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/compose": {
+			"version": "7.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.46.0.tgz",
+			"integrity": "sha512-6Yv9Wb6tlA4JYU9bdWWuIWpTTzBAVA1zrYu1GY9x2/mCOckk9iLcEEfbKULxdjwwcMo3SKqvyby4f6kEUw/Wsw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/priority-queue": "^3.46.0",
+				"@wordpress/undo-manager": "^1.46.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/data": {
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
+				"deepmerge": "^4.3.1",
+				"equivalent-key-map": "^0.2.2",
+				"is-plain-object": "^5.1.0",
+				"is-promise": "^4.0.0",
+				"redux": "^5.0.1",
+				"rememo": "^4.0.2",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dataviews": {
+			"version": "14.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-14.3.0.tgz",
+			"integrity": "sha512-2fFSgyatDldjPb2gO+vLDwkbI2Jw+8zd/O0/BwLftQ5QhrrRtAqECFp+eYzcQ8Onh8OMhxq0n7tsaIHE/jWqJQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.21",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/components": "^33.1.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/data": "^10.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/ui": "^0.13.0",
+				"@wordpress/warning": "^3.46.0",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"date-fns": "^4.1.0",
+				"deepmerge": "4.3.1",
+				"fast-deep-equal": "^3.1.3",
+				"remove-accents": "^0.5.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/base-styles": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-8.0.0.tgz",
+			"integrity": "sha512-livtgwnvBm7xbpm/gaBxwtdZm3KCXq210UNsr48WA8TGfi/OfZ4oOzk4Mp4/ZHsq2baaXzhZ0iXjyR7oyaOTsw==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
+			"version": "33.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-33.1.0.tgz",
+			"integrity": "sha512-5nFqe2pk7ePIhJhz+nDNS8r1az5hIJrUycuYJzmL3KL9hYgDknAzJDHb6IUNlVcNDPgLUuxzC780YlVG5Bi0LQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@ariakit/react": "^0.4.22",
+				"@date-fns/utc": "^2.1.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "2.0.8",
+				"@types/gradient-parser": "1.1.0",
+				"@types/highlight-words-core": "1.2.1",
+				"@types/react": "^18.3.27",
+				"@use-gesture/react": "^10.3.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/base-styles": "^8.0.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/date": "^5.46.0",
+				"@wordpress/deprecated": "^4.46.0",
+				"@wordpress/dom": "^4.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/escape-html": "^3.46.0",
+				"@wordpress/hooks": "^4.46.0",
+				"@wordpress/html-entities": "^4.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/is-shallow-equal": "^5.46.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/rich-text": "^7.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/warning": "^3.46.0",
+				"change-case": "^4.1.2",
+				"clsx": "^2.1.1",
+				"colord": "^2.7.0",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.0",
+				"fast-deep-equal": "^3.1.3",
+				"framer-motion": "^11.15.0",
+				"gradient-parser": "1.1.1",
+				"highlight-words-core": "^1.2.2",
+				"is-plain-object": "^5.0.0",
+				"memize": "^2.1.0",
+				"path-to-regexp": "^6.2.1",
+				"re-resizable": "^6.4.0",
+				"react-colorful": "^5.6.1",
+				"react-day-picker": "^9.7.0",
+				"remove-accents": "^0.5.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dataviews/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/date": {
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.54.0.tgz",
+			"integrity": "sha512-i7mWdrszlvGD61u67J+Nz0B/bisw55F0y5glXUbEjJ9LMG4+5eMz45YE20LJe3xfJP2+WoxxEkwIxnLQbs7y0g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"moment": "^2.29.4",
+				"moment-timezone": "^0.5.40"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dom": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/dom-ready": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/element": {
+			"version": "6.46.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.46.0.tgz",
+			"integrity": "sha512-hjnrqZi0cZVdkmN0xQavKfSQJYAkb9pVSnDPpuX65OLxeD9/EWkIXvFzBb+nH8c4NzKKSqQU96XCTQrH37OCIA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.46.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/hooks": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/i18n": {
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@tannin/sprintf": "^1.3.2",
+				"@wordpress/hooks": "^4.54.0",
+				"gettext-parser": "^1.3.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/primitives": {
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.6.0",
+				"clsx": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/style-runtime": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.2.0.tgz",
+			"integrity": "sha512-9pLmilkgWqTvIlrnnXbW7ECfEPvCSYOve7btXgYGgMOzrGs12ijnG+kSGGg0aJhEV8OCzQ/QdVBh4s1zQZ0bLQ==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/theme": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.13.0.tgz",
+			"integrity": "sha512-4Lasso3BPej43c7e+eO+YN/fl/mcg/Q9+nclp1FmV6xdWFiUXvfwAOsEeNQQ/5s5mw5aCgseK3//qX5gydhfUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/ui": {
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.13.0.tgz",
+			"integrity": "sha512-NSP/Hh6X3qbN0B7KsWFGZfmiYp28NiVZnxu8uJSspZs9mzVP+qKC9yOgIxPYIjFuGDrXJ6QK9wL3soRXkJMG0w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@base-ui/react": "^1.4.1",
+				"@wordpress/a11y": "^4.46.0",
+				"@wordpress/compose": "^7.46.0",
+				"@wordpress/element": "^6.46.0",
+				"@wordpress/i18n": "^6.19.0",
+				"@wordpress/icons": "^13.1.0",
+				"@wordpress/keycodes": "^4.46.0",
+				"@wordpress/primitives": "^4.46.0",
+				"@wordpress/private-apis": "^1.46.0",
+				"@wordpress/style-runtime": "^0.2.0",
+				"@wordpress/theme": "^0.13.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "13.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-13.3.0.tgz",
+			"integrity": "sha512-Y/iE3aeHQ4XkX0fffiTPCUfjT8wNw1I7hDJkKqpaLmkD+C5NKWixRrDVfRnaJqU/MxY8RdyVC/nGng2MLPNH0A==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.0.0",
+				"@wordpress/primitives": "^4.48.0",
+				"change-case": "4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/@wordpress/ui/node_modules/@wordpress/icons/node_modules/@wordpress/element": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"@types/react-dom": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/media-fields/node_modules/date-fns": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/@wordpress/media-utils": {
@@ -18244,9 +21626,9 @@
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.50.0.tgz",
-			"integrity": "sha512-OyuAplepKQpNYr8z+nGGGNXWK2v2u9Bqnawkg7V5YkvOKYj/iBJNCiUxiWXOBMeLF1ze36RDR5LEcNDmXRev2Q==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.54.0.tgz",
+			"integrity": "sha512-YOJAKb80OFzHCdamyfKu9L3k+AZWexo5f1Jjm8HFs3+6CIxmkPyTe7uYccpRvmgag8MkVAdus/VaO5thzOy+gA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -18257,9 +21639,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.53.0.tgz",
-			"integrity": "sha512-xXW2yeBC0n/doFLsv6chEl3Qs5phqmRH7wcUyil+Xvh3msVGzUJxvyo0szmKpQcmoYafASpkQux82HCtNp6jxQ==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.54.0.tgz",
+			"integrity": "sha512-OOZXNT5O0D+w6pPipc0RYIfxxNQm8ahzQjIyYkVq6Qep6sq9sXut6cjgiznOApIywQNCsVOn/S34anZ4f2ONMg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -18267,12 +21649,12 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.53.0.tgz",
-			"integrity": "sha512-brrkZHfYSLUFYKrDkxJLTTRXmZbKNAS8iJnWPOWxjBf4QGeOoBPaVaiGHsMjzQZL98lHox8vHeytUW0Id2Px1g==",
+			"version": "5.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.54.0.tgz",
+			"integrity": "sha512-6J8XTpuJALWir8dYDiF4d+MDIl4X+pC2gZ2NyOOy36RGGr4yiB8xNYqZXJDpeeHBUNPENkW7Us7TWjzFlobw4g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"is-plain-object": "^5.0.0",
+				"is-plain-object": "^5.1.0",
 				"is-promise": "^4.0.0",
 				"rungen": "^0.3.2"
 			},
@@ -19052,21 +22434,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.53.0.tgz",
-			"integrity": "sha512-61+P7ht578CcfTePf8sb0/rixIyf4k8fmOn9mvwwmLL8UiIgBhpPzrRJziy8/+Xb4u3grTtl8TGtMI2YHRz41w==",
+			"version": "7.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.54.0.tgz",
+			"integrity": "sha512-zSu1Wv2FrKf4Lh18Wt5VCrDl964CDmyWpR7KAmX0xVFqRjO3HMKxV4lvK6IS6vPzH6k9KKcAnKpkQPnce6R4+w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.53.0",
-				"@wordpress/compose": "^8.6.0",
-				"@wordpress/data": "^10.53.0",
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/dom": "^4.53.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/escape-html": "^3.53.0",
-				"@wordpress/i18n": "^6.26.0",
-				"@wordpress/keycodes": "^4.53.0",
-				"@wordpress/private-apis": "^1.53.0",
+				"@wordpress/a11y": "^4.54.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/data": "^10.54.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/escape-html": "^3.54.0",
+				"@wordpress/i18n": "^6.27.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/private-apis": "^1.54.0",
 				"colord": "^2.9.3"
 			},
 			"engines": {
@@ -19084,13 +22466,13 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/a11y": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.53.0.tgz",
-			"integrity": "sha512-m6/45U8Fhr2LyQiBinHDBEF/iFnMSbSh3vdjb4GPjIjujvomktUKknjedoUWEvJFRsR6UVjIrnRIGcZAznjUhg==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.53.0",
-				"@wordpress/i18n": "^6.26.0"
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -19098,20 +22480,20 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.6.0.tgz",
-			"integrity": "sha512-aurjKO5vgnKl3p4iRM/maMEB3z36e0FdAuJOvPTHKMUjd0OUk8n2M/n2mfRS68QxVHv8mmDm1IEg8zKobwIDmA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/dom": "^4.53.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/is-shallow-equal": "^5.53.0",
-				"@wordpress/keycodes": "^4.53.0",
-				"@wordpress/priority-queue": "^3.53.0",
-				"@wordpress/private-apis": "^1.53.0",
-				"@wordpress/undo-manager": "^1.53.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -19131,21 +22513,21 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/data": {
-			"version": "10.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.53.0.tgz",
-			"integrity": "sha512-J/TnOBv1pJaeHs0Wk+11jL0kvEf05ocOm1cA24KNbOsdysUpcCh2FKEokyfZaEVJOXjWoiuYFyAtpdXVr/tt+g==",
+			"version": "10.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.54.0.tgz",
+			"integrity": "sha512-JPgGSNjAD7+8SXTvXpORSo74Pf8pz4JPGyBiGsoEbfYs0VL2FeIb/QLIMQxtpKOxc6xjODLh0LBXhFbWUqTHkA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^8.6.0",
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/is-shallow-equal": "^5.53.0",
-				"@wordpress/priority-queue": "^3.53.0",
-				"@wordpress/private-apis": "^1.53.0",
-				"@wordpress/redux-routine": "^5.53.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/redux-routine": "^5.54.0",
 				"deepmerge": "^4.3.1",
 				"equivalent-key-map": "^0.2.2",
-				"is-plain-object": "^5.0.0",
+				"is-plain-object": "^5.1.0",
 				"is-promise": "^4.0.0",
 				"redux": "^5.0.1",
 				"rememo": "^4.0.2",
@@ -19165,26 +22547,13 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/deprecated": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
-			"integrity": "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/hooks": "^4.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/dom": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.53.0.tgz",
-			"integrity": "sha512-cf+WkRxuXtPLmAWXYShsbitUIkPOjIgiScUJQztA4OSqy9vfSPvrOgb6pUqijPiIo9+fhBSoyryOFCOg7xABOQ==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.53.0"
+				"@wordpress/deprecated": "^4.54.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -19192,9 +22561,9 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/dom-ready": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.53.0.tgz",
-			"integrity": "sha512-VsTqZZ3XTHDG7K+vbleB/aV2KiRmpBLpOrcs9UplS/q0v2LLBc5aCb1UyGeXLynzlIDszYwJFpBVAQIBFRu44A==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -19202,15 +22571,15 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.5.0.tgz",
-			"integrity": "sha512-d6Ct+JETXRoGjfAxu5kSPjportHloZ3auAPLguQOLEoNBiZJp60fslYYd6LeVw7M7dUR3lArwcYVK0x0G06c9Q==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/escape-html": "^3.53.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
 				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0"
+				"is-plain-object": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -19232,9 +22601,9 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/hooks": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.53.0.tgz",
-			"integrity": "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -19242,65 +22611,18 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.26.0.tgz",
-			"integrity": "sha512-v/LzeB7T5YKIfBgmLM0jYG8zOuu81biZ90j8RY9pHIVu+jdRE+DSmt55S3FvtXRo5J2X9FoigFRzYPKXLbitWA==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.53.0",
+				"@wordpress/hooks": "^4.54.0",
 				"gettext-parser": "^1.3.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
 				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/keycodes": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
-			"integrity": "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/i18n": "^6.26.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@types/react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/priority-queue": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.53.0.tgz",
-			"integrity": "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"requestidlecallback": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/rich-text/node_modules/@wordpress/undo-manager": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.53.0.tgz",
-			"integrity": "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.53.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -20407,20 +23729,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/deprecated": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
-			"integrity": "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/hooks": "^4.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/dom": {
 			"version": "4.53.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.53.0.tgz",
@@ -20464,73 +23772,6 @@
 				"@types/react-dom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/hooks": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.53.0.tgz",
-			"integrity": "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/i18n": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.26.0.tgz",
-			"integrity": "sha512-v/LzeB7T5YKIfBgmLM0jYG8zOuu81biZ90j8RY9pHIVu+jdRE+DSmt55S3FvtXRo5J2X9FoigFRzYPKXLbitWA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.53.0",
-				"gettext-parser": "^1.3.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/keycodes": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
-			"integrity": "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/i18n": "^6.26.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@types/react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/priority-queue": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.53.0.tgz",
-			"integrity": "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"requestidlecallback": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/style-runtime": {
@@ -20588,20 +23829,6 @@
 				"vite": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/undo-manager": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.53.0.tgz",
-			"integrity": "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/stylelint-config/node_modules/colorjs.io": {
@@ -20825,23 +24052,24 @@
 			}
 		},
 		"node_modules/@wordpress/ui": {
-			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.20.0.tgz",
-			"integrity": "sha512-otLrXwHKekMy9RX3z/vlTWDwvtQlZW18niCOWcd7FtzSWZYRk4Nu7wwRLEv4oq3HyuTCbL+oOOOBPeQrN9IyeQ==",
+			"version": "0.21.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.21.0.tgz",
+			"integrity": "sha512-/FeDG6daDYGEeIl3lKxoA3Xf5cCGC97v7wzj+ExNUPg8mjmiYt3CKwWJiV0DyjJJ53riXMOc3Mizh9U08Wimvw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@base-ui/react": "^1.6.0",
+				"@base-ui/react": "^1.7.0",
 				"@daypicker/react": "^10.0.1",
-				"@wordpress/a11y": "^4.53.0",
-				"@wordpress/compose": "^8.6.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/i18n": "^6.26.0",
-				"@wordpress/icons": "^15.4.0",
-				"@wordpress/keycodes": "^4.53.0",
-				"@wordpress/primitives": "^4.53.0",
-				"@wordpress/private-apis": "^1.53.0",
-				"@wordpress/style-runtime": "^0.9.0",
-				"@wordpress/theme": "^1.2.0",
+				"@wordpress/a11y": "^4.54.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/i18n": "^6.27.0",
+				"@wordpress/icons": "^15.5.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/primitives": "^4.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/style-runtime": "^0.10.0",
+				"@wordpress/theme": "^2.0.0",
+				"@wordpress/warning": "^3.54.0",
 				"clsx": "^2.1.1",
 				"date-fns": "^4.4.0",
 				"tabbable": "^6.4.0"
@@ -20862,15 +24090,15 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@base-ui/react": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
-			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.7.0.tgz",
+			"integrity": "sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
-				"@base-ui/utils": "0.3.1",
-				"@floating-ui/react-dom": "^2.1.8",
-				"@floating-ui/utils": "^0.2.11",
+				"@base-ui/utils": "0.3.2",
+				"@floating-ui/react-dom": "^2.1.9",
+				"@floating-ui/utils": "^0.2.12",
 				"use-sync-external-store": "^1.6.0"
 			},
 			"engines": {
@@ -20899,6 +24127,28 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/ui/node_modules/@base-ui/utils": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.2.tgz",
+			"integrity": "sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.12",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/ui/node_modules/@floating-ui/react-dom": {
 			"version": "2.1.9",
 			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
@@ -20913,13 +24163,13 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/a11y": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.53.0.tgz",
-			"integrity": "sha512-m6/45U8Fhr2LyQiBinHDBEF/iFnMSbSh3vdjb4GPjIjujvomktUKknjedoUWEvJFRsR6UVjIrnRIGcZAznjUhg==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.54.0.tgz",
+			"integrity": "sha512-nRB471rKurl32bTClZkdlL/1p5pLgzF4ltMpfYY2VUTm8RYX5VtsWj4tQbytk6Ch+KA2U47SgJRUyl6etEMolQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.53.0",
-				"@wordpress/i18n": "^6.26.0"
+				"@wordpress/dom-ready": "^4.54.0",
+				"@wordpress/i18n": "^6.27.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -20927,20 +24177,20 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/compose": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.6.0.tgz",
-			"integrity": "sha512-aurjKO5vgnKl3p4iRM/maMEB3z36e0FdAuJOvPTHKMUjd0OUk8n2M/n2mfRS68QxVHv8mmDm1IEg8zKobwIDmA==",
+			"version": "8.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.7.0.tgz",
+			"integrity": "sha512-wx+J+ffWOiKhFsmCLio9dE8JGK1/xh6IIEuVqQ7KV/Hakrwt6C1Zdfyhv+6tiNzYowB9gX2aXi5ESnHtDNzd5Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/dom": "^4.53.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/is-shallow-equal": "^5.53.0",
-				"@wordpress/keycodes": "^4.53.0",
-				"@wordpress/priority-queue": "^3.53.0",
-				"@wordpress/private-apis": "^1.53.0",
-				"@wordpress/undo-manager": "^1.53.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/dom": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/is-shallow-equal": "^5.54.0",
+				"@wordpress/keycodes": "^4.54.0",
+				"@wordpress/priority-queue": "^3.54.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/undo-manager": "^1.54.0",
 				"change-case": "^4.1.2",
 				"mousetrap": "^1.6.5",
 				"use-memo-one": "^1.1.1"
@@ -20959,26 +24209,13 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/deprecated": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.53.0.tgz",
-			"integrity": "sha512-JaIWiGVoKEmsiWP4XwAZvrET44T34EtPG+xCJe9vPIs9O3DHPyB83VHV4WxVRxddaf1osTmR6iPLx0sBvVTjZw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/hooks": "^4.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/dom": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.53.0.tgz",
-			"integrity": "sha512-cf+WkRxuXtPLmAWXYShsbitUIkPOjIgiScUJQztA4OSqy9vfSPvrOgb6pUqijPiIo9+fhBSoyryOFCOg7xABOQ==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.54.0.tgz",
+			"integrity": "sha512-HcxOhNVwkFqOakvViddUsSjjkbqHyRhFqmjkPJpiLWWtuIaCzIenPhT/GJID8W8MgLhWFU87krLDXg3yJuLnzQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.53.0"
+				"@wordpress/deprecated": "^4.54.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -20986,9 +24223,9 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/dom-ready": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.53.0.tgz",
-			"integrity": "sha512-VsTqZZ3XTHDG7K+vbleB/aV2KiRmpBLpOrcs9UplS/q0v2LLBc5aCb1UyGeXLynzlIDszYwJFpBVAQIBFRu44A==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.54.0.tgz",
+			"integrity": "sha512-gEJxddZ+KZ7FkeV2EFr9f5f4gefOOtcgBP6BIIL6Wum4a1liBPphlbkBVfFTsReHIrvqsj8S3EtpHXl/RlXSgA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -20996,15 +24233,15 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/element": {
-			"version": "8.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.5.0.tgz",
-			"integrity": "sha512-d6Ct+JETXRoGjfAxu5kSPjportHloZ3auAPLguQOLEoNBiZJp60fslYYd6LeVw7M7dUR3lArwcYVK0x0G06c9Q==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.6.0.tgz",
+			"integrity": "sha512-9stRsEfNoJf7K3jmP4GEvdUPdRqUn/JCYobSsrDzREmaAKNy1OBVW5ZqgK3/s+hbKBlkX8WKU48sTgJ/9aqCzQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/escape-html": "^3.53.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/escape-html": "^3.54.0",
 				"change-case": "^4.1.2",
-				"is-plain-object": "^5.0.0"
+				"is-plain-object": "^5.1.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -21026,9 +24263,9 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/hooks": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.53.0.tgz",
-			"integrity": "sha512-YU30rweJCTu5g7X8bc+w6QyoxJBYLEHH++Wwo/IbbROHUC/4I7e+ZtxnPWls8BTtMP4d28JJ74s+UoKpzd2J7w==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.54.0.tgz",
+			"integrity": "sha512-9eMe48ixxAd+ILuXe3n+zOc1XlphfPppf0drTuJEjJy0xGXV7eUw459KEvk4KCrznb9pKemHjj4mGjogV5f1CQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -21036,13 +24273,13 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/i18n": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.26.0.tgz",
-			"integrity": "sha512-v/LzeB7T5YKIfBgmLM0jYG8zOuu81biZ90j8RY9pHIVu+jdRE+DSmt55S3FvtXRo5J2X9FoigFRzYPKXLbitWA==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.27.0.tgz",
+			"integrity": "sha512-6+mBSNGrB9EvnGa33tgNzZ7/vq98yCJ75eX81CU1XBKcoIvPcz5/G+zURpSuoOwAgAYaCxoXMDFX4gJDJjSbaw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.53.0",
+				"@wordpress/hooks": "^4.54.0",
 				"gettext-parser": "^1.3.1",
 				"tannin": "^1.2.0"
 			},
@@ -21055,13 +24292,13 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
-			"version": "15.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.4.0.tgz",
-			"integrity": "sha512-0NNoJkGZuFM4j60vdxzINXfUpMOGkoyPRqN0an6sRLoa6wHYuM4Yt4sZJet4xA6ft3z8+xNUvrAd92dF2tpFBg==",
+			"version": "15.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.5.0.tgz",
+			"integrity": "sha512-ES/PmxhDyBvx5Z+SqMXJCO1hLJ6XLs4L6FZNQLfqhFDn/xppjkFtFw6B0EnfumpdcZX/tSYDU3PfcicFilIGKQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/primitives": "^4.53.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/primitives": "^4.54.0",
 				"change-case": "^4.1.2"
 			},
 			"engines": {
@@ -21078,34 +24315,13 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/keycodes": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.53.0.tgz",
-			"integrity": "sha512-e2o0NjkyGpPUGz8sfRd1OeEHdeOk3UVlL1J8P4Y9/fgQQJumTjulbiwps6yheE5kRNqbrh2o424QLdMaODu9Kw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/i18n": "^6.26.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"@types/react": "^18 || ^19"
-			},
-			"peerDependenciesMeta": {
-				"@types/react": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/primitives": {
-			"version": "4.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.53.0.tgz",
-			"integrity": "sha512-yZdmql3vzzVhC0mcu5sKGMUXBrKGODQYZWvHsLwJMSSciFHvns/TyDloodID/naJZL243xUSN/hfKp7PIzXNRw==",
+			"version": "4.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.54.0.tgz",
+			"integrity": "sha512-N583UM1CYpzT71bW78NGgWMeyeC+LwoiTJ5yBSPXpoHEZn4G4VNsIl6nrlPLJgtRpLV6dnVGPiyne5bd8ADJvg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^8.5.0",
+				"@wordpress/element": "^8.6.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -21122,23 +24338,10 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/priority-queue": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.53.0.tgz",
-			"integrity": "sha512-HQ5AatN1QWimFHQnhhhzrfgNoiVWTqwhUEv5326hhTnyUxvh5SOYxg46IBGow+zj/VJjIPyaxv1ftuqzVxgRMQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"requestidlecallback": "^0.3.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/style-runtime": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.9.0.tgz",
-			"integrity": "sha512-K2T4OfVbqgsp07zi7C6UemlJK7fF78EPmxFYuxSjnbbB14fJcOxX+Tqi/4y24hn9ECahoGjCKHZCY2U2kts8dQ==",
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.10.0.tgz",
+			"integrity": "sha512-yZm2r8qzt++oW+4X2UEHl2FBuO/9O+BazXsQbSjGxcabA2g4apjBH2pEZqKbdbNqlArkj5KZm0LCxY1p6DKYTQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=20.10.0",
@@ -21146,16 +24349,16 @@
 			}
 		},
 		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.2.0.tgz",
-			"integrity": "sha512-pILS4ytGGiASrpJ8sLp+pRbcBspFYeMTr5LdM4fWBv/EN2CIKhBLpX3qGlXwKzS+HzjrbXZwj60Bfbg/PxvQew==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-2.0.0.tgz",
+			"integrity": "sha512-4yFei1ayJinMOVY6cTzKZV961p2Vjex9Nst1SReIFKv3ckb6ih5QN+qMpJQdpuukwabXrBTaoiA4ZB1akl2CfQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^8.6.0",
-				"@wordpress/deprecated": "^4.53.0",
-				"@wordpress/element": "^8.5.0",
-				"@wordpress/private-apis": "^1.53.0",
-				"@wordpress/style-runtime": "^0.9.0",
+				"@wordpress/compose": "^8.7.0",
+				"@wordpress/deprecated": "^4.54.0",
+				"@wordpress/element": "^8.6.0",
+				"@wordpress/private-apis": "^1.54.0",
+				"@wordpress/style-runtime": "^0.10.0",
 				"colorjs.io": "^0.7.1",
 				"memize": "^2.1.1"
 			},
@@ -21190,19 +24393,6 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/ui/node_modules/@wordpress/undo-manager": {
-			"version": "1.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.53.0.tgz",
-			"integrity": "sha512-0MtlfeCa0uFWAGubP2rAJ1NoWQOWOuzW0kTwZgqfFFg81HEgNIBb8LU3eXMbMxERjdZYpCrqUL3MbVPl7ExiGw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.53.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/ui/node_modules/colorjs.io": {
 			"version": "0.7.1",
 			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.7.1.tgz",
@@ -21224,12 +24414,12 @@
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
-			"version": "1.50.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.50.0.tgz",
-			"integrity": "sha512-599I3GPXSMpmAE2jqzHteqypI7rdt5HPDAw8GrHMkDWR1T9gK2L3gObv8I1Hs4eSDM88wgAB0Ifnqpy7zPn5rw==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.54.0.tgz",
+			"integrity": "sha512-6b10QkKqvvWl1v67CXT04V/eM9dOzSoTcu7ZenA8ZmImLjYT1fDJ5ckJnldY5HkCMO8STd6gnJMgs/ZkXYv35A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.50.0"
+				"@wordpress/is-shallow-equal": "^5.54.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -22186,9 +25376,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.53.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.53.0.tgz",
-			"integrity": "sha512-pNco8mfQM5EUJZ4m6zuHxyjnCvOKeZtxu9UGYQIRtEEMAKQJgz6HdHXKt+xQHvLA5Wi/bd0kPK5AWrl1wM22Tg==",
+			"version": "3.54.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.54.0.tgz",
+			"integrity": "sha512-0QWxBc/CHQdgzTwnUg+Ha5Ir0qyuIQUDzA2gmGSbbVshgm3d5FugLGpZHL1/S2+KlczyjKS2fftDJmK1dxdsEg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -30226,9 +33416,9 @@
 			}
 		},
 		"node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.1.0.tgz",
+			"integrity": "sha512-bUi/yjmtKYcRVUtWRGr0UA6xEFh2I6zWUwMrUXB3s7bmYCaZ8a+0ZsTRkrawh/mzlSD1Y0Ph8bp/U+TvBpWDNw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@wordpress/core-abilities": "0.10.0",
 		"@wordpress/core-data": "7.44.0",
 		"@wordpress/data": "10.44.0",
-		"@wordpress/dataviews": "14.1.0",
+		"@wordpress/dataviews": "18.1.0",
 		"@wordpress/date": "5.44.0",
 		"@wordpress/dom": "4.47.0",
 		"@wordpress/dom-ready": "4.44.0",
@@ -90,7 +90,7 @@
 		"@wordpress/notices": "5.44.0",
 		"@wordpress/plugins": "7.44.0",
 		"@wordpress/primitives": "4.45.0",
-		"@wordpress/ui": "0.20.0",
+		"@wordpress/ui": "0.21.0",
 		"@wordpress/url": "4.44.0",
 		"@wordpress/wordcount": "4.44.0",
 		"react": "18.3.1"


### PR DESCRIPTION
## What?

Updates `@wordpress/dataviews` and `@wordpress/ui` to their latest versions.

## Why?

The AI settings page is currently broken on Gutenberg `trunk`, and will be broken in the next release of Gutenberg unless fixed.

The issue stems back to https://github.com/WordPress/gutenberg/pull/81478 removing `@wordpress/dataviews` as an allowlisted package in `@wordpress/private-apis`, as the result of the work done in https://github.com/WordPress/gutenberg/issues/81230 to remove private APIs usage in DataViews. 

By removing DataViews from the allowlist, any consumer which bundles an older version of `@wordpress/dataviews` that still relies on those private APIs will fail. From the consumer point of view, the mitigation is to upgrade to the latest version.

## How?

Upgrades DataViews to the latest version.

The `package-lock.json` diff is much larger than I'd anticipate or hope, but I'm not sure it's avoidable. This is what results from `npm install` after bumping the versions in `package.json`. 

### Use of AI Tools

AI assistance: Yes
Tool(s): Cursor IDE
Model(s): Auto (likely Composer)
Used for: Research of impact based on related pull request and equivalent fixes in other projects like https://github.com/Automattic/jetpack/pull/51701, as well as actual bumping of versions. Changes were reviewed by myself.

## Testing Instructions

Test with changes alongside Gutenberg either `trunk` or [23.9.0 RC1 prerelease](https://github.com/WordPress/gutenberg/releases/tag/v23.9.0-rc.1).

To test locally, I created a `.wp-env.override.json` with the following contents to load from my sibling `gutenberg` code directory:

```json
{
	"$schema": "https://schemas.wp.org/trunk/wp-env.json",
	"plugins": [
		".",
		"../gutenberg",
		"https://downloads.wordpress.org/plugin/ai-provider-for-google.zip",
		"https://downloads.wordpress.org/plugin/ai-provider-for-openai.zip"
	]
}
```

Then run `npm run build && npm run wp-env start`.

Go to http://localhost:8888/wp-admin/options-general.php?page=ai-wp-admin

Confirm page loads as expected.

Before|After
---|---
<img width="1328" height="1068" alt="image" src="https://github.com/user-attachments/assets/f99d1aa5-5e17-41b6-a12f-c2f2d1b3f299" />|<img width="1388" height="1287" alt="image" src="https://github.com/user-attachments/assets/28f0bda2-6e4e-46e8-bd67-ecd09779d07b" />


## Changelog Entry


See include CHANGELOG.md edit.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-984-1acd99bb0daa42fcf968e3a7476d013e8826c9c8.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->