### PR TITLE
Add MCP Access experiment: adapter auto-install and ability exposure controls

### DIFF
--- a/includes/Experiments/Experiments.php
+++ b/includes/Experiments/Experiments.php
@@ -42,6 +42,7 @@ final class Experiments {
 		\WordPress\AI\Experiments\Editorial_Notes\Editorial_Notes::class,
 		\WordPress\AI\Experiments\Editorial_Updates\Editorial_Updates::class,
 		\WordPress\AI\Experiments\Excerpt_Generation\Excerpt_Generation::class,
+		\WordPress\AI\Experiments\MCP_Adapter\MCP_Adapter::class,
 		\WordPress\AI\Experiments\Meta_Description\Meta_Description::class,
 		\WordPress\AI\Experiments\Slug_Generation\Slug_Generation::class,
 		\WordPress\AI\Experiments\Title_Generation\Title_Generation::class,

--- a/includes/Experiments/MCP_Adapter/Admin_Page.php
+++ b/includes/Experiments/MCP_Adapter/Admin_Page.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Admin page for the MCP Access screen.
+ *
+ * @package WordPress\AI\Experiments\MCP_Adapter
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\MCP_Adapter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers and renders the MCP Access admin page.
+ *
+ * @since 0.9.0
+ */
+class Admin_Page {
+	/**
+	 * The admin page slug.
+	 *
+	 * @since 0.9.0
+	 * @var string
+	 */
+	public const PAGE_SLUG = 'ai-mcp-access';
+
+	/**
+	 * Initializes the admin page hooks.
+	 *
+	 * @since 0.9.0
+	 */
+	public function init(): void {
+		add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
+	}
+
+	/**
+	 * Adds the Tools submenu page.
+	 *
+	 * @since 0.9.0
+	 */
+	public function add_admin_menu(): void {
+		add_submenu_page(
+			'tools.php',
+			__( 'MCP Access', 'ai' ),
+			__( 'MCP Access', 'ai' ),
+			'manage_options',
+			self::PAGE_SLUG,
+			array( $this, 'render_page' )
+		);
+	}
+
+	/**
+	 * Renders the page mount point for the React app.
+	 *
+	 * @since 0.9.0
+	 */
+	public function render_page(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'ai' ) );
+		}
+
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'MCP Access', 'ai' ) . '</h1>';
+		echo '<div id="ai-mcp-access-root"></div>';
+		echo '</div>';
+	}
+}

