### PR TITLE
Update DataViews usage to use `/wp` entrypoint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -97,12 +97,6 @@ export default [
 				'error',
 				{
 					selector:
-						'ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]',
-					message:
-						'Path access on WordPress dependencies is not allowed.',
-				},
-				{
-					selector:
 						'JSXAttribute[name.name="id"][value.type="Literal"]',
 					message:
 						'Do not use string literals for IDs; use withInstanceId instead.',

--- a/routes/ai-home/components/DeveloperSettings.tsx
+++ b/routes/ai-home/components/DeveloperSettings.tsx
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { Button, Spinner } from '@wordpress/components';
-import { DataForm } from '@wordpress/dataviews';
-import type { Field, Form } from '@wordpress/dataviews';
+import { DataForm } from '@wordpress/dataviews/wp';
+import type { Field, Form } from '@wordpress/dataviews/wp';
 import {
 	useCallback,
 	useEffect,

--- a/routes/ai-home/components/FeatureToggle.tsx
+++ b/routes/ai-home/components/FeatureToggle.tsx
@@ -4,7 +4,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Spinner, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import type { DataFormControlProps } from '@wordpress/dataviews';
+import type { DataFormControlProps } from '@wordpress/dataviews/wp';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -21,7 +21,11 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
-import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews/wp';
+import type {
+	DataFormControlProps,
+	Field,
+	Form,
+} from '@wordpress/dataviews/wp';
 import { DataForm } from '@wordpress/dataviews/wp';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';

--- a/routes/ai-home/stage.tsx
+++ b/routes/ai-home/stage.tsx
@@ -21,8 +21,8 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
-import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews';
-import { DataForm } from '@wordpress/dataviews';
+import type { DataFormControlProps, Field, Form } from '@wordpress/dataviews/wp';
+import { DataForm } from '@wordpress/dataviews/wp';
 import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import {

--- a/src/admin/ai-request-logs/components/LogsTable.tsx
+++ b/src/admin/ai-request-logs/components/LogsTable.tsx
@@ -9,7 +9,7 @@ import {
 	type Operator,
 	type Filter,
 	type ViewTable,
-} from '@wordpress/dataviews';
+} from '@wordpress/dataviews/wp';
 import { dateI18n, getSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { useCallback, useMemo, useState } from '@wordpress/element';

--- a/src/experiments/alt-text-generation/components/MediaEditorAltTextControl.tsx
+++ b/src/experiments/alt-text-generation/components/MediaEditorAltTextControl.tsx
@@ -11,7 +11,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { dispatch } from '@wordpress/data';
 import { store as noticesStore } from '@wordpress/notices';
-import type { DataFormControlProps } from '@wordpress/dataviews';
+import type { DataFormControlProps } from '@wordpress/dataviews/wp';
 
 /**
  * Internal dependencies

--- a/src/experiments/alt-text-generation/media-editor.tsx
+++ b/src/experiments/alt-text-generation/media-editor.tsx
@@ -8,7 +8,7 @@
 import { registerEntityField, store as editorStore } from '@wordpress/editor';
 import { subscribe, select } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import type { Field } from '@wordpress/dataviews';
+import type { Field } from '@wordpress/dataviews/wp';
 
 /**
  * Internal dependencies

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -8,7 +8,6 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * WordPress dependencies
  */
-// eslint-disable-next-line no-restricted-syntax
 import baseConfig from '@wordpress/scripts/config/playwright.config.js';
 
 const config = defineConfig( {


### PR DESCRIPTION
## What?

Updates imports of `@wordpress/dataviews` to use its `/wp` entrypoint.

Alternative to #984

## Why?

Fixes broken AI settings page when running Gutenberg 23.9.0 or newer.

This is the documented recommendation for using DataViews in plugins built using `@wordpress/scripts`:

> If you're trying to use the DataViews component in a WordPress plugin or theme and you are building your scripts using the `@wordpress/scripts` package, you need to import the components from `@wordpress/dataviews/wp` instead of `@wordpress/dataviews`.

Source: https://github.com/WordPress/gutenberg/tree/trunk/packages/dataviews

The reason this is recommended is also the reason I'm proposing this update now: Since not using the `/wp` entrypoint causes DataViews to use shared WordPress scripts (instead of bundling those dependencies), DataViews' internal references to APIs could become unreliable if it depends on newer or removed APIs. See also #984

### Use of AI Tools

See AI disclosure in #984, though in this pull request I did not use any AI for updating the imports.

## Testing Instructions

Repeat Testing Instructions from #984

## Screenshots or screencast

Before|After
---|---
<img width="1328" height="1068" alt="image" src="https://github.com/user-attachments/assets/f99d1aa5-5e17-41b6-a12f-c2f2d1b3f299" />|<img width="1388" height="1287" alt="image" src="https://github.com/user-attachments/assets/28f0bda2-6e4e-46e8-bd67-ecd09779d07b" />

## Changelog Entry

> Fixed - Settings page failing to render on Gutenberg 23.9+ after `@wordpress/dataviews` was removed from the private-apis allowlist.

cc @youknowriad @ntsekouras @oandregal

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-989-890b912d816d5f83cf61f97b865313df75b18143.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->