### PR TITLE
Import core's prefixed PSR EventDispatcher in the vendored EmbeddingBuilder

### DIFF
--- a/includes/Vendor/AiClient/README.md
+++ b/includes/Vendor/AiClient/README.md
@@ -55,7 +55,25 @@ upstream whenever a later PR touches the embedding execution path.
 
 ## Modifications applied
 
-**None.** Unlike the `Secrets` vendor directory, these files keep their real
+**One prefixed import.** WordPress core scopes the PHP AI Client's PSR dependencies under
+`WordPress\AiClientDependencies\`, so the unprefixed names do not exist under a WordPress
+bootstrap. `src/Builders/EmbeddingBuilder.php` imports
+`Psr\EventDispatcher\EventDispatcherInterface`, and the vendored copy uses core's prefixed name.
+Only the `use` line differs from upstream; the class body is byte-identical.
+
+| File | Upstream import | Vendored import |
+| --- | --- | --- |
+| `src/Builders/EmbeddingBuilder.php` | `Psr\EventDispatcher\EventDispatcherInterface` | `WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface` |
+
+This is a vendoring adaptation, not an upstream bug: upstream installs its PSR packages through
+Composer, where the bare name is correct. It is not a change to send upstream.
+
+`SDK_OverlayTest::test_vendored_files_use_the_prefixed_psr_dependencies()` asserts that no vendored
+file imports an unprefixed `Nyholm\…` or `Psr\…` symbol, so a future re-vendor cannot silently
+reintroduce one. It matches every `Psr\` namespace rather than `Psr\Http\` alone, because core
+prefixes `Psr\EventDispatcher\` and `Psr\SimpleCache\` the same way.
+
+Otherwise unchanged. Unlike the `Secrets` vendor directory, these files keep their real
 `WordPress\AiClient\…` namespace unchanged. That is required: the updated OpenAI/Google/Ollama
 provider plugins must implement *this* `EmbeddingGenerationModelInterface` symbol, so it has to be
 the canonical class, not a re-namespaced copy.

--- a/includes/Vendor/AiClient/src/Builders/EmbeddingBuilder.php
+++ b/includes/Vendor/AiClient/src/Builders/EmbeddingBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace WordPress\AiClient\Builders;
 
-use Psr\EventDispatcher\EventDispatcherInterface;
+use WordPress\AiClientDependencies\Psr\EventDispatcher\EventDispatcherInterface;
 use WordPress\AiClient\Builders\Traits\ModelConfigurationTrait;
 use WordPress\AiClient\Common\AbstractEnum;
 use WordPress\AiClient\Common\Contracts\AiClientExceptionInterface;

--- a/tests/Integration/Includes/SDK_OverlayTest.php
+++ b/tests/Integration/Includes/SDK_OverlayTest.php
@@ -284,4 +284,44 @@ class SDK_OverlayTest extends WP_UnitTestCase {
 			SDK_Overlay::plan_served_classes( $features, array( 'embeddings' => 'activate' ) )
 		);
 	}
+
+	/**
+	 * Vendored files import core's prefixed PSR/Nyholm dependencies, never the bare names.
+	 *
+	 * WordPress core scopes its PSR dependencies under `WordPress\AiClientDependencies\`. An
+	 * unprefixed import resolves to nothing and fatals at runtime.
+	 *
+	 * The match covers every `Psr\` namespace rather than `Psr\Http\` alone. Core scopes more
+	 * than PSR-7 -- `Psr\EventDispatcher\` and `Psr\SimpleCache\` are prefixed the same way --
+	 * and a narrower pattern let an unprefixed `Psr\EventDispatcher\` import sit in the vendored
+	 * tree undetected. It stayed latent only because the symbol appeared solely as a nullable type,
+	 * which PHP never resolves while the value is null; passing a real dispatcher would have raised
+	 * a TypeError, because the prefixed interface does not satisfy the unprefixed name.
+	 */
+	public function test_vendored_files_use_the_prefixed_psr_dependencies(): void {
+		$files = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( SDK_Overlay::src_dir(), \FilesystemIterator::SKIP_DOTS )
+		);
+
+		$checked = 0;
+
+		foreach ( $files as $file ) {
+			if ( 'php' !== $file->getExtension() ) {
+				continue;
+			}
+
+			++$checked;
+
+			$this->assertDoesNotMatchRegularExpression(
+				'/^use (Nyholm|Psr)\\\\/m',
+				(string) file_get_contents( $file->getPathname() ),
+				sprintf(
+					'%s imports an unprefixed PSR dependency; core scopes these under WordPress\\AiClientDependencies\\.',
+					$file->getPathname()
+				)
+			);
+		}
+
+		$this->assertGreaterThan( 0, $checked, 'The vendored tree must contain PHP files.' );
+	}
 }


### PR DESCRIPTION
The vendored `EmbeddingBuilder` imports an unprefixed PSR interface that does not exist under a WordPress bootstrap.

## The bug

WordPress core scopes the PHP AI Client's PSR dependencies under `WordPress\AiClientDependencies\`. Core ships the interface at `wp-includes/php-ai-client/third-party/Psr/EventDispatcher/EventDispatcherInterface.php`, declaring `namespace WordPress\AiClientDependencies\Psr\EventDispatcher`. The vendored file imports the bare name instead:

```php
use Psr\EventDispatcher\EventDispatcherInterface;
```

**Why it has not blown up yet.** The symbol appears only as a nullable typed property and constructor parameter:

```php
private ?EventDispatcherInterface $eventDispatcher;
public function __construct( …, ?EventDispatcherInterface $eventDispatcher = null )
```

PHP does not resolve a nullable type while the value is null, and nothing currently passes a dispatcher. The first caller to pass a real one gets a `TypeError` — core's prefixed interface does not satisfy the unprefixed name. The failure lands when the feature is first *used*, not when it was introduced, which is the worst time to find it.

## Not an upstream change

This is a vendoring adaptation, not a defect in [php-ai-client](https://github.com/WordPress/php-ai-client). Upstream installs its PSR packages through Composer, where the bare name is correct — prefixing there would break their builds to fix a problem only WordPress has. There is nothing to send upstream.

## The missing guard

Nothing asserted this property, so a future re-vendor could reintroduce it silently. This adds `SDK_OverlayTest::test_vendored_files_use_the_prefixed_psr_dependencies()`, which scans the vendored tree and fails on any unprefixed `Nyholm\` or `Psr\` import.

It deliberately matches **every** `Psr\` namespace rather than `Psr\Http\` alone: core prefixes `Psr\EventDispatcher\` and `Psr\SimpleCache\` the same way, and a PSR-7-only pattern is narrower than the hazard it exists to prevent — which is precisely how this import went unnoticed.

## Testing

- `npm run test:php` — **1571 tests, 4487 assertions, 39 skipped, 0 failures.**
- `composer run-script lint` — clean.
- `vendor/bin/phpstan analyse --memory-limit=3G` (level 8) — no errors.

The guard was verified load-bearing rather than assumed: reverting the import to the bare name fails the new test, naming the offending file. Restored, it passes across all vendored files.

## Relationship to #1004

These same changes are also present in #1004 (AI Workspace), where the guard is needed for the streaming files that PR vendors. They are byte-identical, so **whichever merges first makes the other a no-op.** This PR exists so the fix is not blocked behind that much larger, still-draft branch.

---

AI assistance: Yes. Tool(s): Claude Code (Opus 5). Used for: diagnosis, the fix, the guard test, and this description.

> **@whyisjake — this attestation is deliberately left for you.** The [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/) require the contributor to understand every line submitted and explain it under review; that is not something an agent can satisfy on your behalf. Replace this block before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRSJEyQyYp3XTeum8fiq3L

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1005-eca91ea150cb61096427244359c3512ec0b95eb9.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->