--- a/includes/Experiments/MCP_Adapter/Exposure_Overrides.php
+++ b/includes/Experiments/MCP_Adapter/Exposure_Overrides.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Site-owner overrides for MCP ability exposure.
+ *
+ * @package WordPress\AI\Experiments\MCP_Adapter
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\MCP_Adapter;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Applies stored per-ability exposure overrides to ability registration.
+ *
+ * The MCP Adapter plugin resolves exposure from `meta.mcp.public` (falling
+ * back to `meta.public`). Overrides saved from the MCP Access screen are
+ * injected into that meta key at registration time, so the adapter's default
+ * server picks them up without the two plugins depending on each other.
+ *
+ * @since 0.9.0
+ */
+final class Exposure_Overrides {
+	/**
+	 * Option storing the per-ability exposure overrides.
+	 *
+	 * Map of ability name => bool (true: exposed, false: hidden). Abilities
+	 * not present in the map keep their registration-time default.
+	 *
+	 * @since 0.9.0
+	 * @var string
+	 */
+	public const OPTION_NAME = 'wpai_mcp_exposed_abilities';
+
+	/**
+	 * Filters ability registration args to apply a stored exposure override.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, mixed> $args Ability registration args.
+	 * @param string               $name Ability name.
+	 *
+	 * @return array<string, mixed> Filtered args.
+	 */
+	public static function filter_ability_args( array $args, string $name ): array {
+		$overrides = self::get_overrides();
+
+		if ( ! array_key_exists( $name, $overrides ) ) {
+			return $args;
+		}
+
+		if ( ! isset( $args['meta'] ) || ! is_array( $args['meta'] ) ) {
+			$args['meta'] = array();
+		}
+
+		if ( ! isset( $args['meta']['mcp'] ) || ! is_array( $args['meta']['mcp'] ) ) {
+			$args['meta']['mcp'] = array();
+		}
+
+		$args['meta']['mcp']['public'] = $overrides[ $name ];
+
+		return $args;
+	}
+
+	/**
+	 * Returns the stored exposure overrides.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return array<string, bool> Map of ability name => exposed flag.
+	 */
+	public static function get_overrides(): array {
+		$overrides = get_option( self::OPTION_NAME, array() );
+
+		if ( ! is_array( $overrides ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $overrides as $name => $exposed ) {
+			if ( ! is_string( $name ) || '' === $name ) {
+				continue;
+			}
+
+			$sanitized[ $name ] = (bool) $exposed;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Persists exposure overrides, merging into the stored map.
+	 *
+	 * A `null` value removes the override for that ability, restoring the
+	 * ability's registration-time default.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, bool|null> $changes Map of ability name => exposed flag or null.
+	 */
+	public static function save_overrides( array $changes ): void {
+		$overrides = self::get_overrides();
+
+		foreach ( $changes as $name => $exposed ) {
+			if ( null === $exposed ) {
+				unset( $overrides[ $name ] );
+				continue;
+			}
+
+			$overrides[ $name ] = (bool) $exposed;
+		}
+
+		update_option( self::OPTION_NAME, $overrides );
+	}
+}

--- a/includes/Experiments/MCP_Adapter/Exposure_Overrides.php
+++ b/includes/Experiments/MCP_Adapter/Exposure_Overrides.php
@@ -36,7 +36,26 @@ final class Exposure_Overrides {
 	public const OPTION_NAME = 'wpai_mcp_exposed_abilities';
 
 	/**
+	 * Registration-time exposure defaults, keyed by ability name.
+	 *
+	 * Captured before an override is injected, so the original default stays
+	 * recoverable for the settings screen even though the override is baked
+	 * into the registered ability's meta.
+	 *
+	 * @since 0.9.0
+	 * @var array<string, bool>
+	 */
+	private static array $registration_defaults = array();
+
+	/**
 	 * Filters ability registration args to apply a stored exposure override.
+	 *
+	 * Known limitation, mirrored from the MCP Adapter's own guidance: the
+	 * registration layer cannot guarantee the last word on exposure. Consumers
+	 * that trigger ability registration before this filter is added (early
+	 * `init` access) see unfiltered defaults for that request, and later
+	 * `wp_register_ability_args` callbacks can still change the meta. A
+	 * resolution-time filter in the adapter is the planned long-term fix.
 	 *
 	 * @since 0.9.0
 	 *
@@ -56,6 +75,8 @@ final class Exposure_Overrides {
 			$args['meta'] = array();
 		}
 
+		self::$registration_defaults[ $name ] = self::resolve_meta_exposure( $args['meta'] );
+
 		if ( ! isset( $args['meta']['mcp'] ) || ! is_array( $args['meta']['mcp'] ) ) {
 			$args['meta']['mcp'] = array();
 		}
@@ -63,6 +84,55 @@ final class Exposure_Overrides {
 		$args['meta']['mcp']['public'] = $overrides[ $name ];
 
 		return $args;
+	}
+
+	/**
+	 * Returns the stashed registration-time exposure default for an ability.
+	 *
+	 * Only available for abilities that had an override applied during
+	 * registration in the current request.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $name Ability name.
+	 *
+	 * @return bool|null The registration-time default, or null if not stashed.
+	 */
+	public static function get_registration_default( string $name ): ?bool {
+		return self::$registration_defaults[ $name ] ?? null;
+	}
+
+	/**
+	 * Resolves effective MCP exposure from ability meta.
+	 *
+	 * Delegates to the MCP Adapter's resolver when the plugin is active, so
+	 * the screen always agrees with what the server actually exposes. The
+	 * local fallback mirrors the adapter's documented resolution: an explicit
+	 * `meta.mcp.public` wins, otherwise exposure is inherited from
+	 * `meta.public`.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, mixed> $meta Ability meta.
+	 *
+	 * @return bool Whether the meta resolves to MCP exposure.
+	 */
+	public static function resolve_meta_exposure( array $meta ): bool {
+		if ( class_exists( '\WP\MCP\Abilities\McpAbilityExposure' ) ) {
+			return \WP\MCP\Abilities\McpAbilityExposure::is_meta_public( $meta );
+		}
+
+		$mcp_meta = $meta['mcp'] ?? array();
+
+		if ( ! is_array( $mcp_meta ) ) {
+			return false;
+		}
+
+		if ( isset( $mcp_meta['public'] ) ) {
+			return (bool) $mcp_meta['public'];
+		}
+
+		return true === ( $meta['public'] ?? false );
 	}
 
 	/**

--- a/includes/Experiments/MCP_Adapter/MCP_Adapter.php
+++ b/includes/Experiments/MCP_Adapter/MCP_Adapter.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * MCP Adapter Experiment
+ *
+ * Surfaces MCP support in the AI plugin: a toggle that wires the site up to
+ * the MCP Adapter companion plugin, and an admin screen for controlling which
+ * abilities are exposed through MCP.
+ *
+ * @package WordPress\AI\Experiments\MCP_Adapter
+ * @since 0.9.0
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\MCP_Adapter;
+
+use WordPress\AI\Abstracts\Abstract_Feature;
+use WordPress\AI\Asset_Loader;
+use WordPress\AI\Experiments\Experiment_Category;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * MCP Adapter Experiment Class.
+ *
+ * @since 0.9.0
+ */
+class MCP_Adapter extends Abstract_Feature {
+	/**
+	 * {@inheritDoc}
+	 */
+	public static function get_id(): string {
+		return 'mcp-adapter';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function load_metadata(): array {
+		return array(
+			'label'       => __( 'MCP Access', 'ai' ),
+			'description' => __( 'Expose WordPress abilities to AI agents over the Model Context Protocol via the MCP Adapter plugin, with a screen to control exactly what gets exposed.', 'ai' ),
+			'category'    => Experiment_Category::ADMIN,
+			'capability'  => 'none',
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function register(): void {
+		add_filter( 'wp_register_ability_args', array( Exposure_Overrides::class, 'filter_ability_args' ), 100, 2 );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+
+		$admin_page = new Admin_Page();
+		$admin_page->init();
+	}
+
+	/**
+	 * Registers the settings REST routes.
+	 *
+	 * @since 0.9.0
+	 */
+	public function register_rest_routes(): void {
+		( new Settings_Controller() )->register_routes();
+	}
+
+	/**
+	 * Enqueues the MCP Access screen assets.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
+	 */
+	public function enqueue_assets( string $hook_suffix ): void {
+		if ( 'tools_page_' . Admin_Page::PAGE_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		Asset_Loader::enqueue_script( 'mcp_adapter', 'experiments/mcp-adapter' );
+		Asset_Loader::enqueue_style( 'mcp_adapter', 'experiments/mcp-adapter' );
+	}
+}

--- a/includes/Experiments/MCP_Adapter/MCP_Adapter.php
+++ b/includes/Experiments/MCP_Adapter/MCP_Adapter.php
@@ -2,9 +2,12 @@
 /**
  * MCP Adapter Experiment
  *
- * Surfaces MCP support in the AI plugin: a toggle that wires the site up to
- * the MCP Adapter companion plugin, and an admin screen for controlling which
- * abilities are exposed through MCP.
+ * Adds an MCP Access screen for controlling which abilities are exposed
+ * through the MCP Adapter companion plugin's server. The adapter itself runs
+ * independently: this experiment does not install, activate, or start it,
+ * and the exposure overrides saved here are only enforced while the
+ * experiment is enabled — disabling it returns abilities to the defaults the
+ * adapter would serve on its own.
  *
  * @package WordPress\AI\Experiments\MCP_Adapter
  * @since 0.9.0
@@ -41,7 +44,7 @@ class MCP_Adapter extends Abstract_Feature {
 	protected function load_metadata(): array {
 		return array(
 			'label'       => __( 'MCP Access', 'ai' ),
-			'description' => __( 'Expose WordPress abilities to AI agents over the Model Context Protocol via the MCP Adapter plugin, with a screen to control exactly what gets exposed.', 'ai' ),
+			'description' => __( 'Control which WordPress abilities the MCP Adapter plugin exposes to AI agents. Requires the MCP Adapter plugin; exposure choices apply only while this experiment is enabled.', 'ai' ),
 			'category'    => Experiment_Category::ADMIN,
 			'capability'  => 'none',
 		);

--- a/includes/Experiments/MCP_Adapter/MCP_Adapter.php
+++ b/includes/Experiments/MCP_Adapter/MCP_Adapter.php
@@ -3,11 +3,12 @@
  * MCP Adapter Experiment
  *
  * Adds an MCP Access screen for controlling which abilities are exposed
- * through the MCP Adapter companion plugin's server. The adapter itself runs
- * independently: this experiment does not install, activate, or start it,
- * and the exposure overrides saved here are only enforced while the
- * experiment is enabled — disabling it returns abilities to the defaults the
- * adapter would serve on its own.
+ * through the MCP Adapter companion plugin's server. While the experiment is
+ * enabled it installs and activates the companion plugin from WordPress.org
+ * if it is not already active (see Plugin_Installer). Disabling the
+ * experiment does not deactivate the adapter, and the exposure overrides
+ * saved here are only enforced while the experiment is enabled — disabling
+ * it returns abilities to the defaults the adapter serves on its own.
  *
  * @package WordPress\AI\Experiments\MCP_Adapter
  * @since 0.9.0
@@ -44,7 +45,7 @@ class MCP_Adapter extends Abstract_Feature {
 	protected function load_metadata(): array {
 		return array(
 			'label'       => __( 'MCP Access', 'ai' ),
-			'description' => __( 'Control which WordPress abilities the MCP Adapter plugin exposes to AI agents. Requires the MCP Adapter plugin; exposure choices apply only while this experiment is enabled.', 'ai' ),
+			'description' => __( 'Control which WordPress abilities are exposed to AI agents over the Model Context Protocol. Enabling this experiment installs and activates the MCP Adapter plugin from WordPress.org if it is not already active; exposure choices apply only while the experiment is enabled.', 'ai' ),
 			'category'    => Experiment_Category::ADMIN,
 			'capability'  => 'none',
 		);
@@ -60,6 +61,9 @@ class MCP_Adapter extends Abstract_Feature {
 
 		$admin_page = new Admin_Page();
 		$admin_page->init();
+
+		$installer = new Plugin_Installer();
+		$installer->init();
 	}
 
 	/**

--- a/includes/Experiments/MCP_Adapter/Plugin_Installer.php
+++ b/includes/Experiments/MCP_Adapter/Plugin_Installer.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Auto-installer for the MCP Adapter companion plugin.
+ *
+ * @package WordPress\AI\Experiments\MCP_Adapter
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\MCP_Adapter;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Installs and activates the MCP Adapter plugin while the experiment is enabled.
+ *
+ * Enabling the MCP Access experiment is meant to wire the site up to the
+ * companion plugin without a separate install chore. Because the experiment
+ * framework only runs enabled experiments, the attempt happens on the first
+ * admin page load after enabling (rather than on the option change itself,
+ * which fires in a request where this code is not yet hooked).
+ *
+ * A failed attempt is locked for an hour so admin pages are not slowed down
+ * by repeated download attempts; the MCP Access screen's manual button
+ * remains available as the immediate retry path.
+ *
+ * @since 0.9.0
+ */
+class Plugin_Installer {
+	/**
+	 * Transient locking further automatic attempts after a failure.
+	 *
+	 * @since 0.9.0
+	 * @var string
+	 */
+	public const LOCK_TRANSIENT = 'wpai_mcp_adapter_autoinstall_lock';
+
+	/**
+	 * Hooks the automatic install attempt into admin page loads.
+	 *
+	 * @since 0.9.0
+	 */
+	public function init(): void {
+		add_action( 'admin_init', array( $this, 'maybe_install_and_activate' ) );
+	}
+
+	/**
+	 * Installs and activates the companion plugin when needed and allowed.
+	 *
+	 * Silently does nothing when the plugin is already active, the current
+	 * user lacks the required capabilities, or a recent attempt failed.
+	 *
+	 * @since 0.9.0
+	 */
+	public function maybe_install_and_activate(): void {
+		$state = self::get_state();
+
+		if ( 'active' === $state['status'] ) {
+			return;
+		}
+
+		$capable = 'missing' === $state['status']
+			? $state['can_install'] && $state['can_activate']
+			: $state['can_activate'];
+
+		if ( ! $capable ) {
+			return;
+		}
+
+		if ( false !== get_transient( self::LOCK_TRANSIENT ) ) {
+			return;
+		}
+
+		$result = $this->install_and_activate( $state );
+
+		if ( ! is_wp_error( $result ) ) {
+			return;
+		}
+
+		set_transient( self::LOCK_TRANSIENT, $result->get_error_message(), HOUR_IN_SECONDS );
+	}
+
+	/**
+	 * Performs the actual install and/or activation.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, mixed> $state The plugin state, see {@see self::get_state()}.
+	 *
+	 * @return true|\WP_Error True on success, WP_Error on failure.
+	 */
+	protected function install_and_activate( array $state ) {
+		/**
+		 * Short-circuits the automatic install of the MCP Adapter plugin.
+		 *
+		 * Return true to report success or a WP_Error to report failure
+		 * without touching the filesystem. Used in tests and available to
+		 * hosts that manage plugins externally.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param true|\WP_Error|null  $pre   The short-circuit result. Default null (proceed).
+		 * @param array<string, mixed> $state The plugin state.
+		 */
+		$pre = apply_filters( 'wpai_pre_mcp_adapter_autoinstall', null, $state );
+		if ( null !== $pre ) {
+			return $pre;
+		}
+
+		$file = $state['file'];
+
+		if ( 'missing' === $state['status'] ) {
+			$file = $this->download_and_install( $state['slug'] );
+
+			if ( is_wp_error( $file ) ) {
+				return $file;
+			}
+		}
+
+		if ( ! is_string( $file ) || '' === $file ) {
+			return new WP_Error( 'wpai_mcp_install_failed', __( 'The plugin file could not be determined after installation.', 'ai' ) );
+		}
+
+		$activated = activate_plugin( $file );
+
+		return is_wp_error( $activated ) ? $activated : true;
+	}
+
+	/**
+	 * Downloads and installs the plugin from WordPress.org.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param string $slug The plugin slug.
+	 *
+	 * @return string|\WP_Error The installed plugin file, or WP_Error on failure.
+	 */
+	private function download_and_install( string $slug ) {
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+
+		$api = plugins_api(
+			'plugin_information',
+			array(
+				'slug'   => $slug,
+				'fields' => array( 'sections' => false ),
+			)
+		);
+
+		if ( is_wp_error( $api ) ) {
+			return $api;
+		}
+
+		$upgrader  = new \Plugin_Upgrader( new \Automatic_Upgrader_Skin() );
+		$installed = $upgrader->install( $api->download_link );
+
+		if ( is_wp_error( $installed ) ) {
+			return $installed;
+		}
+
+		if ( true !== $installed ) {
+			return new WP_Error( 'wpai_mcp_install_failed', __( 'The plugin could not be installed.', 'ai' ) );
+		}
+
+		$file = $upgrader->plugin_info();
+
+		if ( ! is_string( $file ) || '' === $file ) {
+			return new WP_Error( 'wpai_mcp_install_failed', __( 'The plugin file could not be determined after installation.', 'ai' ) );
+		}
+
+		return $file;
+	}
+
+	/**
+	 * Describes the companion plugin's install state for the current site.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return array{slug: string, status: string, file: string|null, can_install: bool, can_activate: bool} The plugin state.
+	 */
+	public static function get_state(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		/**
+		 * Filters the WordPress.org slug of the MCP Adapter companion plugin.
+		 *
+		 * Useful for testing the install flow against a stand-in plugin while
+		 * the adapter is not yet published on WordPress.org.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param string $slug The plugin slug.
+		 */
+		$slug = apply_filters( 'wpai_mcp_adapter_plugin_slug', 'mcp-adapter' );
+
+		$file   = null;
+		$status = 'missing';
+		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
+			if ( 0 !== strpos( $plugin_file, $slug . '/' ) ) {
+				continue;
+			}
+
+			$file   = $plugin_file;
+			$status = is_plugin_active( $plugin_file ) ? 'active' : 'installed';
+			break;
+		}
+
+		$last_error = get_transient( self::LOCK_TRANSIENT );
+
+		return array(
+			'slug'              => $slug,
+			'status'            => $status,
+			'file'              => $file,
+			// DISALLOW_FILE_MODS already strips install_plugins via map_meta_cap.
+			'can_install'       => current_user_can( 'install_plugins' ),
+			'can_activate'      => current_user_can( 'activate_plugins' ),
+			'autoinstall_error' => is_string( $last_error ) ? $last_error : null,
+		);
+	}
+}

--- a/includes/Experiments/MCP_Adapter/Plugin_Installer.php
+++ b/includes/Experiments/MCP_Adapter/Plugin_Installer.php
@@ -155,8 +155,14 @@ class Plugin_Installer {
 			return $api;
 		}
 
+		$download_link = is_object( $api ) ? ( $api->download_link ?? '' ) : ( $api['download_link'] ?? '' );
+
+		if ( ! is_string( $download_link ) || '' === $download_link ) {
+			return new WP_Error( 'wpai_mcp_install_failed', __( 'The plugin download link could not be determined.', 'ai' ) );
+		}
+
 		$upgrader  = new \Plugin_Upgrader( new \Automatic_Upgrader_Skin() );
-		$installed = $upgrader->install( $api->download_link );
+		$installed = $upgrader->install( $download_link );
 
 		if ( is_wp_error( $installed ) ) {
 			return $installed;
@@ -180,7 +186,7 @@ class Plugin_Installer {
 	 *
 	 * @since 0.9.0
 	 *
-	 * @return array{slug: string, status: string, file: string|null, can_install: bool, can_activate: bool} The plugin state.
+	 * @return array{slug: string, status: 'active'|'installed'|'missing', file: string|null, can_install: bool, can_activate: bool, autoinstall_error: string|null} The plugin state.
 	 */
 	public static function get_state(): array {
 		if ( ! function_exists( 'get_plugins' ) ) {
@@ -206,8 +212,8 @@ class Plugin_Installer {
 				continue;
 			}
 
-			$file   = $plugin_file;
-			$status = is_plugin_active( $plugin_file ) ? 'active' : 'installed';
+			$file   = (string) $plugin_file;
+			$status = is_plugin_active( $file ) ? 'active' : 'installed';
 			break;
 		}
 

--- a/includes/Experiments/MCP_Adapter/Settings_Controller.php
+++ b/includes/Experiments/MCP_Adapter/Settings_Controller.php
@@ -195,57 +195,7 @@ class Settings_Controller {
 			'abilities'      => $abilities,
 			'overrides'      => empty( $overrides ) ? (object) array() : $overrides,
 			'endpoint'       => $adapter_active ? $this->get_endpoint_url() : null,
-			'plugin'         => $this->get_plugin_state(),
-		);
-	}
-
-	/**
-	 * Describes the companion plugin's install state for the current site.
-	 *
-	 * The install/activate buttons on the MCP Access screen drive WordPress
-	 * core's `wp/v2/plugins` endpoint; this block tells the UI which action
-	 * applies and whether the current user is allowed to take it.
-	 *
-	 * @since 0.9.0
-	 *
-	 * @return array<string, mixed> The plugin state.
-	 */
-	private function get_plugin_state(): array {
-		if ( ! function_exists( 'get_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		}
-
-		/**
-		 * Filters the WordPress.org slug of the MCP Adapter companion plugin.
-		 *
-		 * Useful for testing the install flow against a stand-in plugin while
-		 * the adapter is not yet published on WordPress.org.
-		 *
-		 * @since 0.9.0
-		 *
-		 * @param string $slug The plugin slug.
-		 */
-		$slug = apply_filters( 'wpai_mcp_adapter_plugin_slug', 'mcp-adapter' );
-
-		$file   = null;
-		$status = 'missing';
-		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
-			if ( 0 !== strpos( $plugin_file, $slug . '/' ) ) {
-				continue;
-			}
-
-			$file   = $plugin_file;
-			$status = is_plugin_active( $plugin_file ) ? 'active' : 'installed';
-			break;
-		}
-
-		return array(
-			'slug'         => $slug,
-			'status'       => $status,
-			'file'         => $file,
-			// DISALLOW_FILE_MODS already strips install_plugins via map_meta_cap.
-			'can_install'  => current_user_can( 'install_plugins' ),
-			'can_activate' => current_user_can( 'activate_plugins' ),
+			'plugin'         => Plugin_Installer::get_state(),
 		);
 	}
 

--- a/includes/Experiments/MCP_Adapter/Settings_Controller.php
+++ b/includes/Experiments/MCP_Adapter/Settings_Controller.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * REST controller for the MCP Access settings.
+ *
+ * @package WordPress\AI\Experiments\MCP_Adapter
+ */
+
+declare( strict_types=1 );
+
+namespace WordPress\AI\Experiments\MCP_Adapter;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Exposes the MCP Access settings over the REST API.
+ *
+ * @since 0.9.0
+ */
+class Settings_Controller {
+	/**
+	 * Pattern a valid ability name must match.
+	 *
+	 * @since 0.9.0
+	 * @var string
+	 */
+	private const ABILITY_NAME_PATTERN = '#^[a-z0-9-]+/[a-z0-9-]+$#';
+
+	/**
+	 * Registers the settings routes.
+	 *
+	 * @since 0.9.0
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			'ai/v1',
+			'/mcp/settings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_settings' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'update_settings' ),
+					'permission_callback' => array( $this, 'permission_callback' ),
+					'args'                => array(
+						'overrides' => array(
+							'required'          => true,
+							'type'              => 'object',
+							'validate_callback' => array( $this, 'validate_overrides' ),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Checks that the current user can manage the site.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return bool Whether the request is allowed.
+	 */
+	public function permission_callback(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Validates the overrides parameter.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param mixed $overrides The raw parameter value.
+	 *
+	 * @return bool Whether the value is a valid overrides map.
+	 */
+	public function validate_overrides( $overrides ): bool {
+		if ( ! is_array( $overrides ) ) {
+			return false;
+		}
+
+		foreach ( $overrides as $name => $exposed ) {
+			if ( ! is_string( $name ) || 1 !== preg_match( self::ABILITY_NAME_PATTERN, $name ) ) {
+				return false;
+			}
+
+			if ( null !== $exposed && ! is_bool( $exposed ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the MCP Access settings payload.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return \WP_REST_Response The settings response.
+	 */
+	public function get_settings(): WP_REST_Response {
+		return new WP_REST_Response( $this->build_payload() );
+	}
+
+	/**
+	 * Persists exposure overrides and returns the updated settings payload.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param \WP_REST_Request $request The request.
+	 *
+	 * @return \WP_REST_Response The updated settings response.
+	 */
+	public function update_settings( WP_REST_Request $request ): WP_REST_Response {
+		/** @var array<string, bool|null> $changes */
+		$changes = $request->get_param( 'overrides' );
+
+		Exposure_Overrides::save_overrides( $changes );
+
+		return new WP_REST_Response( $this->build_payload() );
+	}
+
+	/**
+	 * Builds the settings payload.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return array<string, mixed> The settings payload.
+	 */
+	private function build_payload(): array {
+		$adapter_active = class_exists( '\WP\MCP\Core\McpAdapter' );
+		$overrides      = Exposure_Overrides::get_overrides();
+
+		$abilities = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			$abilities[] = array(
+				'name'        => $ability->get_name(),
+				'label'       => $ability->get_label(),
+				'description' => $ability->get_description(),
+				'exposed'     => $this->is_exposed( $ability->get_meta() ),
+			);
+		}
+
+		return array(
+			'adapter_active' => $adapter_active,
+			'abilities'      => $abilities,
+			'overrides'      => empty( $overrides ) ? (object) array() : $overrides,
+			'endpoint'       => $adapter_active ? rest_url( 'mcp/mcp-adapter-default-server' ) : null,
+		);
+	}
+
+	/**
+	 * Resolves effective MCP exposure from ability meta.
+	 *
+	 * Mirrors the MCP Adapter's resolution: an explicit `meta.mcp.public`
+	 * wins, otherwise exposure is inherited from `meta.public`.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, mixed> $meta Ability meta.
+	 *
+	 * @return bool Whether the ability is exposed through MCP.
+	 */
+	private function is_exposed( array $meta ): bool {
+		$mcp_meta = $meta['mcp'] ?? array();
+
+		if ( ! is_array( $mcp_meta ) ) {
+			return false;
+		}
+
+		if ( isset( $mcp_meta['public'] ) ) {
+			return (bool) $mcp_meta['public'];
+		}
+
+		return true === ( $meta['public'] ?? false );
+	}
+}

--- a/includes/Experiments/MCP_Adapter/Settings_Controller.php
+++ b/includes/Experiments/MCP_Adapter/Settings_Controller.php
@@ -24,6 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Settings_Controller {
 	/**
+	 * The REST API namespace.
+	 *
+	 * @since 0.9.0
+	 * @var string
+	 */
+	public const REST_NAMESPACE = 'ai/v1';
+
+	/**
 	 * Pattern a valid ability name must match.
 	 *
 	 * @since 0.9.0
@@ -38,7 +46,7 @@ class Settings_Controller {
 	 */
 	public function register_routes(): void {
 		register_rest_route(
-			'ai/v1',
+			self::REST_NAMESPACE,
 			'/mcp/settings',
 			array(
 				array(
@@ -55,6 +63,7 @@ class Settings_Controller {
 							'required'          => true,
 							'type'              => 'object',
 							'validate_callback' => array( $this, 'validate_overrides' ),
+							'sanitize_callback' => array( $this, 'sanitize_overrides' ),
 						),
 					),
 				),
@@ -76,6 +85,10 @@ class Settings_Controller {
 	/**
 	 * Validates the overrides parameter.
 	 *
+	 * Runs before sanitization, so boolean-like strings from form-encoded
+	 * requests ("true", "1", …) must be accepted here and coerced in
+	 * {@see self::sanitize_overrides()}.
+	 *
 	 * @since 0.9.0
 	 *
 	 * @param mixed $overrides The raw parameter value.
@@ -92,12 +105,31 @@ class Settings_Controller {
 				return false;
 			}
 
-			if ( null !== $exposed && ! is_bool( $exposed ) ) {
+			if ( null !== $exposed && ! is_bool( $exposed ) && ! rest_is_boolean( $exposed ) ) {
 				return false;
 			}
 		}
 
 		return true;
+	}
+
+	/**
+	 * Sanitizes the overrides parameter, coercing boolean-like values.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @param array<string, mixed> $overrides The validated overrides map.
+	 *
+	 * @return array<string, bool|null> The sanitized overrides map.
+	 */
+	public function sanitize_overrides( array $overrides ): array {
+		$sanitized = array();
+
+		foreach ( $overrides as $name => $exposed ) {
+			$sanitized[ $name ] = null === $exposed ? null : rest_sanitize_boolean( $exposed );
+		}
+
+		return $sanitized;
 	}
 
 	/**
@@ -142,11 +174,19 @@ class Settings_Controller {
 
 		$abilities = array();
 		foreach ( wp_get_abilities() as $ability ) {
+			$name    = $ability->get_name();
+			$default = Exposure_Overrides::get_registration_default( $name );
+
+			if ( null === $default ) {
+				$default = Exposure_Overrides::resolve_meta_exposure( $ability->get_meta() );
+			}
+
 			$abilities[] = array(
-				'name'        => $ability->get_name(),
+				'name'        => $name,
 				'label'       => $ability->get_label(),
 				'description' => $ability->get_description(),
-				'exposed'     => $this->is_exposed( $ability->get_meta() ),
+				'exposed'     => array_key_exists( $name, $overrides ) ? $overrides[ $name ] : $default,
+				'default'     => $default,
 			);
 		}
 
@@ -154,33 +194,34 @@ class Settings_Controller {
 			'adapter_active' => $adapter_active,
 			'abilities'      => $abilities,
 			'overrides'      => empty( $overrides ) ? (object) array() : $overrides,
-			'endpoint'       => $adapter_active ? rest_url( 'mcp/mcp-adapter-default-server' ) : null,
+			'endpoint'       => $adapter_active ? $this->get_endpoint_url() : null,
 		);
 	}
 
 	/**
-	 * Resolves effective MCP exposure from ability meta.
+	 * Resolves the MCP server endpoint URL from the adapter's registered servers.
 	 *
-	 * Mirrors the MCP Adapter's resolution: an explicit `meta.mcp.public`
-	 * wins, otherwise exposure is inherited from `meta.public`.
+	 * Prefers the adapter's default server, falls back to the first registered
+	 * server, and returns null when no server is registered (for example when
+	 * default-server creation is disabled via filter).
 	 *
 	 * @since 0.9.0
 	 *
-	 * @param array<string, mixed> $meta Ability meta.
-	 *
-	 * @return bool Whether the ability is exposed through MCP.
+	 * @return string|null The endpoint URL, or null when no server is registered.
 	 */
-	private function is_exposed( array $meta ): bool {
-		$mcp_meta = $meta['mcp'] ?? array();
+	private function get_endpoint_url(): ?string {
+		$adapter = \WP\MCP\Core\McpAdapter::instance();
+		$server  = $adapter->get_server( 'mcp-adapter-default-server' );
 
-		if ( ! is_array( $mcp_meta ) ) {
-			return false;
+		if ( null === $server ) {
+			$servers = $adapter->get_servers();
+			$server  = empty( $servers ) ? null : reset( $servers );
 		}
 
-		if ( isset( $mcp_meta['public'] ) ) {
-			return (bool) $mcp_meta['public'];
+		if ( null === $server ) {
+			return null;
 		}
 
-		return true === ( $meta['public'] ?? false );
+		return rest_url( $server->get_server_route_namespace() . '/' . $server->get_server_route() );
 	}
 }

--- a/includes/Experiments/MCP_Adapter/Settings_Controller.php
+++ b/includes/Experiments/MCP_Adapter/Settings_Controller.php
@@ -195,6 +195,57 @@ class Settings_Controller {
 			'abilities'      => $abilities,
 			'overrides'      => empty( $overrides ) ? (object) array() : $overrides,
 			'endpoint'       => $adapter_active ? $this->get_endpoint_url() : null,
+			'plugin'         => $this->get_plugin_state(),
+		);
+	}
+
+	/**
+	 * Describes the companion plugin's install state for the current site.
+	 *
+	 * The install/activate buttons on the MCP Access screen drive WordPress
+	 * core's `wp/v2/plugins` endpoint; this block tells the UI which action
+	 * applies and whether the current user is allowed to take it.
+	 *
+	 * @since 0.9.0
+	 *
+	 * @return array<string, mixed> The plugin state.
+	 */
+	private function get_plugin_state(): array {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		/**
+		 * Filters the WordPress.org slug of the MCP Adapter companion plugin.
+		 *
+		 * Useful for testing the install flow against a stand-in plugin while
+		 * the adapter is not yet published on WordPress.org.
+		 *
+		 * @since 0.9.0
+		 *
+		 * @param string $slug The plugin slug.
+		 */
+		$slug = apply_filters( 'wpai_mcp_adapter_plugin_slug', 'mcp-adapter' );
+
+		$file   = null;
+		$status = 'missing';
+		foreach ( array_keys( get_plugins() ) as $plugin_file ) {
+			if ( 0 !== strpos( $plugin_file, $slug . '/' ) ) {
+				continue;
+			}
+
+			$file   = $plugin_file;
+			$status = is_plugin_active( $plugin_file ) ? 'active' : 'installed';
+			break;
+		}
+
+		return array(
+			'slug'         => $slug,
+			'status'       => $status,
+			'file'         => $file,
+			// DISALLOW_FILE_MODS already strips install_plugins via map_meta_cap.
+			'can_install'  => current_user_can( 'install_plugins' ),
+			'can_activate' => current_user_can( 'activate_plugins' ),
 		);
 	}
 

--- a/includes/Experiments/MCP_Adapter/Settings_Controller.php
+++ b/includes/Experiments/MCP_Adapter/Settings_Controller.php
@@ -126,7 +126,12 @@ class Settings_Controller {
 		$sanitized = array();
 
 		foreach ( $overrides as $name => $exposed ) {
-			$sanitized[ $name ] = null === $exposed ? null : rest_sanitize_boolean( $exposed );
+			if ( null === $exposed ) {
+				$sanitized[ $name ] = null;
+				continue;
+			}
+
+			$sanitized[ $name ] = is_bool( $exposed ) ? $exposed : rest_sanitize_boolean( (string) $exposed );
 		}
 
 		return $sanitized;
@@ -211,6 +216,10 @@ class Settings_Controller {
 	 * @return string|null The endpoint URL, or null when no server is registered.
 	 */
 	private function get_endpoint_url(): ?string {
+		if ( ! class_exists( '\WP\MCP\Core\McpAdapter' ) ) {
+			return null;
+		}
+
 		$adapter = \WP\MCP\Core\McpAdapter::instance();
 		$server  = $adapter->get_server( 'mcp-adapter-default-server' );
 

--- a/src/experiments/mcp-adapter/components/McpAccessApp.tsx
+++ b/src/experiments/mcp-adapter/components/McpAccessApp.tsx
@@ -12,37 +12,50 @@ import {
 	Notice,
 	Spinner,
 } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import type { McpSettings } from '../types';
+import { getErrorMessage } from '../../../utils/errors';
+import type { McpAbility, McpSettings, PendingOverrides } from '../types';
 
 const SETTINGS_PATH = '/ai/v1/mcp/settings';
 
 export default function McpAccessApp() {
 	const [ settings, setSettings ] = useState< McpSettings | null >( null );
-	const [ overrides, setOverrides ] = useState<
-		Record< string, boolean | null >
-	>( {} );
+	const [ pending, setPending ] = useState< PendingOverrides >( {} );
 	const [ isSaving, setIsSaving ] = useState( false );
-	const [ error, setError ] = useState< string | null >( null );
+	const [ loadError, setLoadError ] = useState< string | null >( null );
+	const [ saveError, setSaveError ] = useState< string | null >( null );
 	const [ savedNotice, setSavedNotice ] = useState( false );
 
-	useEffect( () => {
+	const load = useCallback( () => {
+		setLoadError( null );
 		apiFetch< McpSettings >( { path: SETTINGS_PATH } )
 			.then( ( data ) => setSettings( data ) )
-			.catch( () =>
-				setError( __( 'Failed to load MCP settings.', 'ai' ) )
+			.catch( ( error ) =>
+				setLoadError(
+					getErrorMessage(
+						error,
+						__( 'Failed to load MCP settings.', 'ai' )
+					)
+				)
 			);
 	}, [] );
 
-	if ( error ) {
+	useEffect( () => {
+		load();
+	}, [ load ] );
+
+	if ( loadError ) {
 		return (
 			<Notice status="error" isDismissible={ false }>
-				{ error }
+				{ loadError }{ ' ' }
+				<Button variant="link" onClick={ load }>
+					{ __( 'Retry', 'ai' ) }
+				</Button>
 			</Notice>
 		);
 	}
@@ -51,36 +64,82 @@ export default function McpAccessApp() {
 		return <Spinner />;
 	}
 
-	const effectiveExposed = ( name: string, fallback: boolean ): boolean => {
-		const pending = overrides[ name ];
-		if ( pending !== undefined && pending !== null ) {
-			return pending;
-		}
+	const hasSavedOverride = ( name: string ): boolean =>
+		name in settings.overrides;
 
-		const saved = settings.overrides[ name ];
-		if ( saved !== undefined ) {
-			return saved;
+	// A pending entry always wins over the saved state; `null` means the
+	// saved override is being cleared back to the ability's default.
+	const hasOverride = ( ability: McpAbility ): boolean => {
+		const edit = pending[ ability.name ];
+		if ( edit !== undefined ) {
+			return edit !== null;
 		}
-
-		return fallback;
+		return hasSavedOverride( ability.name );
 	};
 
-	const isDirty = Object.keys( overrides ).length > 0;
+	const effectiveExposed = ( ability: McpAbility ): boolean => {
+		const edit = pending[ ability.name ];
+		if ( edit !== undefined ) {
+			return edit === null ? ability.default : edit;
+		}
+		return ability.exposed;
+	};
+
+	const setExposed = ( ability: McpAbility, checked: boolean ) => {
+		setPending( ( prev ) => {
+			const next = { ...prev };
+			if (
+				checked === ability.default &&
+				! hasSavedOverride( ability.name )
+			) {
+				// Back to the untouched default: no override needed.
+				delete next[ ability.name ];
+			} else if (
+				checked === ability.default &&
+				hasSavedOverride( ability.name )
+			) {
+				// Matches the default but an override is stored: clear it.
+				next[ ability.name ] = null;
+			} else {
+				next[ ability.name ] = checked;
+			}
+			return next;
+		} );
+	};
+
+	const resetToDefault = ( ability: McpAbility ) => {
+		setPending( ( prev ) => {
+			const next = { ...prev };
+			if ( hasSavedOverride( ability.name ) ) {
+				next[ ability.name ] = null;
+			} else {
+				delete next[ ability.name ];
+			}
+			return next;
+		} );
+	};
+
+	const isDirty = Object.keys( pending ).length > 0;
 
 	const save = async () => {
 		setIsSaving( true );
-		setError( null );
+		setSaveError( null );
 		try {
 			const updated = await apiFetch< McpSettings >( {
 				path: SETTINGS_PATH,
 				method: 'POST',
-				data: { overrides },
+				data: { overrides: pending },
 			} );
 			setSettings( updated );
-			setOverrides( {} );
+			setPending( {} );
 			setSavedNotice( true );
-		} catch {
-			setError( __( 'Failed to save MCP settings.', 'ai' ) );
+		} catch ( error ) {
+			setSaveError(
+				getErrorMessage(
+					error,
+					__( 'Failed to save MCP settings.', 'ai' )
+				)
+			);
 		} finally {
 			setIsSaving( false );
 		}
@@ -97,6 +156,13 @@ export default function McpAccessApp() {
 				</Notice>
 			) }
 
+			<Notice status="info" isDismissible={ false }>
+				{ __(
+					'Exposure choices apply only while the MCP Access experiment is enabled. When it is disabled, abilities return to the defaults the MCP Adapter serves on its own.',
+					'ai'
+				) }
+			</Notice>
+
 			{ settings.adapter_active && settings.endpoint && (
 				<p>
 					{ sprintf(
@@ -105,6 +171,21 @@ export default function McpAccessApp() {
 						settings.endpoint
 					) }
 				</p>
+			) }
+
+			{ settings.adapter_active && ! settings.endpoint && (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'The MCP Adapter is active but no MCP server is registered on this site.',
+						'ai'
+					) }
+				</Notice>
+			) }
+
+			{ saveError && (
+				<Notice status="error" onRemove={ () => setSaveError( null ) }>
+					{ saveError }
+				</Notice>
 			) }
 
 			{ savedNotice && (
@@ -129,6 +210,7 @@ export default function McpAccessApp() {
 						<th scope="col">{ __( 'Exposed', 'ai' ) }</th>
 						<th scope="col">{ __( 'Ability', 'ai' ) }</th>
 						<th scope="col">{ __( 'Description', 'ai' ) }</th>
+						<th scope="col">{ __( 'Status', 'ai' ) }</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -137,15 +219,9 @@ export default function McpAccessApp() {
 							<td>
 								<CheckboxControl
 									__nextHasNoMarginBottom
-									checked={ effectiveExposed(
-										ability.name,
-										ability.exposed
-									) }
+									checked={ effectiveExposed( ability ) }
 									onChange={ ( checked ) =>
-										setOverrides( ( prev ) => ( {
-											...prev,
-											[ ability.name ]: checked,
-										} ) )
+										setExposed( ability, checked )
 									}
 									aria-label={ sprintf(
 										/* translators: %s: ability name. */
@@ -160,6 +236,23 @@ export default function McpAccessApp() {
 								<code>{ ability.name }</code>
 							</td>
 							<td>{ ability.description }</td>
+							<td>
+								{ hasOverride( ability ) ? (
+									<>
+										{ __( 'Overridden', 'ai' ) }{ ' ' }
+										<Button
+											variant="link"
+											onClick={ () =>
+												resetToDefault( ability )
+											}
+										>
+											{ __( 'Reset to default', 'ai' ) }
+										</Button>
+									</>
+								) : (
+									__( 'Default', 'ai' )
+								) }
+							</td>
 						</tr>
 					) ) }
 				</tbody>

--- a/src/experiments/mcp-adapter/components/McpAccessApp.tsx
+++ b/src/experiments/mcp-adapter/components/McpAccessApp.tsx
@@ -1,0 +1,181 @@
+/**
+ * MCP Access management screen.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import {
+	Button,
+	CheckboxControl,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { McpSettings } from '../types';
+
+const SETTINGS_PATH = '/ai/v1/mcp/settings';
+
+export default function McpAccessApp() {
+	const [ settings, setSettings ] = useState< McpSettings | null >( null );
+	const [ overrides, setOverrides ] = useState<
+		Record< string, boolean | null >
+	>( {} );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ error, setError ] = useState< string | null >( null );
+	const [ savedNotice, setSavedNotice ] = useState( false );
+
+	useEffect( () => {
+		apiFetch< McpSettings >( { path: SETTINGS_PATH } )
+			.then( ( data ) => setSettings( data ) )
+			.catch( () =>
+				setError( __( 'Failed to load MCP settings.', 'ai' ) )
+			);
+	}, [] );
+
+	if ( error ) {
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ error }
+			</Notice>
+		);
+	}
+
+	if ( ! settings ) {
+		return <Spinner />;
+	}
+
+	const effectiveExposed = ( name: string, fallback: boolean ): boolean => {
+		const pending = overrides[ name ];
+		if ( pending !== undefined && pending !== null ) {
+			return pending;
+		}
+
+		const saved = settings.overrides[ name ];
+		if ( saved !== undefined ) {
+			return saved;
+		}
+
+		return fallback;
+	};
+
+	const isDirty = Object.keys( overrides ).length > 0;
+
+	const save = async () => {
+		setIsSaving( true );
+		setError( null );
+		try {
+			const updated = await apiFetch< McpSettings >( {
+				path: SETTINGS_PATH,
+				method: 'POST',
+				data: { overrides },
+			} );
+			setSettings( updated );
+			setOverrides( {} );
+			setSavedNotice( true );
+		} catch {
+			setError( __( 'Failed to save MCP settings.', 'ai' ) );
+		} finally {
+			setIsSaving( false );
+		}
+	};
+
+	return (
+		<div className="ai-mcp-access">
+			{ ! settings.adapter_active && (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'The MCP Adapter plugin is not active. Exposure choices are saved and will take effect once it is installed and activated.',
+						'ai'
+					) }
+				</Notice>
+			) }
+
+			{ settings.adapter_active && settings.endpoint && (
+				<p>
+					{ sprintf(
+						/* translators: %s: MCP server endpoint URL. */
+						__( 'MCP server endpoint: %s', 'ai' ),
+						settings.endpoint
+					) }
+				</p>
+			) }
+
+			{ savedNotice && (
+				<Notice
+					status="success"
+					onRemove={ () => setSavedNotice( false ) }
+				>
+					{ __( 'MCP exposure settings saved.', 'ai' ) }
+				</Notice>
+			) }
+
+			<p>
+				{ __(
+					'Choose which abilities are exposed to AI agents through the MCP server. Abilities keep their default visibility unless changed here.',
+					'ai'
+				) }
+			</p>
+
+			<table className="widefat striped">
+				<thead>
+					<tr>
+						<th scope="col">{ __( 'Exposed', 'ai' ) }</th>
+						<th scope="col">{ __( 'Ability', 'ai' ) }</th>
+						<th scope="col">{ __( 'Description', 'ai' ) }</th>
+					</tr>
+				</thead>
+				<tbody>
+					{ settings.abilities.map( ( ability ) => (
+						<tr key={ ability.name }>
+							<td>
+								<CheckboxControl
+									__nextHasNoMarginBottom
+									checked={ effectiveExposed(
+										ability.name,
+										ability.exposed
+									) }
+									onChange={ ( checked ) =>
+										setOverrides( ( prev ) => ( {
+											...prev,
+											[ ability.name ]: checked,
+										} ) )
+									}
+									aria-label={ sprintf(
+										/* translators: %s: ability name. */
+										__( 'Expose %s over MCP', 'ai' ),
+										ability.name
+									) }
+								/>
+							</td>
+							<td>
+								<strong>{ ability.label }</strong>
+								<br />
+								<code>{ ability.name }</code>
+							</td>
+							<td>{ ability.description }</td>
+						</tr>
+					) ) }
+				</tbody>
+			</table>
+
+			<p>
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					onClick={ save }
+					isBusy={ isSaving }
+					disabled={ ! isDirty || isSaving }
+				>
+					{ __( 'Save changes', 'ai' ) }
+				</Button>
+			</p>
+		</div>
+	);
+}

--- a/src/experiments/mcp-adapter/components/McpAccessApp.tsx
+++ b/src/experiments/mcp-adapter/components/McpAccessApp.tsx
@@ -193,13 +193,19 @@ export default function McpAccessApp() {
 				<Notice status="warning" isDismissible={ false }>
 					{ plugin.status === 'missing'
 						? __(
-								'The MCP Adapter plugin is not installed. Exposure choices are saved and will take effect once it is installed and activated.',
+								'The MCP Adapter plugin is not active yet. It is installed and activated automatically from WordPress.org while this experiment is enabled. Exposure choices are saved and take effect once it is active.',
 								'ai'
 						  )
 						: __(
-								'The MCP Adapter plugin is installed but not active. Exposure choices are saved and will take effect once it is activated.',
+								'The MCP Adapter plugin is installed but not active. It is activated automatically while this experiment is enabled. Exposure choices are saved and take effect once it is active.',
 								'ai'
 						  ) }{ ' ' }
+					{ plugin.autoinstall_error &&
+						sprintf(
+							/* translators: %s: error message. */
+							__( 'The last automatic attempt failed: %s', 'ai' ),
+							plugin.autoinstall_error
+						) }{ ' ' }
 					{ canFix && (
 						<Button
 							__next40pxDefaultSize

--- a/src/experiments/mcp-adapter/components/McpAccessApp.tsx
+++ b/src/experiments/mcp-adapter/components/McpAccessApp.tsx
@@ -27,6 +27,7 @@ export default function McpAccessApp() {
 	const [ settings, setSettings ] = useState< McpSettings | null >( null );
 	const [ pending, setPending ] = useState< PendingOverrides >( {} );
 	const [ isSaving, setIsSaving ] = useState( false );
+	const [ isInstalling, setIsInstalling ] = useState( false );
 	const [ loadError, setLoadError ] = useState< string | null >( null );
 	const [ saveError, setSaveError ] = useState< string | null >( null );
 	const [ savedNotice, setSavedNotice ] = useState( false );
@@ -145,13 +146,80 @@ export default function McpAccessApp() {
 		}
 	};
 
+	const installOrActivate = async () => {
+		setIsInstalling( true );
+		setSaveError( null );
+		try {
+			if ( settings.plugin.status === 'missing' ) {
+				await apiFetch( {
+					path: '/wp/v2/plugins',
+					method: 'POST',
+					data: { slug: settings.plugin.slug, status: 'active' },
+				} );
+			} else {
+				await apiFetch( {
+					path: `/wp/v2/plugins/${ settings.plugin.file?.replace(
+						/\.php$/,
+						''
+					) }`,
+					method: 'PUT',
+					data: { status: 'active' },
+				} );
+			}
+			// Re-fetch: plugin state, adapter detection, and endpoint all changed.
+			const updated = await apiFetch< McpSettings >( {
+				path: SETTINGS_PATH,
+			} );
+			setSettings( updated );
+		} catch ( error ) {
+			setSaveError(
+				getErrorMessage(
+					error,
+					__( 'Failed to install the plugin.', 'ai' )
+				)
+			);
+		} finally {
+			setIsInstalling( false );
+		}
+	};
+
+	const plugin = settings.plugin;
+	const canFix =
+		plugin.status === 'missing' ? plugin.can_install : plugin.can_activate;
+
 	return (
 		<div className="ai-mcp-access">
-			{ ! settings.adapter_active && (
+			{ plugin.status !== 'active' && (
 				<Notice status="warning" isDismissible={ false }>
-					{ __(
-						'The MCP Adapter plugin is not active. Exposure choices are saved and will take effect once it is installed and activated.',
-						'ai'
+					{ plugin.status === 'missing'
+						? __(
+								'The MCP Adapter plugin is not installed. Exposure choices are saved and will take effect once it is installed and activated.',
+								'ai'
+						  )
+						: __(
+								'The MCP Adapter plugin is installed but not active. Exposure choices are saved and will take effect once it is activated.',
+								'ai'
+						  ) }{ ' ' }
+					{ canFix && (
+						<Button
+							__next40pxDefaultSize
+							variant="secondary"
+							isBusy={ isInstalling }
+							disabled={ isInstalling }
+							onClick={ installOrActivate }
+						>
+							{ plugin.status === 'missing'
+								? sprintf(
+										/* translators: %s: plugin slug. */
+										__( 'Install & activate %s', 'ai' ),
+										plugin.slug
+								  )
+								: sprintf(
+										/* translators: %s: plugin slug. */
+										__( 'Activate %s', 'ai' ),
+										plugin.slug
+								  ) }
+						</Button>
 					) }
 				</Notice>
 			) }

--- a/src/experiments/mcp-adapter/index.scss
+++ b/src/experiments/mcp-adapter/index.scss
@@ -1,0 +1,11 @@
+.ai-mcp-access {
+	max-width: 960px;
+
+	table {
+		margin: 16px 0;
+	}
+
+	td:first-child {
+		width: 80px;
+	}
+}

--- a/src/experiments/mcp-adapter/index.tsx
+++ b/src/experiments/mcp-adapter/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * MCP Access admin page entry point.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { createRoot } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import McpAccessApp from './components/McpAccessApp';
+import './index.scss';
+
+domReady( () => {
+	const root = document.getElementById( 'ai-mcp-access-root' );
+	if ( ! root ) {
+		return;
+	}
+	createRoot( root ).render( <McpAccessApp /> );
+} );

--- a/src/experiments/mcp-adapter/types.ts
+++ b/src/experiments/mcp-adapter/types.ts
@@ -12,6 +12,7 @@ export interface McpPluginState {
 	file: string | null;
 	can_install: boolean;
 	can_activate: boolean;
+	autoinstall_error: string | null;
 }
 
 export interface McpSettings {

--- a/src/experiments/mcp-adapter/types.ts
+++ b/src/experiments/mcp-adapter/types.ts
@@ -6,11 +6,20 @@ export interface McpAbility {
 	default: boolean;
 }
 
+export interface McpPluginState {
+	slug: string;
+	status: 'active' | 'installed' | 'missing';
+	file: string | null;
+	can_install: boolean;
+	can_activate: boolean;
+}
+
 export interface McpSettings {
 	adapter_active: boolean;
 	abilities: McpAbility[];
 	overrides: Record< string, boolean >;
 	endpoint: string | null;
+	plugin: McpPluginState;
 }
 
 /**

--- a/src/experiments/mcp-adapter/types.ts
+++ b/src/experiments/mcp-adapter/types.ts
@@ -1,0 +1,13 @@
+export interface McpAbility {
+	name: string;
+	label: string;
+	description: string;
+	exposed: boolean;
+}
+
+export interface McpSettings {
+	adapter_active: boolean;
+	abilities: McpAbility[];
+	overrides: Record< string, boolean >;
+	endpoint: string | null;
+}

--- a/src/experiments/mcp-adapter/types.ts
+++ b/src/experiments/mcp-adapter/types.ts
@@ -3,6 +3,7 @@ export interface McpAbility {
 	label: string;
 	description: string;
 	exposed: boolean;
+	default: boolean;
 }
 
 export interface McpSettings {
@@ -11,3 +12,9 @@ export interface McpSettings {
 	overrides: Record< string, boolean >;
 	endpoint: string | null;
 }
+
+/**
+ * Pending, unsaved override edits. `true`/`false` sets an override,
+ * `null` clears a saved override back to the ability's default.
+ */
+export type PendingOverrides = Record< string, boolean | null >;

--- a/tests/Integration/Includes/Experiments/ExperimentsTest.php
+++ b/tests/Integration/Includes/Experiments/ExperimentsTest.php
@@ -13,6 +13,7 @@ use WordPress\AI\Experiments\Connector_Approval\Connector_Approval;
 use WordPress\AI\Experiments\Comment_Moderation\Comment_Moderation;
 use WordPress\AI\Experiments\Suggest_Reply\Suggest_Reply;
 use WordPress\AI\Experiments\Experiments;
+use WordPress\AI\Experiments\MCP_Adapter\MCP_Adapter;
 use WordPress\AI\Experiments\Type_Ahead\Type_Ahead;
 
 /**
@@ -43,5 +44,6 @@ class ExperimentsTest extends WP_UnitTestCase {
 		$this->assertContains( Connector_Approval::class, $results, 'Connector_Approval should be registered as a default experiment.' );
 		$this->assertContains( Comment_Moderation::class, $results, 'Comment_Moderation should be registered as a default experiment.' );
 		$this->assertContains( Suggest_Reply::class, $results, 'Suggest_Reply should be registered as a default experiment.' );
+		$this->assertContains( MCP_Adapter::class, $results, 'MCP_Adapter should be registered as a default experiment.' );
 	}
 }

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/MCP_AdapterTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/MCP_AdapterTest.php
@@ -99,7 +99,7 @@ class MCP_AdapterTest extends WP_UnitTestCase {
 			'Should hook wp_register_ability_args to apply exposure overrides.'
 		);
 		$this->assertNotFalse(
-			has_action( 'rest_api_init' ),
+			has_action( 'rest_api_init', array( $this->experiment, 'register_rest_routes' ) ),
 			'Should register REST routes.'
 		);
 	}
@@ -146,6 +146,21 @@ class MCP_AdapterTest extends WP_UnitTestCase {
 		$meta    = $ability->get_meta();
 
 		$this->assertArrayNotHasKey( 'mcp', $meta, 'Without an override the mcp meta key should not be injected.' );
+	}
+
+	/**
+	 * Tests that the registration-time default is stashed when an override is applied.
+	 */
+	public function test_override_stashes_registration_default() {
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai-test/mcp-exposure' => false ) );
+		$this->experiment->register();
+
+		$this->register_test_ability( array( 'public' => true ) );
+
+		$this->assertTrue(
+			Exposure_Overrides::get_registration_default( 'ai-test/mcp-exposure' ),
+			'The pre-override exposure default should be recoverable.'
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/MCP_AdapterTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/MCP_AdapterTest.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Integration tests for the MCP_Adapter experiment class.
+ *
+ * @package WordPress\AI\Tests\Integration\Experiments\MCP_Adapter
+ */
+
+namespace WordPress\AI\Tests\Integration\Experiments\MCP_Adapter;
+
+use WP_UnitTestCase;
+use WordPress\AI\Experiments\Experiment_Category;
+use WordPress\AI\Experiments\MCP_Adapter\Exposure_Overrides;
+use WordPress\AI\Experiments\MCP_Adapter\MCP_Adapter;
+
+/**
+ * MCP_Adapter experiment test case.
+ */
+class MCP_AdapterTest extends WP_UnitTestCase {
+	/**
+	 * Experiment under test.
+	 *
+	 * @var \WordPress\AI\Experiments\MCP_Adapter\MCP_Adapter
+	 */
+	private MCP_Adapter $experiment;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->experiment = new MCP_Adapter();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		delete_option( Exposure_Overrides::OPTION_NAME );
+		remove_all_filters( 'wp_register_ability_args' );
+
+		if ( wp_get_ability( 'ai-test/mcp-exposure' ) ) {
+			wp_unregister_ability( 'ai-test/mcp-exposure' );
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Registers a test ability with the given meta.
+	 *
+	 * @param array<string, mixed> $meta Ability meta.
+	 */
+	private function register_test_ability( array $meta = array() ): void {
+		global $wp_current_filter;
+
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+
+		try {
+			wp_register_ability(
+				'ai-test/mcp-exposure',
+				array(
+					'label'               => 'MCP exposure test ability',
+					'description'         => 'Test ability for MCP exposure overrides.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+					'meta'                => $meta,
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Tests the experiment id.
+	 */
+	public function test_get_id() {
+		$this->assertSame( 'mcp-adapter', MCP_Adapter::get_id() );
+	}
+
+	/**
+	 * Tests the experiment metadata.
+	 */
+	public function test_metadata() {
+		$this->assertNotEmpty( $this->experiment->get_label() );
+		$this->assertNotEmpty( $this->experiment->get_description() );
+		$this->assertSame( Experiment_Category::ADMIN, $this->experiment->get_category() );
+	}
+
+	/**
+	 * Tests that register() hooks the exposure filter and REST routes.
+	 */
+	public function test_register_adds_hooks() {
+		$this->experiment->register();
+
+		$this->assertNotFalse(
+			has_filter( 'wp_register_ability_args', array( Exposure_Overrides::class, 'filter_ability_args' ) ),
+			'Should hook wp_register_ability_args to apply exposure overrides.'
+		);
+		$this->assertNotFalse(
+			has_action( 'rest_api_init' ),
+			'Should register REST routes.'
+		);
+	}
+
+	/**
+	 * Tests that a saved override hides an otherwise public ability.
+	 */
+	public function test_override_hides_public_ability() {
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai-test/mcp-exposure' => false ) );
+		$this->experiment->register();
+
+		$this->register_test_ability( array( 'public' => true ) );
+
+		$ability = wp_get_ability( 'ai-test/mcp-exposure' );
+		$meta    = $ability->get_meta();
+
+		$this->assertFalse( $meta['mcp']['public'], 'Override should force meta.mcp.public to false.' );
+	}
+
+	/**
+	 * Tests that a saved override exposes an otherwise private ability.
+	 */
+	public function test_override_exposes_private_ability() {
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai-test/mcp-exposure' => true ) );
+		$this->experiment->register();
+
+		$this->register_test_ability();
+
+		$ability = wp_get_ability( 'ai-test/mcp-exposure' );
+		$meta    = $ability->get_meta();
+
+		$this->assertTrue( $meta['mcp']['public'], 'Override should force meta.mcp.public to true.' );
+	}
+
+	/**
+	 * Tests that abilities without an override keep their meta untouched.
+	 */
+	public function test_no_override_leaves_meta_untouched() {
+		$this->experiment->register();
+
+		$this->register_test_ability( array( 'public' => true ) );
+
+		$ability = wp_get_ability( 'ai-test/mcp-exposure' );
+		$meta    = $ability->get_meta();
+
+		$this->assertArrayNotHasKey( 'mcp', $meta, 'Without an override the mcp meta key should not be injected.' );
+	}
+
+	/**
+	 * Tests that the admin menu page is registered for admins.
+	 */
+	public function test_admin_menu_registered() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->experiment->register();
+		do_action( 'admin_menu' );
+
+		$this->assertNotEmpty(
+			menu_page_url( 'ai-mcp-access', false ),
+			'MCP Access admin page should be registered under Tools.'
+		);
+	}
+}

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Plugin_InstallerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Plugin_InstallerTest.php
@@ -15,6 +15,24 @@ use WordPress\AI\Experiments\MCP_Adapter\Plugin_Installer;
  */
 class Plugin_InstallerTest extends WP_UnitTestCase {
 	/**
+	 * Creates a user allowed to install and activate plugins.
+	 *
+	 * On multisite those capabilities belong to super admins, not site
+	 * administrators.
+	 *
+	 * @return int The user id.
+	 */
+	private function create_installer_user(): int {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		if ( is_multisite() ) {
+			grant_super_admin( $user_id );
+		}
+
+		return $user_id;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function tearDown(): void {
@@ -61,7 +79,7 @@ class Plugin_InstallerTest extends WP_UnitTestCase {
 	 * Tests that an attempt is made for capable users and no attempt repeats while locked.
 	 */
 	public function test_attempt_runs_once_and_locks_on_failure() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->create_installer_user() );
 
 		$attempts = 0;
 		add_filter(
@@ -84,7 +102,7 @@ class Plugin_InstallerTest extends WP_UnitTestCase {
 	 * Tests that a successful attempt does not set the failure lock.
 	 */
 	public function test_successful_attempt_does_not_lock() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->create_installer_user() );
 
 		add_filter( 'wpai_pre_mcp_adapter_autoinstall', '__return_true' );
 

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Plugin_InstallerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Plugin_InstallerTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Integration tests for the MCP Adapter Plugin_Installer class.
+ *
+ * @package WordPress\AI\Tests\Integration\Experiments\MCP_Adapter
+ */
+
+namespace WordPress\AI\Tests\Integration\Experiments\MCP_Adapter;
+
+use WP_UnitTestCase;
+use WordPress\AI\Experiments\MCP_Adapter\Plugin_Installer;
+
+/**
+ * Plugin_Installer test case.
+ */
+class Plugin_InstallerTest extends WP_UnitTestCase {
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		delete_transient( Plugin_Installer::LOCK_TRANSIENT );
+		remove_all_filters( 'wpai_mcp_adapter_plugin_slug' );
+		remove_all_filters( 'wpai_pre_mcp_adapter_autoinstall' );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that the plugin state reports a missing plugin.
+	 */
+	public function test_get_state_reports_missing_plugin() {
+		$state = Plugin_Installer::get_state();
+
+		$this->assertSame( 'mcp-adapter', $state['slug'] );
+		$this->assertSame( 'missing', $state['status'] );
+		$this->assertNull( $state['file'] );
+	}
+
+	/**
+	 * Tests that users without install capability never trigger an install.
+	 */
+	public function test_no_attempt_without_capability() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'editor' ) ) );
+
+		$attempted = false;
+		add_filter(
+			'wpai_pre_mcp_adapter_autoinstall',
+			static function () use ( &$attempted ) {
+				$attempted = true;
+				return true;
+			}
+		);
+
+		( new Plugin_Installer() )->maybe_install_and_activate();
+
+		$this->assertFalse( $attempted, 'Users without install_plugins must not trigger an install.' );
+	}
+
+	/**
+	 * Tests that an attempt is made for capable users and no attempt repeats while locked.
+	 */
+	public function test_attempt_runs_once_and_locks_on_failure() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$attempts = 0;
+		add_filter(
+			'wpai_pre_mcp_adapter_autoinstall',
+			static function () use ( &$attempts ) {
+				++$attempts;
+				return new \WP_Error( 'install_failed', 'Simulated failure.' );
+			}
+		);
+
+		$installer = new Plugin_Installer();
+		$installer->maybe_install_and_activate();
+		$installer->maybe_install_and_activate();
+
+		$this->assertSame( 1, $attempts, 'A failed attempt must set the lock and not retry immediately.' );
+		$this->assertNotFalse( get_transient( Plugin_Installer::LOCK_TRANSIENT ) );
+	}
+
+	/**
+	 * Tests that a successful attempt does not set the failure lock.
+	 */
+	public function test_successful_attempt_does_not_lock() {
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		add_filter( 'wpai_pre_mcp_adapter_autoinstall', '__return_true' );
+
+		( new Plugin_Installer() )->maybe_install_and_activate();
+
+		$this->assertFalse( get_transient( Plugin_Installer::LOCK_TRANSIENT ) );
+	}
+}

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
@@ -63,6 +63,11 @@ class Settings_ControllerTest extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		delete_option( Exposure_Overrides::OPTION_NAME );
+		remove_all_filters( 'wp_register_ability_args' );
+
+		if ( wp_get_ability( 'ai-test/mcp-settings' ) ) {
+			wp_unregister_ability( 'ai-test/mcp-settings' );
+		}
 
 		global $wp_rest_server;
 		$wp_rest_server = null;
@@ -157,6 +162,119 @@ class Settings_ControllerTest extends WP_UnitTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array(), get_option( Exposure_Overrides::OPTION_NAME ) );
+	}
+
+	/**
+	 * Registers a test ability inside the abilities API init context.
+	 *
+	 * @param array<string, mixed> $meta Ability meta.
+	 */
+	private function register_test_ability( array $meta = array() ): void {
+		global $wp_current_filter;
+
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+
+		try {
+			wp_register_ability(
+				'ai-test/mcp-settings',
+				array(
+					'label'               => 'MCP settings test ability',
+					'description'         => 'Test ability for the MCP settings controller.',
+					'category'            => WPAI_DEFAULT_ABILITY_CATEGORY,
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+					'meta'                => $meta,
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Returns the payload row for the test ability from a response.
+	 *
+	 * @param \WP_REST_Response $response The response to search.
+	 *
+	 * @return array<string, mixed>|null The ability row, or null.
+	 */
+	private function find_test_ability( $response ): ?array {
+		foreach ( $response->get_data()['abilities'] as $ability ) {
+			if ( 'ai-test/mcp-settings' === $ability['name'] ) {
+				return $ability;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Tests that abilities report both effective and default exposure.
+	 */
+	public function test_get_reports_effective_and_default_exposure() {
+		wp_set_current_user( self::$admin_id );
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai-test/mcp-settings' => false ) );
+		add_filter( 'wp_register_ability_args', array( Exposure_Overrides::class, 'filter_ability_args' ), 100, 2 );
+
+		$this->register_test_ability( array( 'public' => true ) );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$ability  = $this->find_test_ability( $response );
+
+		$this->assertNotNull( $ability );
+		$this->assertFalse( $ability['exposed'], 'Effective exposure should honor the override.' );
+		$this->assertTrue( $ability['default'], 'Default exposure should be the registration-time value.' );
+	}
+
+	/**
+	 * Tests that removing an override restores the registration default in the same response.
+	 */
+	public function test_post_null_removal_reports_fresh_exposure() {
+		wp_set_current_user( self::$admin_id );
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai-test/mcp-settings' => false ) );
+		add_filter( 'wp_register_ability_args', array( Exposure_Overrides::class, 'filter_ability_args' ), 100, 2 );
+
+		// Force registration before the save, baking the pre-save override into ability meta.
+		$this->register_test_ability( array( 'public' => true ) );
+		wp_get_abilities();
+
+		$request = new WP_REST_Request( 'POST', '/ai/v1/mcp/settings' );
+		$request->set_body_params( array( 'overrides' => array( 'ai-test/mcp-settings' => null ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$ability = $this->find_test_ability( $response );
+		$this->assertNotNull( $ability );
+		$this->assertTrue( $ability['exposed'], 'Removing the override should restore the registration default in the response.' );
+	}
+
+	/**
+	 * Tests that string booleans from form-encoded requests are accepted and coerced.
+	 */
+	public function test_post_accepts_string_booleans() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/ai/v1/mcp/settings' );
+		$request->set_body_params(
+			array(
+				'overrides' => array(
+					'ai/get-post'    => 'true',
+					'ai/delete-post' => '0',
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			array(
+				'ai/get-post'    => true,
+				'ai/delete-post' => false,
+			),
+			get_option( Exposure_Overrides::OPTION_NAME )
+		);
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
@@ -278,6 +278,41 @@ class Settings_ControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that the payload describes the companion plugin's install state.
+	 */
+	public function test_get_reports_plugin_install_state() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$plugin   = $response->get_data()['plugin'];
+
+		$this->assertSame( 'mcp-adapter', $plugin['slug'] );
+		$this->assertSame( 'missing', $plugin['status'], 'The adapter is not installed in the test environment.' );
+		$this->assertNull( $plugin['file'] );
+		$this->assertIsBool( $plugin['can_install'] );
+		$this->assertIsBool( $plugin['can_activate'] );
+		$this->assertTrue( $plugin['can_install'], 'Admins with file mods allowed should be able to install.' );
+	}
+
+	/**
+	 * Tests that the companion plugin slug is filterable.
+	 */
+	public function test_plugin_slug_is_filterable() {
+		wp_set_current_user( self::$admin_id );
+		add_filter(
+			'wpai_mcp_adapter_plugin_slug',
+			static function (): string {
+				return 'hello-dolly';
+			}
+		);
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$this->assertSame( 'hello-dolly', $response->get_data()['plugin']['slug'] );
+
+		remove_all_filters( 'wpai_mcp_adapter_plugin_slug' );
+	}
+
+	/**
 	 * Tests that invalid ability names are rejected.
 	 */
 	public function test_post_rejects_invalid_ability_name() {

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
@@ -283,15 +283,24 @@ class Settings_ControllerTest extends WP_UnitTestCase {
 	public function test_get_reports_plugin_install_state() {
 		wp_set_current_user( self::$admin_id );
 
+		// On multisite, installing plugins requires super admin.
+		if ( is_multisite() ) {
+			grant_super_admin( self::$admin_id );
+		}
+
 		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
 		$plugin   = $response->get_data()['plugin'];
+
+		if ( is_multisite() ) {
+			revoke_super_admin( self::$admin_id );
+		}
 
 		$this->assertSame( 'mcp-adapter', $plugin['slug'] );
 		$this->assertSame( 'missing', $plugin['status'], 'The adapter is not installed in the test environment.' );
 		$this->assertNull( $plugin['file'] );
 		$this->assertIsBool( $plugin['can_install'] );
 		$this->assertIsBool( $plugin['can_activate'] );
-		$this->assertTrue( $plugin['can_install'], 'Admins with file mods allowed should be able to install.' );
+		$this->assertTrue( $plugin['can_install'], 'Users who can install plugins should be reported as able to install.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
+++ b/tests/Integration/Includes/Experiments/MCP_Adapter/Settings_ControllerTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * Integration tests for the MCP Adapter Settings_Controller class.
+ *
+ * @package WordPress\AI\Tests\Integration\Experiments\MCP_Adapter
+ */
+
+namespace WordPress\AI\Tests\Integration\Experiments\MCP_Adapter;
+
+use WP_REST_Request;
+use WP_UnitTestCase;
+use WordPress\AI\Experiments\MCP_Adapter\Exposure_Overrides;
+use WordPress\AI\Experiments\MCP_Adapter\Settings_Controller;
+
+/**
+ * Settings_Controller test case.
+ */
+class Settings_ControllerTest extends WP_UnitTestCase {
+	/**
+	 * Administrator user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Subscriber user id.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * Creates shared fixtures.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id      = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$subscriber_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		add_action(
+			'rest_api_init',
+			static function (): void {
+				( new Settings_Controller() )->register_routes();
+			}
+		);
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function tearDown(): void {
+		delete_option( Exposure_Overrides::OPTION_NAME );
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Tests that the settings route is registered.
+	 */
+	public function test_route_is_registered() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/ai/v1/mcp/settings', $routes );
+	}
+
+	/**
+	 * Tests that unauthenticated requests are rejected.
+	 */
+	public function test_get_requires_authentication() {
+		wp_set_current_user( 0 );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Tests that non-admin users are rejected.
+	 */
+	public function test_get_requires_manage_options() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Tests the GET response shape.
+	 */
+	public function test_get_returns_settings() {
+		wp_set_current_user( self::$admin_id );
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai/get-post' => false ) );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/ai/v1/mcp/settings' ) );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'adapter_active', $data );
+		$this->assertArrayHasKey( 'abilities', $data );
+		$this->assertIsArray( $data['abilities'] );
+		$this->assertArrayHasKey( 'overrides', $data );
+		$this->assertSame( array( 'ai/get-post' => false ), $data['overrides'] );
+	}
+
+	/**
+	 * Tests that POST persists overrides.
+	 */
+	public function test_post_saves_overrides() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/ai/v1/mcp/settings' );
+		$request->set_body_params(
+			array(
+				'overrides' => array(
+					'ai/get-post'    => true,
+					'ai/delete-post' => false,
+				),
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+
+		$this->assertSame(
+			array(
+				'ai/get-post'    => true,
+				'ai/delete-post' => false,
+			),
+			get_option( Exposure_Overrides::OPTION_NAME )
+		);
+	}
+
+	/**
+	 * Tests that a null override removes the stored entry.
+	 */
+	public function test_post_null_removes_override() {
+		wp_set_current_user( self::$admin_id );
+		update_option( Exposure_Overrides::OPTION_NAME, array( 'ai/get-post' => false ) );
+
+		$request = new WP_REST_Request( 'POST', '/ai/v1/mcp/settings' );
+		$request->set_body_params( array( 'overrides' => array( 'ai/get-post' => null ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( array(), get_option( Exposure_Overrides::OPTION_NAME ) );
+	}
+
+	/**
+	 * Tests that invalid ability names are rejected.
+	 */
+	public function test_post_rejects_invalid_ability_name() {
+		wp_set_current_user( self::$admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/ai/v1/mcp/settings' );
+		$request->set_body_params( array( 'overrides' => array( 'Not A Valid Name!' => true ) ) );
+
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 400, $response->get_status() );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,11 @@ module.exports = {
 			'src/experiments/abilities-explorer',
 			'index.js'
 		),
+		'experiments/mcp-adapter': path.resolve(
+			process.cwd(),
+			'src/experiments/mcp-adapter',
+			'index.tsx'
+		),
 		'experiments/content-resizing': path.resolve(
 			process.cwd(),
 			'src/experiments/content-resizing',


### PR DESCRIPTION
## What?

See WordPress/mcp-adapter#178 (AI-plugin integration discussed in the comments); related to #354.

Adds an **MCP Access** experiment that wires a site up to the [MCP Adapter](https://github.com/WordPress/mcp-adapter) companion plugin and gives site owners a place to control which abilities are exposed to AI agents over the Model Context Protocol:

- Enabling the experiment **installs and activates the MCP Adapter plugin from WordPress.org** if it is not already active. The experiment description states this explicitly.
- A **Tools → MCP Access** screen lists registered abilities with per-ability expose/hide checkboxes and a reset-to-default affordance, shows the MCP server endpoint URL, and surfaces the adapter's install state.

## Why?

Discussed in WordPress/mcp-adapter#178: the adapter stays a standalone, headless plugin (reusable by other consumers, no admin UI of its own — see WordPress/mcp-adapter#184), while the AI plugin provides the user-facing control layer. Abilities come from arbitrary plugins; site owners need a clear place to decide what is reachable by AI agents (the same need behind #354).

## How?

**Experiment** (`includes/Experiments/MCP_Adapter/`): standard `Abstract_Feature` experiment (`mcp-adapter`, admin category, no AI-capability requirement).

**Auto-install** (`Plugin_Installer`): runs on `admin_init` while the experiment is enabled; installs via core's `plugins_api()` + `Plugin_Upgrader` (silent skin) and activates. Guards: skips when already active; requires `install_plugins`/`activate_plugins` (which `DISALLOW_FILE_MODS` strips via `map_meta_cap`); a failed attempt sets a 1-hour transient lock so admin pages never stall on repeated downloads; a `wpai_pre_mcp_adapter_autoinstall` filter short-circuits the attempt for tests and externally managed hosts. The attempt runs on the first admin load after enabling because the experiments framework does not run disabled experiments' code in the request that enables them. While the plugin is missing/inactive, the screen shows the state, the last auto-attempt error if any, and a manual install/activate button (driving core's `wp/v2/plugins`) as the immediate retry path. The slug is filterable (`wpai_mcp_adapter_plugin_slug`) so the flow can be exercised before the adapter is published on WordPress.org.

**Exposure overrides** (`Exposure_Overrides`): stored in the `wpai_mcp_exposed_abilities` option as an ability-name → bool map; applied by injecting `meta.mcp.public` through the `wp_register_ability_args` filter (priority 100). The adapter's default server resolves exposure from exactly that key (`McpAbilityExposure`), so overrides take effect with no hard dependency between the plugins. The registration-time default is stashed before injection so the screen can always report and restore it. Abilities without an override keep their developer-declared visibility.

**Settings REST** (`Settings_Controller`, `ai/v1/mcp/settings`, `manage_options`): GET returns adapter/plugin state, endpoint URL (read from the adapter's registered servers, not hardcoded), and per-ability effective + default exposure — delegating to `McpAbilityExposure::is_meta_public()` when the adapter is active so the screen always agrees with the server. POST persists overrides (`null` removes one); values are validated with `rest_is_boolean` and coerced via `sanitize_callback`, so form-encoded clients work.

**UI** (`src/experiments/mcp-adapter/`): React screen following the existing experiment app patterns; recoverable inline error notices, `getErrorMessage()` for REST errors.

### Open questions for reviewers

1. **Enforcement layer for site-owner overrides.** Registration-time injection has the limitations the adapter's own `McpAbilityExposure` docblock warns about: consumers that trigger ability registration before `init:15` see unfiltered defaults for that request, later `wp_register_ability_args` callbacks can overwrite the injected meta, and the mutation is visible to every meta consumer. I checked whether the WP 7.1 `wp_get_abilities()` filtering ([#64990](https://core.trac.wordpress.org/ticket/64990), `wp_get_abilities_item_include`) could carry the overrides instead: it covers **discovery** (the default server lists via `wp_get_abilities()`), but not **enforcement** — `execute-ability` and `get-ability-info` fetch by name via `wp_get_ability()` and gate on `McpAbilityExposure::is_public()`, which reads meta unfiltered. Would a resolution-time filter in the adapter — e.g. `apply_filters( 'mcp_ability_is_public', $resolved, $ability )` inside `is_public()` — be acceptable? It would give site-owner controls (and eventually the "surfaces" idea from #354) a reliable enforcement point at the adapter layer, matching what 7.1 did for queries at the core layer. I'm happy to PR it to mcp-adapter; this PR's option format and screen would carry over unchanged.
2. **Relationship to #354.** This screen is deliberately scoped to MCP exposure. If the unified "surfaces" model lands, the stored option can migrate into it — flagging so we align early rather than fork the UX.
3. **Disable semantics.** Disabling the experiment stops enforcing overrides while the adapter keeps serving its defaults (the framework does not run disabled experiments' code). The description and screen state this explicitly. If reviewers prefer harder guarantees, that also lands on the resolution-time filter from question 1.
4. **Install timing.** `admin_init` (first admin load after enabling) vs. hooking the settings-save moment — happy to change if there's a preference.

### Use of AI Tools

AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Fable 5
Used for: Implementation, integration tests, and an adversarial self-review pass (which produced the hardening in the second commit). All code was reviewed, exercised locally, and is submitted under my responsibility.

## Testing Instructions

1. `npm install && composer install && npm run wp-env start`, `npm run build`.
2. Since `mcp-adapter` is not on WordPress.org yet, point the installer at a stand-in plugin — e.g. as an mu-plugin:
   ```php
   add_filter( 'wpai_mcp_adapter_plugin_slug', static fn (): string => 'hello-dolly' );
   ```
3. Enable **Settings → AI → Experiments → MCP Access**. Note the description mentions the WordPress.org install.
4. Load any wp-admin page: the stand-in plugin is installed from WordPress.org and activated automatically. (Deactivate + delete it and revisit to watch it again; as a non-admin or with `DISALLOW_FILE_MODS`, no install is attempted.)
5. Visit **Tools → MCP Access**: toggle an ability's exposure, save, confirm the "Overridden / Reset to default" state; reset and confirm the developer default returns.
6. With the real adapter active (e.g. mounted via `.wp-env.override.json`), confirm the endpoint URL row and that `WP\MCP\Abilities\McpAbilityExposure::is_public()` agrees with the screen for an overridden ability.
7. `npm run test:php -- --filter "MCP_Adapter|Settings_Controller|Plugin_Installer"` — 24 tests.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| _(n/a — new screen)_ | _TODO: add screenshot of Tools → MCP Access (missing-plugin state + ability table)_ |

## Changelog Entry

> Added - MCP Access experiment: installs and activates the MCP Adapter plugin from WordPress.org when enabled, and adds a Tools → MCP Access screen to control which abilities are exposed to AI agents over MCP.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-992-b9a2fea14439d8351c4b41b0ff9a327c95b28bff.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->