### PR TITLE
Fix: Read Guidelines from wp_knowledge storage

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -249,7 +249,7 @@ The plugin also includes the following action hooks:
 
 ### Editorial Guidelines
 
-When the `wp_guideline` post type is available, AI abilities can opt into site-wide editorial guidance for tone, copy, image, and other prompt constraints. The plugin consumes those guidelines; it does not manage the guidelines UI.
+When the `wp_knowledge` post type is available, AI abilities can opt into site-wide editorial guidance for tone, copy, image, and other prompt constraints. Each guideline lives in its own published `wp_knowledge` row (for example `guideline-site` or `guideline-copy`) with the text in the post content. The plugin consumes those guidelines; it does not manage the guidelines UI.
 
 Abilities opt in by returning the categories they support:
 

--- a/docs/experiments/title-generation.md
+++ b/docs/experiments/title-generation.md
@@ -88,7 +88,7 @@ protected function guideline_categories(): array {
 }
 ```
 
-When the `wp_guideline` CPT is registered (Gutenberg ≥ 23.0) and the corresponding `_guideline_site` / `_guideline_copy` post-meta values are set, `Abstract_Ability::get_system_instruction()` automatically prepends them to the title-generation system prompt as `<guidelines><site-context>...</site-context><copy-guidelines>...</copy-guidelines></guidelines>`. See [Editorial Guidelines](../DEVELOPER_GUIDE.md#editorial-guidelines) in the Developer Guide for the shared Guidelines surface.
+When the `wp_knowledge` post type is registered (the Gutenberg Knowledge experiment) and published `guideline-site` / `guideline-copy` rows exist, `Abstract_Ability::get_system_instruction()` automatically prepends their content to the title-generation system prompt as `<guidelines><site-context>...</site-context><copy-guidelines>...</copy-guidelines></guidelines>`. See [Editorial Guidelines](../DEVELOPER_GUIDE.md#editorial-guidelines) in the Developer Guide for the shared Guidelines surface.
 
 ## Using the Ability via REST API
 
@@ -206,7 +206,7 @@ add_filter( 'wpai_system_instruction', function ( string $instruction, string $n
 
 ### Adjusting Editorial Guidelines
 
-Because the ability declares `guideline_categories(): ['site', 'copy']`, populating the `_guideline_site` and `_guideline_copy` post-meta on the latest `wp_guideline` post is enough to reshape every title generation prompt site-wide. Use `wpai_max_guideline_length` to cap how much of each category gets injected (default 5000 characters), and `wpai_use_guidelines` (`__return_false`) to disable injection on staging.
+Because the ability declares `guideline_categories(): ['site', 'copy']`, publishing `wp_knowledge` rows with the slugs `guideline-site` and `guideline-copy` is enough to reshape every title generation prompt site-wide. Use `wpai_max_guideline_length` to cap how much of each category gets injected (default 5000 characters), and `wpai_use_guidelines` (`__return_false`) to disable injection on staging.
 
 ### Filtering Preferred Models
 
@@ -276,7 +276,7 @@ add_filter( 'wpai_get_post_details', function ( array $details, int $post_id, ar
    - Verify no toolbar / button appears (the asset enqueue is skipped)
 
 5. **Test guideline injection:**
-   - With a populated `wp_guideline` post (`_guideline_site`, `_guideline_copy`), verify generated titles reflect the configured tone
+   - With published `wp_knowledge` rows slugged `guideline-site` and `guideline-copy`, verify generated titles reflect the configured tone
    - Set `add_filter( 'wpai_use_guidelines', '__return_false' )` and re-test — guidelines should no longer affect output
 
 6. **Test REST API:**

--- a/includes/Services/Guidelines.php
+++ b/includes/Services/Guidelines.php
@@ -2,7 +2,7 @@
 /**
  * Guidelines service.
  *
- * Fetches and caches Guidelines from Gutenberg's wp_guideline CPT.
+ * Fetches and caches guidelines from the shared `wp_knowledge` post type.
  *
  * @package WordPress\AI\Services
  */
@@ -11,13 +11,19 @@ declare( strict_types=1 );
 
 namespace WordPress\AI\Services;
 
+use WP_Post;
 use WP_Query;
 
 /**
  * Guidelines service class.
  *
- * Provides a centralized interface for fetching and formatting Guidelines
- * from the wp_guideline custom post type. Requires Gutenberg 23.0+.
+ * Provides a centralized interface for fetching and formatting guidelines from
+ * the `wp_knowledge` post type. Each guideline lives in its own published row:
+ * `guideline-{scope}` for a registry scope and `guideline-block-{block_name}`
+ * for a per-block guideline, with the text in `post_content`.
+ *
+ * The post type is provided by whichever compatible plugin declared it. This
+ * service only reads, so it works regardless of which plugin owns the storage.
  *
  * @since 0.8.0
  */
@@ -30,25 +36,54 @@ class Guidelines {
 	 *
 	 * @var string
 	 */
-	public const POST_TYPE = 'wp_guideline';
+	public const POST_TYPE = 'wp_knowledge';
 
 	/**
-	 * Taxonomy slug used by Gutenberg 23.1+ to split guideline posts by purpose.
+	 * Taxonomy slug that splits knowledge rows by purpose.
 	 *
 	 * @since 1.0.1
 	 *
 	 * @var string
 	 */
-	public const TAXONOMY = 'wp_guideline_type';
+	public const TAXONOMY = 'wp_knowledge_type';
 
 	/**
-	 * Term slug for the site-wide content guideline singleton.
+	 * Term slug for guideline-typed knowledge rows.
 	 *
-	 * @since 1.0.1
+	 * @since x.x.x
 	 *
 	 * @var string
 	 */
-	public const TERM_CONTENT = 'content';
+	public const TERM_GUIDELINE = 'guideline';
+
+	/**
+	 * Slug prefix for a registry scope row.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const SCOPE_PREFIX = 'guideline-';
+
+	/**
+	 * Slug prefix for a per-block guideline row.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const BLOCK_PREFIX = 'guideline-block-';
+
+	/**
+	 * The registry scope that holds per-block guidelines.
+	 *
+	 * It has no single row of its own, so it is skipped when reading scopes.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	private const BLOCKS_SCOPE = 'blocks';
 
 	/**
 	 * Singleton instance.
@@ -60,7 +95,7 @@ class Guidelines {
 	private static ?self $instance = null;
 
 	/**
-	 * Cached guidelines data.
+	 * Cached scope guidelines, keyed by scope slug.
 	 *
 	 * @since 0.8.0
 	 *
@@ -69,31 +104,30 @@ class Guidelines {
 	private static $cached_guidelines = false;
 
 	/**
-	 * Cached guidelines post ID.
+	 * Cached per-block guidelines, keyed by block name.
 	 *
-	 * @since 0.8.0
+	 * A null value means the block has been looked up and has no guideline.
 	 *
-	 * @var int|null
+	 * @since x.x.x
+	 *
+	 * @var array<string, string|null>
 	 */
-	private static ?int $cached_post_id = null;
+	private static array $cached_block_guidelines = array();
 
 	/**
-	 * Post meta keys for each guideline category.
+	 * Scope slugs used when the guideline scope registry is unavailable.
 	 *
-	 * @since 0.8.0
+	 * @since x.x.x
 	 *
-	 * @var array<string, string>
+	 * @var array<int, string>
 	 */
 	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition.DisallowedMultiConstantDefinition
-	private const CATEGORY_META_KEYS = array(
-		'copy'       => '_guideline_copy',
-		'images'     => '_guideline_images',
-		'site'       => '_guideline_site',
-		'additional' => '_guideline_additional',
-	);
+	private const FALLBACK_SCOPES = array( 'site', 'copy', 'images', 'additional' );
 
 	/**
-	 * XML tag names for each guideline category.
+	 * XML tag names for each guideline scope.
+	 *
+	 * Scopes without an entry fall back to their own slug.
 	 *
 	 * @since 0.8.0
 	 *
@@ -108,7 +142,7 @@ class Guidelines {
 	);
 
 	/**
-	 * Default maximum character length per guideline category.
+	 * Default maximum character length per guideline scope.
 	 *
 	 * @since 0.8.0
 	 *
@@ -142,18 +176,18 @@ class Guidelines {
 	 *
 	 * @since 0.8.0
 	 *
-	 * @return bool True if the guidelines CPT is registered.
+	 * @return bool True if the knowledge post type is registered.
 	 */
 	public function is_available(): bool {
 		return post_type_exists( self::POST_TYPE );
 	}
 
 	/**
-	 * Retrieves guidelines, optionally filtered by category.
+	 * Retrieves guidelines, optionally filtered by scope.
 	 *
 	 * @since 0.8.0
 	 *
-	 * @param string|null $category Optional. Guideline category to retrieve ('site', 'copy', 'images', 'additional').
+	 * @param string|null $category Optional. Guideline scope to retrieve ('site', 'copy', 'images', 'additional').
 	 * @return array<string, string>|null Keyed array of guidelines, or null when unavailable.
 	 */
 	public function get_guidelines( ?string $category = null ): ?array {
@@ -190,21 +224,16 @@ class Guidelines {
 			return null;
 		}
 
-		$this->fetch_guidelines();
-
-		if ( null === self::$cached_post_id ) {
-			return null;
+		if ( array_key_exists( $block_name, self::$cached_block_guidelines ) ) {
+			return self::$cached_block_guidelines[ $block_name ];
 		}
 
-		$sanitized_name = str_replace( '/', '_', $block_name );
-		$meta_key       = '_guideline_block_' . $sanitized_name;
-		$value          = get_post_meta( self::$cached_post_id, $meta_key, true );
+		$rows  = $this->fetch_rows( array( self::block_slug( $block_name ) ) );
+		$value = reset( $rows );
 
-		if ( ! is_string( $value ) || '' === $value ) {
-			return null;
-		}
+		self::$cached_block_guidelines[ $block_name ] = false === $value || '' === $value ? null : $value;
 
-		return $value;
+		return self::$cached_block_guidelines[ $block_name ];
 	}
 
 	/**
@@ -212,8 +241,8 @@ class Guidelines {
 	 *
 	 * @since 0.8.0
 	 *
-	 * @param list<string> $categories  Guideline category slugs to include.
-	 * @param string|null  $block_name  Optional block name for block-specific guidelines.
+	 * @param list<string> $categories Guideline scope slugs to include.
+	 * @param string|null  $block_name Optional block name for block-specific guidelines.
 	 * @return string Formatted guidelines XML string, or empty string if nothing to include.
 	 */
 	public function format_for_prompt( array $categories, ?string $block_name = null ): string {
@@ -224,18 +253,10 @@ class Guidelines {
 		$guidelines = $this->fetch_guidelines();
 
 		if ( null === $guidelines ) {
-			return '';
+			$guidelines = array();
 		}
 
-		/**
-		 * Filters the maximum character length per guideline category.
-		 *
-		 * @since 0.8.0
-		 *
-		 * @param int $max_length The maximum character length per category. Default 2000.
-		 * @return int The filtered maximum length.
-		 */
-		$max_length = (int) apply_filters( 'wpai_max_guideline_length', self::DEFAULT_MAX_GUIDELINE_LENGTH );
+		$max_length = $this->get_max_length();
 
 		$parts = array();
 
@@ -281,8 +302,38 @@ class Guidelines {
 	 * @return void
 	 */
 	public static function reset_cache(): void {
-		self::$cached_guidelines = false;
-		self::$cached_post_id    = null;
+		self::$cached_guidelines       = false;
+		self::$cached_block_guidelines = array();
+	}
+
+	/**
+	 * Builds the row slug for a registry scope.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $scope Scope slug (e.g. 'copy').
+	 * @return string Row slug (e.g. 'guideline-copy').
+	 */
+	private static function scope_slug( string $scope ): string {
+		return self::SCOPE_PREFIX . $scope;
+	}
+
+	/**
+	 * Builds the row slug for a per-block guideline.
+	 *
+	 * The namespace separator becomes `_` rather than `-`. Block names are
+	 * `<namespace>/<name>` where both parts match `[a-z0-9-]+` and never contain
+	 * `_`, so `_` keeps the mapping unique. Using `-` would collapse distinct
+	 * names such as `foo/bar-baz` and `foo-bar/baz` onto the same slug. This
+	 * matches the client (see routes/guidelines/data.ts).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $block_name Exact block name (e.g. 'core/paragraph').
+	 * @return string Row slug (e.g. 'guideline-block-core_paragraph').
+	 */
+	private static function block_slug( string $block_name ): string {
+		return self::BLOCK_PREFIX . str_replace( '/', '_', $block_name );
 	}
 
 	/**
@@ -303,17 +354,66 @@ class Guidelines {
 		 * @since 0.8.0
 		 *
 		 * @param bool $use_guidelines Whether to use guidelines. Default true.
-		 * @return bool Whether to use guidelines.
 		 */
 		return (bool) apply_filters( 'wpai_use_guidelines', true );
 	}
 
 	/**
-	 * Fetches guidelines from the database, using cache when available.
+	 * Gets the maximum character length allowed per guideline.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return int Maximum number of characters.
+	 */
+	private function get_max_length(): int {
+		$max_length = function_exists( 'wp_guideline_max_length' )
+			? wp_guideline_max_length()
+			: self::DEFAULT_MAX_GUIDELINE_LENGTH;
+
+		/**
+		 * Filters the maximum character length per guideline scope.
+		 *
+		 * @since 0.8.0
+		 *
+		 * @param int $max_length The maximum character length per scope.
+		 */
+		return (int) apply_filters( 'wpai_max_guideline_length', $max_length );
+	}
+
+	/**
+	 * Returns the guideline scope slugs to read.
+	 *
+	 * Uses the shared scope registry when it is available so scopes added by
+	 * other plugins are picked up too. The `blocks` scope is skipped: it has no
+	 * single row of its own.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<int, string> Scope slugs.
+	 */
+	private function get_scopes(): array {
+		if ( ! function_exists( 'wp_guideline_scopes' ) ) {
+			return self::FALLBACK_SCOPES;
+		}
+
+		$scopes = array_keys( wp_guideline_scopes() );
+
+		return array_values(
+			array_filter(
+				$scopes,
+				static function ( $scope ): bool {
+					return is_string( $scope ) && self::BLOCKS_SCOPE !== $scope;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Fetches the scope guidelines from the database, using cache when available.
 	 *
 	 * @since 0.8.0
 	 *
-	 * @return array<string, string>|null Keyed array of guidelines, or null when unavailable.
+	 * @return array<string, string>|null Keyed array of guidelines, or null when there are none.
 	 */
 	private function fetch_guidelines(): ?array {
 		// Return cached result if available.
@@ -321,50 +421,22 @@ class Guidelines {
 			return self::$cached_guidelines;
 		}
 
-		// Gutenberg saves guidelines as 'draft' by default; both statuses are valid.
-		$query_args = array(
-			'post_type'      => self::POST_TYPE,
-			'posts_per_page' => 1,
-			'post_status'    => array( 'publish', 'draft' ),
-			'orderby'        => 'date',
-			'order'          => 'DESC',
-			'no_found_rows'  => true,
-		);
+		$scopes = $this->get_scopes();
 
-		// Gutenberg 23.1+ splits guidelines into types via the wp_guideline_type
-		// taxonomy. Without this filter the newest artifact guideline would shadow
-		// the content singleton in prompt assembly. On older Gutenberg the
-		// taxonomy isn't registered and we fall back to the legacy "newest wins".
-		if ( taxonomy_exists( self::TAXONOMY ) ) {
-			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				array(
-					'taxonomy' => self::TAXONOMY,
-					'field'    => 'slug',
-					'terms'    => self::TERM_CONTENT,
-				),
-			);
+		$slug_to_scope = array();
+		foreach ( $scopes as $scope ) {
+			$slug_to_scope[ self::scope_slug( $scope ) ] = $scope;
 		}
 
-		$query = new WP_Query( $query_args );
-
-		$post = $query->posts[0] ?? null;
-
-		if ( ! $post instanceof \WP_Post ) {
-			self::$cached_guidelines = null;
-			return null;
-		}
-
-		self::$cached_post_id = $post->ID;
+		$rows = $this->fetch_rows( array_keys( $slug_to_scope ) );
 
 		$guidelines = array();
-
-		foreach ( self::CATEGORY_META_KEYS as $category => $meta_key ) {
-			$value = get_post_meta( $post->ID, $meta_key, true );
-			if ( ! is_string( $value ) || '' === $value ) {
+		foreach ( $rows as $slug => $content ) {
+			if ( '' === $content || ! isset( $slug_to_scope[ $slug ] ) ) {
 				continue;
 			}
 
-			$guidelines[ $category ] = $value;
+			$guidelines[ $slug_to_scope[ $slug ] ] = $content;
 		}
 
 		if ( empty( $guidelines ) ) {
@@ -374,5 +446,46 @@ class Guidelines {
 
 		self::$cached_guidelines = $guidelines;
 		return $guidelines;
+	}
+
+	/**
+	 * Reads published knowledge rows by exact slug.
+	 *
+	 * Only published rows are read. That is what the Settings → Guidelines page
+	 * treats as canonical, and it keeps other users' private rows out of prompts.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<int, string> $slugs Exact row slugs to look up.
+	 * @return array<string, string> Row content keyed by slug. Missing rows are absent.
+	 */
+	private function fetch_rows( array $slugs ): array {
+		if ( empty( $slugs ) ) {
+			return array();
+		}
+
+		$query = new WP_Query(
+			array(
+				'post_type'              => self::POST_TYPE,
+				'post_status'            => 'publish',
+				'post_name__in'          => $slugs,
+				'posts_per_page'         => count( $slugs ),
+				'no_found_rows'          => true,
+				'ignore_sticky_posts'    => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			)
+		);
+
+		$rows = array();
+		foreach ( $query->posts as $post ) {
+			if ( ! $post instanceof WP_Post ) {
+				continue;
+			}
+
+			$rows[ $post->post_name ] = $post->post_content;
+		}
+
+		return $rows;
 	}
 }

--- a/includes/Services/Guidelines.php
+++ b/includes/Services/Guidelines.php
@@ -115,19 +115,10 @@ class Guidelines {
 	private static array $cached_block_guidelines = array();
 
 	/**
-	 * Scope slugs used when the guideline scope registry is unavailable.
-	 *
-	 * @since x.x.x
-	 *
-	 * @var array<int, string>
-	 */
-	// phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition.DisallowedMultiConstantDefinition
-	private const FALLBACK_SCOPES = array( 'site', 'copy', 'images', 'additional' );
-
-	/**
 	 * XML tag names for each guideline scope.
 	 *
-	 * Scopes without an entry fall back to their own slug.
+	 * Scopes without an entry fall back to their own slug. The keys double as
+	 * the fallback scope list when the scope registry is unavailable.
 	 *
 	 * @since 0.8.0
 	 *
@@ -224,14 +215,13 @@ class Guidelines {
 			return null;
 		}
 
-		if ( array_key_exists( $block_name, self::$cached_block_guidelines ) ) {
-			return self::$cached_block_guidelines[ $block_name ];
+		if ( ! array_key_exists( $block_name, self::$cached_block_guidelines ) ) {
+			$slug  = self::block_slug( $block_name );
+			$rows  = $this->fetch_rows( array( $slug ) );
+			$value = $rows[ $slug ] ?? '';
+
+			self::$cached_block_guidelines[ $block_name ] = '' === $value ? null : $value;
 		}
-
-		$rows  = $this->fetch_rows( array( self::block_slug( $block_name ) ) );
-		$value = reset( $rows );
-
-		self::$cached_block_guidelines[ $block_name ] = false === $value || '' === $value ? null : $value;
 
 		return self::$cached_block_guidelines[ $block_name ];
 	}
@@ -250,11 +240,8 @@ class Guidelines {
 			return '';
 		}
 
-		$guidelines = $this->fetch_guidelines();
-
-		if ( null === $guidelines ) {
-			$guidelines = array();
-		}
+		// Passing the block name fetches the block row in the same query.
+		$guidelines = $this->fetch_guidelines( $block_name ) ?? array();
 
 		$max_length = $this->get_max_length();
 
@@ -266,11 +253,7 @@ class Guidelines {
 			}
 
 			$tag_name = self::CATEGORY_TAG_NAMES[ $category ] ?? $category;
-			$content  = wp_strip_all_tags( $guidelines[ $category ] );
-
-			if ( mb_strlen( $content, 'UTF-8' ) > $max_length ) {
-				$content = mb_substr( $content, 0, $max_length, 'UTF-8' );
-			}
+			$content  = $this->prepare_content( $guidelines[ $category ], $max_length );
 
 			$parts[] = '<' . $tag_name . '>' . $content . '</' . $tag_name . '>';
 		}
@@ -279,10 +262,8 @@ class Guidelines {
 		if ( null !== $block_name ) {
 			$block_guidelines = $this->get_block_guidelines( $block_name );
 			if ( null !== $block_guidelines ) {
-				$block_content = wp_strip_all_tags( $block_guidelines );
-				if ( mb_strlen( $block_content, 'UTF-8' ) > $max_length ) {
-					$block_content = mb_substr( $block_content, 0, $max_length, 'UTF-8' );
-				}
+				$block_content = $this->prepare_content( $block_guidelines, $max_length );
+
 				$parts[] = '<block-guidelines>' . $block_content . '</block-guidelines>';
 			}
 		}
@@ -292,6 +273,27 @@ class Guidelines {
 		}
 
 		return '<guidelines>' . "\n" . implode( "\n", $parts ) . "\n" . '</guidelines>';
+	}
+
+	/**
+	 * Prepares guideline text for prompt injection.
+	 *
+	 * Strips markup and truncates to the maximum length.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $content    Raw guideline text.
+	 * @param int    $max_length Maximum number of characters to keep.
+	 * @return string Prepared text.
+	 */
+	private function prepare_content( string $content, int $max_length ): string {
+		$content = wp_strip_all_tags( $content );
+
+		if ( mb_strlen( $content, 'UTF-8' ) > $max_length ) {
+			$content = mb_substr( $content, 0, $max_length, 'UTF-8' );
+		}
+
+		return $content;
 	}
 
 	/**
@@ -314,7 +316,7 @@ class Guidelines {
 	 * @param string $scope Scope slug (e.g. 'copy').
 	 * @return string Row slug (e.g. 'guideline-copy').
 	 */
-	private static function scope_slug( string $scope ): string {
+	public static function scope_slug( string $scope ): string {
 		return self::SCOPE_PREFIX . $scope;
 	}
 
@@ -332,7 +334,7 @@ class Guidelines {
 	 * @param string $block_name Exact block name (e.g. 'core/paragraph').
 	 * @return string Row slug (e.g. 'guideline-block-core_paragraph').
 	 */
-	private static function block_slug( string $block_name ): string {
+	public static function block_slug( string $block_name ): string {
 		return self::BLOCK_PREFIX . str_replace( '/', '_', $block_name );
 	}
 
@@ -387,65 +389,85 @@ class Guidelines {
 	 * other plugins are picked up too. The `blocks` scope is skipped: it has no
 	 * single row of its own.
 	 *
+	 * The registry function is owned by whichever plugin declared it first, so
+	 * its return value is not trusted blindly. When it yields no usable slugs
+	 * (not an array, empty, or not slug-keyed), the built-in scopes are used.
+	 *
 	 * @since x.x.x
 	 *
 	 * @return array<int, string> Scope slugs.
 	 */
 	private function get_scopes(): array {
-		if ( ! function_exists( 'wp_guideline_scopes' ) ) {
-			return self::FALLBACK_SCOPES;
+		$registry = function_exists( 'wp_guideline_scopes' ) ? wp_guideline_scopes() : null;
+
+		$scopes = is_array( $registry )
+			? array_values( array_filter( array_keys( $registry ), 'is_string' ) )
+			: array();
+
+		if ( array() === $scopes ) {
+			return array_keys( self::CATEGORY_TAG_NAMES );
 		}
 
-		$scopes = array_keys( wp_guideline_scopes() );
-
-		return array_values(
-			array_filter(
-				$scopes,
-				static function ( $scope ): bool {
-					return is_string( $scope ) && self::BLOCKS_SCOPE !== $scope;
-				}
-			)
-		);
+		return array_values( array_diff( $scopes, array( self::BLOCKS_SCOPE ) ) );
 	}
 
 	/**
 	 * Fetches the scope guidelines from the database, using cache when available.
 	 *
+	 * When a block name is given, its row is fetched in the same query and the
+	 * per-block cache is primed, so a following get_block_guidelines() call for
+	 * that block costs no extra query.
+	 *
 	 * @since 0.8.0
 	 *
+	 * @param string|null $block_name Optional block name to fetch alongside the scopes.
 	 * @return array<string, string>|null Keyed array of guidelines, or null when there are none.
 	 */
-	private function fetch_guidelines(): ?array {
-		// Return cached result if available.
-		if ( false !== self::$cached_guidelines ) {
+	private function fetch_guidelines( ?string $block_name = null ): ?array {
+		$block_slug = null;
+		if ( null !== $block_name && ! array_key_exists( $block_name, self::$cached_block_guidelines ) ) {
+			$block_slug = self::block_slug( $block_name );
+		}
+
+		// Return cached result if there is nothing new to fetch.
+		if ( false !== self::$cached_guidelines && null === $block_slug ) {
 			return self::$cached_guidelines;
 		}
 
-		$scopes = $this->get_scopes();
-
 		$slug_to_scope = array();
-		foreach ( $scopes as $scope ) {
-			$slug_to_scope[ self::scope_slug( $scope ) ] = $scope;
+		if ( false === self::$cached_guidelines ) {
+			foreach ( $this->get_scopes() as $scope ) {
+				$slug_to_scope[ self::scope_slug( $scope ) ] = $scope;
+			}
 		}
 
-		$rows = $this->fetch_rows( array_keys( $slug_to_scope ) );
+		$slugs = array_keys( $slug_to_scope );
+		if ( null !== $block_slug ) {
+			$slugs[] = $block_slug;
+		}
 
-		$guidelines = array();
-		foreach ( $rows as $slug => $content ) {
-			if ( '' === $content || ! isset( $slug_to_scope[ $slug ] ) ) {
-				continue;
+		$rows = $this->fetch_rows( $slugs );
+
+		if ( null !== $block_name && null !== $block_slug ) {
+			$value = $rows[ $block_slug ] ?? '';
+
+			self::$cached_block_guidelines[ $block_name ] = '' === $value ? null : $value;
+		}
+
+		if ( false === self::$cached_guidelines ) {
+			$guidelines = array();
+			foreach ( $slug_to_scope as $slug => $scope ) {
+				if ( ! isset( $rows[ $slug ] ) || '' === $rows[ $slug ] ) {
+					continue;
+				}
+
+				$guidelines[ $scope ] = $rows[ $slug ];
 			}
 
-			$guidelines[ $slug_to_scope[ $slug ] ] = $content;
+			self::$cached_guidelines = array() === $guidelines ? null : $guidelines;
 		}
 
-		if ( empty( $guidelines ) ) {
-			self::$cached_guidelines = null;
-			return null;
-		}
-
-		self::$cached_guidelines = $guidelines;
-		return $guidelines;
+		return self::$cached_guidelines;
 	}
 
 	/**
@@ -453,6 +475,10 @@ class Guidelines {
 	 *
 	 * Only published rows are read. That is what the Settings → Guidelines page
 	 * treats as canonical, and it keeps other users' private rows out of prompts.
+	 *
+	 * When the knowledge type taxonomy is registered, only guideline-typed rows
+	 * are read. The post type is shared, so this keeps a foreign row that
+	 * happens to hold a `guideline-*` slug out of prompts.
 	 *
 	 * @since x.x.x
 	 *
@@ -464,18 +490,28 @@ class Guidelines {
 			return array();
 		}
 
-		$query = new WP_Query(
-			array(
-				'post_type'              => self::POST_TYPE,
-				'post_status'            => 'publish',
-				'post_name__in'          => $slugs,
-				'posts_per_page'         => count( $slugs ),
-				'no_found_rows'          => true,
-				'ignore_sticky_posts'    => true,
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-			)
+		$query_args = array(
+			'post_type'              => self::POST_TYPE,
+			'post_status'            => 'publish',
+			'post_name__in'          => $slugs,
+			'posts_per_page'         => count( $slugs ),
+			'no_found_rows'          => true,
+			'ignore_sticky_posts'    => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
 		);
+
+		if ( taxonomy_exists( self::TAXONOMY ) ) {
+			$query_args['tax_query'] = array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+				array(
+					'taxonomy' => self::TAXONOMY,
+					'field'    => 'slug',
+					'terms'    => self::TERM_GUIDELINE,
+				),
+			);
+		}
+
+		$query = new WP_Query( $query_args );
 
 		$rows = array();
 		foreach ( $query->posts as $post ) {

--- a/tests/Integration/Includes/Abstracts/Abstract_Ability_Guidelines_Test.php
+++ b/tests/Integration/Includes/Abstracts/Abstract_Ability_Guidelines_Test.php
@@ -299,8 +299,8 @@ class Abstract_Ability_Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_system_instruction_includes_block_guidelines(): void {
 		$this->register_guidelines_cpt();
-		$post_id = $this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
-		update_post_meta( $post_id, '_guideline_block_core_paragraph', 'Keep paragraphs concise.' );
+		$this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
 
 		$ability = new Test_Ability_With_Guidelines(
 			'ai/test-with-guidelines',
@@ -367,8 +367,8 @@ class Abstract_Ability_Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_block_name_passthrough_for_block_specific_guidelines(): void {
 		$this->register_guidelines_cpt();
-		$post_id = $this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
-		update_post_meta( $post_id, '_guideline_block_core_paragraph', 'Keep paragraphs concise.' );
+		$this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
 
 		$ability = new Test_Ability_With_Guidelines(
 			'ai/test-with-guidelines',
@@ -385,5 +385,4 @@ class Abstract_Ability_Guidelines_Test extends WP_UnitTestCase {
 			$result
 		);
 	}
-
 }

--- a/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
+++ b/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Shared helpers for tests that exercise the Guidelines CPT.
+ * Shared helpers for tests that exercise the guidelines storage.
  *
  * @package WordPress\AI\Tests\Integration\Includes\Services
  */
@@ -12,31 +12,21 @@ namespace WordPress\AI\Tests\Integration\Includes\Services;
 use WordPress\AI\Services\Guidelines;
 
 /**
- * Provides registration and factory helpers for the guidelines CPT.
+ * Provides registration and factory helpers for the `wp_knowledge` post type.
  *
- * Consumed by test classes that need to populate guidelines posts and meta
- * without duplicating boilerplate across each file.
+ * Consumed by test classes that need to populate guideline rows without
+ * duplicating boilerplate across each file.
  *
  * @since 0.8.0
  */
 trait Guidelines_CPT_Helpers {
 
 	/**
-	 * Meta key mapping for guideline categories.
+	 * Registers a minimal `wp_knowledge` post type for testing.
 	 *
-	 * @since 0.8.0
-	 *
-	 * @var array<string, string>
-	 */
-	private static array $guideline_category_meta_keys = array(
-		'copy'       => '_guideline_copy',
-		'images'     => '_guideline_images',
-		'site'       => '_guideline_site',
-		'additional' => '_guideline_additional',
-	);
-
-	/**
-	 * Registers the guidelines CPT for testing.
+	 * The real registration lives in the Knowledge experiment (or in the
+	 * Gutenberg plugin). These tests only read rows, so a bare post type with
+	 * REST turned off is enough.
 	 *
 	 * @since 0.8.0
 	 *
@@ -56,64 +46,72 @@ trait Guidelines_CPT_Helpers {
 	}
 
 	/**
-	 * Registers the wp_guideline_type taxonomy for testing.
-	 *
-	 * Mirrors Gutenberg 23.1+'s taxonomy registration so the service can
-	 * filter by the `content` term.
-	 *
-	 * @since 1.0.1
-	 *
-	 * @return void
-	 */
-	private function register_guidelines_taxonomy(): void {
-		$this->register_guidelines_cpt();
-
-		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
-			return;
-		}
-
-		register_taxonomy(
-			Guidelines::TAXONOMY,
-			Guidelines::POST_TYPE,
-			array(
-				'public'       => false,
-				'hierarchical' => true,
-			)
-		);
-	}
-
-	/**
-	 * Creates a guidelines post with the given category meta values.
+	 * Creates one guideline row per scope.
 	 *
 	 * @since 0.8.0
 	 *
-	 * @param array<string, string> $categories  Keyed array of category => guideline text.
+	 * @param array<string, string> $categories  Keyed array of scope => guideline text.
 	 * @param string                $post_status Optional. The post status. Defaults to 'publish'.
-	 * @param string|null           $type        Optional. wp_guideline_type term slug to assign. Defaults to null (no assignment).
+	 * @return array<string, int> Created post IDs keyed by scope.
+	 */
+	private function create_guidelines_post( array $categories, string $post_status = 'publish' ): array {
+		$ids = array();
+
+		foreach ( $categories as $scope => $value ) {
+			$ids[ $scope ] = $this->create_guideline_row(
+				'guideline-' . $scope,
+				$value,
+				$post_status
+			);
+		}
+
+		// Reset cache so the service picks up the new rows.
+		Guidelines::reset_cache();
+
+		return $ids;
+	}
+
+	/**
+	 * Creates a guideline row for a single block.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $block_name Block name (e.g. 'core/paragraph').
+	 * @param string $content    Guideline text.
 	 * @return int The created post ID.
 	 */
-	private function create_guidelines_post( array $categories, string $post_status = 'publish', ?string $type = null ): int {
-		$post_id = self::factory()->post->create(
+	private function create_block_guideline( string $block_name, string $content ): int {
+		$post_id = $this->create_guideline_row(
+			'guideline-block-' . str_replace( '/', '_', $block_name ),
+			$content
+		);
+
+		Guidelines::reset_cache();
+
+		return $post_id;
+	}
+
+	/**
+	 * Creates a single knowledge row with the given slug and content.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $slug        Exact row slug.
+	 * @param string $content     Row content.
+	 * @param string $post_status Optional. The post status. Defaults to 'publish'.
+	 * @return int The created post ID.
+	 */
+	private function create_guideline_row( string $slug, string $content, string $post_status = 'publish' ): int {
+		$post_id = (int) self::factory()->post->create(
 			array(
-				'post_type'   => Guidelines::POST_TYPE,
-				'post_status' => $post_status,
-				'post_title'  => 'Content Guidelines',
+				'post_type'    => Guidelines::POST_TYPE,
+				'post_status'  => $post_status,
+				'post_name'    => $slug,
+				'post_title'   => $slug,
+				'post_content' => $content,
 			)
 		);
 
-		foreach ( $categories as $category => $value ) {
-			if ( ! isset( self::$guideline_category_meta_keys[ $category ] ) ) {
-				continue;
-			}
-
-			update_post_meta( $post_id, self::$guideline_category_meta_keys[ $category ], $value );
-		}
-
-		if ( null !== $type && taxonomy_exists( Guidelines::TAXONOMY ) ) {
-			wp_set_object_terms( $post_id, $type, Guidelines::TAXONOMY );
-		}
-
-		// Reset cache so the service picks up the new post.
 		Guidelines::reset_cache();
 
 		return $post_id;

--- a/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
+++ b/tests/Integration/Includes/Services/Guidelines_CPT_Helpers.php
@@ -46,6 +46,28 @@ trait Guidelines_CPT_Helpers {
 	}
 
 	/**
+	 * Registers a minimal `wp_knowledge_type` taxonomy for testing.
+	 *
+	 * The real registration lives in the Knowledge experiment (or in the
+	 * Gutenberg plugin).
+	 *
+	 * @since x.x.x
+	 *
+	 * @return void
+	 */
+	private function register_guidelines_taxonomy(): void {
+		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
+			return;
+		}
+
+		register_taxonomy(
+			Guidelines::TAXONOMY,
+			Guidelines::POST_TYPE,
+			array( 'public' => false )
+		);
+	}
+
+	/**
 	 * Creates one guideline row per scope.
 	 *
 	 * @since 0.8.0
@@ -59,14 +81,11 @@ trait Guidelines_CPT_Helpers {
 
 		foreach ( $categories as $scope => $value ) {
 			$ids[ $scope ] = $this->create_guideline_row(
-				'guideline-' . $scope,
+				Guidelines::scope_slug( $scope ),
 				$value,
 				$post_status
 			);
 		}
-
-		// Reset cache so the service picks up the new rows.
-		Guidelines::reset_cache();
 
 		return $ids;
 	}
@@ -81,18 +100,17 @@ trait Guidelines_CPT_Helpers {
 	 * @return int The created post ID.
 	 */
 	private function create_block_guideline( string $block_name, string $content ): int {
-		$post_id = $this->create_guideline_row(
-			'guideline-block-' . str_replace( '/', '_', $block_name ),
+		return $this->create_guideline_row(
+			Guidelines::block_slug( $block_name ),
 			$content
 		);
-
-		Guidelines::reset_cache();
-
-		return $post_id;
 	}
 
 	/**
 	 * Creates a single knowledge row with the given slug and content.
+	 *
+	 * When the knowledge type taxonomy is registered, the row gets the
+	 * `guideline` term, mirroring what the canonical writer does on save.
 	 *
 	 * @since x.x.x
 	 *
@@ -111,6 +129,10 @@ trait Guidelines_CPT_Helpers {
 				'post_content' => $content,
 			)
 		);
+
+		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
+			wp_set_object_terms( $post_id, Guidelines::TERM_GUIDELINE, Guidelines::TAXONOMY );
+		}
 
 		Guidelines::reset_cache();
 

--- a/tests/Integration/Includes/Services/Guidelines_Test.php
+++ b/tests/Integration/Includes/Services/Guidelines_Test.php
@@ -376,7 +376,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_guidelines_returns_null_when_post_has_no_content(): void {
 		$this->register_guidelines_cpt();
-		$this->create_guideline_row( 'guideline-site', '' );
+		$this->create_guideline_row( Guidelines::scope_slug( 'site' ), '' );
 
 		$this->assertNull(
 			$this->service->get_guidelines(),
@@ -398,6 +398,52 @@ class Guidelines_Test extends WP_UnitTestCase {
 		$this->assertNull(
 			$this->service->get_block_guidelines( 'core/paragraph' ),
 			'Should return null when filter disables guidelines'
+		);
+	}
+
+	/**
+	 * Tests that guideline-typed rows are read when the taxonomy is registered.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_guidelines_reads_guideline_typed_rows_when_taxonomy_registered(): void {
+		$this->register_guidelines_cpt();
+		$this->register_guidelines_taxonomy();
+		$this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
+
+		$guidelines = $this->service->get_guidelines( 'site' );
+
+		$this->assertIsArray( $guidelines, 'Should read rows that carry the guideline term' );
+		$this->assertEquals( 'Professional tone.', $guidelines['site'] );
+	}
+
+	/**
+	 * Tests that rows of other knowledge types are ignored.
+	 *
+	 * The post type is shared, so a foreign row can hold a `guideline-*` slug.
+	 * Such a row must never reach a prompt.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_guidelines_ignores_rows_of_other_knowledge_types(): void {
+		$this->register_guidelines_cpt();
+		$this->register_guidelines_taxonomy();
+
+		$post_id = (int) self::factory()->post->create(
+			array(
+				'post_type'    => Guidelines::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_name'    => Guidelines::scope_slug( 'site' ),
+				'post_title'   => 'Guideline site',
+				'post_content' => 'Not a guideline.',
+			)
+		);
+		wp_set_object_terms( $post_id, 'note', Guidelines::TAXONOMY );
+		Guidelines::reset_cache();
+
+		$this->assertNull(
+			$this->service->get_guidelines(),
+			'Should ignore knowledge rows that are not guideline-typed'
 		);
 	}
 

--- a/tests/Integration/Includes/Services/Guidelines_Test.php
+++ b/tests/Integration/Includes/Services/Guidelines_Test.php
@@ -47,10 +47,6 @@ class Guidelines_Test extends WP_UnitTestCase {
 		remove_all_filters( 'wpai_use_guidelines' );
 		remove_all_filters( 'wpai_max_guideline_length' );
 
-		if ( taxonomy_exists( Guidelines::TAXONOMY ) ) {
-			unregister_taxonomy( Guidelines::TAXONOMY );
-		}
-
 		parent::tearDown();
 	}
 
@@ -67,30 +63,29 @@ class Guidelines_Test extends WP_UnitTestCase {
 
 		$this->assertFalse(
 			$this->service->is_available(),
-			'Should return false when the guidelines CPT is not registered'
+			'Should return false when the knowledge CPT is not registered'
 		);
 	}
 
 	/**
-	 * Tests that get_guidelines() returns guidelines from a draft-status post.
+	 * Tests that a draft row is ignored.
 	 *
-	 * Gutenberg's REST controller saves new guideline posts as 'draft' by default,
-	 * so the service must accept both 'publish' and 'draft' statuses.
+	 * The Settings → Guidelines page treats the published row as the canonical
+	 * one, so anything else is a placeholder the service must not read.
 	 *
-	 * @since 0.8.0
+	 * @since x.x.x
 	 */
-	public function test_get_guidelines_returns_array_for_draft_post(): void {
+	public function test_get_guidelines_ignores_draft_rows(): void {
 		$this->register_guidelines_cpt();
 		$this->create_guidelines_post(
 			array( 'site' => 'Use a professional tone.' ),
 			'draft'
 		);
 
-		$result = $this->service->get_guidelines( 'site' );
-
-		$this->assertIsArray( $result );
-		$this->assertArrayHasKey( 'site', $result );
-		$this->assertEquals( 'Use a professional tone.', $result['site'] );
+		$this->assertNull(
+			$this->service->get_guidelines( 'site' ),
+			'Should ignore rows that are not published'
+		);
 	}
 
 	/**
@@ -106,7 +101,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_guidelines() returns null when no guidelines post exists.
+	 * Tests that get_guidelines() returns null when no guideline row exists.
 	 *
 	 * @since 0.8.0
 	 */
@@ -115,12 +110,12 @@ class Guidelines_Test extends WP_UnitTestCase {
 
 		$this->assertNull(
 			$this->service->get_guidelines(),
-			'Should return null when no guidelines post exists'
+			'Should return null when no guideline row exists'
 		);
 	}
 
 	/**
-	 * Tests that get_guidelines() returns a keyed array when a post exists.
+	 * Tests that get_guidelines() returns a keyed array when rows exist.
 	 *
 	 * @since 0.8.0
 	 */
@@ -143,7 +138,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_guidelines() filters by category when a category is passed.
+	 * Tests that get_guidelines() filters by scope when a scope is passed.
 	 *
 	 * @since 0.8.0
 	 */
@@ -164,7 +159,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_guidelines() returns null for a nonexistent category.
+	 * Tests that get_guidelines() returns null for a nonexistent scope.
 	 *
 	 * @since 0.8.0
 	 */
@@ -178,7 +173,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 
 		$this->assertNull(
 			$this->service->get_guidelines( 'nonexistent' ),
-			'Should return null for a nonexistent category'
+			'Should return null for a nonexistent scope'
 		);
 	}
 
@@ -189,14 +184,28 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_block_guidelines_returns_string(): void {
 		$this->register_guidelines_cpt();
-		$post_id = $this->create_guidelines_post(
-			array( 'site' => 'Professional tone.' )
-		);
-		update_post_meta( $post_id, '_guideline_block_core_paragraph', 'Keep paragraphs concise.' );
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
 
 		$result = $this->service->get_block_guidelines( 'core/paragraph' );
 
 		$this->assertEquals( 'Keep paragraphs concise.', $result );
+	}
+
+	/**
+	 * Tests that block slugs keep namespaced block names apart.
+	 *
+	 * `foo/bar-baz` and `foo-bar/baz` would collide if the namespace separator
+	 * were encoded as `-`.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_get_block_guidelines_keeps_similar_block_names_apart(): void {
+		$this->register_guidelines_cpt();
+		$this->create_block_guideline( 'foo/bar-baz', 'First block.' );
+		$this->create_block_guideline( 'foo-bar/baz', 'Second block.' );
+
+		$this->assertSame( 'First block.', $this->service->get_block_guidelines( 'foo/bar-baz' ) );
+		$this->assertSame( 'Second block.', $this->service->get_block_guidelines( 'foo-bar/baz' ) );
 	}
 
 	/**
@@ -263,7 +272,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 
 		$result = $this->service->format_for_prompt( array( 'site' ) );
 
-		// Default max is 5000 chars per category.
+		// Default max is 5000 chars per scope.
 		$this->assertStringContainsString( '<site-context>', $result );
 		// The content between the tags should be truncated.
 		preg_match( '/<site-context>(.*?)<\/site-context>/s', $result, $matches );
@@ -278,8 +287,22 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_format_for_prompt_includes_block_guidelines(): void {
 		$this->register_guidelines_cpt();
-		$post_id = $this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
-		update_post_meta( $post_id, '_guideline_block_core_paragraph', 'Keep paragraphs concise.' );
+		$this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
+
+		$result = $this->service->format_for_prompt( array( 'site' ), 'core/paragraph' );
+
+		$this->assertStringContainsString( '<block-guidelines>Keep paragraphs concise.</block-guidelines>', $result );
+	}
+
+	/**
+	 * Tests that block guidelines alone still produce a prompt string.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_format_for_prompt_returns_block_guidelines_without_scopes(): void {
+		$this->register_guidelines_cpt();
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
 
 		$result = $this->service->format_for_prompt( array( 'site' ), 'core/paragraph' );
 
@@ -347,25 +370,17 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_guidelines() returns null when a post exists but has no guideline meta.
+	 * Tests that get_guidelines() returns null when a row exists but is empty.
 	 *
 	 * @since 0.8.0
 	 */
-	public function test_get_guidelines_returns_null_when_post_has_no_meta(): void {
+	public function test_get_guidelines_returns_null_when_post_has_no_content(): void {
 		$this->register_guidelines_cpt();
-
-		// Create a guidelines post with no meta values.
-		self::factory()->post->create(
-			array(
-				'post_type'   => Guidelines::POST_TYPE,
-				'post_status' => 'publish',
-				'post_title'  => 'Empty Guidelines',
-			)
-		);
+		$this->create_guideline_row( 'guideline-site', '' );
 
 		$this->assertNull(
 			$this->service->get_guidelines(),
-			'Should return null when post exists but has no guideline meta'
+			'Should return null when the row exists but has no content'
 		);
 	}
 
@@ -376,8 +391,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_block_guidelines_returns_null_when_disabled_by_filter(): void {
 		$this->register_guidelines_cpt();
-		$post_id = $this->create_guidelines_post( array( 'site' => 'Professional tone.' ) );
-		update_post_meta( $post_id, '_guideline_block_core_paragraph', 'Keep paragraphs concise.' );
+		$this->create_block_guideline( 'core/paragraph', 'Keep paragraphs concise.' );
 
 		add_filter( 'wpai_use_guidelines', '__return_false' );
 
@@ -388,90 +402,7 @@ class Guidelines_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get_guidelines() returns the content-typed post even when
-	 * a newer artifact-typed post exists.
-	 *
-	 * Regression test for the issue where Gutenberg 23.1's wp_guideline_type
-	 * taxonomy allows artifact guidelines to coexist with the content singleton,
-	 * and the service used to pick whichever was most recent.
-	 *
-	 * @since 1.0.1
-	 */
-	public function test_get_guidelines_prefers_content_type_over_newer_artifact(): void {
-		$this->register_guidelines_taxonomy();
-
-		$content_post_id = $this->create_guidelines_post(
-			array( 'site' => 'Content guideline.' ),
-			'publish',
-			Guidelines::TERM_CONTENT
-		);
-
-		// Bump the content post's date into the past so the artifact is strictly newer.
-		wp_update_post(
-			array(
-				'ID'            => $content_post_id,
-				'post_date'     => '2026-01-01 00:00:00',
-				'post_date_gmt' => '2026-01-01 00:00:00',
-			)
-		);
-
-		$this->create_guidelines_post(
-			array( 'site' => 'Artifact guideline.' ),
-			'publish',
-			'artifact'
-		);
-
-		Guidelines::reset_cache();
-
-		$result = $this->service->get_guidelines( 'site' );
-
-		$this->assertIsArray( $result );
-		$this->assertSame( 'Content guideline.', $result['site'] );
-	}
-
-	/**
-	 * Tests that get_guidelines() returns null when only artifact-typed
-	 * guidelines exist, since artifacts are not site-wide content guidelines.
-	 *
-	 * @since 1.0.1
-	 */
-	public function test_get_guidelines_returns_null_when_only_artifact_exists(): void {
-		$this->register_guidelines_taxonomy();
-		$this->create_guidelines_post(
-			array( 'site' => 'Artifact guideline.' ),
-			'publish',
-			'artifact'
-		);
-
-		$this->assertNull(
-			$this->service->get_guidelines(),
-			'Should ignore artifact-typed guidelines when looking up the content singleton'
-		);
-	}
-
-	/**
-	 * Tests that on older Gutenberg builds where the taxonomy is not registered,
-	 * the service still returns the most recent guideline post.
-	 *
-	 * @since 1.0.1
-	 */
-	public function test_get_guidelines_falls_back_to_latest_when_taxonomy_unavailable(): void {
-		$this->register_guidelines_cpt();
-		$this->create_guidelines_post( array( 'site' => 'Legacy guideline.' ) );
-
-		$this->assertFalse(
-			taxonomy_exists( Guidelines::TAXONOMY ),
-			'Taxonomy must not be registered for this scenario'
-		);
-
-		$result = $this->service->get_guidelines( 'site' );
-
-		$this->assertIsArray( $result );
-		$this->assertSame( 'Legacy guideline.', $result['site'] );
-	}
-
-	/**
-	 * Tests that format_for_prompt() skips empty categories.
+	 * Tests that format_for_prompt() skips empty scopes.
 	 *
 	 * @since 0.8.0
 	 */


### PR DESCRIPTION
## What?

Follow-up to #949. This extracts the Guidelines service repair requested in https://github.com/WordPress/ai/pull/949#issuecomment-5454647383 so it can be reviewed and merged independently.

The service now reads published guideline rows from the shared `wp_knowledge` post type instead of the removed `wp_guideline` post type and its post meta.

## Why?

Current Gutenberg stores each guideline scope and per-block guideline as its own `wp_knowledge` row. The AI plugin still queried the removed storage model, so prompt-building integrations quietly stopped receiving guidelines.

## How?

- Read scope rows by their canonical `guideline-{scope}` slugs.
- Read block rows by their canonical `guideline-block-{namespace}_{name}` slugs.
- Use the shared scope and maximum-length APIs when available, with standalone fallbacks.
- Cache scope and block lookups independently.
- Ignore non-published rows so private knowledge cannot enter prompts.
- Update the shared integration fixtures and all dependent tests for the current storage model.

### Use of AI Tools

AI assistance: Yes
Tool(s): OpenAI Codex
Model(s): GPT-5
Used for: Extracting the fix from #949, adapting it to remain standalone, identifying a registry key type-safety issue, and adding verification. The resulting diff and test output were reviewed.

## Testing Instructions

The original Guidelines integration was implemented in #359 for #322. These steps adapt its testing instructions to the current `wp_knowledge` storage.

### Automated testing

1. Start the test environment:

```sh
npm run wp-env:test start
```

2. Run PHP coding standards and static analysis:

```sh
composer lint
composer phpstan
```

3. Run the Guidelines-dependent integration tests:

```sh
npx wp-env --config=.wp-env.test.json run cli --env-cwd=wp-content/plugins/ai vendor/bin/phpunit -c phpunit.xml.dist --filter '/(Guidelines_Test|Abstract_Ability_Guidelines_Test|HelpersTest|Editorial_NotesTest)/'
```

4. Run the full regression suites:

```sh
npm run test:php
npm run test:e2e
```

5. Stop the test environment:

```sh
npm run wp-env:test stop
```

Validation on the latest commit:

- Targeted Guidelines-dependent suite: 154 tests, 401 assertions, and 4 existing skips.
- Full PHP suite: 1,453 tests, 4,093 assertions, and 44 existing skips.
- PHP coding standards and static analysis pass.

### Manual testing without Guidelines storage

1. With no plugin providing the `wp_knowledge` post type, open a post and run a guideline-aware AI ability such as title generation.
2. Verify the ability completes normally without PHP errors or warnings. This confirms graceful degradation when Guidelines storage is unavailable.

### Manual testing with the Gutenberg Guidelines experiment

1. Install and activate a Gutenberg build that provides the `wp_knowledge` storage, then enable **Guidelines** under Gutenberg → Experiments.
2. Open Settings → Guidelines and save distinctive Site and Copy guidelines. Optionally add a guideline for the Paragraph block.
3. Run title generation and verify the generated result reflects the Site and Copy guidance. Inspect the AI request through debug logging or the configured provider trace and confirm the system instruction contains `<guidelines>`, `<site-context>`, and `<copy-guidelines>`.
4. For the Paragraph block guideline, run a block-aware ability such as Type Ahead or Editorial Notes and confirm the system instruction also contains `<block-guidelines>`.
5. Clear a guideline, repeat the request, and verify the removed text is no longer injected.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-988-d26ca81e5c71915413bb2098b72e6616073c80e6.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->