### PR TITLE
AI Home: Set minimum container height for settings page during loading

### DIFF
--- a/routes/ai-home/style.scss
+++ b/routes/ai-home/style.scss
@@ -13,7 +13,13 @@
 	width: 100%;
 	max-width: 680px;
 	margin: 0 auto;
+	min-height: calc(100vh - var(--wp-admin--admin-bar--height, 32px) - 93px);
 	padding: 24px;
+	flex-grow: 1;
+
+	@media (max-width: 782px) {
+		min-height: calc(100vh - var(--wp-admin--admin-bar--height, 46px) - 93px);
+	}
 
 	@media (max-width: 480px) {
 		padding: 8px;
@@ -66,6 +72,7 @@ body:has(.ai-settings-page) .components-popover {
 }
 
 .ai-settings-page__loading {
+	flex-grow: 1;
 	min-height: calc(50vh); // Leave space for the page header.
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to the AI plugin! Please follow the AI Plugin Contributing Guidelines:
https://github.com/WordPress/ai/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- Link this PR to its associated issue with an appropriate keyword: Closes, See, Follow up to, etc. -->

This PR updates `.ai-settings-page` CSS to set a `min-height` that spans the full viewport height minus the WordPress admin bar and page header heights, ensuring the page content container spans the full height even during loading state.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Previously, when the AI settings page was loading, the container lacked explicit full-height sizing, causing the loading state container to appear cramped and resulting in layout shifts once loaded.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Sonnet 4.6
Used for: Validating bug, suggesting a fix.

## Testing Instructions
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
1. Navigate to **Settings > AI** in `wp-admin` (`/wp-admin/options-general.php?page=ai-wp-admin`).
2. Refresh or observe the initial page loading state.
3. Verify that the loading spinner is vertically centered within the main content region below the header.
4. Verify that the settings page container spans the full viewport height without overflow or awkward layout shifts once data finishes loading.

## Screenshots or screencast

| Before | After |
| ------ | ----- |
| <img width="1126" height="801" alt="Screenshot 2026-09-10 at 1 06 35 PM" src="https://github.com/user-attachments/assets/170c7b6c-8c95-485c-82ea-06ec98e90f41" /> | <img width="1174" height="926" alt="Screenshot 2026-09-10 at 1 07 09 PM" src="https://github.com/user-attachments/assets/369010fa-50dd-4c8a-be02-b62aab13f900" /> |

## Changelog Entry
> Changed - Updated AI Settings page container min-height so that it spans the full viewport height

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1013-83e88101168e8066d87a68f0136810b666e4c93d.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->