### PR TITLE
Add core/content-create, core/content-update, and core/content-delete abilities

### DIFF
--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -563,8 +563,9 @@ final class Content {
 	 * @return bool True if the author and sticky inputs are permitted.
 	 */
 	private function check_author_and_sticky_permission( array $input, \WP_Post_Type $post_type_object ): bool {
-		$author = isset( $input['author'] ) ? $this->input_int( $input['author'] ) : 0;
-		if ( $author > 0
+		// An author that is not a positive integer is treated as absent; execution rejects it.
+		$author = isset( $input['author'] ) ? $this->parse_filter_int( $input['author'], 1 ) : null;
+		if ( null !== $author
 			&& get_current_user_id() !== $author
 			&& ! current_user_can( $this->post_type_cap( $post_type_object, 'edit_others_posts' ) ) // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
 		) {
@@ -2424,7 +2425,9 @@ final class Content {
 	 * The post must exist, belong to a post type exposed to abilities, and match the
 	 * `post_type` guard when one is given. This is the abilities counterpart of the REST
 	 * controller's `get_post()` lookup, where a post of another type is not found either
-	 * because each REST route is bound to one post type.
+	 * because each REST route is bound to one post type. An ID that is not a positive
+	 * integer never resolves, so a negative or malformed value cannot be coerced onto
+	 * another post.
 	 *
 	 * @since x.x.x
 	 *
@@ -2432,8 +2435,8 @@ final class Content {
 	 * @return \WP_Post|null The post, or null when it cannot be resolved.
 	 */
 	private function get_exposed_post( array $input ): ?WP_Post {
-		$post_id = isset( $input['id'] ) ? $this->input_int( $input['id'] ) : 0;
-		if ( $post_id < 1 ) {
+		$post_id = isset( $input['id'] ) ? $this->parse_filter_int( $input['id'], 1 ) : null;
+		if ( null === $post_id ) {
 			return null;
 		}
 

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -177,10 +177,21 @@ final class Content {
 	 * @since 1.2.0
 	 */
 	public function register(): void {
-		$this->register_content_query();
-		$this->register_content_create();
-		$this->register_content_update();
-		$this->register_content_delete();
+		/*
+		 * Post types must be registered with `show_in_abilities` before the abilities are
+		 * registered so they are included in the input schemas.
+		 */
+		$post_types = array_keys( $this->get_exposed_post_types() );
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		$this->register_content_query( $post_types );
+
+		$write_properties = $this->get_content_write_properties();
+		$this->register_content_create( $post_types, $write_properties );
+		$this->register_content_update( $post_types, $write_properties );
+		$this->register_content_delete( $post_types );
 	}
 
 	/**
@@ -189,31 +200,19 @@ final class Content {
 	 * Also registers `core/read-content` as a deprecated alias.
 	 *
 	 * @since 1.2.0
-	 * @since x.x.x Renamed from `core/read-content`.
+	 * @since x.x.x Renamed from `core/read-content`, and takes the exposed post types.
+	 *
+	 * @param list<string> $post_types Exposed post type names.
 	 */
-	private function register_content_query(): void {
-		/*
-		 * Post types must be registered with `show_in_abilities` before the ability is
-		 * registered so they are included in its input schema.
-		 */
-		$post_types = array_keys( $this->get_exposed_post_types() );
-		if ( empty( $post_types ) ) {
-			return;
-		}
-
-		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/content-query' ) ) {
-			wp_unregister_ability( 'core/content-query' );
-		}
-
+	private function register_content_query( array $post_types ): void {
 		/*
 		 * Internal statuses (e.g. `inherit`) are excluded, so post types that rely on
 		 * them (attachments) are only reachable by ID. Revisit if such a post type is
 		 * ever exposed via `show_in_abilities`.
 		 */
-		$statuses = array_values( get_post_stati( array( 'internal' => false ) ) );
+		$statuses = $this->get_writable_statuses();
 
-		wp_register_ability(
+		$this->register_ability_override(
 			'core/content-query',
 			array(
 				'label'               => __( 'Content Query', 'ai' ),
@@ -245,25 +244,18 @@ final class Content {
 	 * Registers the `core/content-create` ability.
 	 *
 	 * @since x.x.x
+	 *
+	 * @param list<string>         $post_types       Exposed post type names.
+	 * @param array<string, mixed> $write_properties The input properties shared by the write abilities.
 	 */
-	private function register_content_create(): void {
-		$post_types = array_keys( $this->get_exposed_post_types() );
-		if ( empty( $post_types ) ) {
-			return;
-		}
-
-		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/content-create' ) ) {
-			wp_unregister_ability( 'core/content-create' );
-		}
-
-		wp_register_ability(
+	private function register_content_create( array $post_types, array $write_properties ): void {
+		$this->register_ability_override(
 			'core/content-create',
 			array(
 				'label'               => __( 'Content Create', 'ai' ),
 				'description'         => __( 'Creates a post of a post type exposed to abilities. Accepts a title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky flag, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the created post; use `fields` to choose which post fields are returned. Requires an authenticated user who can create posts of the post type.', 'ai' ),
 				'category'            => self::CATEGORY,
-				'input_schema'        => $this->get_content_create_input_schema( $post_types ),
+				'input_schema'        => $this->get_content_create_input_schema( $post_types, $write_properties ),
 				'output_schema'       => $this->get_post_output_schema(),
 				'execute_callback'    => array( $this, 'execute_content_create' ),
 				'permission_callback' => array( $this, 'check_create_permission' ),
@@ -285,39 +277,35 @@ final class Content {
 	 * Registers the `core/content-update` ability.
 	 *
 	 * @since x.x.x
+	 *
+	 * @param list<string>         $post_types       Exposed post type names.
+	 * @param array<string, mixed> $write_properties The input properties shared by the write abilities.
 	 */
-	private function register_content_update(): void {
-		$post_types = array_keys( $this->get_exposed_post_types() );
-		if ( empty( $post_types ) ) {
-			return;
-		}
-
-		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/content-update' ) ) {
-			wp_unregister_ability( 'core/content-update' );
-		}
-
-		wp_register_ability(
+	private function register_content_update( array $post_types, array $write_properties ): void {
+		$this->register_ability_override(
 			'core/content-update',
 			array(
 				'label'               => __( 'Content Update', 'ai' ),
 				'description'         => __( 'Updates a post by ID. Only the provided fields change; omitted fields keep their current values. Accepts a title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky flag, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the updated post; use `fields` to choose which post fields are returned. Requires an authenticated user who can edit the post.', 'ai' ),
 				'category'            => self::CATEGORY,
-				'input_schema'        => $this->get_content_update_input_schema( $post_types ),
+				'input_schema'        => $this->get_content_update_input_schema( $post_types, $write_properties ),
 				'output_schema'       => $this->get_post_output_schema(),
 				'execute_callback'    => array( $this, 'execute_content_update' ),
 				'permission_callback' => array( $this, 'check_update_permission' ),
 				'meta'                => array(
 					'annotations'  => array(
 						'readonly'    => false,
+						// Overwrites post fields, and revisions do not always keep the
+						// previous values (the first revision of a post is taken after the
+						// update, and not every post type keeps revisions).
+						'destructive' => true,
 						/*
-						 * Not flagged destructive: overwritten content is kept as a revision,
-						 * and the Abilities API serves destructive idempotent abilities over the
-						 * DELETE method, whose query-string input cannot carry post content.
+						 * Every call touches the modified date. Not flagging the ability
+						 * idempotent also keeps it on the POST method: the Abilities API serves
+						 * destructive idempotent abilities over DELETE, whose query-string
+						 * input cannot carry post content.
 						 */
-						'destructive' => false,
-						// Repeating the same update leaves the post in the same state.
-						'idempotent'  => true,
+						'idempotent'  => false,
 						'open_world'  => false,
 					),
 					'show_in_rest' => true,
@@ -330,19 +318,11 @@ final class Content {
 	 * Registers the `core/content-delete` ability.
 	 *
 	 * @since x.x.x
+	 *
+	 * @param list<string> $post_types Exposed post type names.
 	 */
-	private function register_content_delete(): void {
-		$post_types = array_keys( $this->get_exposed_post_types() );
-		if ( empty( $post_types ) ) {
-			return;
-		}
-
-		// Plugin: unregister any core-provided copy first so the plugin's version wins.
-		if ( wp_has_ability( 'core/content-delete' ) ) {
-			wp_unregister_ability( 'core/content-delete' );
-		}
-
-		wp_register_ability(
+	private function register_content_delete( array $post_types ): void {
+		$this->register_ability_override(
 			'core/content-delete',
 			array(
 				'label'               => __( 'Content Delete', 'ai' ),
@@ -368,6 +348,25 @@ final class Content {
 	}
 
 	/**
+	 * Registers an ability, replacing any copy WordPress core provides.
+	 *
+	 * Plugin: this method has no equivalent in the core class. The plugin registers its
+	 * abilities on the same hook as core but later, so its version must win.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string               $name The ability name.
+	 * @param array<string, mixed> $args The ability registration arguments.
+	 */
+	private function register_ability_override( string $name, array $args ): void {
+		if ( wp_has_ability( $name ) ) {
+			wp_unregister_ability( $name );
+		}
+
+		wp_register_ability( $name, $args );
+	}
+
+	/**
 	 * Permission callback for the `core/content-query` ability.
 	 *
 	 * This gate is the authoritative permission decision for single-post modes: it
@@ -383,8 +382,7 @@ final class Content {
 	 * @return bool True if the request may proceed, false otherwise.
 	 */
 	public function check_permission( $input = array() ): bool {
-		$input   = rest_sanitize_object( $input );
-		$exposed = $this->get_exposed_post_types();
+		$input = rest_sanitize_object( $input );
 
 		if ( ! is_user_logged_in() ) {
 			return false;
@@ -403,13 +401,13 @@ final class Content {
 		}
 
 		// Single-post mode (by slug) and query mode require an exposed post type.
-		$post_type = isset( $input['post_type'] ) && is_string( $input['post_type'] ) ? $input['post_type'] : '';
-		if ( '' === $post_type || ! isset( $exposed[ $post_type ] ) ) {
+		$post_type_object = $this->get_exposed_post_type( $input );
+		if ( ! $post_type_object ) {
 			return false;
 		}
 
 		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) && '' !== $input['slug'] ) {
-			$post = $this->get_post_by_slug( $post_type, $input['slug'] );
+			$post = $this->get_post_by_slug( $post_type_object->name, $input['slug'] );
 			if ( ! $post ) {
 				return false;
 			}
@@ -417,7 +415,6 @@ final class Content {
 			return $requires_edit ? current_user_can( 'edit_post', $post->ID ) : $this->check_read_permission( $post );
 		}
 
-		$post_type_object = $exposed[ $post_type ];
 		if ( $requires_edit ) {
 			return current_user_can( $this->post_type_cap( $post_type_object, 'edit_posts' ) ); // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
 		}
@@ -426,7 +423,7 @@ final class Content {
 	}
 
 	/**
-	 * Permission callback for the `core/content-create` ability.
+	 * Checks permission for the `core/content-create` ability.
 	 *
 	 * The current user must be able to create posts of the requested post type, may only
 	 * create a post as another author when they can edit others' posts, may only make a
@@ -466,7 +463,7 @@ final class Content {
 	}
 
 	/**
-	 * Permission callback for the `core/content-update` ability.
+	 * Checks permission for the `core/content-update` ability.
 	 *
 	 * The post must exist in an exposed post type (and match the `post_type` guard when
 	 * given), the current user must be able to edit it, may only reassign it to another
@@ -487,15 +484,12 @@ final class Content {
 			return false;
 		}
 
-		$post = $this->get_exposed_post( $input );
-		if ( ! $post ) {
+		$resolved = $this->get_exposed_post_with_type( $input );
+		if ( null === $resolved ) {
 			return false;
 		}
 
-		$post_type_object = get_post_type_object( $post->post_type );
-		if ( ! $post_type_object instanceof \WP_Post_Type ) {
-			return false;
-		}
+		[ $post, $post_type_object ] = $resolved;
 
 		// An exposed post type (checked above) and the edit_post meta capability.
 		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
@@ -510,7 +504,7 @@ final class Content {
 	}
 
 	/**
-	 * Permission callback for the `core/content-delete` ability.
+	 * Checks permission for the `core/content-delete` ability.
 	 *
 	 * The post must exist in an exposed post type (and match the `post_type` guard when
 	 * given), and the current user must be able to delete it.
@@ -541,7 +535,8 @@ final class Content {
 	 *
 	 * Creating or updating a post as another author requires the post type's
 	 * `edit_others_posts` capability. Making a post sticky requires `edit_others_posts` or
-	 * `publish_posts`.
+	 * `publish_posts`. Fields the post type does not support are left to execution, which
+	 * rejects them for every role alike.
 	 *
 	 * @since x.x.x
 	 *
@@ -550,13 +545,19 @@ final class Content {
 	 * @return bool True if the author and sticky inputs are permitted.
 	 */
 	private function check_author_and_sticky_permission( array $input, \WP_Post_Type $post_type_object ): bool {
-		// An author that is not a positive integer is treated as absent; execution rejects it.
-		$author = isset( $input['author'] ) ? $this->parse_filter_int( $input['author'], 1 ) : null;
+		$support = $this->get_write_field_support( $post_type_object->name );
+
+		// An author that is not a positive integer is treated as absent, like an author of 0.
+		$author = $support['author'] && isset( $input['author'] ) ? $this->parse_filter_int( $input['author'], 1 ) : null;
 		if ( null !== $author
 			&& get_current_user_id() !== $author
 			&& ! current_user_can( $this->post_type_cap( $post_type_object, 'edit_others_posts' ) ) // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
 		) {
 			return false;
+		}
+
+		if ( ! $support['sticky'] ) {
+			return true;
 		}
 
 		return true !== $this->input_bool( $input['sticky'] ?? null ) || $this->can_make_sticky( $post_type_object );
@@ -594,33 +595,31 @@ final class Content {
 	}
 
 	/**
-	 * Parses a raw filter value into an integer of at least a minimum, or null when invalid.
+	 * Parses a raw input value into an integer of at least a minimum, or null when invalid.
 	 *
-	 * Unlike {@see self::input_int()}, which coerces any non-integer to 0, this rejects
-	 * values that are not integers so a filter whose value cannot be honored can fail
-	 * loudly instead of silently widening the query: `author => 0` drops the author
-	 * filter (matching every author) and `post_parent => 0` becomes a top-level query.
-	 * Accepts native integers and unsigned integer strings, mirroring how the JSON
-	 * Schema `integer` type and the query-string transport respectively deliver them.
+	 * Accepts every form the JSON Schema `integer` type accepts (native integers, whole
+	 * floats, and numeric strings such as "12", "12.0", or "+12"), so a value that passed
+	 * validation always resolves. Unlike {@see self::input_int()}, which coerces any
+	 * non-integer to 0, this rejects values that are not integers so a filter whose value
+	 * cannot be honored can fail loudly instead of silently widening the query:
+	 * `author => 0` drops the author filter (matching every author) and `post_parent => 0`
+	 * becomes a top-level query.
 	 *
 	 * @since 1.2.0
+	 * @since x.x.x Accepts every form the JSON Schema `integer` type accepts.
 	 *
 	 * @param mixed $value The raw input value.
 	 * @param int   $min   The smallest acceptable value.
 	 * @return int|null The parsed integer, or null when the value is not an integer >= $min.
 	 */
 	private function parse_filter_int( $value, int $min ): ?int {
-		if ( is_int( $value ) ) {
-			return $value >= $min ? $value : null;
+		if ( ! rest_is_integer( $value ) ) {
+			return null;
 		}
 
-		if ( is_string( $value ) && '' !== $value && ctype_digit( $value ) ) {
-			$int = (int) $value;
+		$int = is_int( $value ) ? $value : (int) (float) $value;
 
-			return $int >= $min ? $int : null;
-		}
-
-		return null;
+		return $int >= $min ? $int : null;
 	}
 
 	/**
@@ -813,7 +812,6 @@ final class Content {
 	 */
 	public function execute_content_query( $input = array() ) {
 		$input         = rest_sanitize_object( $input );
-		$exposed       = $this->get_exposed_post_types();
 		$fields        = $this->normalize_fields( $input );
 		$requires_edit = $this->has_explicit_edit_fields( $input );
 
@@ -828,10 +826,12 @@ final class Content {
 		}
 
 		// Single-post mode (by slug) and query mode.
-		$post_type = isset( $input['post_type'] ) && is_string( $input['post_type'] ) ? $input['post_type'] : '';
-		if ( '' === $post_type || ! isset( $exposed[ $post_type ] ) ) {
+		$post_type_object = $this->get_exposed_post_type( $input );
+		if ( ! $post_type_object ) {
 			return $this->not_found_error();
 		}
+
+		$post_type = $post_type_object->name;
 
 		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) && '' !== $input['slug'] ) {
 			$post = $this->get_post_by_slug( $post_type, $input['slug'] );
@@ -874,7 +874,7 @@ final class Content {
 
 		$author = null;
 		if ( isset( $input['author'] ) ) {
-			if ( ! post_type_supports( $post_type, 'author' ) ) {
+			if ( ! $this->supports_feature( $post_type, 'author' ) ) {
 				return new WP_Error(
 					'content_invalid_filter',
 					__( 'The author filter is only supported for post types that support authors.', 'ai' ),
@@ -958,7 +958,7 @@ final class Content {
 		 * Prime the author caches with a single query instead of one user lookup
 		 * per post, mirroring the REST posts controller.
 		 */
-		if ( in_array( 'author', $fields, true ) && post_type_supports( $post_type, 'author' ) ) {
+		if ( in_array( 'author', $fields, true ) && $this->supports_feature( $post_type, 'author' ) ) {
 			$query_posts = array_filter(
 				$query->posts,
 				static function ( $queried_post ): bool {
@@ -998,10 +998,7 @@ final class Content {
 	 * Executes the `core/content-create` ability.
 	 *
 	 * {@see WP_Ability::execute()} always runs {@see self::check_create_permission()} first,
-	 * so this only re-validates that the post type is exposed before preparing and
-	 * inserting the post. Errors raised after the post has been inserted (for example while
-	 * assigning terms) are returned as-is: the post exists at that point and its ID is not
-	 * reported.
+	 * so this only re-validates that the post type is exposed before writing the post.
 	 *
 	 * @since x.x.x
 	 *
@@ -1020,74 +1017,14 @@ final class Content {
 			);
 		}
 
-		$unsupported = $this->check_unsupported_fields( $input, $post_type_object );
-		if ( $unsupported instanceof WP_Error ) {
-			return $unsupported;
-		}
-
-		$template = $this->check_template( $input, $post_type_object->name, null );
-		if ( $template instanceof WP_Error ) {
-			return $template;
-		}
-
-		$prepared_post = $this->prepare_item_for_database( $input, $post_type_object, null );
-		if ( $prepared_post instanceof WP_Error ) {
-			return $prepared_post;
-		}
-
-		if ( ! empty( $prepared_post->post_name )
-			&& ! empty( $prepared_post->post_status )
-			&& in_array( $prepared_post->post_status, array( 'draft', 'pending' ), true )
-		) {
-			/*
-			 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
-			 *
-			 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
-			 */
-			$prepared_post->post_name = wp_unique_post_slug(
-				$prepared_post->post_name,
-				0,
-				'publish',
-				$prepared_post->post_type,
-				$prepared_post->post_parent ?? 0
-			);
-		}
-
-		$post_id = wp_insert_post( $this->slash_post_data( $prepared_post ), true, false );
-
-		if ( $post_id instanceof WP_Error ) {
-			$post_id->add_data( array( 'status' => 'db_insert_error' === $post_id->get_error_code() ? 500 : 400 ) );
-
-			return $post_id;
-		}
-
-		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post ) {
-			return $this->not_found_error();
-		}
-
-		$extras = $this->handle_post_extras( $post, $input, $post_type_object, true );
-		if ( $extras instanceof WP_Error ) {
-			return $extras;
-		}
-
-		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post ) {
-			return $this->not_found_error();
-		}
-
-		wp_after_insert_post( $post, false, null );
-
-		return $this->to_output_post( $this->format_post( $post, $this->normalize_fields( $input ) ) );
+		return $this->write_post( $input, $post_type_object, null );
 	}
 
 	/**
 	 * Executes the `core/content-update` ability.
 	 *
 	 * {@see WP_Ability::execute()} always runs {@see self::check_update_permission()} first,
-	 * so this only re-validates the lookup itself before preparing and updating the post.
-	 * Errors raised after the post has been updated (for example while assigning terms) are
-	 * returned as-is.
+	 * so this only re-validates the lookup itself before writing the post.
 	 *
 	 * @since x.x.x
 	 *
@@ -1097,24 +1034,37 @@ final class Content {
 	public function execute_content_update( $input = array() ) {
 		$input = rest_sanitize_object( $input );
 
-		$post_before = $this->get_exposed_post( $input );
-		if ( ! $post_before ) {
+		$resolved = $this->get_exposed_post_with_type( $input );
+		if ( null === $resolved ) {
 			return $this->not_found_error();
 		}
 
-		$post_type_object = get_post_type_object( $post_before->post_type );
-		if ( ! $post_type_object instanceof \WP_Post_Type ) {
-			return $this->not_found_error();
-		}
+		[ $post_before, $post_type_object ] = $resolved;
 
+		return $this->write_post( $input, $post_type_object, $post_before );
+	}
+
+	/**
+	 * Creates or updates a post from the ability input.
+	 *
+	 * Shared by the create and update abilities. Rejects fields the post type does not
+	 * support, prepares the post, validates the objects the input refers to (template,
+	 * featured media, and terms) before anything is written, keeps draft and pending
+	 * slugs unique, writes the post, applies the parts that live outside the posts table,
+	 * and fires the post insertion hook. An error raised after the post was written
+	 * carries the post ID in its data, so the caller knows the post exists.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type of the post being written.
+	 * @param \WP_Post|null $post_before      The post being updated, or null when creating.
+	 * @return array<string, mixed>|\stdClass|\WP_Error The written post, or a WP_Error.
+	 */
+	private function write_post( array $input, \WP_Post_Type $post_type_object, ?WP_Post $post_before ) {
 		$unsupported = $this->check_unsupported_fields( $input, $post_type_object );
 		if ( $unsupported instanceof WP_Error ) {
 			return $unsupported;
-		}
-
-		$template = $this->check_template( $input, $post_type_object->name, $post_before );
-		if ( $template instanceof WP_Error ) {
-			return $template;
 		}
 
 		$prepared_post = $this->prepare_item_for_database( $input, $post_type_object, $post_before );
@@ -1122,27 +1072,45 @@ final class Content {
 			return $prepared_post;
 		}
 
-		$post_status = ! empty( $prepared_post->post_status ) ? $prepared_post->post_status : $post_before->post_status;
+		$template = $this->check_template( $input, $post_type_object->name, $post_before );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
 
-		/*
-		 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
-		 *
-		 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
-		 */
+		$featured_media = $this->check_featured_media( $input, $post_type_object );
+		if ( $featured_media instanceof WP_Error ) {
+			return $featured_media;
+		}
+
+		$terms = $this->check_terms( $input, $post_type_object );
+		if ( $terms instanceof WP_Error ) {
+			return $terms;
+		}
+
+		$post_status = ! empty( $prepared_post->post_status ) ? $prepared_post->post_status : ( $post_before instanceof WP_Post ? $post_before->post_status : '' );
+
 		if ( ! empty( $prepared_post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
+			/*
+			 * wp_unique_post_slug() returns the same slug for draft or pending posts. To
+			 * ensure that a unique slug is generated, pass the post data with the publish
+			 * status. The parent defaults to the existing one, so a child page competes
+			 * with its siblings rather than with top-level pages.
+			 */
 			$prepared_post->post_name = wp_unique_post_slug(
 				$prepared_post->post_name,
-				$post_before->ID,
+				$post_before instanceof WP_Post ? $post_before->ID : 0,
 				'publish',
 				$prepared_post->post_type,
-				! empty( $prepared_post->post_parent ) ? $prepared_post->post_parent : 0
+				$prepared_post->post_parent ?? ( $post_before instanceof WP_Post ? (int) $post_before->post_parent : 0 )
 			);
 		}
 
-		$post_id = wp_update_post( $this->slash_post_data( $prepared_post ), true, false );
+		$post_data = $this->slash_post_data( $prepared_post );
+		$post_id   = $post_before instanceof WP_Post ? wp_update_post( $post_data, true, false ) : wp_insert_post( $post_data, true, false );
 
 		if ( $post_id instanceof WP_Error ) {
-			$post_id->add_data( array( 'status' => 'db_update_error' === $post_id->get_error_code() ? 500 : 400 ) );
+			$database_error = in_array( $post_id->get_error_code(), array( 'db_insert_error', 'db_update_error' ), true );
+			$post_id->add_data( array( 'status' => $database_error ? 500 : 400 ) );
 
 			return $post_id;
 		}
@@ -1152,19 +1120,31 @@ final class Content {
 			return $this->not_found_error();
 		}
 
-		$extras = $this->handle_post_extras( $post, $input, $post_type_object, false );
+		$extras = $this->handle_post_extras( $post, $input, $post_type_object, ! $post_before instanceof WP_Post );
 		if ( $extras instanceof WP_Error ) {
-			return $extras;
+			return $this->add_post_id_to_error( $extras, (int) $post->ID );
 		}
 
-		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post ) {
-			return $this->not_found_error();
-		}
-
-		wp_after_insert_post( $post, true, $post_before );
+		wp_after_insert_post( $post, $post_before instanceof WP_Post, $post_before );
 
 		return $this->to_output_post( $this->format_post( $post, $this->normalize_fields( $input ) ) );
+	}
+
+	/**
+	 * Adds the ID of an already written post to an error raised after the write.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_Error $error   The error.
+	 * @param int       $post_id The written post ID.
+	 * @return \WP_Error The error, carrying the post ID.
+	 */
+	private function add_post_id_to_error( WP_Error $error, int $post_id ): WP_Error {
+		$data = $error->get_error_data();
+
+		$error->add_data( array_merge( is_array( $data ) ? $data : array(), array( 'post_id' => $post_id ) ) );
+
+		return $error;
 	}
 
 	/**
@@ -1409,6 +1389,20 @@ final class Content {
 		$statuses = $this->parse_list_input( $input, 'status' );
 
 		return array() === $statuses ? array( 'publish' ) : array_map( 'sanitize_key', $statuses );
+	}
+
+	/**
+	 * Returns the statuses a post can be given, in registration order.
+	 *
+	 * Internal statuses (e.g. `trash` or `inherit`) are excluded: a post only enters them
+	 * through dedicated operations such as trashing.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return list<string> The status names.
+	 */
+	private function get_writable_statuses(): array {
+		return array_values( get_post_stati( array( 'internal' => false ) ) );
 	}
 
 	/**
@@ -1782,18 +1776,16 @@ final class Content {
 	 *
 	 * Taxonomy terms are accepted under one property per taxonomy an exposed post type
 	 * registers with `show_in_rest`, keyed by the taxonomy's `rest_base` when it has one
-	 * (e.g. `categories` and `tags` for posts) and by its name otherwise. Support for a
-	 * field depends on the post type; a shared schema cannot express that per post type,
-	 * so the descriptions state the requirement and {@see self::check_unsupported_fields()}
-	 * enforces it at execution time.
+	 * (e.g. `categories` and `tags` for posts) and by its name otherwise; taxonomies must be
+	 * registered before the abilities are. Support for a field depends on the post type; a
+	 * shared schema cannot express that per post type, so the descriptions state the
+	 * requirement and {@see self::check_unsupported_fields()} enforces it at execution time.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return array<string, mixed> Write property definitions.
 	 */
 	private function get_content_write_properties(): array {
-		$statuses = array_values( get_post_stati( array( 'internal' => false ) ) );
-
 		$raw_object = array(
 			'raw' => array(
 				'type' => 'string',
@@ -1804,21 +1796,24 @@ final class Content {
 			'title'          => array(
 				'type'        => array( 'string', 'object' ),
 				'properties'  => $raw_object,
+				'required'    => array( 'raw' ),
 				'description' => __( 'The raw post title, as a string or as an object with a `raw` key. Only supported for post types that support titles.', 'ai' ),
 			),
 			'content'        => array(
 				'type'        => array( 'string', 'object' ),
 				'properties'  => $raw_object,
+				'required'    => array( 'raw' ),
 				'description' => __( 'The raw post content, as block markup or HTML, given as a string or as an object with a `raw` key. Only supported for post types that support the editor.', 'ai' ),
 			),
 			'excerpt'        => array(
 				'type'        => array( 'string', 'object' ),
 				'properties'  => $raw_object,
+				'required'    => array( 'raw' ),
 				'description' => __( 'The raw post excerpt, as a string or as an object with a `raw` key. Only supported for post types that support excerpts.', 'ai' ),
 			),
 			'status'         => array(
 				'type'        => 'string',
-				'enum'        => $statuses,
+				'enum'        => $this->get_writable_statuses(),
 				'description' => __( 'The post status. Defaults to draft when creating. Publishing, scheduling, or making a post private requires the publish capability for the post type.', 'ai' ),
 			),
 			'slug'           => array(
@@ -1837,8 +1832,8 @@ final class Content {
 			),
 			'author'         => array(
 				'type'        => 'integer',
-				'minimum'     => 1,
-				'description' => __( 'The author user ID. Assigning another user requires the capability to edit their posts. Only supported for post types that support authors.', 'ai' ),
+				'minimum'     => 0,
+				'description' => __( 'The author user ID; 0 is ignored. Assigning another user requires the capability to edit their posts. Only supported for post types that support authors.', 'ai' ),
 			),
 			'password'       => array(
 				'type'        => 'string',
@@ -1886,7 +1881,6 @@ final class Content {
 		foreach ( $this->get_all_writable_taxonomies() as $key => $taxonomy ) {
 			$properties[ $key ] = array(
 				'type'        => 'array',
-				'uniqueItems' => true,
 				'items'       => array(
 					'type'    => 'integer',
 					'minimum' => 1,
@@ -1910,10 +1904,11 @@ final class Content {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param list<string> $post_types Exposed post type names.
+	 * @param list<string>         $post_types       Exposed post type names.
+	 * @param array<string, mixed> $write_properties The input properties shared by the write abilities.
 	 * @return array<string, mixed> The input JSON Schema.
 	 */
-	private function get_content_create_input_schema( array $post_types ): array {
+	private function get_content_create_input_schema( array $post_types, array $write_properties ): array {
 		return array(
 			'type'                 => 'object',
 			'required'             => array( 'post_type' ),
@@ -1926,7 +1921,7 @@ final class Content {
 						'description' => __( 'The post type of the post to create.', 'ai' ),
 					),
 				),
-				$this->get_content_write_properties(),
+				$write_properties,
 				array( 'fields' => $this->get_fields_input_schema() )
 			),
 		);
@@ -1935,12 +1930,26 @@ final class Content {
 	/**
 	 * Builds the input schema for the `core/content-update` ability.
 	 *
+	 * The status is not restricted by an enum here: a post may keep its current status even
+	 * when it is an internal one such as `trash`, so the status is validated during
+	 * execution against the post being updated.
+	 *
 	 * @since x.x.x
 	 *
-	 * @param list<string> $post_types Exposed post type names.
+	 * @param list<string>         $post_types       Exposed post type names.
+	 * @param array<string, mixed> $write_properties The input properties shared by the write abilities.
 	 * @return array<string, mixed> The input JSON Schema.
 	 */
-	private function get_content_update_input_schema( array $post_types ): array {
+	private function get_content_update_input_schema( array $post_types, array $write_properties ): array {
+		$write_properties['status'] = array(
+			'type'        => 'string',
+			'description' => sprintf(
+				/* translators: %s: Comma-separated list of post statuses. */
+				__( 'The post status: one of %s, or the current status of the post. Publishing, scheduling, or making a post private requires the publish capability for the post type.', 'ai' ),
+				implode( ', ', $this->get_writable_statuses() )
+			),
+		);
+
 		return array(
 			'type'                 => 'object',
 			'required'             => array( 'id' ),
@@ -1958,7 +1967,7 @@ final class Content {
 						'description' => __( 'Optional. Restrict the update to this post type; the post is only updated if it matches.', 'ai' ),
 					),
 				),
-				$this->get_content_write_properties(),
+				$write_properties,
 				array( 'fields' => $this->get_fields_input_schema() )
 			),
 		);
@@ -2147,39 +2156,39 @@ final class Content {
 			$data['link'] = (string) get_permalink( $post );
 		}
 
-		if ( isset( $requested['title_raw'] ) && post_type_supports( $post_type, 'title' ) ) {
+		if ( isset( $requested['title_raw'] ) && $this->supports_feature( $post_type, 'title' ) ) {
 			$data['title_raw'] = $post->post_title;
 		}
 
-		if ( isset( $requested['title_rendered'] ) && post_type_supports( $post_type, 'title' ) ) {
+		if ( isset( $requested['title_rendered'] ) && $this->supports_feature( $post_type, 'title' ) ) {
 			$data['title_rendered'] = $this->get_title( $post );
 		}
 
-		if ( isset( $requested['excerpt_raw'] ) && post_type_supports( $post_type, 'excerpt' ) ) {
+		if ( isset( $requested['excerpt_raw'] ) && $this->supports_feature( $post_type, 'excerpt' ) ) {
 			$data['excerpt_raw'] = $post->post_excerpt;
 		}
 
-		if ( isset( $requested['excerpt_rendered'] ) && post_type_supports( $post_type, 'excerpt' ) ) {
+		if ( isset( $requested['excerpt_rendered'] ) && $this->supports_feature( $post_type, 'excerpt' ) ) {
 			$data['excerpt_rendered'] = $is_protected ? '' : $this->get_rendered_excerpt( $post );
 		}
 
-		if ( isset( $requested['excerpt_protected'] ) && post_type_supports( $post_type, 'excerpt' ) ) {
+		if ( isset( $requested['excerpt_protected'] ) && $this->supports_feature( $post_type, 'excerpt' ) ) {
 			$data['excerpt_protected'] = (bool) $post->post_password;
 		}
 
-		if ( isset( $requested['content_raw'] ) && post_type_supports( $post_type, 'editor' ) ) {
+		if ( isset( $requested['content_raw'] ) && $this->supports_feature( $post_type, 'editor' ) ) {
 			$data['content_raw'] = $post->post_content;
 		}
 
-		if ( isset( $requested['content_rendered'] ) && post_type_supports( $post_type, 'editor' ) ) {
+		if ( isset( $requested['content_rendered'] ) && $this->supports_feature( $post_type, 'editor' ) ) {
 			$data['content_rendered'] = $is_protected ? '' : $this->get_rendered_content( $post );
 		}
 
-		if ( isset( $requested['content_protected'] ) && post_type_supports( $post_type, 'editor' ) ) {
+		if ( isset( $requested['content_protected'] ) && $this->supports_feature( $post_type, 'editor' ) ) {
 			$data['content_protected'] = (bool) $post->post_password;
 		}
 
-		if ( isset( $requested['author'] ) && post_type_supports( $post_type, 'author' ) ) {
+		if ( isset( $requested['author'] ) && $this->supports_feature( $post_type, 'author' ) ) {
 			$author         = get_userdata( (int) $post->post_author );
 			$data['author'] = array(
 				'id'   => (int) $post->post_author,
@@ -2418,11 +2427,31 @@ final class Content {
 			return null;
 		}
 
-		return $this->get_exposed_post_types()[ $post_type ] ?? null;
+		$post_type_object = get_post_type_object( $post_type );
+		if ( ! $post_type_object instanceof \WP_Post_Type || ! $this->is_exposed_post_type( $post_type_object ) ) {
+			return null;
+		}
+
+		return $post_type_object;
 	}
 
 	/**
-	 * Resolves the exposed post an `id` input refers to.
+	 * Checks whether a post type is exposed to abilities.
+	 *
+	 * Read on every call rather than cached, for the reason given in
+	 * {@see self::get_exposed_post_types()}.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return bool True when the post type is exposed.
+	 */
+	private function is_exposed_post_type( \WP_Post_Type $post_type_object ): bool {
+		return ! empty( $post_type_object->show_in_abilities );
+	}
+
+	/**
+	 * Resolves the exposed post an `id` input refers to, with its post type.
 	 *
 	 * The post must exist, belong to a post type exposed to abilities, and match the
 	 * `post_type` guard when one is given. An ID that is not a positive integer never
@@ -2431,16 +2460,21 @@ final class Content {
 	 * @since x.x.x
 	 *
 	 * @param array<mixed> $input The ability input.
-	 * @return \WP_Post|null The post, or null when it cannot be resolved.
+	 * @return array{0: \WP_Post, 1: \WP_Post_Type}|null The post and its post type, or null when they cannot be resolved.
 	 */
-	private function get_exposed_post( array $input ): ?WP_Post {
+	private function get_exposed_post_with_type( array $input ): ?array {
 		$post_id = isset( $input['id'] ) ? $this->parse_filter_int( $input['id'], 1 ) : null;
 		if ( null === $post_id ) {
 			return null;
 		}
 
 		$post = get_post( $post_id );
-		if ( ! $post instanceof WP_Post || ! isset( $this->get_exposed_post_types()[ $post->post_type ] ) ) {
+		if ( ! $post instanceof WP_Post ) {
+			return null;
+		}
+
+		$post_type_object = get_post_type_object( $post->post_type );
+		if ( ! $post_type_object instanceof \WP_Post_Type || ! $this->is_exposed_post_type( $post_type_object ) ) {
 			return null;
 		}
 
@@ -2448,15 +2482,28 @@ final class Content {
 			return null;
 		}
 
-		return $post;
+		return array( $post, $post_type_object );
+	}
+
+	/**
+	 * Resolves the exposed post an `id` input refers to.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return \WP_Post|null The post, or null when it cannot be resolved.
+	 */
+	private function get_exposed_post( array $input ): ?WP_Post {
+		$resolved = $this->get_exposed_post_with_type( $input );
+
+		return null === $resolved ? null : $resolved[0];
 	}
 
 	/**
 	 * Casts a raw input value to a boolean, or null when it was not provided.
 	 *
 	 * Boolean inputs arrive as native booleans from a JSON body and as strings such as
-	 * "true" or "0" from a query string: the strings "false" and "0" are false, any other
-	 * value casts to boolean.
+	 * "true" or "0" from a query string; rest_sanitize_boolean() reads both.
 	 *
 	 * @since x.x.x
 	 *
@@ -2468,55 +2515,46 @@ final class Content {
 			return null;
 		}
 
-		if ( is_string( $value ) && in_array( strtolower( $value ), array( 'false', '0' ), true ) ) {
-			return false;
-		}
-
-		return (bool) $value;
+		return rest_sanitize_boolean( is_string( $value ) ? $value : (bool) $value );
 	}
 
 	/**
 	 * Reads a text input given either as a string or as an object with a `raw` key.
 	 *
-	 * The object form matches how the title, content, and excerpt are read back by the
-	 * posts endpoints, so a value can be written the same way it was fetched.
+	 * The object form is how the title, content, and excerpt are read back from the posts
+	 * endpoints, so a value can be written the same way it was fetched. The schema requires
+	 * the `raw` key, so an object is exactly equivalent to its `raw` string.
 	 *
 	 * @since x.x.x
 	 *
-	 * @param array<mixed> $input           The ability input.
-	 * @param string       $key             The input key holding the text.
-	 * @param bool         $allow_empty_raw Whether an empty `raw` value counts as provided.
+	 * @param array<mixed> $input The ability input.
+	 * @param string       $key   The input key holding the text.
 	 * @return string|null The text, or null when the input does not provide it.
 	 */
-	private function get_text_input( array $input, string $key, bool $allow_empty_raw ): ?string {
+	private function get_text_input( array $input, string $key ): ?string {
 		$value = $input[ $key ] ?? null;
-
-		if ( is_string( $value ) ) {
-			return $value;
-		}
 
 		if ( is_object( $value ) ) {
 			$value = (array) $value;
 		}
 
-		if ( ! is_array( $value ) || ! isset( $value['raw'] ) || ! is_string( $value['raw'] ) ) {
-			return null;
+		if ( is_array( $value ) ) {
+			$value = $value['raw'] ?? null;
 		}
 
-		if ( ! $allow_empty_raw && empty( $value['raw'] ) ) {
-			return null;
-		}
-
-		return $value['raw'];
+		return is_string( $value ) ? $value : null;
 	}
 
 	/**
 	 * Returns which write fields a post type supports, keyed by input key.
 	 *
 	 * `title`, `content`, `excerpt`, `author`, `featured_media`, `comment_status`,
-	 * `ping_status`, `menu_order`, and `format` need the matching post type support,
+	 * `ping_status`, `menu_order`, and `format` need the matching post type feature,
 	 * `parent` needs a hierarchical post type, and `sticky` is only available for posts.
-	 * Fields every post type accepts map to true.
+	 * Fields every post type accepts map to true. This map is the single source of truth
+	 * for field support: the schema descriptions, {@see self::check_unsupported_fields()},
+	 * {@see self::prepare_item_for_database()}, and {@see self::handle_post_extras()} all
+	 * follow it.
 	 *
 	 * @since x.x.x
 	 *
@@ -2525,24 +2563,62 @@ final class Content {
 	 */
 	private function get_write_field_support( string $post_type ): array {
 		return array(
-			'title'          => post_type_supports( $post_type, 'title' ),
-			'content'        => post_type_supports( $post_type, 'editor' ),
-			'excerpt'        => post_type_supports( $post_type, 'excerpt' ),
+			'title'          => $this->supports_feature( $post_type, 'title' ),
+			'content'        => $this->supports_feature( $post_type, 'editor' ),
+			'excerpt'        => $this->supports_feature( $post_type, 'excerpt' ),
 			'status'         => true,
 			'slug'           => true,
 			'date'           => true,
 			'date_gmt'       => true,
-			'author'         => post_type_supports( $post_type, 'author' ),
+			'author'         => $this->supports_feature( $post_type, 'author' ),
 			'password'       => true,
 			'parent'         => is_post_type_hierarchical( $post_type ),
-			'menu_order'     => post_type_supports( $post_type, 'page-attributes' ),
-			'comment_status' => post_type_supports( $post_type, 'comments' ),
-			'ping_status'    => post_type_supports( $post_type, 'comments' ),
-			'format'         => post_type_supports( $post_type, 'post-formats' ),
-			'featured_media' => post_type_supports( $post_type, 'thumbnail' ),
+			'menu_order'     => $this->supports_feature( $post_type, 'page-attributes' ),
+			'comment_status' => $this->supports_feature( $post_type, 'comments' ),
+			'ping_status'    => $this->supports_feature( $post_type, 'comments' ),
+			'format'         => $this->supports_feature( $post_type, 'post-formats' ),
+			'featured_media' => $this->supports_feature( $post_type, 'thumbnail' ),
 			'sticky'         => 'post' === $post_type,
 			'template'       => true,
 		);
+	}
+
+	/**
+	 * Checks whether a post type supports a feature, the way the posts endpoints decide it.
+	 *
+	 * The built-in `post`, `page`, and `attachment` types follow fixed feature lists rather
+	 * than post_type_supports(), so a page accepts and returns an excerpt although the post
+	 * type does not declare that support. Every other post type follows what it declares.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $post_type The post type name.
+	 * @param string $feature   The feature, e.g. 'title', 'editor', or 'excerpt'.
+	 * @return bool True when the post type supports the feature.
+	 */
+	private function supports_feature( string $post_type, string $feature ): bool {
+		$fixed_features = array(
+			'post'       => array( 'title', 'editor', 'author', 'excerpt', 'thumbnail', 'comments', 'revisions', 'post-formats', 'custom-fields' ),
+			'page'       => array( 'title', 'editor', 'author', 'excerpt', 'thumbnail', 'comments', 'revisions', 'page-attributes', 'custom-fields' ),
+			'attachment' => array( 'title', 'author', 'comments', 'revisions', 'custom-fields', 'thumbnail' ),
+		);
+
+		if ( isset( $fixed_features[ $post_type ] ) ) {
+			return in_array( $feature, $fixed_features[ $post_type ], true );
+		}
+
+		return post_type_supports( $post_type, $feature );
+	}
+
+	/**
+	 * Returns the input keys that address the request rather than a post field.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return list<string> The request input keys.
+	 */
+	private function get_request_keys(): array {
+		return array( 'id', 'post_type', 'force', 'fields' );
 	}
 
 	/**
@@ -2560,7 +2636,7 @@ final class Content {
 	 * @return array<string, \WP_Taxonomy> Taxonomy objects keyed by input key.
 	 */
 	private function get_writable_taxonomies( string $post_type ): array {
-		$reserved   = array_merge( array( 'id', 'post_type', 'force', 'fields' ), array_keys( $this->get_write_field_support( $post_type ) ) );
+		$reserved   = array_merge( $this->get_request_keys(), array_keys( $this->get_write_field_support( $post_type ) ) );
 		$taxonomies = array();
 
 		foreach ( get_object_taxonomies( $post_type, 'objects' ) as $taxonomy ) {
@@ -2597,42 +2673,49 @@ final class Content {
 	}
 
 	/**
-	 * Rejects write fields the post type does not support.
+	 * Rejects input keys the post type does not support.
 	 *
-	 * A shared input schema cannot express per post type which fields apply. A field that
-	 * cannot be honored fails loudly here instead of being silently dropped, so a caller
-	 * never believes it set something that was ignored. This mirrors how
-	 * `core/content-query` treats unsupported filters.
+	 * A shared input schema cannot express per post type which fields apply, and it lists
+	 * the taxonomies known when the ability was registered. Every input key is therefore
+	 * checked here against what the post type supports right now: a field or taxonomy that
+	 * cannot be honored fails loudly instead of being silently dropped, so a caller never
+	 * believes it set something that was ignored. This mirrors how `core/content-query`
+	 * treats unsupported filters.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param array<mixed>  $input            The ability input.
 	 * @param \WP_Post_Type $post_type_object The post type object.
-	 * @return \WP_Error|null A WP_Error for the first unsupported field, or null when all fields are supported.
+	 * @return \WP_Error|null A WP_Error for the first unsupported key, or null when every key is supported.
 	 */
 	private function check_unsupported_fields( array $input, \WP_Post_Type $post_type_object ): ?WP_Error {
 		$post_type = $post_type_object->name;
-		$supported = $this->get_write_field_support( $post_type );
+		$allowed   = array_fill_keys( $this->get_request_keys(), true );
 
-		$writable_taxonomies = $this->get_writable_taxonomies( $post_type );
-		foreach ( array_keys( $this->get_all_writable_taxonomies() ) as $key ) {
-			$supported[ $key ] = isset( $writable_taxonomies[ $key ] );
-		}
-
-		foreach ( $supported as $field => $is_supported ) {
-			if ( $is_supported || ! array_key_exists( $field, $input ) ) {
+		foreach ( $this->get_write_field_support( $post_type ) as $field => $is_supported ) {
+			if ( ! $is_supported ) {
 				continue;
 			}
 
-			return new WP_Error(
-				'content_invalid_field',
+			$allowed[ $field ] = true;
+		}
+
+		foreach ( array_keys( $this->get_writable_taxonomies( $post_type ) ) as $key ) {
+			$allowed[ $key ] = true;
+		}
+
+		foreach ( array_keys( $input ) as $field ) {
+			if ( isset( $allowed[ $field ] ) ) {
+				continue;
+			}
+
+			return $this->invalid_field_error(
 				sprintf(
 					/* translators: 1: Field name, 2: Post type name. */
 					__( 'The %1$s field is not supported by the %2$s post type.', 'ai' ),
-					$field,
+					(string) $field,
 					$post_type
-				),
-				array( 'status' => 400 )
+				)
 			);
 		}
 
@@ -2651,8 +2734,8 @@ final class Content {
 	 * blocks from the submitted content would mark them as ignored after every
 	 * read-modify-write cycle.
 	 *
-	 * Field support is checked beforehand by {@see self::check_unsupported_fields()}; the
-	 * support checks here keep the method safe to call on its own.
+	 * Unsupported fields were rejected by {@see self::check_unsupported_fields()} before this
+	 * runs; the support map is consulted again so the method is safe on its own.
 	 *
 	 * @since x.x.x
 	 *
@@ -2665,6 +2748,7 @@ final class Content {
 		$prepared_post  = new stdClass();
 		$current_status = '';
 		$post_type      = $post_type_object->name;
+		$support        = $this->get_write_field_support( $post_type );
 
 		// Post ID.
 		if ( $existing_post instanceof WP_Post ) {
@@ -2672,20 +2756,20 @@ final class Content {
 			$current_status    = $existing_post->post_status;
 		}
 
-		// Post title. An empty `raw` title is ignored, unlike an empty title string.
-		$title = post_type_supports( $post_type, 'title' ) ? $this->get_text_input( $input, 'title', false ) : null;
+		// Post title.
+		$title = $support['title'] ? $this->get_text_input( $input, 'title' ) : null;
 		if ( null !== $title ) {
 			$prepared_post->post_title = $title;
 		}
 
 		// Post content.
-		$content = post_type_supports( $post_type, 'editor' ) ? $this->get_text_input( $input, 'content', true ) : null;
+		$content = $support['content'] ? $this->get_text_input( $input, 'content' ) : null;
 		if ( null !== $content ) {
 			$prepared_post->post_content = $content;
 		}
 
 		// Post excerpt.
-		$excerpt = post_type_supports( $post_type, 'excerpt' ) ? $this->get_text_input( $input, 'excerpt', true ) : null;
+		$excerpt = $support['excerpt'] ? $this->get_text_input( $input, 'excerpt' ) : null;
 		if ( null !== $excerpt ) {
 			$prepared_post->post_excerpt = $excerpt;
 		}
@@ -2693,11 +2777,8 @@ final class Content {
 		// Post type: the requested type when creating, the existing type when updating.
 		$prepared_post->post_type = $post_type;
 
-		// Post status.
-		if ( isset( $input['status'] )
-			&& is_string( $input['status'] )
-			&& ( '' === $current_status || $current_status !== $input['status'] )
-		) {
+		// Post status. Keeping the current status is always allowed, even an internal one.
+		if ( isset( $input['status'] ) && is_string( $input['status'] ) && $current_status !== $input['status'] ) {
 			$status = $this->handle_status_param( $input['status'], $post_type_object );
 			if ( $status instanceof WP_Error ) {
 				return $status;
@@ -2743,8 +2824,8 @@ final class Content {
 			$prepared_post->post_name = sanitize_title( $input['slug'] );
 		}
 
-		// Author.
-		if ( post_type_supports( $post_type, 'author' ) && ! empty( $input['author'] ) ) {
+		// Author. An author of 0 is ignored, so a post can be written back as it was read.
+		if ( $support['author'] && ! empty( $input['author'] ) ) {
 			$post_author = $this->parse_filter_int( $input['author'], 1 );
 
 			if ( null === $post_author || ( get_current_user_id() !== $post_author && ! get_userdata( $post_author ) ) ) {
@@ -2758,8 +2839,8 @@ final class Content {
 			$prepared_post->post_author = $post_author;
 		}
 
-		// Post password. Sticky is only available for posts.
-		$sticky = 'post' === $post_type ? $this->input_bool( $input['sticky'] ?? null ) : null;
+		// Post password.
+		$sticky = $support['sticky'] ? $this->input_bool( $input['sticky'] ?? null ) : null;
 
 		if ( isset( $input['password'] ) && is_string( $input['password'] ) ) {
 			$prepared_post->post_password = $input['password'];
@@ -2780,7 +2861,7 @@ final class Content {
 		}
 
 		// Parent.
-		if ( is_post_type_hierarchical( $post_type ) && isset( $input['parent'] ) ) {
+		if ( $support['parent'] && isset( $input['parent'] ) ) {
 			$parent_id   = $this->parse_filter_int( $input['parent'], 0 );
 			$parent_post = null !== $parent_id && $parent_id > 0 ? get_post( $parent_id ) : null;
 
@@ -2796,17 +2877,17 @@ final class Content {
 		}
 
 		// Menu order.
-		if ( post_type_supports( $post_type, 'page-attributes' ) && isset( $input['menu_order'] ) && is_scalar( $input['menu_order'] ) ) {
+		if ( $support['menu_order'] && isset( $input['menu_order'] ) && is_scalar( $input['menu_order'] ) ) {
 			$prepared_post->menu_order = (int) $input['menu_order'];
 		}
 
 		// Comment status.
-		if ( post_type_supports( $post_type, 'comments' ) && ! empty( $input['comment_status'] ) && is_string( $input['comment_status'] ) ) {
+		if ( $support['comment_status'] && ! empty( $input['comment_status'] ) && is_string( $input['comment_status'] ) ) {
 			$prepared_post->comment_status = $input['comment_status'];
 		}
 
 		// Ping status.
-		if ( post_type_supports( $post_type, 'comments' ) && ! empty( $input['ping_status'] ) && is_string( $input['ping_status'] ) ) {
+		if ( $support['ping_status'] && ! empty( $input['ping_status'] ) && is_string( $input['ping_status'] ) ) {
 			$prepared_post->ping_status = $input['ping_status'];
 		}
 
@@ -2819,20 +2900,25 @@ final class Content {
 	/**
 	 * Determines validity and normalizes the given status parameter.
 	 *
-	 * Publishing, scheduling, and private posts require the post type's publish capability;
-	 * a status that is not registered falls back to draft.
+	 * Only registered non-internal statuses can be set. Publishing, scheduling, and
+	 * private posts require the post type's publish capability.
 	 *
 	 * @since x.x.x
 	 *
 	 * @param string        $post_status      Post status.
 	 * @param \WP_Post_Type $post_type_object Post type.
-	 * @return string|\WP_Error Post status or WP_Error if lacking the proper permission.
+	 * @return string|\WP_Error Post status, or WP_Error if the status is invalid or lacks the proper permission.
 	 */
 	private function handle_status_param( string $post_status, \WP_Post_Type $post_type_object ) {
+		if ( ! in_array( $post_status, $this->get_writable_statuses(), true ) ) {
+			return new WP_Error(
+				'content_invalid_status',
+				__( 'Invalid post status.', 'ai' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		switch ( $post_status ) {
-			case 'draft':
-			case 'pending':
-				break;
 			case 'private':
 				if ( ! current_user_can( $this->post_type_cap( $post_type_object, 'publish_posts' ) ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
 					return new WP_Error(
@@ -2852,11 +2938,6 @@ final class Content {
 					);
 				}
 				break;
-			default:
-				if ( ! get_post_status_object( $post_status ) ) {
-					$post_status = 'draft';
-				}
-				break;
 		}
 
 		return $post_status;
@@ -2864,7 +2945,9 @@ final class Content {
 
 	/**
 	 * Applies the parts of a write that live outside the posts table: sticky, featured
-	 * media, post format, template, and terms. An invalid featured media ID is reported.
+	 * media, post format, template, and terms.
+	 *
+	 * The featured media, template, and terms were validated before the post was written.
 	 * Post meta is not handled; it has no abilities counterpart yet.
 	 *
 	 * @since x.x.x
@@ -2876,10 +2959,10 @@ final class Content {
 	 * @return \WP_Error|null A WP_Error on failure, null otherwise.
 	 */
 	private function handle_post_extras( WP_Post $post, array $input, \WP_Post_Type $post_type_object, bool $creating ): ?WP_Error {
-		$post_type = $post_type_object->name;
-		$post_id   = (int) $post->ID;
+		$support = $this->get_write_field_support( $post_type_object->name );
+		$post_id = (int) $post->ID;
 
-		if ( 'post' === $post_type ) {
+		if ( $support['sticky'] ) {
 			$sticky = $this->input_bool( $input['sticky'] ?? null );
 
 			// On creation sticky is always resolved, defaulting to not sticky.
@@ -2892,19 +2975,16 @@ final class Content {
 			}
 		}
 
-		if ( post_type_supports( $post_type, 'thumbnail' ) && isset( $input['featured_media'] ) ) {
-			$featured_media = $this->handle_featured_media( $this->input_int( $input['featured_media'] ), $post_id );
-			if ( $featured_media instanceof WP_Error ) {
-				return $featured_media;
-			}
+		if ( $support['featured_media'] && isset( $input['featured_media'] ) ) {
+			$this->handle_featured_media( $this->input_int( $input['featured_media'] ), $post_id );
 		}
 
-		if ( post_type_supports( $post_type, 'post-formats' ) && ! empty( $input['format'] ) && is_string( $input['format'] ) ) {
+		if ( $support['format'] && ! empty( $input['format'] ) && is_string( $input['format'] ) ) {
 			set_post_format( $post, $input['format'] );
 		}
 
 		if ( isset( $input['template'] ) && is_string( $input['template'] ) ) {
-			$this->handle_template( $input['template'], $post_id, $creating );
+			$this->handle_template( $input['template'], $post_id );
 		}
 
 		return $this->handle_terms( $post_id, $input, $post_type_object );
@@ -2913,26 +2993,54 @@ final class Content {
 	/**
 	 * Sets or removes the featured media of a post.
 	 *
+	 * The ID was validated by {@see self::check_featured_media()} before the post was
+	 * written. The return values are deliberately not interpreted: set_post_thumbnail()
+	 * reports an unchanged value as a failure.
+	 *
 	 * @since x.x.x
 	 *
 	 * @param int $featured_media Featured Media ID; 0 removes the featured media.
 	 * @param int $post_id        Post ID.
-	 * @return bool|\WP_Error Whether the post thumbnail was successfully deleted, otherwise WP_Error.
 	 */
-	private function handle_featured_media( int $featured_media, int $post_id ) {
+	private function handle_featured_media( int $featured_media, int $post_id ): void {
 		if ( $featured_media > 0 ) {
-			if ( set_post_thumbnail( $post_id, $featured_media ) ) {
-				return true;
-			}
+			set_post_thumbnail( $post_id, $featured_media );
 
-			return new WP_Error(
-				'content_invalid_featured_media',
-				__( 'Invalid featured media ID.', 'ai' ),
-				array( 'status' => 400 )
-			);
+			return;
 		}
 
-		return delete_post_thumbnail( $post_id );
+		delete_post_thumbnail( $post_id );
+	}
+
+	/**
+	 * Checks that the featured media input refers to an image attachment.
+	 *
+	 * Validated before the post is written, so a bad ID never leaves a half-applied write.
+	 * set_post_thumbnail() itself would silently remove the thumbnail for a non-image
+	 * attachment.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return true|\WP_Error True when the featured media is absent, 0, or an image attachment.
+	 */
+	private function check_featured_media( array $input, \WP_Post_Type $post_type_object ) {
+		$support = $this->get_write_field_support( $post_type_object->name );
+		if ( ! $support['featured_media'] || ! isset( $input['featured_media'] ) ) {
+			return true;
+		}
+
+		$featured_media = $this->input_int( $input['featured_media'] );
+		if ( 0 === $featured_media || '' !== wp_get_attachment_image( $featured_media, 'thumbnail' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'content_invalid_featured_media',
+			__( 'Invalid featured media ID.', 'ai' ),
+			array( 'status' => 400 )
+		);
 	}
 
 	/**
@@ -2983,25 +3091,21 @@ final class Content {
 	/**
 	 * Sets the template for a post.
 	 *
+	 * The template was validated by {@see self::check_template()} before the post was written.
+	 *
 	 * @since x.x.x
 	 *
 	 * @param string $template Page template filename.
 	 * @param int    $post_id  Post ID.
-	 * @param bool   $validate Whether to validate that the template selected is valid.
 	 */
-	private function handle_template( string $template, int $post_id, bool $validate = false ): void {
-		if ( $validate && ! array_key_exists( $template, wp_get_theme()->get_page_templates( get_post( $post_id ) ) ) ) {
-			$template = '';
-		}
-
+	private function handle_template( string $template, int $post_id ): void {
 		update_post_meta( $post_id, '_wp_page_template', $template );
 	}
 
 	/**
 	 * Updates the post's terms from the ability input.
 	 *
-	 * Term lists are normalized to unique positive IDs first, because wp_set_object_terms()
-	 * would create a new term for a string.
+	 * The terms were validated by {@see self::check_terms()} before the post was written.
 	 *
 	 * @since x.x.x
 	 *
@@ -3011,12 +3115,8 @@ final class Content {
 	 * @return \WP_Error|null WP_Error on an error assigning any of the terms, otherwise null.
 	 */
 	private function handle_terms( int $post_id, array $input, \WP_Post_Type $post_type_object ): ?WP_Error {
-		foreach ( $this->get_writable_taxonomies( $post_type_object->name ) as $key => $taxonomy ) {
-			if ( ! isset( $input[ $key ] ) ) {
-				continue;
-			}
-
-			$result = wp_set_object_terms( $post_id, $this->parse_id_list_input( $input, $key ), $taxonomy->name );
+		foreach ( $this->get_input_terms( $input, $post_type_object ) as $taxonomy => $term_ids ) {
+			$result = wp_set_object_terms( $post_id, $term_ids, $taxonomy );
 
 			if ( $result instanceof WP_Error ) {
 				return $result;
@@ -3024,6 +3124,75 @@ final class Content {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Checks that every term the input assigns exists in its taxonomy.
+	 *
+	 * Validated before the post is written: wp_set_object_terms() silently skips unknown
+	 * term IDs and would then remove every current term, so an unknown ID fails loudly like
+	 * an unknown parent, author, or featured media ID.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return true|\WP_Error True when every term exists, or a WP_Error naming the first unknown one.
+	 */
+	private function check_terms( array $input, \WP_Post_Type $post_type_object ) {
+		foreach ( $this->get_input_terms( $input, $post_type_object ) as $taxonomy => $term_ids ) {
+			foreach ( $term_ids as $term_id ) {
+				if ( get_term( $term_id, $taxonomy ) instanceof \WP_Term ) {
+					continue;
+				}
+
+				return new WP_Error(
+					'content_invalid_term',
+					sprintf(
+						/* translators: 1: Term ID, 2: Taxonomy name. */
+						__( 'Invalid term ID %1$d for the %2$s taxonomy.', 'ai' ),
+						$term_id,
+						$taxonomy
+					),
+					array( 'status' => 400 )
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the term IDs the input assigns, keyed by taxonomy name.
+	 *
+	 * Term lists are normalized to unique positive IDs, because wp_set_object_terms() would
+	 * create a new term for a string. The term caches are primed in one query so the checks
+	 * that follow do not query one term at a time.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return array<string, list<int>> Term IDs keyed by taxonomy name.
+	 */
+	private function get_input_terms( array $input, \WP_Post_Type $post_type_object ): array {
+		$terms    = array();
+		$term_ids = array();
+
+		foreach ( $this->get_writable_taxonomies( $post_type_object->name ) as $key => $taxonomy ) {
+			if ( ! isset( $input[ $key ] ) ) {
+				continue;
+			}
+
+			$terms[ $taxonomy->name ] = $this->parse_id_list_input( $input, $key );
+			$term_ids                 = array_merge( $term_ids, $terms[ $taxonomy->name ] );
+		}
+
+		if ( array() !== $term_ids ) {
+			_prime_term_caches( $term_ids, false );
+		}
+
+		return $terms;
 	}
 
 	/**
@@ -3036,14 +3205,10 @@ final class Content {
 	 * @return bool Whether the current user can assign the provided terms.
 	 */
 	private function check_assign_terms_permission( array $input, \WP_Post_Type $post_type_object ): bool {
-		foreach ( $this->get_writable_taxonomies( $post_type_object->name ) as $key => $taxonomy ) {
-			if ( ! isset( $input[ $key ] ) ) {
-				continue;
-			}
-
-			foreach ( $this->parse_id_list_input( $input, $key ) as $term_id ) {
-				// Invalid terms will be rejected later.
-				if ( ! get_term( $term_id, $taxonomy->name ) ) {
+		foreach ( $this->get_input_terms( $input, $post_type_object ) as $taxonomy => $term_ids ) {
+			foreach ( $term_ids as $term_id ) {
+				// Unknown terms are rejected during execution.
+				if ( ! get_term( $term_id, $taxonomy ) instanceof \WP_Term ) {
 					continue;
 				}
 
@@ -3083,8 +3248,8 @@ final class Content {
 	/**
 	 * Slashes a prepared post for wp_insert_post() or wp_update_post().
 	 *
-	 * Both functions expect slashed data, and wp_update_post() expects an array rather than
-	 * an object so it does not unslash the input again.
+	 * Both functions expect slashed data. wp_update_post() slashes an object itself, so it
+	 * is given an array to avoid slashing the data twice.
 	 *
 	 * @since x.x.x
 	 *

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * The `core/content-query` WordPress Ability.
+ * The `core/content-*` WordPress Abilities.
  *
  * @package WordPress\AI
  *
@@ -14,6 +14,7 @@ namespace WordPress\AI\Abilities\Content;
 use WP_Error;
 use WP_Post;
 use WP_Query;
+use stdClass;
 
 use function WordPress\AI\register_deprecated_ability_alias;
 
@@ -23,11 +24,26 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class - Content
  *
- * Registers the read-only `core/content-query` ability, which retrieves readable posts of a
- * post type exposed to abilities via `show_in_abilities`. Supports fetching a single
- * readable post by ID or by post type and slug, or querying multiple readable posts filtered
- * by post type, status, author, parent, or included IDs. Raw fields are only returned for
- * posts the current user can edit.
+ * Registers the content abilities, which read and manage posts of the post types exposed
+ * to abilities via `show_in_abilities`:
+ *
+ *   - `core/content-query` (read-only): retrieves a single readable post by ID or by post
+ *     type and slug, or queries multiple readable posts filtered by post type, status,
+ *     author, parent, or included IDs. Raw fields are only returned for posts the current
+ *     user can edit.
+ *   - `core/content-create`: creates a post of an exposed post type.
+ *   - `core/content-update`: updates a post by ID.
+ *   - `core/content-delete`: moves a post to the trash, or deletes it permanently.
+ *
+ * The write abilities mirror the create, update, and delete endpoints of the REST posts
+ * controller (`WP_REST_Posts_Controller`): they accept the same fields, apply the same
+ * capability checks, and prepare the post for the database the same way. The
+ * transport-agnostic parts of that controller are reproduced here as private helpers
+ * ({@see self::prepare_item_for_database()} and the methods around it), named after their
+ * REST counterparts so a future core refactor can share them between REST and abilities.
+ * REST-specific hooks, request and response objects, and the meta fields machinery are
+ * deliberately not reproduced. The written post is returned through the same field
+ * projection `core/content-query` uses.
  *
  * This class is kept almost identical to the WordPress core class `WP_Content_Abilities`
  * so the two implementations stay in sync. Differences from the core class are marked with
@@ -165,13 +181,9 @@ final class Content {
 	 */
 	public function register(): void {
 		$this->register_content_query();
-
-		/*
-		 * A future write-oriented ability can be registered here, reusing the shared
-		 * helpers below (get_exposed_post_types(), format_post(), check_permission()):
-		 *
-		 *     $this->register_manage_content();
-		 */
+		$this->register_content_create();
+		$this->register_content_update();
+		$this->register_content_delete();
 	}
 
 	/**
@@ -233,6 +245,139 @@ final class Content {
 	}
 
 	/**
+	 * Registers the `core/content-create` ability.
+	 *
+	 * Mirrors the create endpoint of the REST posts controller.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_content_create(): void {
+		$post_types = array_keys( $this->get_exposed_post_types() );
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		// Plugin: unregister any core-provided copy first so the plugin's version wins.
+		if ( wp_has_ability( 'core/content-create' ) ) {
+			wp_unregister_ability( 'core/content-create' );
+		}
+
+		wp_register_ability(
+			'core/content-create',
+			array(
+				'label'               => __( 'Content Create', 'ai' ),
+				'description'         => __( 'Creates a post of a post type exposed to abilities. Accepts the same fields as the REST API posts endpoints: title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the created post; use `fields` to choose which post fields are returned. Requires an authenticated user who can create posts of the post type.', 'ai' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => $this->get_content_create_input_schema( $post_types ),
+				'output_schema'       => $this->get_post_output_schema(),
+				'execute_callback'    => array( $this, 'execute_content_create' ),
+				'permission_callback' => array( $this, 'check_create_permission' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => false,
+						// Every call creates a new post.
+						'idempotent'  => false,
+						'open_world'  => false,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Registers the `core/content-update` ability.
+	 *
+	 * Mirrors the update endpoint of the REST posts controller.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_content_update(): void {
+		$post_types = array_keys( $this->get_exposed_post_types() );
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		// Plugin: unregister any core-provided copy first so the plugin's version wins.
+		if ( wp_has_ability( 'core/content-update' ) ) {
+			wp_unregister_ability( 'core/content-update' );
+		}
+
+		wp_register_ability(
+			'core/content-update',
+			array(
+				'label'               => __( 'Content Update', 'ai' ),
+				'description'         => __( 'Updates a post by ID. Only the provided fields change; omitted fields keep their current values. Accepts the same fields as the REST API posts endpoints: title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the updated post; use `fields` to choose which post fields are returned. Requires an authenticated user who can edit the post.', 'ai' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => $this->get_content_update_input_schema( $post_types ),
+				'output_schema'       => $this->get_post_output_schema(),
+				'execute_callback'    => array( $this, 'execute_content_update' ),
+				'permission_callback' => array( $this, 'check_update_permission' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						/*
+						 * Not flagged destructive: overwritten content is kept as a revision,
+						 * and the Abilities REST run controller routes destructive idempotent
+						 * abilities to the DELETE method, whose query-string input cannot carry
+						 * post content.
+						 */
+						'destructive' => false,
+						// Repeating the same update leaves the post in the same state.
+						'idempotent'  => true,
+						'open_world'  => false,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Registers the `core/content-delete` ability.
+	 *
+	 * Mirrors the delete endpoint of the REST posts controller.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_content_delete(): void {
+		$post_types = array_keys( $this->get_exposed_post_types() );
+		if ( empty( $post_types ) ) {
+			return;
+		}
+
+		// Plugin: unregister any core-provided copy first so the plugin's version wins.
+		if ( wp_has_ability( 'core/content-delete' ) ) {
+			wp_unregister_ability( 'core/content-delete' );
+		}
+
+		wp_register_ability(
+			'core/content-delete',
+			array(
+				'label'               => __( 'Content Delete', 'ai' ),
+				'description'         => __( 'Moves a post to the trash by ID, or deletes it permanently when `force` is true. Trashing a post that is already in the trash is an error, as is trashing when the site has the trash disabled; set `force` to delete permanently in that case. Returns the trashed post, or the deleted post under `previous` when `force` is true; use `fields` to choose which post fields are returned. Requires an authenticated user who can delete the post.', 'ai' ),
+				'category'            => self::CATEGORY,
+				'input_schema'        => $this->get_content_delete_input_schema( $post_types ),
+				'output_schema'       => $this->get_content_delete_output_schema(),
+				'execute_callback'    => array( $this, 'execute_content_delete' ),
+				'permission_callback' => array( $this, 'check_delete_permission' ),
+				'meta'                => array(
+					'annotations'  => array(
+						'readonly'    => false,
+						'destructive' => true,
+						// Repeating a deletion has no further effect; the Abilities REST run
+						// controller routes destructive idempotent abilities to the DELETE method.
+						'idempotent'  => true,
+						'open_world'  => false,
+					),
+					'show_in_rest' => true,
+				),
+			)
+		);
+	}
+
+	/**
 	 * Permission callback for the `core/content-query` ability.
 	 *
 	 * This gate is the authoritative permission decision for single-post modes: it
@@ -259,12 +404,8 @@ final class Content {
 
 		// Single-post mode (by ID).
 		if ( ! empty( $input['id'] ) ) {
-			$post = get_post( $this->input_int( $input['id'] ) );
-
-			if ( ! $post
-				|| ! isset( $exposed[ $post->post_type ] )
-				|| ( ! empty( $input['post_type'] ) && $post->post_type !== $input['post_type'] )
-			) {
+			$post = $this->get_exposed_post( $input );
+			if ( ! $post ) {
 				return false;
 			}
 
@@ -292,6 +433,165 @@ final class Content {
 		}
 
 		return $this->can_query_statuses( $input, $post_type_object );
+	}
+
+	/**
+	 * Permission callback for the `core/content-create` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::create_item_permissions_check()`: the current user
+	 * must be able to create posts of the requested post type, may only create a post as
+	 * another author when they can edit others' posts, may only make a post sticky when they
+	 * can edit others' posts or publish posts, and must be allowed to assign every provided
+	 * term. The Abilities API requires a boolean here, so the distinct REST error codes
+	 * collapse into the generic permission error.
+	 *
+	 * The publish capability required by some statuses is enforced during execution, where
+	 * the REST controller enforces it too (in its post preparation).
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return bool True if the request may proceed, false otherwise.
+	 */
+	public function check_create_permission( $input = array() ): bool {
+		$input = rest_sanitize_object( $input );
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		$post_type_object = $this->get_exposed_post_type( $input );
+		if ( ! $post_type_object ) {
+			return false;
+		}
+
+		if ( ! $this->check_author_and_sticky_permission( $input, $post_type_object ) ) {
+			return false;
+		}
+
+		if ( ! current_user_can( $this->post_type_cap( $post_type_object, 'create_posts' ) ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+			return false;
+		}
+
+		return $this->check_assign_terms_permission( $input, $post_type_object );
+	}
+
+	/**
+	 * Permission callback for the `core/content-update` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::update_item_permissions_check()`: the post must
+	 * exist in an exposed post type (and match the `post_type` guard when given), the
+	 * current user must be able to edit it, may only reassign it to another author when
+	 * they can edit others' posts, may only make it sticky when they can edit others' posts
+	 * or publish posts, and must be allowed to assign every provided term. The Abilities
+	 * API requires a boolean here, so the distinct REST error codes collapse into the
+	 * generic permission error.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return bool True if the request may proceed, false otherwise.
+	 */
+	public function check_update_permission( $input = array() ): bool {
+		$input = rest_sanitize_object( $input );
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		$post = $this->get_exposed_post( $input );
+		if ( ! $post ) {
+			return false;
+		}
+
+		$post_type_object = get_post_type_object( $post->post_type );
+		if ( ! $post_type_object instanceof \WP_Post_Type ) {
+			return false;
+		}
+
+		// REST's check_update_permission(): an exposed post type and the edit_post meta capability.
+		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+			return false;
+		}
+
+		if ( ! $this->check_author_and_sticky_permission( $input, $post_type_object ) ) {
+			return false;
+		}
+
+		return $this->check_assign_terms_permission( $input, $post_type_object );
+	}
+
+	/**
+	 * Permission callback for the `core/content-delete` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::delete_item_permissions_check()`: the post must
+	 * exist in an exposed post type (and match the `post_type` guard when given), and the
+	 * current user must be able to delete it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return bool True if the request may proceed, false otherwise.
+	 */
+	public function check_delete_permission( $input = array() ): bool {
+		$input = rest_sanitize_object( $input );
+
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		$post = $this->get_exposed_post( $input );
+		if ( ! $post ) {
+			return false;
+		}
+
+		// REST's check_delete_permission(): an exposed post type and the delete_post meta capability.
+		return current_user_can( 'delete_post', $post->ID );
+	}
+
+	/**
+	 * Checks the author and sticky parts of the REST create/update permission checks.
+	 *
+	 * Creating or updating a post as another author requires the post type's
+	 * `edit_others_posts` capability. Making a post sticky requires `edit_others_posts` or
+	 * `publish_posts`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return bool True if the author and sticky inputs are permitted.
+	 */
+	private function check_author_and_sticky_permission( array $input, \WP_Post_Type $post_type_object ): bool {
+		$author = isset( $input['author'] ) ? $this->input_int( $input['author'] ) : 0;
+		if ( $author > 0
+			&& get_current_user_id() !== $author
+			&& ! current_user_can( $this->post_type_cap( $post_type_object, 'edit_others_posts' ) ) // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+		) {
+			return false;
+		}
+
+		return true !== $this->input_bool( $input['sticky'] ?? null ) || $this->can_make_sticky( $post_type_object );
+	}
+
+	/**
+	 * Checks whether the current user may make posts of a post type sticky.
+	 *
+	 * Mirrors the sticky gate of the REST create/update permission checks: the post type's
+	 * `edit_others_posts` or `publish_posts` capability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return bool True if the current user may make posts sticky.
+	 */
+	private function can_make_sticky( \WP_Post_Type $post_type_object ): bool {
+		// phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+		if ( current_user_can( $this->post_type_cap( $post_type_object, 'edit_others_posts' ) ) ) {
+			return true;
+		}
+
+		return current_user_can( $this->post_type_cap( $post_type_object, 'publish_posts' ) ); // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
 	}
 
 	/**
@@ -532,12 +832,8 @@ final class Content {
 
 		// Single-post mode (by ID).
 		if ( ! empty( $input['id'] ) ) {
-			$post = get_post( $this->input_int( $input['id'] ) );
-
-			if ( ! $post
-				|| ! isset( $exposed[ $post->post_type ] )
-				|| ( ! empty( $input['post_type'] ) && $post->post_type !== $input['post_type'] )
-			) {
+			$post = $this->get_exposed_post( $input );
+			if ( ! $post ) {
 				return $this->not_found_error();
 			}
 
@@ -709,6 +1005,247 @@ final class Content {
 			'total'       => $total,
 			'total_pages' => $total_pages,
 		);
+	}
+
+	/**
+	 * Executes the `core/content-create` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::create_item()`. {@see WP_Ability::execute()} always
+	 * runs {@see self::check_create_permission()} first, so this only re-validates that the
+	 * post type is exposed before preparing and inserting the post. Errors raised after the
+	 * post has been inserted (for example while assigning terms) are returned as-is, as the
+	 * REST controller does: the post exists at that point and its ID is not reported.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return array<string, mixed>|\stdClass|\WP_Error The created post, or a WP_Error.
+	 */
+	public function execute_content_create( $input = array() ) {
+		$input = rest_sanitize_object( $input );
+
+		$post_type_object = $this->get_exposed_post_type( $input );
+		if ( ! $post_type_object ) {
+			return new WP_Error(
+				'content_invalid_post_type',
+				__( 'The post type is not exposed to abilities.', 'ai' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$unsupported = $this->check_unsupported_fields( $input, $post_type_object );
+		if ( $unsupported instanceof WP_Error ) {
+			return $unsupported;
+		}
+
+		$template = $this->check_template( $input, $post_type_object->name, null );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+
+		$prepared_post = $this->prepare_item_for_database( $input, $post_type_object, null );
+		if ( $prepared_post instanceof WP_Error ) {
+			return $prepared_post;
+		}
+
+		if ( ! empty( $prepared_post->post_name )
+			&& ! empty( $prepared_post->post_status )
+			&& in_array( $prepared_post->post_status, array( 'draft', 'pending' ), true )
+		) {
+			/*
+			 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
+			 *
+			 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
+			 */
+			$prepared_post->post_name = wp_unique_post_slug(
+				$prepared_post->post_name,
+				0,
+				'publish',
+				$prepared_post->post_type,
+				$prepared_post->post_parent ?? 0
+			);
+		}
+
+		$post_id = wp_insert_post( $this->slash_post_data( $prepared_post ), true, false );
+
+		if ( $post_id instanceof WP_Error ) {
+			$post_id->add_data( array( 'status' => 'db_insert_error' === $post_id->get_error_code() ? 500 : 400 ) );
+
+			return $post_id;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $this->not_found_error();
+		}
+
+		$extras = $this->handle_post_extras( $post, $input, $post_type_object, true );
+		if ( $extras instanceof WP_Error ) {
+			return $extras;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $this->not_found_error();
+		}
+
+		wp_after_insert_post( $post, false, null );
+
+		return $this->to_output_post( $this->format_post( $post, $this->normalize_fields( $input ) ) );
+	}
+
+	/**
+	 * Executes the `core/content-update` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::update_item()`. {@see WP_Ability::execute()} always
+	 * runs {@see self::check_update_permission()} first, so this only re-validates the
+	 * lookup itself before preparing and updating the post. Errors raised after the post
+	 * has been updated (for example while assigning terms) are returned as-is, as the REST
+	 * controller does.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return array<string, mixed>|\stdClass|\WP_Error The updated post, or a WP_Error.
+	 */
+	public function execute_content_update( $input = array() ) {
+		$input = rest_sanitize_object( $input );
+
+		$post_before = $this->get_exposed_post( $input );
+		if ( ! $post_before ) {
+			return $this->not_found_error();
+		}
+
+		$post_type_object = get_post_type_object( $post_before->post_type );
+		if ( ! $post_type_object instanceof \WP_Post_Type ) {
+			return $this->not_found_error();
+		}
+
+		$unsupported = $this->check_unsupported_fields( $input, $post_type_object );
+		if ( $unsupported instanceof WP_Error ) {
+			return $unsupported;
+		}
+
+		$template = $this->check_template( $input, $post_type_object->name, $post_before );
+		if ( $template instanceof WP_Error ) {
+			return $template;
+		}
+
+		$prepared_post = $this->prepare_item_for_database( $input, $post_type_object, $post_before );
+		if ( $prepared_post instanceof WP_Error ) {
+			return $prepared_post;
+		}
+
+		$post_status = ! empty( $prepared_post->post_status ) ? $prepared_post->post_status : $post_before->post_status;
+
+		/*
+		 * `wp_unique_post_slug()` returns the same slug for 'draft' or 'pending' posts.
+		 *
+		 * To ensure that a unique slug is generated, pass the post data with the 'publish' status.
+		 */
+		if ( ! empty( $prepared_post->post_name ) && in_array( $post_status, array( 'draft', 'pending' ), true ) ) {
+			$prepared_post->post_name = wp_unique_post_slug(
+				$prepared_post->post_name,
+				$post_before->ID,
+				'publish',
+				$prepared_post->post_type,
+				! empty( $prepared_post->post_parent ) ? $prepared_post->post_parent : 0
+			);
+		}
+
+		$post_id = wp_update_post( $this->slash_post_data( $prepared_post ), true, false );
+
+		if ( $post_id instanceof WP_Error ) {
+			$post_id->add_data( array( 'status' => 'db_update_error' === $post_id->get_error_code() ? 500 : 400 ) );
+
+			return $post_id;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $this->not_found_error();
+		}
+
+		$extras = $this->handle_post_extras( $post, $input, $post_type_object, false );
+		if ( $extras instanceof WP_Error ) {
+			return $extras;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post ) {
+			return $this->not_found_error();
+		}
+
+		wp_after_insert_post( $post, true, $post_before );
+
+		return $this->to_output_post( $this->format_post( $post, $this->normalize_fields( $input ) ) );
+	}
+
+	/**
+	 * Executes the `core/content-delete` ability.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::delete_item()`. {@see WP_Ability::execute()} always
+	 * runs {@see self::check_delete_permission()} first, so this only re-validates the
+	 * lookup itself. Without `force` the post is moved to the trash and returned; with
+	 * `force` it is deleted permanently and returned under `previous`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $input Optional. The ability input. Default empty array.
+	 * @return array<string, mixed>|\stdClass|\WP_Error The trashed post, a `deleted`/`previous` pair, or a WP_Error.
+	 */
+	public function execute_content_delete( $input = array() ) {
+		$input = rest_sanitize_object( $input );
+
+		$post = $this->get_exposed_post( $input );
+		if ( ! $post ) {
+			return $this->not_found_error();
+		}
+
+		$fields = $this->normalize_fields( $input );
+
+		// If we're forcing, then delete permanently.
+		if ( true === $this->input_bool( $input['force'] ?? null ) ) {
+			$previous = $this->to_output_post( $this->format_post( $post, $fields ) );
+
+			if ( ! wp_delete_post( $post->ID, true ) ) {
+				return $this->cannot_delete_error();
+			}
+
+			return array(
+				'deleted'  => true,
+				'previous' => $previous,
+			);
+		}
+
+		// If we don't support trashing for this type, error out.
+		if ( ! $this->supports_trash( $post ) ) {
+			return new WP_Error(
+				'content_trash_not_supported',
+				__( 'The post does not support trashing. Set `force` to true to delete it permanently.', 'ai' ),
+				array( 'status' => 501 )
+			);
+		}
+
+		// Otherwise, only trash if we haven't already.
+		if ( 'trash' === $post->post_status ) {
+			return new WP_Error(
+				'content_already_trashed',
+				__( 'The post has already been deleted.', 'ai' ),
+				array( 'status' => 410 )
+			);
+		}
+
+		if ( ! wp_trash_post( $post->ID ) ) {
+			return $this->cannot_delete_error();
+		}
+
+		$trashed = get_post( $post->ID );
+		if ( ! $trashed instanceof WP_Post ) {
+			return $this->cannot_delete_error();
+		}
+
+		return $this->to_output_post( $this->format_post( $trashed, $fields ) );
 	}
 
 	/**
@@ -888,14 +1425,28 @@ final class Content {
 	 * @return list<int> Unique positive post IDs.
 	 */
 	private function normalize_include( array $input ): array {
-		$include = $input['include'] ?? null;
-		if ( ! is_array( $include ) && ! is_string( $include ) ) {
+		return $this->parse_id_list_input( $input, 'include' );
+	}
+
+	/**
+	 * Parses a raw list input into a list of unique positive IDs.
+	 *
+	 * A GET request delivers list inputs as scalar/CSV strings; wp_parse_id_list()
+	 * accepts both and yields unique positive IDs, matching schema validation.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @param string       $key   The input key holding the list.
+	 * @return list<int> Unique positive IDs; empty when absent or unparseable.
+	 */
+	private function parse_id_list_input( array $input, string $key ): array {
+		$value = $input[ $key ] ?? null;
+		if ( ! is_array( $value ) && ! is_string( $value ) ) {
 			return array();
 		}
 
-		// A GET request delivers list inputs as scalar/CSV strings; wp_parse_id_list()
-		// accepts both and yields unique positive IDs, matching schema validation.
-		return array_values( array_filter( wp_parse_id_list( $include ) ) );
+		return array_values( array_filter( wp_parse_id_list( $value ) ) );
 	}
 
 	/**
@@ -1047,15 +1598,7 @@ final class Content {
 	 * @return array<string, mixed> The input JSON Schema.
 	 */
 	private function get_content_query_input_schema( array $post_types, array $statuses ): array {
-		$fields  = array(
-			'type'        => 'array',
-			'uniqueItems' => true,
-			'items'       => array(
-				'type' => 'string',
-				'enum' => array_keys( $this->get_post_properties() ),
-			),
-			'description' => __( 'Limit each returned post to these fields. If omitted, a lean set of common read fields is returned. Explicit raw field requests require edit access.', 'ai' ),
-		);
+		$fields  = $this->get_fields_input_schema();
 		$include = array(
 			'type'        => 'array',
 			'minItems'    => 1,
@@ -1170,11 +1713,7 @@ final class Content {
 	 * @return array<string, mixed> The output JSON Schema.
 	 */
 	private function get_content_query_output_schema(): array {
-		$post_schema = array(
-			'type'                 => 'object',
-			'additionalProperties' => false,
-			'properties'           => $this->get_post_properties(),
-		);
+		$post_schema = $this->get_post_output_schema();
 
 		$query_schema = array(
 			'type'                 => 'object',
@@ -1202,6 +1741,288 @@ final class Content {
 			'oneOf' => array(
 				$post_schema,
 				$query_schema,
+			),
+		);
+	}
+
+	/**
+	 * Builds the schema of the `fields` input shared by every content ability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> The `fields` JSON Schema.
+	 */
+	private function get_fields_input_schema(): array {
+		return array(
+			'type'        => 'array',
+			'uniqueItems' => true,
+			'items'       => array(
+				'type' => 'string',
+				'enum' => array_keys( $this->get_post_properties() ),
+			),
+			'description' => __( 'Limit each returned post to these fields. If omitted, a lean set of common read fields is returned. Explicit raw field requests require edit access.', 'ai' ),
+		);
+	}
+
+	/**
+	 * Builds the output schema of a single post, shared by every content ability.
+	 *
+	 * No field is marked required because the `fields` input lets the caller request any
+	 * subset, and a field is only present when its post type supports it.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> The post JSON Schema.
+	 */
+	private function get_post_output_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => $this->get_post_properties(),
+		);
+	}
+
+	/**
+	 * Returns the input properties shared by the create and update abilities, keyed by field name.
+	 *
+	 * These mirror the writable properties of the REST posts item schema, including one
+	 * property per taxonomy the REST API exposes for an exposed post type, under the same
+	 * key the REST API uses (e.g. `categories` and `tags` for posts). The REST controller
+	 * only registers each property for the post types that support it; a shared schema
+	 * cannot express that per post type, so the descriptions state the requirement and
+	 * {@see self::check_unsupported_fields()} enforces it at execution time.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> Write property definitions.
+	 */
+	private function get_content_write_properties(): array {
+		$statuses = array_values( get_post_stati( array( 'internal' => false ) ) );
+
+		$properties = array(
+			'title'          => array(
+				'type'        => 'string',
+				'description' => __( 'The raw post title. Only supported for post types that support titles.', 'ai' ),
+			),
+			'content'        => array(
+				'type'        => 'string',
+				'description' => __( 'The raw post content, as block markup or HTML. Only supported for post types that support the editor.', 'ai' ),
+			),
+			'excerpt'        => array(
+				'type'        => 'string',
+				'description' => __( 'The raw post excerpt. Only supported for post types that support excerpts.', 'ai' ),
+			),
+			'status'         => array(
+				'type'        => 'string',
+				'enum'        => $statuses,
+				'description' => __( 'The post status. Defaults to draft when creating. Publishing, scheduling, or making a post private requires the publish capability for the post type.', 'ai' ),
+			),
+			'slug'           => array(
+				'type'        => 'string',
+				'description' => __( 'The post slug. Sanitized like a title, and adjusted when it collides with another post of the same type.', 'ai' ),
+			),
+			'date'           => array(
+				'type'        => array( 'string', 'null' ),
+				'format'      => 'date-time',
+				'description' => __( "The publication date in ISO 8601 format, in the site's timezone unless it carries a timezone offset. Pass null to reset the date: the post is dated now, and drafts get a floating date.", 'ai' ),
+			),
+			'date_gmt'       => array(
+				'type'        => array( 'string', 'null' ),
+				'format'      => 'date-time',
+				'description' => __( 'The publication date in ISO 8601 format, as GMT. Ignored when `date` is also given. Pass null to reset the date.', 'ai' ),
+			),
+			'author'         => array(
+				'type'        => 'integer',
+				'minimum'     => 1,
+				'description' => __( 'The author user ID. Assigning another user requires the capability to edit their posts. Only supported for post types that support authors.', 'ai' ),
+			),
+			'password'       => array(
+				'type'        => 'string',
+				'description' => __( 'A password to protect access to the content and excerpt. Pass an empty string to remove it. A post cannot be both sticky and password protected.', 'ai' ),
+			),
+			'parent'         => array(
+				'type'        => 'integer',
+				'minimum'     => 0,
+				'description' => __( 'The parent post ID; 0 for a top-level post. Only supported for hierarchical post types.', 'ai' ),
+			),
+			'menu_order'     => array(
+				'type'        => 'integer',
+				'description' => __( 'The order of the post in relation to other posts. Only supported for post types that support page attributes.', 'ai' ),
+			),
+			'comment_status' => array(
+				'type'        => 'string',
+				'enum'        => array( 'open', 'closed' ),
+				'description' => __( 'Whether comments are open on the post. Only supported for post types that support comments.', 'ai' ),
+			),
+			'ping_status'    => array(
+				'type'        => 'string',
+				'enum'        => array( 'open', 'closed' ),
+				'description' => __( 'Whether the post can be pinged. Only supported for post types that support comments.', 'ai' ),
+			),
+			'format'         => array(
+				'type'        => 'string',
+				'enum'        => array_values( get_post_format_slugs() ),
+				'description' => __( 'The post format. Only supported for post types that support post formats.', 'ai' ),
+			),
+			'featured_media' => array(
+				'type'        => 'integer',
+				'minimum'     => 0,
+				'description' => __( 'The attachment ID of the featured image; 0 removes it. Only supported for post types that support thumbnails.', 'ai' ),
+			),
+			'sticky'         => array(
+				'type'        => 'boolean',
+				'description' => __( "Whether the post is sticky. Requires the capability to edit others' posts or to publish posts. Only supported for the post post type.", 'ai' ),
+			),
+			'template'       => array(
+				'type'        => 'string',
+				'description' => __( 'The theme template file to display the post with; an empty string selects the default template. Must be one of the templates the active theme offers for the post type.', 'ai' ),
+			),
+		);
+
+		foreach ( $this->get_all_writable_taxonomies() as $key => $taxonomy ) {
+			$properties[ $key ] = array(
+				'type'        => 'array',
+				'uniqueItems' => true,
+				'items'       => array(
+					'type'    => 'integer',
+					'minimum' => 1,
+				),
+				'description' => sprintf(
+					/* translators: %s: Taxonomy name. */
+					__( 'The IDs of the terms assigned to the post in the %s taxonomy. Replaces the current terms; an empty list removes them all. Only supported for post types associated with the taxonomy.', 'ai' ),
+					$taxonomy->name
+				),
+			);
+		}
+
+		return $properties;
+	}
+
+	/**
+	 * Builds the input schema for the `core/content-create` ability.
+	 *
+	 * `additionalProperties: false` rejects unknown fields instead of dropping them, so e.g.
+	 * passing an `id` fails validation the way the REST controller rejects creating an
+	 * existing post.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param list<string> $post_types Exposed post type names.
+	 * @return array<string, mixed> The input JSON Schema.
+	 */
+	private function get_content_create_input_schema( array $post_types ): array {
+		return array(
+			'type'                 => 'object',
+			'required'             => array( 'post_type' ),
+			'additionalProperties' => false,
+			'properties'           => array_merge(
+				array(
+					'post_type' => array(
+						'type'        => 'string',
+						'enum'        => $post_types,
+						'description' => __( 'The post type of the post to create.', 'ai' ),
+					),
+				),
+				$this->get_content_write_properties(),
+				array( 'fields' => $this->get_fields_input_schema() )
+			),
+		);
+	}
+
+	/**
+	 * Builds the input schema for the `core/content-update` ability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param list<string> $post_types Exposed post type names.
+	 * @return array<string, mixed> The input JSON Schema.
+	 */
+	private function get_content_update_input_schema( array $post_types ): array {
+		return array(
+			'type'                 => 'object',
+			'required'             => array( 'id' ),
+			'additionalProperties' => false,
+			'properties'           => array_merge(
+				array(
+					'id'        => array(
+						'type'        => 'integer',
+						'minimum'     => 1,
+						'description' => __( 'The ID of the post to update.', 'ai' ),
+					),
+					'post_type' => array(
+						'type'        => 'string',
+						'enum'        => $post_types,
+						'description' => __( 'Optional. Restrict the update to this post type; the post is only updated if it matches.', 'ai' ),
+					),
+				),
+				$this->get_content_write_properties(),
+				array( 'fields' => $this->get_fields_input_schema() )
+			),
+		);
+	}
+
+	/**
+	 * Builds the input schema for the `core/content-delete` ability.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param list<string> $post_types Exposed post type names.
+	 * @return array<string, mixed> The input JSON Schema.
+	 */
+	private function get_content_delete_input_schema( array $post_types ): array {
+		return array(
+			'type'                 => 'object',
+			'required'             => array( 'id' ),
+			'additionalProperties' => false,
+			'properties'           => array(
+				'id'        => array(
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'description' => __( 'The ID of the post to delete.', 'ai' ),
+				),
+				'post_type' => array(
+					'type'        => 'string',
+					'enum'        => $post_types,
+					'description' => __( 'Optional. Restrict the deletion to this post type; the post is only deleted if it matches.', 'ai' ),
+				),
+				'force'     => array(
+					'type'        => 'boolean',
+					'description' => __( 'Whether to bypass the trash and delete the post permanently. Defaults to false, which moves the post to the trash.', 'ai' ),
+				),
+				'fields'    => $this->get_fields_input_schema(),
+			),
+		);
+	}
+
+	/**
+	 * Builds the output schema for the `core/content-delete` ability.
+	 *
+	 * Trashing returns the trashed post directly; a forced deletion returns a `deleted`
+	 * flag with the deleted post under `previous`, matching the REST controller.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, mixed> The output JSON Schema.
+	 */
+	private function get_content_delete_output_schema(): array {
+		$post_schema = $this->get_post_output_schema();
+
+		return array(
+			'type'  => 'object',
+			'oneOf' => array(
+				$post_schema,
+				array(
+					'type'                 => 'object',
+					'additionalProperties' => false,
+					'required'             => array( 'deleted', 'previous' ),
+					'properties'           => array(
+						'deleted'  => array(
+							'type'        => 'boolean',
+							'description' => __( 'Whether the post was permanently deleted.', 'ai' ),
+						),
+						'previous' => $post_schema,
+					),
+				),
 			),
 		);
 	}
@@ -1581,16 +2402,711 @@ final class Content {
 	}
 
 	/**
+	 * Resolves the exposed post type a `post_type` input refers to.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return \WP_Post_Type|null The post type object, or null when absent or not exposed.
+	 */
+	private function get_exposed_post_type( array $input ): ?\WP_Post_Type {
+		$post_type = isset( $input['post_type'] ) && is_string( $input['post_type'] ) ? $input['post_type'] : '';
+		if ( '' === $post_type ) {
+			return null;
+		}
+
+		return $this->get_exposed_post_types()[ $post_type ] ?? null;
+	}
+
+	/**
+	 * Resolves the exposed post an `id` input refers to.
+	 *
+	 * The post must exist, belong to a post type exposed to abilities, and match the
+	 * `post_type` guard when one is given. This is the abilities counterpart of the REST
+	 * controller's `get_post()` lookup, where a post of another type is not found either
+	 * because each REST route is bound to one post type.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input The ability input.
+	 * @return \WP_Post|null The post, or null when it cannot be resolved.
+	 */
+	private function get_exposed_post( array $input ): ?WP_Post {
+		$post_id = isset( $input['id'] ) ? $this->input_int( $input['id'] ) : 0;
+		if ( $post_id < 1 ) {
+			return null;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || ! isset( $this->get_exposed_post_types()[ $post->post_type ] ) ) {
+			return null;
+		}
+
+		if ( ! empty( $input['post_type'] ) && $post->post_type !== $input['post_type'] ) {
+			return null;
+		}
+
+		return $post;
+	}
+
+	/**
+	 * Casts a raw input value to a boolean, or null when it was not provided.
+	 *
+	 * Boolean inputs arrive as native booleans from a JSON body and as strings such as
+	 * "true" or "0" from a query string. Both are read the way rest_sanitize_boolean()
+	 * reads them: the strings "false" and "0" are false, any other value casts to boolean.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $value The raw input value.
+	 * @return bool|null The boolean value, or null when the value is null.
+	 */
+	private function input_bool( $value ): ?bool {
+		if ( null === $value ) {
+			return null;
+		}
+
+		if ( is_string( $value ) && in_array( strtolower( $value ), array( 'false', '0' ), true ) ) {
+			return false;
+		}
+
+		return (bool) $value;
+	}
+
+	/**
+	 * Returns which write fields a post type supports, keyed by input key.
+	 *
+	 * This is the abilities counterpart of the per-post-type property registration in the
+	 * REST posts item schema: the REST controller registers `title`, `content`, `excerpt`,
+	 * `author`, `featured_media`, `comment_status`/`ping_status`, `menu_order`, and `format`
+	 * only for post types that declare the matching support, `parent` only for hierarchical
+	 * post types, and `sticky` only for posts. Fields every post type accepts map to true.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $post_type The post type name.
+	 * @return array<string, bool> Whether each write field is supported.
+	 */
+	private function get_write_field_support( string $post_type ): array {
+		return array(
+			'title'          => post_type_supports( $post_type, 'title' ),
+			'content'        => post_type_supports( $post_type, 'editor' ),
+			'excerpt'        => post_type_supports( $post_type, 'excerpt' ),
+			'status'         => true,
+			'slug'           => true,
+			'date'           => true,
+			'date_gmt'       => true,
+			'author'         => post_type_supports( $post_type, 'author' ),
+			'password'       => true,
+			'parent'         => is_post_type_hierarchical( $post_type ),
+			'menu_order'     => post_type_supports( $post_type, 'page-attributes' ),
+			'comment_status' => post_type_supports( $post_type, 'comments' ),
+			'ping_status'    => post_type_supports( $post_type, 'comments' ),
+			'format'         => post_type_supports( $post_type, 'post-formats' ),
+			'featured_media' => post_type_supports( $post_type, 'thumbnail' ),
+			'sticky'         => 'post' === $post_type,
+			'template'       => true,
+		);
+	}
+
+	/**
+	 * Returns the taxonomies whose terms a post type accepts through the write abilities,
+	 * keyed by input key.
+	 *
+	 * Mirrors the REST posts controller, which exposes every taxonomy registered for the
+	 * post type with `show_in_rest` under its `rest_base` (falling back to the taxonomy
+	 * name), so an ability call carries terms under the same keys a REST request would.
+	 * A taxonomy whose key collides with another input key is skipped, as the REST
+	 * controller reports that registration as incorrect usage.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $post_type The post type name.
+	 * @return array<string, \WP_Taxonomy> Taxonomy objects keyed by input key.
+	 */
+	private function get_writable_taxonomies( string $post_type ): array {
+		$reserved   = array_merge( array( 'id', 'post_type', 'force', 'fields' ), array_keys( $this->get_write_field_support( $post_type ) ) );
+		$taxonomies = array();
+
+		foreach ( get_object_taxonomies( $post_type, 'objects' ) as $taxonomy ) {
+			if ( empty( $taxonomy->show_in_rest ) ) {
+				continue;
+			}
+
+			$key = is_string( $taxonomy->rest_base ) && '' !== $taxonomy->rest_base ? $taxonomy->rest_base : $taxonomy->name;
+			if ( in_array( $key, $reserved, true ) ) {
+				continue;
+			}
+
+			$taxonomies[ $key ] = $taxonomy;
+		}
+
+		return $taxonomies;
+	}
+
+	/**
+	 * Returns the taxonomies accepted across every exposed post type, keyed by input key.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, \WP_Taxonomy> Taxonomy objects keyed by input key.
+	 */
+	private function get_all_writable_taxonomies(): array {
+		$taxonomies = array();
+
+		foreach ( array_keys( $this->get_exposed_post_types() ) as $post_type ) {
+			$taxonomies += $this->get_writable_taxonomies( $post_type );
+		}
+
+		return $taxonomies;
+	}
+
+	/**
+	 * Rejects write fields the post type does not support.
+	 *
+	 * The REST posts controller only registers each field for the post types that support
+	 * it and silently drops the rest; a shared input schema cannot express that per post
+	 * type. A field that cannot be honored fails loudly here instead, so a caller never
+	 * believes it set something that was ignored. This mirrors how `core/content-query`
+	 * treats unsupported filters.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return \WP_Error|null A WP_Error for the first unsupported field, or null when all fields are supported.
+	 */
+	private function check_unsupported_fields( array $input, \WP_Post_Type $post_type_object ): ?WP_Error {
+		$post_type = $post_type_object->name;
+		$supported = $this->get_write_field_support( $post_type );
+
+		$writable_taxonomies = $this->get_writable_taxonomies( $post_type );
+		foreach ( array_keys( $this->get_all_writable_taxonomies() ) as $key ) {
+			$supported[ $key ] = isset( $writable_taxonomies[ $key ] );
+		}
+
+		foreach ( $supported as $field => $is_supported ) {
+			if ( $is_supported || ! array_key_exists( $field, $input ) ) {
+				continue;
+			}
+
+			return new WP_Error(
+				'content_invalid_field',
+				sprintf(
+					/* translators: 1: Field name, 2: Post type name. */
+					__( 'The %1$s field is not supported by the %2$s post type.', 'ai' ),
+					$field,
+					$post_type
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Prepares a single post for creation or update.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::prepare_item_for_database()` without its
+	 * REST-specific parts: the `rest_pre_insert_{$post_type}` filter, and the Block Hooks
+	 * metadata update (`update_ignored_hooked_blocks_postmeta()`). That update assumes the
+	 * content being saved was read through REST with hooked blocks inserted, while
+	 * `core/content-query` returns the stored content verbatim; running it here would mark
+	 * hooked blocks as ignored after every read-modify-write cycle.
+	 *
+	 * Field support is checked beforehand by {@see self::check_unsupported_fields()}; the
+	 * support checks here are the REST controller's schema guards, kept for parity.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type of the post being prepared.
+	 * @param \WP_Post|null $existing_post    The post being updated, or null when creating.
+	 * @return \stdClass|\WP_Error Post object prepared for wp_insert_post() or wp_update_post(), or a WP_Error.
+	 */
+	private function prepare_item_for_database( array $input, \WP_Post_Type $post_type_object, ?WP_Post $existing_post ) {
+		$prepared_post  = new stdClass();
+		$current_status = '';
+		$post_type      = $post_type_object->name;
+
+		// Post ID.
+		if ( $existing_post instanceof WP_Post ) {
+			$prepared_post->ID = $existing_post->ID;
+			$current_status    = $existing_post->post_status;
+		}
+
+		// Post title.
+		if ( post_type_supports( $post_type, 'title' ) && isset( $input['title'] ) && is_string( $input['title'] ) ) {
+			$prepared_post->post_title = $input['title'];
+		}
+
+		// Post content.
+		if ( post_type_supports( $post_type, 'editor' ) && isset( $input['content'] ) && is_string( $input['content'] ) ) {
+			$prepared_post->post_content = $input['content'];
+		}
+
+		// Post excerpt.
+		if ( post_type_supports( $post_type, 'excerpt' ) && isset( $input['excerpt'] ) && is_string( $input['excerpt'] ) ) {
+			$prepared_post->post_excerpt = $input['excerpt'];
+		}
+
+		// Post type: the requested type when creating, the existing type when updating.
+		$prepared_post->post_type = $post_type;
+
+		// Post status.
+		if ( isset( $input['status'] )
+			&& is_string( $input['status'] )
+			&& ( '' === $current_status || $current_status !== $input['status'] )
+		) {
+			$status = $this->handle_status_param( $input['status'], $post_type_object );
+			if ( $status instanceof WP_Error ) {
+				return $status;
+			}
+
+			$prepared_post->post_status = $status;
+		}
+
+		// Post date.
+		if ( ! empty( $input['date'] ) && is_string( $input['date'] ) ) {
+			$current_date = $existing_post instanceof WP_Post ? $existing_post->post_date : false;
+			$date_data    = rest_get_date_with_gmt( $input['date'] );
+
+			if ( ! empty( $date_data ) && $current_date !== $date_data[0] ) {
+				[ $prepared_post->post_date, $prepared_post->post_date_gmt ] = $date_data;
+
+				$prepared_post->edit_date = true;
+			}
+		} elseif ( ! empty( $input['date_gmt'] ) && is_string( $input['date_gmt'] ) ) {
+			$current_date = $existing_post instanceof WP_Post ? $existing_post->post_date_gmt : false;
+			$date_data    = rest_get_date_with_gmt( $input['date_gmt'], true );
+
+			if ( ! empty( $date_data ) && $current_date !== $date_data[1] ) {
+				[ $prepared_post->post_date, $prepared_post->post_date_gmt ] = $date_data;
+
+				$prepared_post->edit_date = true;
+			}
+		}
+
+		/*
+		 * Sending a null date or date_gmt value resets date and date_gmt to their
+		 * default values (`0000-00-00 00:00:00`).
+		 */
+		if ( ( array_key_exists( 'date_gmt', $input ) && null === $input['date_gmt'] )
+			|| ( array_key_exists( 'date', $input ) && null === $input['date'] )
+		) {
+			$prepared_post->post_date_gmt = null;
+			$prepared_post->post_date     = null;
+		}
+
+		// Post slug. The REST controller sanitizes its `slug` argument with sanitize_title().
+		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) ) {
+			$prepared_post->post_name = sanitize_title( $input['slug'] );
+		}
+
+		// Author.
+		if ( post_type_supports( $post_type, 'author' ) && ! empty( $input['author'] ) ) {
+			$post_author = $this->parse_filter_int( $input['author'], 1 );
+
+			if ( null === $post_author || ( get_current_user_id() !== $post_author && ! get_userdata( $post_author ) ) ) {
+				return new WP_Error(
+					'content_invalid_author',
+					__( 'Invalid author ID.', 'ai' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$prepared_post->post_author = $post_author;
+		}
+
+		// Post password. Sticky is only registered for posts, as in the REST posts item schema.
+		$sticky = 'post' === $post_type ? $this->input_bool( $input['sticky'] ?? null ) : null;
+
+		if ( isset( $input['password'] ) && is_string( $input['password'] ) ) {
+			$prepared_post->post_password = $input['password'];
+
+			if ( '' !== $input['password'] ) {
+				if ( true === $sticky ) {
+					return $this->invalid_field_error( __( 'A post can not be sticky and have a password.', 'ai' ) );
+				}
+
+				if ( ! empty( $prepared_post->ID ) && is_sticky( $prepared_post->ID ) ) {
+					return $this->invalid_field_error( __( 'A sticky post can not be password protected.', 'ai' ) );
+				}
+			}
+		}
+
+		if ( true === $sticky && ! empty( $prepared_post->ID ) && post_password_required( $prepared_post->ID ) ) {
+			return $this->invalid_field_error( __( 'A password protected post can not be set to sticky.', 'ai' ) );
+		}
+
+		// Parent.
+		if ( is_post_type_hierarchical( $post_type ) && isset( $input['parent'] ) ) {
+			$parent_id   = $this->parse_filter_int( $input['parent'], 0 );
+			$parent_post = null !== $parent_id && $parent_id > 0 ? get_post( $parent_id ) : null;
+
+			if ( null === $parent_id || ( $parent_id > 0 && ! $parent_post instanceof WP_Post ) ) {
+				return new WP_Error(
+					'content_invalid_parent',
+					__( 'Invalid post parent ID.', 'ai' ),
+					array( 'status' => 400 )
+				);
+			}
+
+			$prepared_post->post_parent = $parent_post instanceof WP_Post ? (int) $parent_post->ID : 0;
+		}
+
+		// Menu order.
+		if ( post_type_supports( $post_type, 'page-attributes' ) && isset( $input['menu_order'] ) && is_scalar( $input['menu_order'] ) ) {
+			$prepared_post->menu_order = (int) $input['menu_order'];
+		}
+
+		// Comment status.
+		if ( post_type_supports( $post_type, 'comments' ) && ! empty( $input['comment_status'] ) && is_string( $input['comment_status'] ) ) {
+			$prepared_post->comment_status = $input['comment_status'];
+		}
+
+		// Ping status.
+		if ( post_type_supports( $post_type, 'comments' ) && ! empty( $input['ping_status'] ) && is_string( $input['ping_status'] ) ) {
+			$prepared_post->ping_status = $input['ping_status'];
+		}
+
+		// Force template to null so that it can be handled exclusively by handle_template().
+		$prepared_post->page_template = null;
+
+		return $prepared_post;
+	}
+
+	/**
+	 * Determines validity and normalizes the given status parameter.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::handle_status_param()`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string        $post_status      Post status.
+	 * @param \WP_Post_Type $post_type_object Post type.
+	 * @return string|\WP_Error Post status or WP_Error if lacking the proper permission.
+	 */
+	private function handle_status_param( string $post_status, \WP_Post_Type $post_type_object ) {
+		switch ( $post_status ) {
+			case 'draft':
+			case 'pending':
+				break;
+			case 'private':
+				if ( ! current_user_can( $this->post_type_cap( $post_type_object, 'publish_posts' ) ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+					return new WP_Error(
+						'content_cannot_publish',
+						__( 'Sorry, you are not allowed to create private posts in this post type.', 'ai' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+				break;
+			case 'publish':
+			case 'future':
+				if ( ! current_user_can( $this->post_type_cap( $post_type_object, 'publish_posts' ) ) ) { // phpcs:ignore WordPress.WP.Capabilities.Undetermined -- Capability is resolved from the post type's capability object.
+					return new WP_Error(
+						'content_cannot_publish',
+						__( 'Sorry, you are not allowed to publish posts in this post type.', 'ai' ),
+						array( 'status' => rest_authorization_required_code() )
+					);
+				}
+				break;
+			default:
+				if ( ! get_post_status_object( $post_status ) ) {
+					$post_status = 'draft';
+				}
+				break;
+		}
+
+		return $post_status;
+	}
+
+	/**
+	 * Applies the parts of a write that live outside the posts table.
+	 *
+	 * Mirrors the post-insert steps of `WP_REST_Posts_Controller::create_item()` and
+	 * `update_item()`: sticky, featured media, post format, template, and terms. Unlike the
+	 * REST controller, which discards the result of its featured media handling, an invalid
+	 * featured media ID is reported. Meta is not handled; it belongs to the REST meta fields
+	 * machinery, which has no abilities counterpart yet.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_Post      $post             The inserted or updated post.
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @param bool          $creating         True when creating a post, false when updating.
+	 * @return \WP_Error|null A WP_Error on failure, null otherwise.
+	 */
+	private function handle_post_extras( WP_Post $post, array $input, \WP_Post_Type $post_type_object, bool $creating ): ?WP_Error {
+		$post_type = $post_type_object->name;
+		$post_id   = (int) $post->ID;
+
+		if ( 'post' === $post_type ) {
+			$sticky = $this->input_bool( $input['sticky'] ?? null );
+
+			// The REST controller always resolves sticky on creation, defaulting to not sticky.
+			if ( $creating || null !== $sticky ) {
+				if ( true === $sticky ) {
+					stick_post( $post_id );
+				} else {
+					unstick_post( $post_id );
+				}
+			}
+		}
+
+		if ( post_type_supports( $post_type, 'thumbnail' ) && isset( $input['featured_media'] ) ) {
+			$featured_media = $this->handle_featured_media( $this->input_int( $input['featured_media'] ), $post_id );
+			if ( $featured_media instanceof WP_Error ) {
+				return $featured_media;
+			}
+		}
+
+		if ( post_type_supports( $post_type, 'post-formats' ) && ! empty( $input['format'] ) && is_string( $input['format'] ) ) {
+			set_post_format( $post, $input['format'] );
+		}
+
+		if ( isset( $input['template'] ) && is_string( $input['template'] ) ) {
+			$this->handle_template( $input['template'], $post_id, $creating );
+		}
+
+		return $this->handle_terms( $post_id, $input, $post_type_object );
+	}
+
+	/**
+	 * Determines the featured media based on an input value.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::handle_featured_media()`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int $featured_media Featured Media ID; 0 removes the featured media.
+	 * @param int $post_id        Post ID.
+	 * @return bool|\WP_Error Whether the post thumbnail was successfully deleted, otherwise WP_Error.
+	 */
+	private function handle_featured_media( int $featured_media, int $post_id ) {
+		if ( $featured_media > 0 ) {
+			if ( set_post_thumbnail( $post_id, $featured_media ) ) {
+				return true;
+			}
+
+			return new WP_Error(
+				'content_invalid_featured_media',
+				__( 'Invalid featured media ID.', 'ai' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return delete_post_thumbnail( $post_id );
+	}
+
+	/**
+	 * Checks whether the requested template is valid for the post.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::check_template()`, which REST runs as the
+	 * validation callback of its `template` argument. Updating a post to the template it
+	 * already uses is always allowed, even if that template is no longer supported.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input     The ability input.
+	 * @param string        $post_type The post type name.
+	 * @param \WP_Post|null $post      The post being updated, or null when creating.
+	 * @return true|\WP_Error True if the template is valid or unchanged, or a WP_Error if it is not supported.
+	 */
+	private function check_template( array $input, string $post_type, ?WP_Post $post ) {
+		$template = isset( $input['template'] ) && is_string( $input['template'] ) ? $input['template'] : '';
+		if ( '' === $template ) {
+			return true;
+		}
+
+		$current_template = $post instanceof WP_Post ? (string) get_page_template_slug( $post ) : '';
+
+		// Always allow for updating a post to the same template, even if that template is no longer supported.
+		if ( $template === $current_template ) {
+			return true;
+		}
+
+		// When creating there is no post yet, and the theme falls back to the passed post type.
+		$allowed_templates = wp_get_theme()->get_page_templates( $post, $post_type );
+
+		if ( isset( $allowed_templates[ $template ] ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'content_invalid_template',
+			sprintf(
+				/* translators: 1: Parameter, 2: List of valid values. */
+				__( '%1$s is not one of %2$s.', 'ai' ),
+				'template',
+				implode( ', ', array_keys( $allowed_templates ) )
+			),
+			array( 'status' => 400 )
+		);
+	}
+
+	/**
+	 * Sets the template for a post.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::handle_template()`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $template Page template filename.
+	 * @param int    $post_id  Post ID.
+	 * @param bool   $validate Whether to validate that the template selected is valid.
+	 */
+	private function handle_template( string $template, int $post_id, bool $validate = false ): void {
+		if ( $validate && ! array_key_exists( $template, wp_get_theme()->get_page_templates( get_post( $post_id ) ) ) ) {
+			$template = '';
+		}
+
+		update_post_meta( $post_id, '_wp_page_template', $template );
+	}
+
+	/**
+	 * Updates the post's terms from the ability input.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::handle_terms()`. Term lists are normalized to
+	 * unique positive IDs first: the REST controller receives them already coerced by its
+	 * schema, and wp_set_object_terms() would otherwise create a new term for a string.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int           $post_id          The post ID to update the terms of.
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return \WP_Error|null WP_Error on an error assigning any of the terms, otherwise null.
+	 */
+	private function handle_terms( int $post_id, array $input, \WP_Post_Type $post_type_object ): ?WP_Error {
+		foreach ( $this->get_writable_taxonomies( $post_type_object->name ) as $key => $taxonomy ) {
+			if ( ! isset( $input[ $key ] ) ) {
+				continue;
+			}
+
+			$result = wp_set_object_terms( $post_id, $this->parse_id_list_input( $input, $key ), $taxonomy->name );
+
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Checks whether the current user can assign all terms sent with the ability input.
+	 *
+	 * Mirrors `WP_REST_Posts_Controller::check_assign_terms_permission()`.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed>  $input            The ability input.
+	 * @param \WP_Post_Type $post_type_object The post type object.
+	 * @return bool Whether the current user can assign the provided terms.
+	 */
+	private function check_assign_terms_permission( array $input, \WP_Post_Type $post_type_object ): bool {
+		foreach ( $this->get_writable_taxonomies( $post_type_object->name ) as $key => $taxonomy ) {
+			if ( ! isset( $input[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $this->parse_id_list_input( $input, $key ) as $term_id ) {
+				// Invalid terms will be rejected later.
+				if ( ! get_term( $term_id, $taxonomy->name ) ) {
+					continue;
+				}
+
+				if ( ! current_user_can( 'assign_term', $term_id ) ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks whether a post can be moved to the trash rather than deleted permanently.
+	 *
+	 * Mirrors the trash support resolution of `WP_REST_Posts_Controller::delete_item()`
+	 * without its `rest_{$post_type}_trashable` filter. The constants are read through
+	 * constant() because they are defined at runtime, and an undefined constant counts as
+	 * no trash support so a deletion is never silently made permanent.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_Post $post The post being deleted.
+	 * @return bool Whether the post supports trashing.
+	 */
+	private function supports_trash( WP_Post $post ): bool {
+		$trash_days     = defined( 'EMPTY_TRASH_DAYS' ) ? (int) constant( 'EMPTY_TRASH_DAYS' ) : 0;
+		$supports_trash = $trash_days > 0;
+
+		if ( 'attachment' === $post->post_type ) {
+			$supports_trash = $supports_trash && defined( 'MEDIA_TRASH' ) && (bool) constant( 'MEDIA_TRASH' );
+		}
+
+		return $supports_trash;
+	}
+
+	/**
+	 * Slashes a prepared post for wp_insert_post() or wp_update_post().
+	 *
+	 * Both functions expect slashed data, and wp_update_post() expects an array rather than
+	 * an object so it does not unslash the input again.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \stdClass $prepared_post The prepared post.
+	 * @return array<string, mixed> The slashed post data.
+	 */
+	private function slash_post_data( stdClass $prepared_post ): array {
+		$slashed = wp_slash( (array) $prepared_post );
+
+		return is_array( $slashed ) ? $slashed : array();
+	}
+
+	/**
+	 * Builds the error returned when an input combination is invalid.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $message The error message.
+	 * @return \WP_Error The invalid-field error.
+	 */
+	private function invalid_field_error( string $message ): WP_Error {
+		return new WP_Error( 'content_invalid_field', $message, array( 'status' => 400 ) );
+	}
+
+	/**
+	 * Builds the error returned when trashing or deleting a post fails.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return \WP_Error The cannot-delete error.
+	 */
+	private function cannot_delete_error(): WP_Error {
+		return new WP_Error(
+			'content_cannot_delete',
+			__( 'The post cannot be deleted.', 'ai' ),
+			array( 'status' => 500 )
+		);
+	}
+
+	/**
 	 * Builds the uniform not-found error.
 	 *
-	 * Unreachable through gated transports, which run {@see self::check_permission()}
-	 * first and deny the same lookups. It is kept so that a direct call to the execute
+	 * Unreachable through gated transports, which run the ability's permission callback
+	 * first and deny the same lookups. It is kept so that a direct call to an execute
 	 * callback still fails closed on a structural lookup failure: a missing post, a post
 	 * type that is not exposed, or a post type that does not match the requested one.
 	 *
-	 * This is not a permission check. The execute callback deliberately does not repeat
-	 * the read/edit checks that {@see self::check_permission()} already performed, so a
-	 * direct call bypasses them. Only invoke the callback through
+	 * This is not a permission check. The execute callbacks deliberately do not repeat
+	 * the read, edit, or delete checks that the permission callbacks already performed,
+	 * so a direct call bypasses them. Only invoke the callbacks through
 	 * {@see WP_Ability::execute()}, which always runs the permission callback first.
 	 *
 	 * @since 1.2.0

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -1785,18 +1785,27 @@ final class Content {
 	private function get_content_write_properties(): array {
 		$statuses = array_values( get_post_stati( array( 'internal' => false ) ) );
 
+		$raw_object = array(
+			'raw' => array(
+				'type' => 'string',
+			),
+		);
+
 		$properties = array(
 			'title'          => array(
-				'type'        => 'string',
-				'description' => __( 'The raw post title. Only supported for post types that support titles.', 'ai' ),
+				'type'        => array( 'string', 'object' ),
+				'properties'  => $raw_object,
+				'description' => __( 'The raw post title, as a string or as an object with a `raw` key. Only supported for post types that support titles.', 'ai' ),
 			),
 			'content'        => array(
-				'type'        => 'string',
-				'description' => __( 'The raw post content, as block markup or HTML. Only supported for post types that support the editor.', 'ai' ),
+				'type'        => array( 'string', 'object' ),
+				'properties'  => $raw_object,
+				'description' => __( 'The raw post content, as block markup or HTML, given as a string or as an object with a `raw` key. Only supported for post types that support the editor.', 'ai' ),
 			),
 			'excerpt'        => array(
-				'type'        => 'string',
-				'description' => __( 'The raw post excerpt. Only supported for post types that support excerpts.', 'ai' ),
+				'type'        => array( 'string', 'object' ),
+				'properties'  => $raw_object,
+				'description' => __( 'The raw post excerpt, as a string or as an object with a `raw` key. Only supported for post types that support excerpts.', 'ai' ),
 			),
 			'status'         => array(
 				'type'        => 'string',
@@ -2458,6 +2467,41 @@ final class Content {
 	}
 
 	/**
+	 * Reads a text input given either as a string or as an object with a `raw` key.
+	 *
+	 * The object form matches how the title, content, and excerpt are read back by the
+	 * posts endpoints, so a value can be written the same way it was fetched.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<mixed> $input           The ability input.
+	 * @param string       $key             The input key holding the text.
+	 * @param bool         $allow_empty_raw Whether an empty `raw` value counts as provided.
+	 * @return string|null The text, or null when the input does not provide it.
+	 */
+	private function get_text_input( array $input, string $key, bool $allow_empty_raw ): ?string {
+		$value = $input[ $key ] ?? null;
+
+		if ( is_string( $value ) ) {
+			return $value;
+		}
+
+		if ( is_object( $value ) ) {
+			$value = (array) $value;
+		}
+
+		if ( ! is_array( $value ) || ! isset( $value['raw'] ) || ! is_string( $value['raw'] ) ) {
+			return null;
+		}
+
+		if ( ! $allow_empty_raw && empty( $value['raw'] ) ) {
+			return null;
+		}
+
+		return $value['raw'];
+	}
+
+	/**
 	 * Returns which write fields a post type supports, keyed by input key.
 	 *
 	 * `title`, `content`, `excerpt`, `author`, `featured_media`, `comment_status`,
@@ -2619,19 +2663,22 @@ final class Content {
 			$current_status    = $existing_post->post_status;
 		}
 
-		// Post title.
-		if ( post_type_supports( $post_type, 'title' ) && isset( $input['title'] ) && is_string( $input['title'] ) ) {
-			$prepared_post->post_title = $input['title'];
+		// Post title. An empty `raw` title is ignored, unlike an empty title string.
+		$title = post_type_supports( $post_type, 'title' ) ? $this->get_text_input( $input, 'title', false ) : null;
+		if ( null !== $title ) {
+			$prepared_post->post_title = $title;
 		}
 
 		// Post content.
-		if ( post_type_supports( $post_type, 'editor' ) && isset( $input['content'] ) && is_string( $input['content'] ) ) {
-			$prepared_post->post_content = $input['content'];
+		$content = post_type_supports( $post_type, 'editor' ) ? $this->get_text_input( $input, 'content', true ) : null;
+		if ( null !== $content ) {
+			$prepared_post->post_content = $content;
 		}
 
 		// Post excerpt.
-		if ( post_type_supports( $post_type, 'excerpt' ) && isset( $input['excerpt'] ) && is_string( $input['excerpt'] ) ) {
-			$prepared_post->post_excerpt = $input['excerpt'];
+		$excerpt = post_type_supports( $post_type, 'excerpt' ) ? $this->get_text_input( $input, 'excerpt', true ) : null;
+		if ( null !== $excerpt ) {
+			$prepared_post->post_excerpt = $excerpt;
 		}
 
 		// Post type: the requested type when creating, the existing type when updating.

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -355,8 +355,8 @@ final class Content {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param string               $name The ability name.
-	 * @param array<string, mixed> $args The ability registration arguments.
+	 * @param lowercase-string&non-falsy-string $name The ability name, for example `core/content-create`.
+	 * @param array<string, mixed>              $args The ability registration arguments.
 	 */
 	private function register_ability_override( string $name, array $args ): void {
 		if ( wp_has_ability( $name ) ) {

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -35,15 +35,12 @@ defined( 'ABSPATH' ) || exit;
  *   - `core/content-update`: updates a post by ID.
  *   - `core/content-delete`: moves a post to the trash, or deletes it permanently.
  *
- * The write abilities mirror the create, update, and delete endpoints of the REST posts
- * controller (`WP_REST_Posts_Controller`): they accept the same fields, apply the same
- * capability checks, and prepare the post for the database the same way. The
- * transport-agnostic parts of that controller are reproduced here as private helpers
- * ({@see self::prepare_item_for_database()} and the methods around it), named after their
- * REST counterparts so a future core refactor can share them between REST and abilities.
- * REST-specific hooks, request and response objects, and the meta fields machinery are
- * deliberately not reproduced. The written post is returned through the same field
- * projection `core/content-query` uses.
+ * The write abilities accept the standard post fields (title, content, excerpt, status,
+ * slug, dates, author, password, parent, menu order, comment and ping status, format,
+ * featured media, sticky, template, and taxonomy terms), apply the post type's
+ * capabilities, and share one post preparation step
+ * ({@see self::prepare_item_for_database()}). The written post is returned through the
+ * same field projection `core/content-query` uses.
  *
  * This class is kept almost identical to the WordPress core class `WP_Content_Abilities`
  * so the two implementations stay in sync. Differences from the core class are marked with
@@ -247,8 +244,6 @@ final class Content {
 	/**
 	 * Registers the `core/content-create` ability.
 	 *
-	 * Mirrors the create endpoint of the REST posts controller.
-	 *
 	 * @since x.x.x
 	 */
 	private function register_content_create(): void {
@@ -266,7 +261,7 @@ final class Content {
 			'core/content-create',
 			array(
 				'label'               => __( 'Content Create', 'ai' ),
-				'description'         => __( 'Creates a post of a post type exposed to abilities. Accepts the same fields as the REST API posts endpoints: title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the created post; use `fields` to choose which post fields are returned. Requires an authenticated user who can create posts of the post type.', 'ai' ),
+				'description'         => __( 'Creates a post of a post type exposed to abilities. Accepts a title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky flag, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the created post; use `fields` to choose which post fields are returned. Requires an authenticated user who can create posts of the post type.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_content_create_input_schema( $post_types ),
 				'output_schema'       => $this->get_post_output_schema(),
@@ -289,8 +284,6 @@ final class Content {
 	/**
 	 * Registers the `core/content-update` ability.
 	 *
-	 * Mirrors the update endpoint of the REST posts controller.
-	 *
 	 * @since x.x.x
 	 */
 	private function register_content_update(): void {
@@ -308,7 +301,7 @@ final class Content {
 			'core/content-update',
 			array(
 				'label'               => __( 'Content Update', 'ai' ),
-				'description'         => __( 'Updates a post by ID. Only the provided fields change; omitted fields keep their current values. Accepts the same fields as the REST API posts endpoints: title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the updated post; use `fields` to choose which post fields are returned. Requires an authenticated user who can edit the post.', 'ai' ),
+				'description'         => __( 'Updates a post by ID. Only the provided fields change; omitted fields keep their current values. Accepts a title, content, excerpt, status, slug, date, author, password, parent, menu order, comment and ping status, format, featured media, sticky flag, template, and taxonomy terms. Fields the post type does not support are rejected rather than ignored. Returns the updated post; use `fields` to choose which post fields are returned. Requires an authenticated user who can edit the post.', 'ai' ),
 				'category'            => self::CATEGORY,
 				'input_schema'        => $this->get_content_update_input_schema( $post_types ),
 				'output_schema'       => $this->get_post_output_schema(),
@@ -319,9 +312,8 @@ final class Content {
 						'readonly'    => false,
 						/*
 						 * Not flagged destructive: overwritten content is kept as a revision,
-						 * and the Abilities REST run controller routes destructive idempotent
-						 * abilities to the DELETE method, whose query-string input cannot carry
-						 * post content.
+						 * and the Abilities API serves destructive idempotent abilities over the
+						 * DELETE method, whose query-string input cannot carry post content.
 						 */
 						'destructive' => false,
 						// Repeating the same update leaves the post in the same state.
@@ -336,8 +328,6 @@ final class Content {
 
 	/**
 	 * Registers the `core/content-delete` ability.
-	 *
-	 * Mirrors the delete endpoint of the REST posts controller.
 	 *
 	 * @since x.x.x
 	 */
@@ -366,8 +356,8 @@ final class Content {
 					'annotations'  => array(
 						'readonly'    => false,
 						'destructive' => true,
-						// Repeating a deletion has no further effect; the Abilities REST run
-						// controller routes destructive idempotent abilities to the DELETE method.
+						// Repeating a deletion has no further effect; the Abilities API serves
+						// destructive idempotent abilities over the DELETE method.
 						'idempotent'  => true,
 						'open_world'  => false,
 					),
@@ -438,15 +428,14 @@ final class Content {
 	/**
 	 * Permission callback for the `core/content-create` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::create_item_permissions_check()`: the current user
-	 * must be able to create posts of the requested post type, may only create a post as
-	 * another author when they can edit others' posts, may only make a post sticky when they
-	 * can edit others' posts or publish posts, and must be allowed to assign every provided
-	 * term. The Abilities API requires a boolean here, so the distinct REST error codes
-	 * collapse into the generic permission error.
+	 * The current user must be able to create posts of the requested post type, may only
+	 * create a post as another author when they can edit others' posts, may only make a
+	 * post sticky when they can edit others' posts or publish posts, and must be allowed to
+	 * assign every provided term. The Abilities API requires a boolean here, so every
+	 * denial collapses into the generic permission error.
 	 *
 	 * The publish capability required by some statuses is enforced during execution, where
-	 * the REST controller enforces it too (in its post preparation).
+	 * the status is resolved.
 	 *
 	 * @since x.x.x
 	 *
@@ -479,12 +468,11 @@ final class Content {
 	/**
 	 * Permission callback for the `core/content-update` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::update_item_permissions_check()`: the post must
-	 * exist in an exposed post type (and match the `post_type` guard when given), the
-	 * current user must be able to edit it, may only reassign it to another author when
-	 * they can edit others' posts, may only make it sticky when they can edit others' posts
-	 * or publish posts, and must be allowed to assign every provided term. The Abilities
-	 * API requires a boolean here, so the distinct REST error codes collapse into the
+	 * The post must exist in an exposed post type (and match the `post_type` guard when
+	 * given), the current user must be able to edit it, may only reassign it to another
+	 * author when they can edit others' posts, may only make it sticky when they can edit
+	 * others' posts or publish posts, and must be allowed to assign every provided term.
+	 * The Abilities API requires a boolean here, so every denial collapses into the
 	 * generic permission error.
 	 *
 	 * @since x.x.x
@@ -509,7 +497,7 @@ final class Content {
 			return false;
 		}
 
-		// REST's check_update_permission(): an exposed post type and the edit_post meta capability.
+		// An exposed post type (checked above) and the edit_post meta capability.
 		if ( ! current_user_can( 'edit_post', $post->ID ) ) {
 			return false;
 		}
@@ -524,9 +512,8 @@ final class Content {
 	/**
 	 * Permission callback for the `core/content-delete` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::delete_item_permissions_check()`: the post must
-	 * exist in an exposed post type (and match the `post_type` guard when given), and the
-	 * current user must be able to delete it.
+	 * The post must exist in an exposed post type (and match the `post_type` guard when
+	 * given), and the current user must be able to delete it.
 	 *
 	 * @since x.x.x
 	 *
@@ -545,12 +532,12 @@ final class Content {
 			return false;
 		}
 
-		// REST's check_delete_permission(): an exposed post type and the delete_post meta capability.
+		// An exposed post type (checked above) and the delete_post meta capability.
 		return current_user_can( 'delete_post', $post->ID );
 	}
 
 	/**
-	 * Checks the author and sticky parts of the REST create/update permission checks.
+	 * Checks the author and sticky parts of the create and update permission checks.
 	 *
 	 * Creating or updating a post as another author requires the post type's
 	 * `edit_others_posts` capability. Making a post sticky requires `edit_others_posts` or
@@ -578,8 +565,7 @@ final class Content {
 	/**
 	 * Checks whether the current user may make posts of a post type sticky.
 	 *
-	 * Mirrors the sticky gate of the REST create/update permission checks: the post type's
-	 * `edit_others_posts` or `publish_posts` capability.
+	 * Either the post type's `edit_others_posts` or its `publish_posts` capability allows it.
 	 *
 	 * @since x.x.x
 	 *
@@ -1011,11 +997,11 @@ final class Content {
 	/**
 	 * Executes the `core/content-create` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::create_item()`. {@see WP_Ability::execute()} always
-	 * runs {@see self::check_create_permission()} first, so this only re-validates that the
-	 * post type is exposed before preparing and inserting the post. Errors raised after the
-	 * post has been inserted (for example while assigning terms) are returned as-is, as the
-	 * REST controller does: the post exists at that point and its ID is not reported.
+	 * {@see WP_Ability::execute()} always runs {@see self::check_create_permission()} first,
+	 * so this only re-validates that the post type is exposed before preparing and
+	 * inserting the post. Errors raised after the post has been inserted (for example while
+	 * assigning terms) are returned as-is: the post exists at that point and its ID is not
+	 * reported.
 	 *
 	 * @since x.x.x
 	 *
@@ -1098,11 +1084,10 @@ final class Content {
 	/**
 	 * Executes the `core/content-update` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::update_item()`. {@see WP_Ability::execute()} always
-	 * runs {@see self::check_update_permission()} first, so this only re-validates the
-	 * lookup itself before preparing and updating the post. Errors raised after the post
-	 * has been updated (for example while assigning terms) are returned as-is, as the REST
-	 * controller does.
+	 * {@see WP_Ability::execute()} always runs {@see self::check_update_permission()} first,
+	 * so this only re-validates the lookup itself before preparing and updating the post.
+	 * Errors raised after the post has been updated (for example while assigning terms) are
+	 * returned as-is.
 	 *
 	 * @since x.x.x
 	 *
@@ -1185,10 +1170,10 @@ final class Content {
 	/**
 	 * Executes the `core/content-delete` ability.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::delete_item()`. {@see WP_Ability::execute()} always
-	 * runs {@see self::check_delete_permission()} first, so this only re-validates the
-	 * lookup itself. Without `force` the post is moved to the trash and returned; with
-	 * `force` it is deleted permanently and returned under `previous`.
+	 * {@see WP_Ability::execute()} always runs {@see self::check_delete_permission()} first,
+	 * so this only re-validates the lookup itself. Without `force` the post is moved to the
+	 * trash and returned; with `force` it is deleted permanently and returned under
+	 * `previous`.
 	 *
 	 * @since x.x.x
 	 *
@@ -1786,12 +1771,12 @@ final class Content {
 	/**
 	 * Returns the input properties shared by the create and update abilities, keyed by field name.
 	 *
-	 * These mirror the writable properties of the REST posts item schema, including one
-	 * property per taxonomy the REST API exposes for an exposed post type, under the same
-	 * key the REST API uses (e.g. `categories` and `tags` for posts). The REST controller
-	 * only registers each property for the post types that support it; a shared schema
-	 * cannot express that per post type, so the descriptions state the requirement and
-	 * {@see self::check_unsupported_fields()} enforces it at execution time.
+	 * Taxonomy terms are accepted under one property per taxonomy an exposed post type
+	 * registers with `show_in_rest`, keyed by the taxonomy's `rest_base` when it has one
+	 * (e.g. `categories` and `tags` for posts) and by its name otherwise. Support for a
+	 * field depends on the post type; a shared schema cannot express that per post type,
+	 * so the descriptions state the requirement and {@see self::check_unsupported_fields()}
+	 * enforces it at execution time.
 	 *
 	 * @since x.x.x
 	 *
@@ -1903,8 +1888,7 @@ final class Content {
 	 * Builds the input schema for the `core/content-create` ability.
 	 *
 	 * `additionalProperties: false` rejects unknown fields instead of dropping them, so e.g.
-	 * passing an `id` fails validation the way the REST controller rejects creating an
-	 * existing post.
+	 * passing an `id` fails validation instead of silently creating a new post.
 	 *
 	 * @since x.x.x
 	 *
@@ -1999,7 +1983,7 @@ final class Content {
 	 * Builds the output schema for the `core/content-delete` ability.
 	 *
 	 * Trashing returns the trashed post directly; a forced deletion returns a `deleted`
-	 * flag with the deleted post under `previous`, matching the REST controller.
+	 * flag with the deleted post under `previous`.
 	 *
 	 * @since x.x.x
 	 *
@@ -2423,11 +2407,8 @@ final class Content {
 	 * Resolves the exposed post an `id` input refers to.
 	 *
 	 * The post must exist, belong to a post type exposed to abilities, and match the
-	 * `post_type` guard when one is given. This is the abilities counterpart of the REST
-	 * controller's `get_post()` lookup, where a post of another type is not found either
-	 * because each REST route is bound to one post type. An ID that is not a positive
-	 * integer never resolves, so a negative or malformed value cannot be coerced onto
-	 * another post.
+	 * `post_type` guard when one is given. An ID that is not a positive integer never
+	 * resolves, so a negative or malformed value cannot be coerced onto another post.
 	 *
 	 * @since x.x.x
 	 *
@@ -2456,8 +2437,8 @@ final class Content {
 	 * Casts a raw input value to a boolean, or null when it was not provided.
 	 *
 	 * Boolean inputs arrive as native booleans from a JSON body and as strings such as
-	 * "true" or "0" from a query string. Both are read the way rest_sanitize_boolean()
-	 * reads them: the strings "false" and "0" are false, any other value casts to boolean.
+	 * "true" or "0" from a query string: the strings "false" and "0" are false, any other
+	 * value casts to boolean.
 	 *
 	 * @since x.x.x
 	 *
@@ -2479,11 +2460,10 @@ final class Content {
 	/**
 	 * Returns which write fields a post type supports, keyed by input key.
 	 *
-	 * This is the abilities counterpart of the per-post-type property registration in the
-	 * REST posts item schema: the REST controller registers `title`, `content`, `excerpt`,
-	 * `author`, `featured_media`, `comment_status`/`ping_status`, `menu_order`, and `format`
-	 * only for post types that declare the matching support, `parent` only for hierarchical
-	 * post types, and `sticky` only for posts. Fields every post type accepts map to true.
+	 * `title`, `content`, `excerpt`, `author`, `featured_media`, `comment_status`,
+	 * `ping_status`, `menu_order`, and `format` need the matching post type support,
+	 * `parent` needs a hierarchical post type, and `sticky` is only available for posts.
+	 * Fields every post type accepts map to true.
 	 *
 	 * @since x.x.x
 	 *
@@ -2516,11 +2496,10 @@ final class Content {
 	 * Returns the taxonomies whose terms a post type accepts through the write abilities,
 	 * keyed by input key.
 	 *
-	 * Mirrors the REST posts controller, which exposes every taxonomy registered for the
-	 * post type with `show_in_rest` under its `rest_base` (falling back to the taxonomy
-	 * name), so an ability call carries terms under the same keys a REST request would.
-	 * A taxonomy whose key collides with another input key is skipped, as the REST
-	 * controller reports that registration as incorrect usage.
+	 * Every taxonomy registered for the post type with `show_in_rest` is accepted, under
+	 * its `rest_base` when it has one (falling back to the taxonomy name), so the built-in
+	 * taxonomies of posts are addressed as `categories` and `tags`. A taxonomy whose key
+	 * collides with another input key is skipped.
 	 *
 	 * @since x.x.x
 	 *
@@ -2567,11 +2546,10 @@ final class Content {
 	/**
 	 * Rejects write fields the post type does not support.
 	 *
-	 * The REST posts controller only registers each field for the post types that support
-	 * it and silently drops the rest; a shared input schema cannot express that per post
-	 * type. A field that cannot be honored fails loudly here instead, so a caller never
-	 * believes it set something that was ignored. This mirrors how `core/content-query`
-	 * treats unsupported filters.
+	 * A shared input schema cannot express per post type which fields apply. A field that
+	 * cannot be honored fails loudly here instead of being silently dropped, so a caller
+	 * never believes it set something that was ignored. This mirrors how
+	 * `core/content-query` treats unsupported filters.
 	 *
 	 * @since x.x.x
 	 *
@@ -2611,15 +2589,17 @@ final class Content {
 	/**
 	 * Prepares a single post for creation or update.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::prepare_item_for_database()` without its
-	 * REST-specific parts: the `rest_pre_insert_{$post_type}` filter, and the Block Hooks
-	 * metadata update (`update_ignored_hooked_blocks_postmeta()`). That update assumes the
-	 * content being saved was read through REST with hooked blocks inserted, while
-	 * `core/content-query` returns the stored content verbatim; running it here would mark
-	 * hooked blocks as ignored after every read-modify-write cycle.
+	 * Builds the data for wp_insert_post() or wp_update_post() from the input: the text
+	 * fields the post type supports, a status the current user may set, dates resolved
+	 * against the site timezone, and the validated author, password, sticky, parent, menu
+	 * order, and comment settings. The Block Hooks metadata
+	 * (`update_ignored_hooked_blocks_postmeta()`) is deliberately left alone:
+	 * `core/content-query` returns the stored content verbatim, so deriving ignored hooked
+	 * blocks from the submitted content would mark them as ignored after every
+	 * read-modify-write cycle.
 	 *
 	 * Field support is checked beforehand by {@see self::check_unsupported_fields()}; the
-	 * support checks here are the REST controller's schema guards, kept for parity.
+	 * support checks here keep the method safe to call on its own.
 	 *
 	 * @since x.x.x
 	 *
@@ -2702,7 +2682,7 @@ final class Content {
 			$prepared_post->post_date     = null;
 		}
 
-		// Post slug. The REST controller sanitizes its `slug` argument with sanitize_title().
+		// Post slug, sanitized like a title.
 		if ( isset( $input['slug'] ) && is_string( $input['slug'] ) ) {
 			$prepared_post->post_name = sanitize_title( $input['slug'] );
 		}
@@ -2722,7 +2702,7 @@ final class Content {
 			$prepared_post->post_author = $post_author;
 		}
 
-		// Post password. Sticky is only registered for posts, as in the REST posts item schema.
+		// Post password. Sticky is only available for posts.
 		$sticky = 'post' === $post_type ? $this->input_bool( $input['sticky'] ?? null ) : null;
 
 		if ( isset( $input['password'] ) && is_string( $input['password'] ) ) {
@@ -2783,7 +2763,8 @@ final class Content {
 	/**
 	 * Determines validity and normalizes the given status parameter.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::handle_status_param()`.
+	 * Publishing, scheduling, and private posts require the post type's publish capability;
+	 * a status that is not registered falls back to draft.
 	 *
 	 * @since x.x.x
 	 *
@@ -2826,13 +2807,9 @@ final class Content {
 	}
 
 	/**
-	 * Applies the parts of a write that live outside the posts table.
-	 *
-	 * Mirrors the post-insert steps of `WP_REST_Posts_Controller::create_item()` and
-	 * `update_item()`: sticky, featured media, post format, template, and terms. Unlike the
-	 * REST controller, which discards the result of its featured media handling, an invalid
-	 * featured media ID is reported. Meta is not handled; it belongs to the REST meta fields
-	 * machinery, which has no abilities counterpart yet.
+	 * Applies the parts of a write that live outside the posts table: sticky, featured
+	 * media, post format, template, and terms. An invalid featured media ID is reported.
+	 * Post meta is not handled; it has no abilities counterpart yet.
 	 *
 	 * @since x.x.x
 	 *
@@ -2849,7 +2826,7 @@ final class Content {
 		if ( 'post' === $post_type ) {
 			$sticky = $this->input_bool( $input['sticky'] ?? null );
 
-			// The REST controller always resolves sticky on creation, defaulting to not sticky.
+			// On creation sticky is always resolved, defaulting to not sticky.
 			if ( $creating || null !== $sticky ) {
 				if ( true === $sticky ) {
 					stick_post( $post_id );
@@ -2878,9 +2855,7 @@ final class Content {
 	}
 
 	/**
-	 * Determines the featured media based on an input value.
-	 *
-	 * Mirrors `WP_REST_Posts_Controller::handle_featured_media()`.
+	 * Sets or removes the featured media of a post.
 	 *
 	 * @since x.x.x
 	 *
@@ -2907,9 +2882,8 @@ final class Content {
 	/**
 	 * Checks whether the requested template is valid for the post.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::check_template()`, which REST runs as the
-	 * validation callback of its `template` argument. Updating a post to the template it
-	 * already uses is always allowed, even if that template is no longer supported.
+	 * Updating a post to the template it already uses is always allowed, even if that
+	 * template is no longer supported.
 	 *
 	 * @since x.x.x
 	 *
@@ -2953,8 +2927,6 @@ final class Content {
 	/**
 	 * Sets the template for a post.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::handle_template()`.
-	 *
 	 * @since x.x.x
 	 *
 	 * @param string $template Page template filename.
@@ -2972,9 +2944,8 @@ final class Content {
 	/**
 	 * Updates the post's terms from the ability input.
 	 *
-	 * Mirrors `WP_REST_Posts_Controller::handle_terms()`. Term lists are normalized to
-	 * unique positive IDs first: the REST controller receives them already coerced by its
-	 * schema, and wp_set_object_terms() would otherwise create a new term for a string.
+	 * Term lists are normalized to unique positive IDs first, because wp_set_object_terms()
+	 * would create a new term for a string.
 	 *
 	 * @since x.x.x
 	 *
@@ -3001,8 +2972,6 @@ final class Content {
 
 	/**
 	 * Checks whether the current user can assign all terms sent with the ability input.
-	 *
-	 * Mirrors `WP_REST_Posts_Controller::check_assign_terms_permission()`.
 	 *
 	 * @since x.x.x
 	 *
@@ -3034,10 +3003,10 @@ final class Content {
 	/**
 	 * Checks whether a post can be moved to the trash rather than deleted permanently.
 	 *
-	 * Mirrors the trash support resolution of `WP_REST_Posts_Controller::delete_item()`
-	 * without its `rest_{$post_type}_trashable` filter. The constants are read through
-	 * constant() because they are defined at runtime, and an undefined constant counts as
-	 * no trash support so a deletion is never silently made permanent.
+	 * Trash support follows `EMPTY_TRASH_DAYS`, and `MEDIA_TRASH` for attachments. The
+	 * constants are read through constant() because they are defined at runtime, and an
+	 * undefined constant counts as no trash support so a deletion is never silently made
+	 * permanent.
 	 *
 	 * @since x.x.x
 	 *

--- a/includes/Abilities/Content/Content.php
+++ b/includes/Abilities/Content/Content.php
@@ -1170,10 +1170,11 @@ final class Content {
 	/**
 	 * Executes the `core/content-delete` ability.
 	 *
-	 * {@see WP_Ability::execute()} always runs {@see self::check_delete_permission()} first,
-	 * so this only re-validates the lookup itself. Without `force` the post is moved to the
-	 * trash and returned; with `force` it is deleted permanently and returned under
-	 * `previous`.
+	 * {@see WP_Ability::execute()} always runs {@see self::check_delete_permission()} first;
+	 * this re-validates the lookup and, because the operation is destructive, checks the
+	 * delete capability once more right before anything is removed. Without `force` the
+	 * post is moved to the trash and returned; with `force` it is deleted permanently and
+	 * returned under `previous`.
 	 *
 	 * @since x.x.x
 	 *
@@ -1186,6 +1187,14 @@ final class Content {
 		$post = $this->get_exposed_post( $input );
 		if ( ! $post ) {
 			return $this->not_found_error();
+		}
+
+		if ( ! current_user_can( 'delete_post', $post->ID ) ) {
+			return new WP_Error(
+				'content_cannot_delete_post',
+				__( 'Sorry, you are not allowed to delete this post.', 'ai' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 
 		$fields = $this->normalize_fields( $input );
@@ -3123,9 +3132,10 @@ final class Content {
 	 * callback still fails closed on a structural lookup failure: a missing post, a post
 	 * type that is not exposed, or a post type that does not match the requested one.
 	 *
-	 * This is not a permission check. The execute callbacks deliberately do not repeat
-	 * the read, edit, or delete checks that the permission callbacks already performed,
-	 * so a direct call bypasses them. Only invoke the callbacks through
+	 * This is not a permission check. The query, create, and update execute callbacks
+	 * deliberately do not repeat the read and edit checks that the permission callbacks
+	 * already performed, so a direct call bypasses them; only the destructive delete
+	 * callback checks its capability again. Only invoke the callbacks through
 	 * {@see WP_Ability::execute()}, which always runs the permission callback first.
 	 *
 	 * @since 1.2.0

--- a/includes/Abilities/Gated/Content_Query.php
+++ b/includes/Abilities/Gated/Content_Query.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Gated ability: content query.
+ * Gated ability: content query, create, update, and delete.
  *
  * @package WordPress\AI\Abilities\Gated
  */
@@ -16,9 +16,11 @@ use WordPress\AI\Abstracts\Abstract_Gated_Ability;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Gates the core/content-query ability.
+ * Gates the content abilities: core/content-query, core/content-create,
+ * core/content-update, and core/content-delete.
  *
  * @since 1.3.0
+ * @since x.x.x Also gates the create, update, and delete abilities.
  */
 final class Content_Query extends Abstract_Gated_Ability {
 	/**

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -959,6 +959,36 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * The title, content, and excerpt can be given as objects with a `raw` key.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_raw(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type' => 'post',
+				'title'     => array( 'raw' => 'Raw title' ),
+				'content'   => array( 'raw' => 'Raw content' ),
+				'excerpt'   => array( 'raw' => 'Raw excerpt' ),
+				'fields'    => array( 'id', 'title_raw', 'content_raw', 'excerpt_raw' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a post from raw objects should succeed.' );
+		$this->assertSame( 'Raw title', $result['title_raw'], 'The raw title should be stored.' );
+		$this->assertSame( 'Raw content', $result['content_raw'], 'The raw content should be stored.' );
+		$this->assertSame( 'Raw excerpt', $result['excerpt_raw'], 'The raw excerpt should be stored.' );
+
+		$post = get_post( $result['id'] );
+		$this->assertSame( 'Raw title', $post->post_title, 'The stored title should match the raw object.' );
+		$this->assertSame( 'Raw content', $post->post_content, 'The stored content should match the raw object.' );
+		$this->assertSame( 'Raw excerpt', $post->post_excerpt, 'The stored excerpt should match the raw object.' );
+	}
+
+	/**
 	 * Quotes survive the slashing round trip.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -1389,6 +1389,174 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * The writable fields carry the same names, types, and enums as the posts and pages endpoints.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_input_schema_matches_the_posts_endpoint_fields(): void {
+		$this->register_ability();
+
+		$properties = wp_get_ability( 'core/content-create' )->get_input_schema()['properties'];
+
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			$endpoint_properties = ( new \WP_REST_Posts_Controller( $post_type ) )->get_item_schema()['properties'];
+
+			foreach ( $endpoint_properties as $field => $definition ) {
+				// Meta has no abilities counterpart; read-only fields are never written.
+				if ( 'meta' === $field || ! empty( $definition['readonly'] ) || ! in_array( 'edit', $definition['context'], true ) ) {
+					continue;
+				}
+
+				$this->assertArrayHasKey( $field, $properties, "The {$field} field of the {$post_type} endpoint should be accepted." );
+
+				$expected_type = 'object' === $definition['type'] ? array( 'string', 'object' ) : $definition['type'];
+				$this->assertSame( $expected_type, $properties[ $field ]['type'], "The {$field} field should have the type of the {$post_type} endpoint." );
+
+				if ( isset( $definition['enum'] ) ) {
+					$this->assertSame( array_values( $definition['enum'] ), $properties[ $field ]['enum'], "The {$field} field should accept the values of the {$post_type} endpoint." );
+				}
+
+				if ( isset( $definition['items'] ) ) {
+					$this->assertSame( $definition['items']['type'], $properties[ $field ]['items']['type'], "The {$field} items should have the type of the {$post_type} endpoint." );
+				}
+			}
+		}
+	}
+
+	/**
+	 * A page template offered by the theme is assigned to the created page.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_template(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$templates = static function (): array {
+			return array( 'page-my-test-template.php' => 'My Test Template' );
+		};
+
+		add_filter( 'theme_page_templates', $templates );
+		try {
+			$result = $this->create(
+				array(
+					'post_type' => 'page',
+					'title'     => 'Templated page',
+					'template'  => 'page-my-test-template.php',
+					'fields'    => array( 'id' ),
+				)
+			);
+		} finally {
+			remove_filter( 'theme_page_templates', $templates );
+		}
+
+		$this->assertIsArray( $result, 'Creating a page with a valid template should succeed.' );
+		$this->assertSame( 'page-my-test-template.php', get_page_template_slug( $result['id'] ), 'The template should be stored on the page.' );
+	}
+
+	/**
+	 * A negative parent fails validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_negative_parent(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type' => 'page',
+				'title'     => 'Orphan page',
+				'parent'    => -1,
+			)
+		);
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'A negative parent should fail validation.' );
+	}
+
+	/**
+	 * Custom taxonomies are accepted under their rest_base, or their name, and only for their post types.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_custom_taxonomy_terms_are_accepted_under_their_rest_base_key(): void {
+		register_post_type(
+			'wpai_book',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title' ),
+			)
+		);
+		register_taxonomy(
+			'wpai_genre',
+			'wpai_book',
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'genres',
+			)
+		);
+		register_taxonomy(
+			'wpai_shelf',
+			'wpai_book',
+			array(
+				'public'       => true,
+				'show_in_rest' => true,
+			)
+		);
+		register_taxonomy(
+			'wpai_hidden_shelf',
+			'wpai_book',
+			array(
+				'public'       => true,
+				'show_in_rest' => false,
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$properties = wp_get_ability( 'core/content-create' )->get_input_schema()['properties'];
+			$this->assertArrayHasKey( 'genres', $properties, 'A taxonomy with a rest_base should be accepted under it.' );
+			$this->assertArrayHasKey( 'wpai_shelf', $properties, 'A taxonomy without a rest_base should be accepted under its name.' );
+			$this->assertArrayNotHasKey( 'wpai_hidden_shelf', $properties, 'A taxonomy without show_in_rest should not be accepted.' );
+
+			$genre = wp_insert_term( 'Fantasy', 'wpai_genre' );
+			$shelf = wp_insert_term( 'Top shelf', 'wpai_shelf' );
+
+			$result = $this->create(
+				array(
+					'post_type'  => 'wpai_book',
+					'title'      => 'A shelved book',
+					'genres'     => array( $genre['term_id'] ),
+					'wpai_shelf' => array( $shelf['term_id'] ),
+					'fields'     => array( 'id' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'Creating a book with custom terms should succeed.' );
+			$this->assertSame( array( $genre['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_genre', array( 'fields' => 'ids' ) ), 'The genre should be assigned.' );
+			$this->assertSame( array( $shelf['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_shelf', array( 'fields' => 'ids' ) ), 'The shelf should be assigned.' );
+
+			$rejected = $this->create(
+				array(
+					'post_type' => 'post',
+					'title'     => 'Not a book',
+					'genres'    => array( $genre['term_id'] ),
+				)
+			);
+			$this->assertAbilityError( $rejected, 'content_invalid_field', 'A taxonomy of another post type should be rejected.' );
+		} finally {
+			unregister_taxonomy( 'wpai_genre' );
+			unregister_taxonomy( 'wpai_shelf' );
+			unregister_taxonomy( 'wpai_hidden_shelf' );
+			unregister_post_type( 'wpai_book' );
+		}
+	}
+
+	/**
 	 * The core post insertion hook fires for the created post.
 	 *
 	 * @since x.x.x
@@ -1529,6 +1697,63 @@ class ContentCreateTest extends Content_Ability_TestCase {
 
 		$fields = array( 'id', 'title_raw', 'title_rendered', 'content_raw', 'content_rendered', 'excerpt_raw', 'excerpt_rendered' );
 
+		$created = $this->create( array_merge( array( 'post_type' => 'post' ), $raw, array( 'fields' => $fields ) ) );
+		$this->assert_roundtrip( $created, $expected );
+
+		$updated = $this->execute_ability( 'core/content-update', array_merge( array( 'id' => $created['id'] ), $raw, array( 'fields' => $fields ) ) );
+		$this->assert_roundtrip( $updated, $expected );
+	}
+
+	/**
+	 * Content written by an editor keeps or loses its scripts depending on unfiltered_html.
+	 *
+	 * Editors have unfiltered_html on single sites and not on multisite, so the outcome
+	 * follows the capability rather than the role.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_post_roundtrip_as_editor_unfiltered_html(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$raw      = array(
+			'title'   => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+			'content' => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+			'excerpt' => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+		);
+		$filtered = array(
+			'title'   => array(
+				'raw'      => 'div <strong>strong</strong> oh noes',
+				'rendered' => 'div <strong>strong</strong> oh noes',
+			),
+			'content' => array(
+				'raw'      => '<div>div</div> <strong>strong</strong> oh noes',
+				'rendered' => "<div>div</div>\n<p> <strong>strong</strong> oh noes</p>",
+			),
+			'excerpt' => array(
+				'raw'      => '<div>div</div> <strong>strong</strong> oh noes',
+				'rendered' => "<div>div</div>\n<p> <strong>strong</strong> oh noes</p>",
+			),
+		);
+		$kept     = array(
+			'title'   => array(
+				'raw'      => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+				'rendered' => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+			),
+			'content' => array(
+				'raw'      => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+				'rendered' => "<div>div</div>\n<p> <strong>strong</strong> <script>oh noes</script></p>",
+			),
+			'excerpt' => array(
+				'raw'      => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+				'rendered' => "<div>div</div>\n<p> <strong>strong</strong> <script>oh noes</script></p>",
+			),
+		);
+
+		$expected = current_user_can( 'unfiltered_html' ) ? $kept : $filtered;
+		$this->assertSame( ! is_multisite(), current_user_can( 'unfiltered_html' ), 'Precondition: editors have unfiltered_html on single sites only.' );
+
+		$fields  = array( 'id', 'title_raw', 'title_rendered', 'content_raw', 'content_rendered', 'excerpt_raw', 'excerpt_rendered' );
 		$created = $this->create( array_merge( array( 'post_type' => 'post' ), $raw, array( 'fields' => $fields ) ) );
 		$this->assert_roundtrip( $created, $expected );
 

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -2,10 +2,6 @@
 /**
  * Integration tests for the core/content-create Ability provided by the plugin.
  *
- * The cases mirror the create tests of the WordPress core REST posts controller
- * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
- * output shapes.
- *
  * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
  */
 
@@ -30,7 +26,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	private $forbidden_category = 0;
 
 	/**
-	 * Returns a create input with every common field set, like the REST test suite's post data.
+	 * Returns a create input with every common field set.
 	 *
 	 * @since x.x.x
 	 *
@@ -66,8 +62,6 @@ class ContentCreateTest extends Content_Ability_TestCase {
 
 	/**
 	 * Asserts that a create result describes a post that exists with the given input values.
-	 *
-	 * The ability counterpart of the REST suite's check_create_post_response().
 	 *
 	 * @since x.x.x
 	 *
@@ -227,11 +221,11 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The input schema requires a post type, lists the REST writable fields, and rejects unknown properties.
+	 * The input schema requires a post type, lists the writable fields, and rejects unknown properties.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_input_schema_mirrors_the_rest_writable_fields(): void {
+	public function test_input_schema_lists_the_writable_fields(): void {
 		$this->register_ability();
 
 		$schema = wp_get_ability( 'core/content-create' )->get_input_schema();
@@ -263,20 +257,19 @@ class ContentCreateTest extends Content_Ability_TestCase {
 			'tags',
 			'fields',
 		);
-		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should mirror the REST posts item schema, with taxonomies under their REST keys.' );
+		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should be listed, with taxonomies under their rest_base keys.' );
 
 		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'Only exposed post types should be accepted.' );
-		$this->assertSame( array_values( get_post_stati( array( 'internal' => false ) ) ), $schema['properties']['status']['enum'], 'The status enum should match the REST status enum.' );
-		$this->assertSame( array_values( get_post_format_slugs() ), $schema['properties']['format']['enum'], 'The format enum should match the REST format enum.' );
-		$this->assertSame( array( 'string', 'null' ), $schema['properties']['date']['type'], 'The date should accept null to reset it, like REST.' );
+		$this->assertSame( array_values( get_post_stati( array( 'internal' => false ) ) ), $schema['properties']['status']['enum'], 'The status enum should list the non-internal statuses.' );
+		$this->assertSame( array_values( get_post_format_slugs() ), $schema['properties']['format']['enum'], 'The format enum should list the registered post formats.' );
+		$this->assertSame( array( 'string', 'null' ), $schema['properties']['date']['type'], 'The date should accept null to reset it.' );
 		$this->assertSame( 'integer', $schema['properties']['categories']['items']['type'], 'Taxonomy terms should be given as term IDs.' );
 	}
 
 	/**
 	 * Unknown properties fail validation, so an `id` cannot be smuggled into a create call.
 	 *
-	 * The REST controller rejects creating an existing post with `rest_post_exists`; here
-	 * the strict schema rejects the property itself.
+	 * The strict schema rejects the property itself, so nothing is silently ignored.
 	 *
 	 * @since x.x.x
 	 */
@@ -432,7 +425,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * A template the theme does not offer is rejected, mirroring the REST validation error.
+	 * A template the theme does not offer is rejected.
 	 *
 	 * @since x.x.x
 	 */
@@ -536,8 +529,8 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	/**
 	 * A sticky flag given as the string "false" is not treated as sticky.
 	 *
-	 * The permission gate reads booleans the way REST sanitizes them, so a query-string
-	 * transport cannot turn "false" into a sticky request.
+	 * The permission gate reads boolean strings, so a query-string transport cannot turn
+	 * "false" into a sticky request.
 	 *
 	 * @since x.x.x
 	 */
@@ -745,7 +738,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * A valid format the theme does not support is still assigned, like REST.
+	 * A valid format the theme does not support is still assigned.
 	 *
 	 * @since x.x.x
 	 */
@@ -786,8 +779,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	/**
 	 * An invalid featured media ID is reported instead of being silently ignored.
 	 *
-	 * The REST controller discards the result of its featured media handling; the ability
-	 * surfaces it so the caller knows the post was created without the image.
+	 * The failure is surfaced so the caller knows the post was created without the image.
 	 *
 	 * @since x.x.x
 	 */
@@ -983,7 +975,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Categories are assigned under the REST `categories` key.
+	 * Categories are assigned under the `categories` key.
 	 *
 	 * @since x.x.x
 	 */
@@ -1007,7 +999,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Tags are assigned under the REST `tags` key.
+	 * Tags are assigned under the `tags` key.
 	 *
 	 * @since x.x.x
 	 */
@@ -1141,7 +1133,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The slug is sanitized like the REST slug argument.
+	 * The slug is sanitized like a title.
 	 *
 	 * @since x.x.x
 	 */
@@ -1178,8 +1170,8 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	/**
 	 * Fields the post type does not support are rejected rather than silently ignored.
 	 *
-	 * The REST controller drops such fields because they are absent from the post type's
-	 * schema; the shared ability schema cannot express that, so execution rejects them.
+	 * A shared schema cannot express per post type which fields apply, so execution
+	 * rejects them.
 	 *
 	 * @since x.x.x
 	 *
@@ -1396,7 +1388,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Provides the REST suite's round-trip cases for a user without unfiltered_html.
+	 * Provides round-trip cases for a user without unfiltered_html.
 	 *
 	 * @return array<int, array{0: array<string, string>, 1: array<string, array<string, string>>}> Raw input and expected values.
 	 */
@@ -1490,7 +1482,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Content written by a user without unfiltered_html is filtered exactly as through REST.
+	 * Content written by a user without unfiltered_html is filtered by kses on the way in.
 	 *
 	 * @since x.x.x
 	 *
@@ -1525,16 +1517,16 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	private function assert_roundtrip( $result, array $expected ): void {
 		$this->assertIsArray( $result, 'The write should succeed.' );
 
-		$this->assertSame( $expected['title']['raw'], $result['title_raw'], 'The raw title should be filtered like REST.' );
-		$this->assertSame( $expected['title']['rendered'], trim( $result['title_rendered'] ), 'The rendered title should match REST.' );
-		$this->assertSame( $expected['content']['raw'], $result['content_raw'], 'The raw content should be filtered like REST.' );
-		$this->assertSame( $expected['content']['rendered'], trim( $result['content_rendered'] ), 'The rendered content should match REST.' );
-		$this->assertSame( $expected['excerpt']['raw'], $result['excerpt_raw'], 'The raw excerpt should be filtered like REST.' );
-		$this->assertSame( $expected['excerpt']['rendered'], trim( $result['excerpt_rendered'] ), 'The rendered excerpt should match REST.' );
+		$this->assertSame( $expected['title']['raw'], $result['title_raw'], 'The raw title should be filtered by kses.' );
+		$this->assertSame( $expected['title']['rendered'], trim( $result['title_rendered'] ), 'The rendered title should be rendered from the stored value.' );
+		$this->assertSame( $expected['content']['raw'], $result['content_raw'], 'The raw content should be filtered by kses.' );
+		$this->assertSame( $expected['content']['rendered'], trim( $result['content_rendered'] ), 'The rendered content should be rendered from the stored value.' );
+		$this->assertSame( $expected['excerpt']['raw'], $result['excerpt_raw'], 'The raw excerpt should be filtered by kses.' );
+		$this->assertSame( $expected['excerpt']['rendered'], trim( $result['excerpt_rendered'] ), 'The rendered excerpt should be rendered from the stored value.' );
 
 		$post = get_post( $result['id'] );
-		$this->assertSame( $expected['title']['raw'], $post->post_title, 'The stored title should be filtered like REST.' );
-		$this->assertSame( $expected['content']['raw'], $post->post_content, 'The stored content should be filtered like REST.' );
-		$this->assertSame( $expected['excerpt']['raw'], $post->post_excerpt, 'The stored excerpt should be filtered like REST.' );
+		$this->assertSame( $expected['title']['raw'], $post->post_title, 'The stored title should be filtered by kses.' );
+		$this->assertSame( $expected['content']['raw'], $post->post_content, 'The stored content should be filtered by kses.' );
+		$this->assertSame( $expected['excerpt']['raw'], $post->post_excerpt, 'The stored excerpt should be filtered by kses.' );
 	}
 }

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -1,0 +1,1540 @@
+<?php
+/**
+ * Integration tests for the core/content-create Ability provided by the plugin.
+ *
+ * The cases mirror the create tests of the WordPress core REST posts controller
+ * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
+ * output shapes.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
+
+use WordPress\AI\Abilities\Content\Content;
+
+/**
+ * Content create ability test case.
+ *
+ * @since x.x.x
+ */
+class ContentCreateTest extends Content_Ability_TestCase {
+
+	/**
+	 * The category the current user is forbidden to assign, when set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	private $forbidden_category = 0;
+
+	/**
+	 * Returns a create input with every common field set, like the REST test suite's post data.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $overrides Input values to override or add.
+	 * @return array<string, mixed> The ability input.
+	 */
+	private function post_data( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'post_type' => 'post',
+				'title'     => 'Post Title',
+				'content'   => 'Post content',
+				'excerpt'   => 'Post excerpt',
+				'status'    => 'publish',
+				'author'    => get_current_user_id(),
+				'fields'    => array( 'id', 'post_type', 'status', 'date', 'date_gmt', 'modified', 'modified_gmt', 'slug', 'link', 'title_raw', 'title_rendered', 'content_raw', 'content_rendered', 'excerpt_raw', 'excerpt_rendered', 'author' ),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Creates a post through the ability and returns the result.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return mixed The ability result.
+	 */
+	private function create( array $input ) {
+		return $this->execute_ability( 'core/content-create', $input );
+	}
+
+	/**
+	 * Asserts that a create result describes a post that exists with the given input values.
+	 *
+	 * The ability counterpart of the REST suite's check_create_post_response().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed                $result The ability result.
+	 * @param array<string, mixed> $input  The input the post was created from.
+	 * @return \WP_Post The created post.
+	 */
+	private function assert_created_post( $result, array $input ): \WP_Post {
+		$this->assertIsArray( $result, 'Creating a post should return the created post.' );
+		$this->assertArrayHasKey( 'id', $result, 'The created post should carry its ID.' );
+
+		$post = get_post( $result['id'] );
+		$this->assertInstanceOf( \WP_Post::class, $post, 'The created post should exist.' );
+		$this->assertSame( $input['post_type'], $post->post_type, 'The post type should match the input.' );
+		$this->assertSame( $input['post_type'], $result['post_type'], 'The returned post type should match the input.' );
+		$this->assertSame( $input['status'], $post->post_status, 'The post status should match the input.' );
+		$this->assertSame( $input['status'], $result['status'], 'The returned status should match the input.' );
+		$this->assertSame( $input['title'], $post->post_title, 'The post title should match the input.' );
+		$this->assertSame( $input['title'], $result['title_raw'], 'The returned raw title should match the input.' );
+		$this->assertSame( $input['content'], $post->post_content, 'The post content should match the input.' );
+		$this->assertSame( $input['content'], $result['content_raw'], 'The returned raw content should match the input.' );
+		$this->assertSame( $input['excerpt'], $post->post_excerpt, 'The post excerpt should match the input.' );
+		$this->assertSame( $input['excerpt'], $result['excerpt_raw'], 'The returned raw excerpt should match the input.' );
+		$this->assertSame( $input['author'], (int) $post->post_author, 'The post author should match the input.' );
+		$this->assertSame( $input['author'], $result['author']['id'], 'The returned author should match the input.' );
+		$this->assertSame( get_permalink( $post ), $result['link'], 'The returned link should be the permalink.' );
+
+		return $post;
+	}
+
+	/**
+	 * Disables INSERT queries so wp_insert_post() fails with a database error.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $query The database query.
+	 * @return string The query, broken when it is an INSERT.
+	 */
+	public function error_insert_query( string $query ): string {
+		if ( 0 === strpos( $query, 'INSERT' ) ) {
+			$query = '],';
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Offers one post template for the tests that need a valid template.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, string> The post templates keyed by file name.
+	 */
+	public function filter_theme_post_templates(): array {
+		return array(
+			'post-my-test-template.php' => 'My Test Template',
+		);
+	}
+
+	/**
+	 * Revokes the assign_term meta capability for the forbidden category.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $caps    The primitive capabilities.
+	 * @param string   $cap     The meta capability being checked.
+	 * @param int      $user_id The user ID.
+	 * @param mixed[]  $args    The capability arguments.
+	 * @return string[] The primitive capabilities.
+	 */
+	public function revoke_assign_term( array $caps, string $cap, int $user_id, array $args ): array {
+		if ( 'assign_term' === $cap && isset( $args[0] ) && $this->forbidden_category === $args[0] ) {
+			$caps = array( 'do_not_allow' );
+		}
+
+		return $caps;
+	}
+
+	/**
+	 * Registers a post type that only supports titles, for the unsupported-field tests.
+	 *
+	 * @since x.x.x
+	 */
+	private function register_title_only_post_type(): void {
+		register_post_type(
+			'wpai_title_only',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title' ),
+			)
+		);
+	}
+
+	/**
+	 * The ability is registered in the `content` category and flagged as a non-idempotent write.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_registers_core_content_create_ability(): void {
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/content-create' );
+
+		$this->assertNotNull( $ability, 'The core/content-create ability should be registered.' );
+		$this->assertSame( 'content', $ability->get_category(), 'The registered ability should use the content category.' );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'The ability should be exposed in REST.' );
+
+		$annotations = $ability->get_meta_item( 'annotations', array() );
+		$this->assertFalse( $annotations['readonly'], 'The ability should not be marked read-only.' );
+		$this->assertFalse( $annotations['destructive'], 'Creating a post is not destructive.' );
+		$this->assertFalse( $annotations['idempotent'], 'Every call creates a new post, so the ability is not idempotent.' );
+		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
+	}
+
+	/**
+	 * The ability is not registered when no post types are exposed to it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_does_not_register_without_exposed_post_types(): void {
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			get_post_type_object( $post_type )->show_in_abilities = false;
+		}
+
+		$this->register_ability();
+
+		$this->assertFalse( wp_has_ability( 'core/content-create' ), 'The create ability should not register without any exposed post types.' );
+	}
+
+	/**
+	 * When core already provides core/content-create, the plugin's version replaces it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_override_replaces_existing_core_content_create(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability(
+				'core/content-create',
+				array(
+					'label'               => 'Core Provided',
+					'description'         => 'Core provided create ability.',
+					'category'            => 'content',
+					'execute_callback'    => '__return_empty_array',
+					'permission_callback' => '__return_true',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->register_ability();
+
+		$this->assertSame( 'Content Create', wp_get_ability( 'core/content-create' )->get_label(), 'The plugin-provided ability should replace the existing one.' );
+	}
+
+	/**
+	 * The input schema requires a post type, lists the REST writable fields, and rejects unknown properties.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_input_schema_mirrors_the_rest_writable_fields(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/content-create' )->get_input_schema();
+
+		$this->assertSame( 'object', $schema['type'], 'The input schema should describe an object.' );
+		$this->assertSame( array( 'post_type' ), $schema['required'], 'Only the post type should be required.' );
+		$this->assertFalse( $schema['additionalProperties'], 'Unknown properties should be rejected.' );
+
+		$expected_keys = array(
+			'post_type',
+			'title',
+			'content',
+			'excerpt',
+			'status',
+			'slug',
+			'date',
+			'date_gmt',
+			'author',
+			'password',
+			'parent',
+			'menu_order',
+			'comment_status',
+			'ping_status',
+			'format',
+			'featured_media',
+			'sticky',
+			'template',
+			'categories',
+			'tags',
+			'fields',
+		);
+		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should mirror the REST posts item schema, with taxonomies under their REST keys.' );
+
+		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'Only exposed post types should be accepted.' );
+		$this->assertSame( array_values( get_post_stati( array( 'internal' => false ) ) ), $schema['properties']['status']['enum'], 'The status enum should match the REST status enum.' );
+		$this->assertSame( array_values( get_post_format_slugs() ), $schema['properties']['format']['enum'], 'The format enum should match the REST format enum.' );
+		$this->assertSame( array( 'string', 'null' ), $schema['properties']['date']['type'], 'The date should accept null to reset it, like REST.' );
+		$this->assertSame( 'integer', $schema['properties']['categories']['items']['type'], 'Taxonomy terms should be given as term IDs.' );
+	}
+
+	/**
+	 * Unknown properties fail validation, so an `id` cannot be smuggled into a create call.
+	 *
+	 * The REST controller rejects creating an existing post with `rest_post_exists`; here
+	 * the strict schema rejects the property itself.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_rejects_unknown_properties_and_missing_post_type(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$with_id = $this->create( $this->post_data( array( 'id' => 3 ) ) );
+		$this->assertAbilityError( $with_id, 'ability_invalid_input', 'Creating with an id should fail validation.' );
+
+		$data = $this->post_data();
+		unset( $data['post_type'] );
+		$without_type = $this->create( $data );
+		$this->assertAbilityError( $without_type, 'ability_invalid_input', 'Creating without a post type should fail validation.' );
+
+		$readonly = $this->create( $this->post_data( array( 'modified' => '2010-06-01T02:00:00Z' ) ) );
+		$this->assertAbilityError( $readonly, 'ability_invalid_input', 'Read-only post fields should be rejected rather than ignored.' );
+	}
+
+	/**
+	 * The output schema describes a single post with the query ability's fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_output_schema_describes_a_post(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/content-create' )->get_output_schema();
+
+		$this->assertSame( 'object', $schema['type'], 'The output schema should describe an object.' );
+		$this->assertFalse( $schema['additionalProperties'], 'The output should only carry known post fields.' );
+		$this->assertArrayNotHasKey( 'required', $schema, 'No field is required, because the caller chooses the fields.' );
+
+		$query_schema = wp_get_ability( 'core/content-query' )->get_output_schema();
+		$this->assertSame( $query_schema['oneOf'][0], $schema, 'The created post should have the same shape as a queried post.' );
+	}
+
+	/**
+	 * An editor can create a published post with the common fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_item(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$data   = $this->post_data();
+		$result = $this->create( $data );
+
+		$post = $this->assert_created_post( $result, $data );
+		$this->assertSame( 'Post Title', $result['title_rendered'], 'The rendered title should be returned.' );
+		$this->assertSame( "<p>Post content</p>\n", $result['content_rendered'], 'The rendered content should be returned.' );
+		$this->assertSame( 'post-title', $post->post_name, 'The slug should be generated from the title.' );
+	}
+
+	/**
+	 * Without a field selection the created post is returned with the lean default fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_returns_lean_default_fields(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$data = $this->post_data();
+		unset( $data['fields'] );
+		$result = $this->create( $data );
+
+		$this->assertIsArray( $result, 'Creating a post should return the created post.' );
+		$this->assertSame( array( 'id', 'post_type', 'status', 'date', 'slug', 'title_rendered' ), array_keys( $result ), 'The default field set should match the query ability.' );
+	}
+
+	/**
+	 * A post created without a status is a draft, like wp_insert_post().
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_defaults_to_draft(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type' => 'post',
+				'title'     => 'Untitled draft',
+				'fields'    => array( 'id', 'status' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a post should return the created post.' );
+		$this->assertSame( 'draft', $result['status'], 'A post created without a status should be a draft.' );
+	}
+
+	/**
+	 * Dates are stored in the site timezone with their GMT counterpart, whether given as local, GMT, or with an offset.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_post_dates
+	 *
+	 * @param string                $status  The post status to create with.
+	 * @param array<string, string> $params  The timezone and date inputs.
+	 * @param array<string, string> $results The expected stored dates.
+	 */
+	public function test_create_post_date( string $status, array $params, array $results ): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		update_option( 'timezone_string', $params['timezone_string'] );
+
+		$input = array(
+			'post_type' => 'post',
+			'status'    => $status,
+			'title'     => 'not empty',
+			'fields'    => array( 'id', 'date', 'date_gmt' ),
+		);
+		if ( isset( $params['date'] ) ) {
+			$input['date'] = $params['date'];
+		}
+		if ( isset( $params['date_gmt'] ) ) {
+			$input['date_gmt'] = $params['date_gmt'];
+		}
+
+		$result = $this->create( $input );
+
+		$this->assertIsArray( $result, 'Creating a post with a date should succeed.' );
+		$post = get_post( $result['id'] );
+
+		$this->assertSame( $results['date'], $post->post_date, 'The stored local date should match.' );
+		$this->assertSame( $results['date_gmt'], $post->post_date_gmt, 'The stored GMT date should match.' );
+		$this->assertSame( str_replace( ' ', 'T', $results['date'] ) . '-05:00', $result['date'], 'The returned local date should carry the site offset.' );
+		$this->assertSame( str_replace( ' ', 'T', $results['date_gmt'] ) . '+00:00', $result['date_gmt'], 'The returned GMT date should be the UTC instant.' );
+	}
+
+	/**
+	 * A template offered by the theme is assigned to the created post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_item_with_template(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		add_filter( 'theme_post_templates', array( $this, 'filter_theme_post_templates' ) );
+		try {
+			$result = $this->create( $this->post_data( array( 'template' => 'post-my-test-template.php' ) ) );
+		} finally {
+			remove_filter( 'theme_post_templates', array( $this, 'filter_theme_post_templates' ) );
+		}
+
+		$this->assertIsArray( $result, 'Creating a post with a valid template should succeed.' );
+		$this->assertSame( 'post-my-test-template.php', get_page_template_slug( get_post( $result['id'] ) ), 'The template should be stored on the post.' );
+	}
+
+	/**
+	 * A template the theme does not offer is rejected, mirroring the REST validation error.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_item_with_template_none_available(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'template' => 'post-my-test-template.php' ) ) );
+
+		$this->assertAbilityError( $result, 'content_invalid_template', 'An unavailable template should be rejected.' );
+		$this->assertSame( 400, $result->get_error_data()['status'], 'An invalid template should be a bad request.' );
+	}
+
+	/**
+	 * An empty template is always accepted and selects the default template.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_item_with_template_none(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'template' => '' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with the default template should succeed.' );
+		$this->assertSame( '', get_page_template_slug( get_post( $result['id'] ) ), 'No template should be stored on the post.' );
+	}
+
+	/**
+	 * A contributor creates a pending post whose GMT date floats, which the output still resolves.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_as_contributor(): void {
+		$this->login_as( 'contributor' );
+		$this->register_ability();
+
+		update_option( 'timezone_string', 'America/Chicago' );
+
+		// A pending post gets the special floating `post_date_gmt` value of '0000-00-00 00:00:00'. See #38883.
+		$data   = $this->post_data( array( 'status' => 'pending' ) );
+		$result = $this->create( $data );
+
+		$post = $this->assert_created_post( $result, $data );
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'A pending post should have a floating GMT date.' );
+		$this->assertNotSame( '', $result['date_gmt'], 'The returned GMT date should be derived from the local date.' );
+		$this->assertStringEndsWith( '+00:00', $result['date_gmt'], 'The derived GMT date should be reported as UTC.' );
+	}
+
+	/**
+	 * An editor can create a sticky post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_sticky(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'sticky' => true ) ) );
+
+		$this->assertIsArray( $result, 'Creating a sticky post should succeed.' );
+		$this->assertTrue( is_sticky( $result['id'] ), 'The post should be sticky.' );
+	}
+
+	/**
+	 * A post created without the sticky flag is not sticky.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_is_not_sticky_by_default(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data() );
+
+		$this->assertIsArray( $result, 'Creating a post should succeed.' );
+		$this->assertFalse( is_sticky( $result['id'] ), 'The post should not be sticky.' );
+	}
+
+	/**
+	 * A contributor cannot make a post sticky.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_sticky_as_contributor(): void {
+		$this->login_as( 'contributor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'sticky' => true,
+					'status' => 'pending',
+				)
+			)
+		);
+
+		$this->assertAbilityDenied( $result, 'A contributor should not be allowed to make posts sticky.' );
+	}
+
+	/**
+	 * A sticky flag given as the string "false" is not treated as sticky.
+	 *
+	 * The permission gate reads booleans the way REST sanitizes them, so a query-string
+	 * transport cannot turn "false" into a sticky request.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_string_false_sticky_is_not_sticky(): void {
+		$this->login_as( 'contributor' );
+
+		$content = new Content();
+		$input   = $this->post_data(
+			array(
+				'sticky' => 'false',
+				'status' => 'pending',
+			)
+		);
+
+		$this->assertTrue( $content->check_create_permission( $input ), 'A "false" sticky string should not require the sticky capability.' );
+
+		$result = $content->execute_content_create( $input );
+		$this->assertIsArray( $result, 'Creating with a "false" sticky string should succeed.' );
+		$this->assertFalse( is_sticky( $result['id'] ), 'The post should not be sticky.' );
+	}
+
+	/**
+	 * An author cannot create a post as another user.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_other_author_without_permission(): void {
+		$this->login_as( 'author' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'author' => self::$user_ids['editor'] ) ) );
+
+		$this->assertAbilityDenied( $result, 'An author should not be allowed to create posts as another user.' );
+	}
+
+	/**
+	 * An editor can create a post as another user.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_as_other_author_with_permission(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$data   = $this->post_data( array( 'author' => self::$user_ids['author'] ) );
+		$result = $this->create( $data );
+
+		$post = $this->assert_created_post( $result, $data );
+		$this->assertSame( self::$user_ids['author'], (int) $post->post_author, 'The post should belong to the given author.' );
+	}
+
+	/**
+	 * Logged-out users and roles without the create capability are denied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_without_permission(): void {
+		$this->register_ability();
+
+		wp_set_current_user( 0 );
+		$data = $this->post_data( array( 'status' => 'draft' ) );
+		// Logged out there is no current user to default the author to.
+		unset( $data['author'] );
+		$logged_out = $this->create( $data );
+		$this->assertAbilityDenied( $logged_out, 'A logged-out user should not be allowed to create posts.' );
+
+		$this->login_as( 'subscriber' );
+		$subscriber = $this->create( $this->post_data( array( 'status' => 'draft' ) ) );
+		$this->assertAbilityDenied( $subscriber, 'A subscriber should not be allowed to create posts.' );
+	}
+
+	/**
+	 * A draft is created with derived GMT dates in the output.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_draft(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'status' => 'draft' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a draft should succeed.' );
+		$post = get_post( $result['id'] );
+		$this->assertSame( 'draft', $result['status'], 'The returned status should be draft.' );
+		$this->assertSame( 'draft', $post->post_status, 'The stored status should be draft.' );
+
+		// The dates are shimmed for the site offset: a draft stores no GMT date.
+		$this->assertSame( gmdate( 'c', strtotime( get_gmt_from_date( $post->post_date ) . ' UTC' ) ), $result['date_gmt'], 'The GMT date should be derived from the local date.' );
+		$this->assertSame( gmdate( 'c', strtotime( get_gmt_from_date( $post->post_modified ) . ' UTC' ) ), $result['modified_gmt'], 'The GMT modified date should be derived from the local date.' );
+	}
+
+	/**
+	 * An editor can create a private post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_private(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'status' => 'private' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a private post should succeed.' );
+		$this->assertSame( 'private', $result['status'], 'The returned status should be private.' );
+		$this->assertSame( 'private', get_post( $result['id'] )->post_status, 'The stored status should be private.' );
+	}
+
+	/**
+	 * Creating a private post requires the publish capability.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_private_without_permission(): void {
+		$author_id = $this->login_as( 'author' );
+		$this->register_ability();
+
+		$this->revoke_current_user_capability( 'publish_posts' );
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'status' => 'private',
+					'author' => $author_id,
+				)
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_cannot_publish', 'Creating a private post without the publish capability should fail.' );
+		$this->assertSame( 403, $result->get_error_data()['status'], 'The publish error should carry the authorization status.' );
+	}
+
+	/**
+	 * Publishing requires the publish capability.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_publish_without_permission(): void {
+		$this->login_as( 'author' );
+		$this->register_ability();
+
+		$this->revoke_current_user_capability( 'publish_posts' );
+
+		$result = $this->create( $this->post_data( array( 'status' => 'publish' ) ) );
+
+		$this->assertAbilityError( $result, 'content_cannot_publish', 'Publishing without the publish capability should fail.' );
+	}
+
+	/**
+	 * A status outside the registered non-internal statuses fails validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_invalid_status(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'status' => 'teststatus' ) ) );
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'An unknown status should fail validation.' );
+	}
+
+	/**
+	 * A post format is assigned to the created post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_format(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'format' => 'gallery' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with a format should succeed.' );
+		$this->assertSame( 'gallery', get_post_format( $result['id'] ), 'The post should have the gallery format.' );
+	}
+
+	/**
+	 * The standard format leaves the post without a format term.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_standard_format(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'format' => 'standard' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with the standard format should succeed.' );
+		$this->assertFalse( get_post_format( $result['id'] ), 'The standard format should not assign a format term.' );
+	}
+
+	/**
+	 * A format outside the registered formats fails validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_invalid_format(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'format' => 'testformat' ) ) );
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'An unknown format should fail validation.' );
+	}
+
+	/**
+	 * A valid format the theme does not support is still assigned, like REST.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_unsupported_format(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'format' => 'link' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with a theme-unsupported format should succeed.' );
+		$this->assertSame( 'link', get_post_format( $result['id'] ), 'The post should have the link format.' );
+	}
+
+	/**
+	 * A featured image is assigned to the created post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_featured_media(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$attachment_id = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'menu_order'     => 1,
+			)
+		);
+
+		$result = $this->create( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with featured media should succeed.' );
+		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( $result['id'] ), 'The attachment should be the post thumbnail.' );
+	}
+
+	/**
+	 * An invalid featured media ID is reported instead of being silently ignored.
+	 *
+	 * The REST controller discards the result of its featured media handling; the ability
+	 * surfaces it so the caller knows the post was created without the image.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_invalid_featured_media(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'featured_media' => 999999 ) ) );
+
+		$this->assertAbilityError( $result, 'content_invalid_featured_media', 'An invalid featured media ID should be reported.' );
+	}
+
+	/**
+	 * A nonexistent author is rejected, and a negative one fails validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_invalid_author(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$negative = $this->create( $this->post_data( array( 'author' => -1 ) ) );
+		$this->assertAbilityError( $negative, 'ability_invalid_input', 'A negative author ID should fail validation.' );
+
+		$missing = $this->create( $this->post_data( array( 'author' => 999999 ) ) );
+		$this->assertAbilityError( $missing, 'content_invalid_author', 'A nonexistent author should be rejected.' );
+	}
+
+	/**
+	 * A post can be created with a password.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_password(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'password' => 'testing' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a password-protected post should succeed.' );
+		$this->assertSame( 'testing', get_post( $result['id'] )->post_password, 'The password should be stored.' );
+	}
+
+	/**
+	 * A falsey password string is kept as-is.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_falsey_password(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'password' => '0' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with the password "0" should succeed.' );
+		$this->assertSame( '0', get_post( $result['id'] )->post_password, 'The password "0" should be stored.' );
+	}
+
+	/**
+	 * An empty password does not conflict with the sticky flag.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_empty_string_password_and_sticky(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'password' => '',
+					'sticky'   => true,
+				)
+			)
+		);
+
+		$this->assertIsArray( $result, 'An empty password should not conflict with sticky.' );
+		$this->assertSame( '', get_post( $result['id'] )->post_password, 'No password should be stored.' );
+		$this->assertTrue( is_sticky( $result['id'] ), 'The post should be sticky.' );
+	}
+
+	/**
+	 * A post cannot be both sticky and password protected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_password_and_sticky_fails(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'password' => '123',
+					'sticky'   => true,
+				)
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_field', 'A sticky post cannot have a password.' );
+	}
+
+	/**
+	 * A UTC date is stored as given on a UTC site.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_custom_date(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'date' => '2010-01-01T02:00:00Z' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with a custom date should succeed.' );
+		$this->assertSame( '2010-01-01T02:00:00+00:00', $result['date'], 'The returned date should match the given instant.' );
+		$this->assertSame( gmmktime( 2, 0, 0, 1, 1, 2010 ), strtotime( get_post( $result['id'] )->post_date ), 'The stored date should match the given instant.' );
+	}
+
+	/**
+	 * A date with a timezone offset is converted to the site timezone.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_custom_date_with_timezone(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'date' => '2010-01-01T02:00:00-10:00' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with an offset date should succeed.' );
+		$post = get_post( $result['id'] );
+		$time = gmmktime( 12, 0, 0, 1, 1, 2010 );
+
+		$this->assertSame( '2010-01-01T12:00:00+00:00', $result['date'], 'The returned date should be converted to the site timezone.' );
+		$this->assertSame( '2010-01-01T12:00:00+00:00', $result['modified'], 'The modified date should match the publication date on creation.' );
+		$this->assertSame( $time, strtotime( $post->post_date ), 'The stored date should be converted to the site timezone.' );
+		$this->assertSame( $time, strtotime( $post->post_modified ), 'The stored modified date should match the publication date on creation.' );
+	}
+
+	/**
+	 * A database failure surfaces as the insert error with a server error status.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_db_error(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		global $wpdb;
+		$wpdb->suppress_errors = true;
+		add_filter( 'query', array( $this, 'error_insert_query' ) );
+		try {
+			$result = $this->create( $this->post_data() );
+		} finally {
+			remove_filter( 'query', array( $this, 'error_insert_query' ) );
+			$wpdb->suppress_errors = false;
+		}
+
+		$this->assertAbilityError( $result, 'db_insert_error', 'A failed insert should surface the database error.' );
+		$this->assertSame( 500, $result->get_error_data()['status'], 'A database error should be a server error.' );
+	}
+
+	/**
+	 * Invalid dates fail validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_invalid_date(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$date = $this->create( $this->post_data( array( 'date' => '2010-60-01T02:00:00Z' ) ) );
+		$this->assertAbilityError( $date, 'ability_invalid_input', 'An invalid date should fail validation.' );
+
+		$date_gmt = $this->create( $this->post_data( array( 'date_gmt' => '2010-60-01T02:00:00' ) ) );
+		$this->assertAbilityError( $date_gmt, 'ability_invalid_input', 'An invalid GMT date should fail validation.' );
+	}
+
+	/**
+	 * Quotes survive the slashing round trip.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_quotes_in_title(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'title' => "Rob O'Rourke's Diary" ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with quotes in the title should succeed.' );
+		$this->assertSame( "Rob O'Rourke's Diary", $result['title_raw'], 'The raw title should keep its quotes.' );
+		$this->assertSame( "Rob O'Rourke's Diary", get_post( $result['id'] )->post_title, 'The stored title should keep its quotes.' );
+	}
+
+	/**
+	 * Categories are assigned under the REST `categories` key.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_categories(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$category = wp_insert_term( 'Test Category', 'category' );
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'password'   => 'testing',
+					'categories' => array( $category['term_id'] ),
+				)
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a post with categories should succeed.' );
+		$this->assertSame( array( $category['term_id'] ), wp_get_post_categories( $result['id'] ), 'The category should be assigned.' );
+	}
+
+	/**
+	 * Tags are assigned under the REST `tags` key.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_tags(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$tag = wp_insert_term( 'Test Tag', 'post_tag' );
+
+		$result = $this->create( $this->post_data( array( 'tags' => array( $tag['term_id'] ) ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with tags should succeed.' );
+		$this->assertSame( array( $tag['term_id'] ), wp_get_post_tags( $result['id'], array( 'fields' => 'ids' ) ), 'The tag should be assigned.' );
+	}
+
+	/**
+	 * A CSV term list is honored when the schema is bypassed, as a query-string transport would deliver it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_honors_csv_categories(): void {
+		$this->login_as( 'editor' );
+
+		$category  = wp_insert_term( 'Chicken', 'category' );
+		$category2 = wp_insert_term( 'Ribs', 'category' );
+
+		$result = ( new Content() )->execute_content_create(
+			$this->post_data( array( 'categories' => $category['term_id'] . ',' . $category2['term_id'] ) )
+		);
+
+		$this->assertIsArray( $result, 'Creating a post with CSV categories should succeed.' );
+		$this->assertSame( array( $category['term_id'], $category2['term_id'] ), wp_get_post_categories( $result['id'] ), 'Both categories should be assigned.' );
+	}
+
+	/**
+	 * Nonexistent term IDs are skipped, leaving the post without categories.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_invalid_categories(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'password'   => 'testing',
+					'categories' => array( 999999 ),
+				)
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a post with an unknown category should succeed.' );
+		$this->assertSame( array(), wp_get_post_categories( $result['id'] ), 'The unknown category should be skipped.' );
+	}
+
+	/**
+	 * Terms the current user cannot assign deny the whole request.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_categories_that_cannot_be_assigned_by_current_user(): void {
+		$categories               = self::factory()->category->create_many( 2 );
+		$this->forbidden_category = $categories[1];
+
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		add_filter( 'map_meta_cap', array( $this, 'revoke_assign_term' ), 10, 4 );
+		try {
+			$result = $this->create(
+				$this->post_data(
+					array(
+						'password'   => 'testing',
+						'categories' => $categories,
+					)
+				)
+			);
+		} finally {
+			remove_filter( 'map_meta_cap', array( $this, 'revoke_assign_term' ), 10 );
+		}
+
+		$this->assertAbilityDenied( $result, 'Terms the user cannot assign should deny the request.' );
+	}
+
+	/**
+	 * A taxonomy that is not registered for the post type is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_categories_is_rejected(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$category = wp_insert_term( 'Page Category', 'category' );
+
+		$result = $this->create(
+			array(
+				'post_type'  => 'page',
+				'title'      => 'A page',
+				'categories' => array( $category['term_id'] ),
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_field', 'Categories should be rejected for pages.' );
+	}
+
+	/**
+	 * A draft slug that collides with a published post is made unique.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_draft_post_does_not_have_the_same_slug_as_existing_post(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		self::factory()->post->create( array( 'post_name' => 'sample-slug' ) );
+
+		$result = $this->create(
+			$this->post_data(
+				array(
+					'status' => 'draft',
+					'slug'   => 'sample-slug',
+				)
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a draft with a taken slug should succeed.' );
+		$this->assertSame( 'sample-slug-2', $result['slug'], 'The draft slug should be made unique.' );
+		$this->assertSame( 'sample-slug-2', get_post( $result['id'] )->post_name, 'The stored draft slug should be made unique.' );
+	}
+
+	/**
+	 * The slug is sanitized like the REST slug argument.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_slug_is_sanitized(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'slug' => 'Tęst Acceńted Chäræcters!' ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with a raw slug should succeed.' );
+		$this->assertSame( 'test-accented-charaecters', $result['slug'], 'The slug should be sanitized.' );
+	}
+
+	/**
+	 * Provides fields that a post type does not support.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: mixed}> Post type, field, and value.
+	 */
+	public function data_unsupported_fields(): array {
+		return array(
+			'parent on a post'          => array( 'post', 'parent', 0 ),
+			'menu order on a post'      => array( 'post', 'menu_order', 1 ),
+			'sticky on a page'          => array( 'page', 'sticky', true ),
+			'format on a page'          => array( 'page', 'format', 'aside' ),
+			'content without editor'    => array( 'wpai_title_only', 'content', 'Body' ),
+			'excerpt without support'   => array( 'wpai_title_only', 'excerpt', 'Excerpt' ),
+			'author without support'    => array( 'wpai_title_only', 'author', 1 ),
+			'featured media unsupported' => array( 'wpai_title_only', 'featured_media', 0 ),
+			'comment status unsupported' => array( 'wpai_title_only', 'comment_status', 'open' ),
+			'ping status unsupported'   => array( 'wpai_title_only', 'ping_status', 'open' ),
+		);
+	}
+
+	/**
+	 * Fields the post type does not support are rejected rather than silently ignored.
+	 *
+	 * The REST controller drops such fields because they are absent from the post type's
+	 * schema; the shared ability schema cannot express that, so execution rejects them.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_unsupported_fields
+	 *
+	 * @param string $post_type The post type to create.
+	 * @param string $field     The unsupported field.
+	 * @param mixed  $value     A valid value for the field.
+	 */
+	public function test_create_rejects_unsupported_fields( string $post_type, string $field, $value ): void {
+		$this->register_title_only_post_type();
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$result = $this->create(
+				array(
+					'post_type' => $post_type,
+					'title'     => 'Unsupported field',
+					$field      => $value,
+				)
+			);
+
+			$this->assertAbilityError( $result, 'content_invalid_field', "The {$field} field should be rejected for the {$post_type} post type." );
+			$this->assertStringContainsString( $field, $result->get_error_message(), 'The error should name the field.' );
+			$this->assertStringContainsString( $post_type, $result->get_error_message(), 'The error should name the post type.' );
+		} finally {
+			unregister_post_type( 'wpai_title_only' );
+		}
+	}
+
+	/**
+	 * A page can be created under a parent page.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_parent(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$parent_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$result = $this->create(
+			array(
+				'post_type' => 'page',
+				'title'     => 'Child page',
+				'parent'    => $parent_id,
+				'fields'    => array( 'id', 'parent' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a child page should succeed.' );
+		$this->assertSame( $parent_id, $result['parent'], 'The returned parent should match.' );
+		$this->assertSame( $parent_id, (int) get_post( $result['id'] )->post_parent, 'The stored parent should match.' );
+
+		$top_level = $this->create(
+			array(
+				'post_type' => 'page',
+				'title'     => 'Top-level page',
+				'parent'    => 0,
+				'fields'    => array( 'id', 'parent' ),
+			)
+		);
+
+		$this->assertIsArray( $top_level, 'Creating a top-level page should succeed.' );
+		$this->assertSame( 0, $top_level['parent'], 'A zero parent should create a top-level page.' );
+	}
+
+	/**
+	 * A nonexistent parent is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_invalid_parent(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type' => 'page',
+				'title'     => 'Orphan page',
+				'parent'    => 999999,
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_parent', 'A nonexistent parent should be rejected.' );
+	}
+
+	/**
+	 * Page attributes and comment settings are stored.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_menu_order_and_comment_settings(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type'      => 'page',
+				'title'          => 'Ordered page',
+				'menu_order'     => 7,
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+				'fields'         => array( 'id' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a page with attributes should succeed.' );
+		$post = get_post( $result['id'] );
+		$this->assertSame( 7, $post->menu_order, 'The menu order should be stored.' );
+		$this->assertSame( 'closed', $post->comment_status, 'The comment status should be stored.' );
+		$this->assertSame( 'closed', $post->ping_status, 'The ping status should be stored.' );
+	}
+
+	/**
+	 * A post type that is not exposed to abilities cannot be created.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_for_unexposed_post_type_is_rejected(): void {
+		register_post_type(
+			'wpai_hidden_cpt',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$input = array(
+				'post_type' => 'wpai_hidden_cpt',
+				'title'     => 'Hidden',
+			);
+
+			$result = $this->create( $input );
+			$this->assertAbilityError( $result, 'ability_invalid_input', 'An unexposed post type should fail the post type enum.' );
+
+			$direct = ( new Content() )->execute_content_create( $input );
+			$this->assertAbilityError( $direct, 'content_invalid_post_type', 'A direct call should still reject an unexposed post type.' );
+		} finally {
+			unregister_post_type( 'wpai_hidden_cpt' );
+		}
+	}
+
+	/**
+	 * A post type registered by another plugin with `show_in_abilities` can be created.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_creates_a_post_type_registered_by_another_plugin(): void {
+		register_post_type(
+			'wpai_book',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title', 'editor' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$result = $this->create(
+				array(
+					'post_type' => 'wpai_book',
+					'title'     => 'A book',
+					'content'   => 'Chapter one.',
+					'status'    => 'publish',
+					'fields'    => array( 'id', 'post_type', 'content_raw' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'Creating a custom post type post should succeed.' );
+			$this->assertSame( 'wpai_book', $result['post_type'], 'The post should have the custom post type.' );
+			$this->assertSame( 'Chapter one.', $result['content_raw'], 'The content should be stored.' );
+		} finally {
+			unregister_post_type( 'wpai_book' );
+		}
+	}
+
+	/**
+	 * The core post insertion hook fires for the created post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_fires_wp_after_insert_post(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$calls    = array();
+		$callback = static function ( $post_id, $post, $update, $post_before ) use ( &$calls ): void {
+			$calls[] = array( $post_id, $update, $post_before );
+		};
+
+		add_action( 'wp_after_insert_post', $callback, 10, 4 );
+		try {
+			$result = $this->create( $this->post_data() );
+		} finally {
+			remove_action( 'wp_after_insert_post', $callback, 10 );
+		}
+
+		$this->assertIsArray( $result, 'Creating a post should succeed.' );
+		$this->assertNotEmpty( $calls, 'wp_after_insert_post should fire.' );
+		$last = end( $calls );
+		$this->assertSame( $result['id'], $last[0], 'The hook should receive the created post.' );
+		$this->assertFalse( $last[1], 'The hook should report a creation.' );
+		$this->assertNull( $last[2], 'There is no previous post on creation.' );
+	}
+
+	/**
+	 * Provides the REST suite's round-trip cases for a user without unfiltered_html.
+	 *
+	 * @return array<int, array{0: array<string, string>, 1: array<string, array<string, string>>}> Raw input and expected values.
+	 */
+	public function data_post_roundtrip_as_author(): array {
+		return array(
+			array(
+				array(
+					'title'   => '\o/ ¯\_(ツ)_/¯',
+					'content' => '\o/ ¯\_(ツ)_/¯',
+					'excerpt' => '\o/ ¯\_(ツ)_/¯',
+				),
+				array(
+					'title'   => array(
+						'raw'      => '\o/ ¯\_(ツ)_/¯',
+						'rendered' => '\o/ ¯\_(ツ)_/¯',
+					),
+					'content' => array(
+						'raw'      => '\o/ ¯\_(ツ)_/¯',
+						'rendered' => '<p>\o/ ¯\_(ツ)_/¯</p>',
+					),
+					'excerpt' => array(
+						'raw'      => '\o/ ¯\_(ツ)_/¯',
+						'rendered' => '<p>\o/ ¯\_(ツ)_/¯</p>',
+					),
+				),
+			),
+			array(
+				array(
+					'title'   => '\\\&\\\ &amp; &invalid; < &lt; &amp;lt;',
+					'content' => '\\\&\\\ &amp; &invalid; < &lt; &amp;lt;',
+					'excerpt' => '\\\&\\\ &amp; &invalid; < &lt; &amp;lt;',
+				),
+				array(
+					'title'   => array(
+						'raw'      => '\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;',
+						'rendered' => '\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;',
+					),
+					'content' => array(
+						'raw'      => '\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;',
+						'rendered' => '<p>\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;</p>',
+					),
+					'excerpt' => array(
+						'raw'      => '\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;',
+						'rendered' => '<p>\\\&amp;\\\ &amp; &amp;invalid; &lt; &lt; &amp;lt;</p>',
+					),
+				),
+			),
+			array(
+				array(
+					'title'   => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+					'content' => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+					'excerpt' => '<div>div</div> <strong>strong</strong> <script>oh noes</script>',
+				),
+				array(
+					'title'   => array(
+						'raw'      => 'div <strong>strong</strong> oh noes',
+						'rendered' => 'div <strong>strong</strong> oh noes',
+					),
+					'content' => array(
+						'raw'      => '<div>div</div> <strong>strong</strong> oh noes',
+						'rendered' => "<div>div</div>\n<p> <strong>strong</strong> oh noes</p>",
+					),
+					'excerpt' => array(
+						'raw'      => '<div>div</div> <strong>strong</strong> oh noes',
+						'rendered' => "<div>div</div>\n<p> <strong>strong</strong> oh noes</p>",
+					),
+				),
+			),
+			array(
+				array(
+					'title'   => '<a href="#" target="_blank" unfiltered=true>link</a>',
+					'content' => '<a href="#" target="_blank" unfiltered=true>link</a>',
+					'excerpt' => '<a href="#" target="_blank" unfiltered=true>link</a>',
+				),
+				array(
+					'title'   => array(
+						'raw'      => '<a href="#">link</a>',
+						'rendered' => '<a href="#">link</a>',
+					),
+					'content' => array(
+						'raw'      => '<a href="#" target="_blank">link</a>',
+						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+					),
+					'excerpt' => array(
+						'raw'      => '<a href="#" target="_blank">link</a>',
+						'rendered' => '<p><a href="#" target="_blank">link</a></p>',
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Content written by a user without unfiltered_html is filtered exactly as through REST.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_post_roundtrip_as_author
+	 *
+	 * @param array<string, string>                $raw      The raw input values.
+	 * @param array<string, array<string, string>> $expected The expected stored and rendered values.
+	 */
+	public function test_post_roundtrip_as_author( array $raw, array $expected ): void {
+		$this->login_as( 'author' );
+		$this->register_ability();
+
+		$this->assertFalse( current_user_can( 'unfiltered_html' ), 'Precondition: authors cannot post unfiltered HTML.' );
+
+		$fields = array( 'id', 'title_raw', 'title_rendered', 'content_raw', 'content_rendered', 'excerpt_raw', 'excerpt_rendered' );
+
+		$created = $this->create( array_merge( array( 'post_type' => 'post' ), $raw, array( 'fields' => $fields ) ) );
+		$this->assert_roundtrip( $created, $expected );
+
+		$updated = $this->execute_ability( 'core/content-update', array_merge( array( 'id' => $created['id'] ), $raw, array( 'fields' => $fields ) ) );
+		$this->assert_roundtrip( $updated, $expected );
+	}
+
+	/**
+	 * Asserts the returned and stored values of a round-trip case.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed                                $result   The ability result.
+	 * @param array<string, array<string, string>> $expected The expected values.
+	 */
+	private function assert_roundtrip( $result, array $expected ): void {
+		$this->assertIsArray( $result, 'The write should succeed.' );
+
+		$this->assertSame( $expected['title']['raw'], $result['title_raw'], 'The raw title should be filtered like REST.' );
+		$this->assertSame( $expected['title']['rendered'], trim( $result['title_rendered'] ), 'The rendered title should match REST.' );
+		$this->assertSame( $expected['content']['raw'], $result['content_raw'], 'The raw content should be filtered like REST.' );
+		$this->assertSame( $expected['content']['rendered'], trim( $result['content_rendered'] ), 'The rendered content should match REST.' );
+		$this->assertSame( $expected['excerpt']['raw'], $result['excerpt_raw'], 'The raw excerpt should be filtered like REST.' );
+		$this->assertSame( $expected['excerpt']['rendered'], trim( $result['excerpt_rendered'] ), 'The rendered excerpt should match REST.' );
+
+		$post = get_post( $result['id'] );
+		$this->assertSame( $expected['title']['raw'], $post->post_title, 'The stored title should be filtered like REST.' );
+		$this->assertSame( $expected['content']['raw'], $post->post_content, 'The stored content should be filtered like REST.' );
+		$this->assertSame( $expected['excerpt']['raw'], $post->post_excerpt, 'The stored excerpt should be filtered like REST.' );
+	}
+}

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -1065,13 +1065,15 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Nonexistent term IDs are skipped, leaving the post without categories.
+	 * A nonexistent term ID is rejected before the post is created.
 	 *
 	 * @since x.x.x
 	 */
 	public function test_create_post_with_invalid_categories(): void {
 		$this->login_as( 'editor' );
 		$this->register_ability();
+
+		$published_before = (int) wp_count_posts()->publish;
 
 		$result = $this->create(
 			$this->post_data(
@@ -1082,8 +1084,141 @@ class ContentCreateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		$this->assertIsArray( $result, 'Creating a post with an unknown category should succeed.' );
-		$this->assertSame( array(), wp_get_post_categories( $result['id'] ), 'The unknown category should be skipped.' );
+		$this->assertAbilityError( $result, 'content_invalid_term', 'An unknown term ID should be rejected.' );
+		$this->assertStringContainsString( '999999', $result->get_error_message(), 'The error should name the unknown term.' );
+		$this->assertSame( $published_before, (int) wp_count_posts()->publish, 'No post should be created when a term is unknown.' );
+	}
+
+	/**
+	 * Duplicate term IDs are accepted and assigned once.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_duplicate_categories(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$category = wp_insert_term( 'Twice', 'category' );
+
+		$result = $this->create( $this->post_data( array( 'categories' => array( $category['term_id'], $category['term_id'] ) ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with a duplicated category should succeed.' );
+		$this->assertSame( array( $category['term_id'] ), wp_get_post_categories( $result['id'] ), 'The category should be assigned once.' );
+	}
+
+	/**
+	 * An author of 0 is ignored, so the post belongs to the current user.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_author_zero(): void {
+		$editor_id = $this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'author' => 0 ) ) );
+
+		$this->assertIsArray( $result, 'Creating a post with an author of 0 should succeed.' );
+		$this->assertSame( $editor_id, (int) get_post( $result['id'] )->post_author, 'The post should belong to the current user.' );
+	}
+
+	/**
+	 * A featured media ID that is not an image attachment is rejected before the post is created.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_non_image_featured_media(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$attachment_id = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/formatting/utf-8/utf-8.txt',
+			0,
+			array( 'post_mime_type' => 'text/plain' )
+		);
+
+		$published_before = (int) wp_count_posts()->publish;
+
+		$result = $this->create( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
+
+		$this->assertAbilityError( $result, 'content_invalid_featured_media', 'A non-image attachment should be rejected as featured media.' );
+		$this->assertSame( $published_before, (int) wp_count_posts()->publish, 'No post should be created when the featured media is invalid.' );
+	}
+
+	/**
+	 * A page accepts an excerpt, and the excerpt is readable again.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_page_with_excerpt(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create(
+			array(
+				'post_type' => 'page',
+				'title'     => 'About',
+				'excerpt'   => 'Summary',
+				'status'    => 'publish',
+				'fields'    => array( 'id', 'excerpt_raw', 'excerpt_rendered' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Creating a page with an excerpt should succeed.' );
+		$this->assertSame( 'Summary', $result['excerpt_raw'], 'The excerpt should be returned for the page.' );
+		$this->assertSame( 'Summary', get_post( $result['id'] )->post_excerpt, 'The excerpt should be stored on the page.' );
+
+		$read = $this->execute_ability(
+			'core/content-query',
+			array(
+				'id'     => $result['id'],
+				'fields' => array( 'excerpt_raw' ),
+			)
+		);
+
+		$this->assertSame( array( 'excerpt_raw' => 'Summary' ), $read, 'The query ability should return the page excerpt.' );
+	}
+
+	/**
+	 * A raw object without a `raw` key fails validation instead of being ignored.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_create_post_with_raw_object_without_raw_key(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->create( $this->post_data( array( 'title' => array( 'rendered' => 'New' ) ) ) );
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'A raw object without a raw key should fail validation.' );
+	}
+
+	/**
+	 * Sticky on a post type without sticky support is rejected as unsupported for every role.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_unsupported_sticky_is_rejected_for_every_role(): void {
+		$this->register_title_only_post_type();
+
+		try {
+			$this->register_ability();
+
+			foreach ( array( 'contributor', 'editor' ) as $role ) {
+				$this->login_as( $role );
+
+				$result = $this->create(
+					array(
+						'post_type' => 'wpai_title_only',
+						'title'     => 'Sticky?',
+						'sticky'    => true,
+					)
+				);
+
+				$this->assertAbilityError( $result, 'content_invalid_field', "A {$role} should see the unsupported field error rather than a permission denial." );
+			}
+		} finally {
+			unregister_post_type( 'wpai_title_only' );
+		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentCreateTest.php
@@ -17,15 +17,6 @@ use WordPress\AI\Abilities\Content\Content;
 class ContentCreateTest extends Content_Ability_TestCase {
 
 	/**
-	 * The category the current user is forbidden to assign, when set.
-	 *
-	 * @since x.x.x
-	 *
-	 * @var int
-	 */
-	private $forbidden_category = 0;
-
-	/**
 	 * Returns a create input with every common field set.
 	 *
 	 * @since x.x.x
@@ -93,70 +84,6 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Disables INSERT queries so wp_insert_post() fails with a database error.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string $query The database query.
-	 * @return string The query, broken when it is an INSERT.
-	 */
-	public function error_insert_query( string $query ): string {
-		if ( 0 === strpos( $query, 'INSERT' ) ) {
-			$query = '],';
-		}
-
-		return $query;
-	}
-
-	/**
-	 * Offers one post template for the tests that need a valid template.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return array<string, string> The post templates keyed by file name.
-	 */
-	public function filter_theme_post_templates(): array {
-		return array(
-			'post-my-test-template.php' => 'My Test Template',
-		);
-	}
-
-	/**
-	 * Revokes the assign_term meta capability for the forbidden category.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string[] $caps    The primitive capabilities.
-	 * @param string   $cap     The meta capability being checked.
-	 * @param int      $user_id The user ID.
-	 * @param mixed[]  $args    The capability arguments.
-	 * @return string[] The primitive capabilities.
-	 */
-	public function revoke_assign_term( array $caps, string $cap, int $user_id, array $args ): array {
-		if ( 'assign_term' === $cap && isset( $args[0] ) && $this->forbidden_category === $args[0] ) {
-			$caps = array( 'do_not_allow' );
-		}
-
-		return $caps;
-	}
-
-	/**
-	 * Registers a post type that only supports titles, for the unsupported-field tests.
-	 *
-	 * @since x.x.x
-	 */
-	private function register_title_only_post_type(): void {
-		register_post_type(
-			'wpai_title_only',
-			array(
-				'public'            => true,
-				'show_in_abilities' => true,
-				'supports'          => array( 'title' ),
-			)
-		);
-	}
-
-	/**
 	 * The ability is registered in the `content` category and flagged as a non-idempotent write.
 	 *
 	 * @since x.x.x
@@ -175,21 +102,6 @@ class ContentCreateTest extends Content_Ability_TestCase {
 		$this->assertFalse( $annotations['destructive'], 'Creating a post is not destructive.' );
 		$this->assertFalse( $annotations['idempotent'], 'Every call creates a new post, so the ability is not idempotent.' );
 		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
-	}
-
-	/**
-	 * The ability is not registered when no post types are exposed to it.
-	 *
-	 * @since x.x.x
-	 */
-	public function test_does_not_register_without_exposed_post_types(): void {
-		foreach ( array( 'post', 'page' ) as $post_type ) {
-			get_post_type_object( $post_type )->show_in_abilities = false;
-		}
-
-		$this->register_ability();
-
-		$this->assertFalse( wp_has_ability( 'core/content-create' ), 'The create ability should not register without any exposed post types.' );
 	}
 
 	/**
@@ -928,15 +840,12 @@ class ContentCreateTest extends Content_Ability_TestCase {
 		$this->login_as( 'editor' );
 		$this->register_ability();
 
-		global $wpdb;
-		$wpdb->suppress_errors = true;
-		add_filter( 'query', array( $this, 'error_insert_query' ) );
-		try {
-			$result = $this->create( $this->post_data() );
-		} finally {
-			remove_filter( 'query', array( $this, 'error_insert_query' ) );
-			$wpdb->suppress_errors = false;
-		}
+		$result = $this->run_with_failing_query(
+			'INSERT',
+			function () {
+				return $this->create( $this->post_data() );
+			}
+		);
 
 		$this->assertAbilityError( $result, 'db_insert_error', 'A failed insert should surface the database error.' );
 		$this->assertSame( 500, $result->get_error_data()['status'], 'A database error should be a server error.' );
@@ -1200,24 +1109,20 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	public function test_unsupported_sticky_is_rejected_for_every_role(): void {
 		$this->register_title_only_post_type();
 
-		try {
-			$this->register_ability();
+		$this->register_ability();
 
-			foreach ( array( 'contributor', 'editor' ) as $role ) {
-				$this->login_as( $role );
+		foreach ( array( 'contributor', 'editor' ) as $role ) {
+			$this->login_as( $role );
 
-				$result = $this->create(
-					array(
-						'post_type' => 'wpai_title_only',
-						'title'     => 'Sticky?',
-						'sticky'    => true,
-					)
-				);
+			$result = $this->create(
+				array(
+					'post_type' => 'wpai_title_only',
+					'title'     => 'Sticky?',
+					'sticky'    => true,
+				)
+			);
 
-				$this->assertAbilityError( $result, 'content_invalid_field', "A {$role} should see the unsupported field error rather than a permission denial." );
-			}
-		} finally {
-			unregister_post_type( 'wpai_title_only' );
+			$this->assertAbilityError( $result, 'content_invalid_field', "A {$role} should see the unsupported field error rather than a permission denial." );
 		}
 	}
 
@@ -1313,22 +1218,23 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Provides fields that a post type does not support.
+	 * Provides fields that a post type does not support, including a title-only post type.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return array<string, array{0: string, 1: string, 2: mixed}> Post type, field, and value.
 	 */
-	public function data_unsupported_fields(): array {
-		return array(
-			'parent on a post'          => array( 'post', 'parent', 0 ),
-			'menu order on a post'      => array( 'post', 'menu_order', 1 ),
-			'sticky on a page'          => array( 'page', 'sticky', true ),
-			'format on a page'          => array( 'page', 'format', 'aside' ),
-			'content without editor'    => array( 'wpai_title_only', 'content', 'Body' ),
-			'excerpt without support'   => array( 'wpai_title_only', 'excerpt', 'Excerpt' ),
-			'author without support'    => array( 'wpai_title_only', 'author', 1 ),
-			'featured media unsupported' => array( 'wpai_title_only', 'featured_media', 0 ),
-			'comment status unsupported' => array( 'wpai_title_only', 'comment_status', 'open' ),
-			'ping status unsupported'   => array( 'wpai_title_only', 'ping_status', 'open' ),
+	public function data_unsupported_fields_including_custom_post_type(): array {
+		return array_merge(
+			$this->data_unsupported_fields(),
+			array(
+				'content without editor'     => array( 'wpai_title_only', 'content', 'Body' ),
+				'excerpt without support'    => array( 'wpai_title_only', 'excerpt', 'Excerpt' ),
+				'author without support'     => array( 'wpai_title_only', 'author', 1 ),
+				'featured media unsupported' => array( 'wpai_title_only', 'featured_media', 0 ),
+				'comment status unsupported' => array( 'wpai_title_only', 'comment_status', 'open' ),
+				'ping status unsupported'    => array( 'wpai_title_only', 'ping_status', 'open' ),
+			)
 		);
 	}
 
@@ -1340,7 +1246,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	 *
 	 * @since x.x.x
 	 *
-	 * @dataProvider data_unsupported_fields
+	 * @dataProvider data_unsupported_fields_including_custom_post_type
 	 *
 	 * @param string $post_type The post type to create.
 	 * @param string $field     The unsupported field.
@@ -1349,24 +1255,20 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	public function test_create_rejects_unsupported_fields( string $post_type, string $field, $value ): void {
 		$this->register_title_only_post_type();
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$result = $this->create(
-				array(
-					'post_type' => $post_type,
-					'title'     => 'Unsupported field',
-					$field      => $value,
-				)
-			);
+		$result = $this->create(
+			array(
+				'post_type' => $post_type,
+				'title'     => 'Unsupported field',
+				$field      => $value,
+			)
+		);
 
-			$this->assertAbilityError( $result, 'content_invalid_field', "The {$field} field should be rejected for the {$post_type} post type." );
-			$this->assertStringContainsString( $field, $result->get_error_message(), 'The error should name the field.' );
-			$this->assertStringContainsString( $post_type, $result->get_error_message(), 'The error should name the post type.' );
-		} finally {
-			unregister_post_type( 'wpai_title_only' );
-		}
+		$this->assertAbilityError( $result, 'content_invalid_field', "The {$field} field should be rejected for the {$post_type} post type." );
+		$this->assertStringContainsString( $field, $result->get_error_message(), 'The error should name the field.' );
+		$this->assertStringContainsString( $post_type, $result->get_error_message(), 'The error should name the post type.' );
 	}
 
 	/**
@@ -1459,7 +1361,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_create_for_unexposed_post_type_is_rejected(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_hidden_cpt',
 			array(
 				'public'   => true,
@@ -1467,23 +1369,19 @@ class ContentCreateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$input = array(
-				'post_type' => 'wpai_hidden_cpt',
-				'title'     => 'Hidden',
-			);
+		$input = array(
+			'post_type' => 'wpai_hidden_cpt',
+			'title'     => 'Hidden',
+		);
 
-			$result = $this->create( $input );
-			$this->assertAbilityError( $result, 'ability_invalid_input', 'An unexposed post type should fail the post type enum.' );
+		$result = $this->create( $input );
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'An unexposed post type should fail the post type enum.' );
 
-			$direct = ( new Content() )->execute_content_create( $input );
-			$this->assertAbilityError( $direct, 'content_invalid_post_type', 'A direct call should still reject an unexposed post type.' );
-		} finally {
-			unregister_post_type( 'wpai_hidden_cpt' );
-		}
+		$direct = ( new Content() )->execute_content_create( $input );
+		$this->assertAbilityError( $direct, 'content_invalid_post_type', 'A direct call should still reject an unexposed post type.' );
 	}
 
 	/**
@@ -1492,7 +1390,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_creates_a_post_type_registered_by_another_plugin(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_book',
 			array(
 				'public'            => true,
@@ -1501,26 +1399,22 @@ class ContentCreateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$result = $this->create(
-				array(
-					'post_type' => 'wpai_book',
-					'title'     => 'A book',
-					'content'   => 'Chapter one.',
-					'status'    => 'publish',
-					'fields'    => array( 'id', 'post_type', 'content_raw' ),
-				)
-			);
+		$result = $this->create(
+			array(
+				'post_type' => 'wpai_book',
+				'title'     => 'A book',
+				'content'   => 'Chapter one.',
+				'status'    => 'publish',
+				'fields'    => array( 'id', 'post_type', 'content_raw' ),
+			)
+		);
 
-			$this->assertIsArray( $result, 'Creating a custom post type post should succeed.' );
-			$this->assertSame( 'wpai_book', $result['post_type'], 'The post should have the custom post type.' );
-			$this->assertSame( 'Chapter one.', $result['content_raw'], 'The content should be stored.' );
-		} finally {
-			unregister_post_type( 'wpai_book' );
-		}
+		$this->assertIsArray( $result, 'Creating a custom post type post should succeed.' );
+		$this->assertSame( 'wpai_book', $result['post_type'], 'The post should have the custom post type.' );
+		$this->assertSame( 'Chapter one.', $result['content_raw'], 'The content should be stored.' );
 	}
 
 	/**
@@ -1551,9 +1445,11 @@ class ContentCreateTest extends Content_Ability_TestCase {
 					$this->assertSame( array_values( $definition['enum'] ), $properties[ $field ]['enum'], "The {$field} field should accept the values of the {$post_type} endpoint." );
 				}
 
-				if ( isset( $definition['items'] ) ) {
-					$this->assertSame( $definition['items']['type'], $properties[ $field ]['items']['type'], "The {$field} items should have the type of the {$post_type} endpoint." );
+				if ( ! isset( $definition['items'] ) ) {
+					continue;
 				}
+
+				$this->assertSame( $definition['items']['type'], $properties[ $field ]['items']['type'], "The {$field} items should have the type of the {$post_type} endpoint." );
 			}
 		}
 	}
@@ -1615,7 +1511,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_custom_taxonomy_terms_are_accepted_under_their_rest_base_key(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_book',
 			array(
 				'public'            => true,
@@ -1623,7 +1519,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 				'supports'          => array( 'title' ),
 			)
 		);
-		register_taxonomy(
+		$this->register_test_taxonomy(
 			'wpai_genre',
 			'wpai_book',
 			array(
@@ -1632,7 +1528,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 				'rest_base'    => 'genres',
 			)
 		);
-		register_taxonomy(
+		$this->register_test_taxonomy(
 			'wpai_shelf',
 			'wpai_book',
 			array(
@@ -1640,7 +1536,7 @@ class ContentCreateTest extends Content_Ability_TestCase {
 				'show_in_rest' => true,
 			)
 		);
-		register_taxonomy(
+		$this->register_test_taxonomy(
 			'wpai_hidden_shelf',
 			'wpai_book',
 			array(
@@ -1649,46 +1545,39 @@ class ContentCreateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$properties = wp_get_ability( 'core/content-create' )->get_input_schema()['properties'];
-			$this->assertArrayHasKey( 'genres', $properties, 'A taxonomy with a rest_base should be accepted under it.' );
-			$this->assertArrayHasKey( 'wpai_shelf', $properties, 'A taxonomy without a rest_base should be accepted under its name.' );
-			$this->assertArrayNotHasKey( 'wpai_hidden_shelf', $properties, 'A taxonomy without show_in_rest should not be accepted.' );
+		$properties = wp_get_ability( 'core/content-create' )->get_input_schema()['properties'];
+		$this->assertArrayHasKey( 'genres', $properties, 'A taxonomy with a rest_base should be accepted under it.' );
+		$this->assertArrayHasKey( 'wpai_shelf', $properties, 'A taxonomy without a rest_base should be accepted under its name.' );
+		$this->assertArrayNotHasKey( 'wpai_hidden_shelf', $properties, 'A taxonomy without show_in_rest should not be accepted.' );
 
-			$genre = wp_insert_term( 'Fantasy', 'wpai_genre' );
-			$shelf = wp_insert_term( 'Top shelf', 'wpai_shelf' );
+		$genre = wp_insert_term( 'Fantasy', 'wpai_genre' );
+		$shelf = wp_insert_term( 'Top shelf', 'wpai_shelf' );
 
-			$result = $this->create(
-				array(
-					'post_type'  => 'wpai_book',
-					'title'      => 'A shelved book',
-					'genres'     => array( $genre['term_id'] ),
-					'wpai_shelf' => array( $shelf['term_id'] ),
-					'fields'     => array( 'id' ),
-				)
-			);
+		$result = $this->create(
+			array(
+				'post_type'  => 'wpai_book',
+				'title'      => 'A shelved book',
+				'genres'     => array( $genre['term_id'] ),
+				'wpai_shelf' => array( $shelf['term_id'] ),
+				'fields'     => array( 'id' ),
+			)
+		);
 
-			$this->assertIsArray( $result, 'Creating a book with custom terms should succeed.' );
-			$this->assertSame( array( $genre['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_genre', array( 'fields' => 'ids' ) ), 'The genre should be assigned.' );
-			$this->assertSame( array( $shelf['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_shelf', array( 'fields' => 'ids' ) ), 'The shelf should be assigned.' );
+		$this->assertIsArray( $result, 'Creating a book with custom terms should succeed.' );
+		$this->assertSame( array( $genre['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_genre', array( 'fields' => 'ids' ) ), 'The genre should be assigned.' );
+		$this->assertSame( array( $shelf['term_id'] ), wp_get_object_terms( $result['id'], 'wpai_shelf', array( 'fields' => 'ids' ) ), 'The shelf should be assigned.' );
 
-			$rejected = $this->create(
-				array(
-					'post_type' => 'post',
-					'title'     => 'Not a book',
-					'genres'    => array( $genre['term_id'] ),
-				)
-			);
-			$this->assertAbilityError( $rejected, 'content_invalid_field', 'A taxonomy of another post type should be rejected.' );
-		} finally {
-			unregister_taxonomy( 'wpai_genre' );
-			unregister_taxonomy( 'wpai_shelf' );
-			unregister_taxonomy( 'wpai_hidden_shelf' );
-			unregister_post_type( 'wpai_book' );
-		}
+		$rejected = $this->create(
+			array(
+				'post_type' => 'post',
+				'title'     => 'Not a book',
+				'genres'    => array( $genre['term_id'] ),
+			)
+		);
+		$this->assertAbilityError( $rejected, 'content_invalid_field', 'A taxonomy of another post type should be rejected.' );
 	}
 
 	/**
@@ -1722,6 +1611,8 @@ class ContentCreateTest extends Content_Ability_TestCase {
 
 	/**
 	 * Provides round-trip cases for a user without unfiltered_html.
+	 *
+	 * @since x.x.x
 	 *
 	 * @return array<int, array{0: array<string, string>, 1: array<string, array<string, string>>}> Raw input and expected values.
 	 */

--- a/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
@@ -462,6 +462,63 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * The execute callback checks the delete capability itself before removing anything.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_rechecks_the_delete_capability(): void {
+		$this->login_as( 'subscriber' );
+
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$user_ids['editor'] ) );
+
+		$content = new Content();
+
+		$trash = $content->execute_content_delete( array( 'id' => $post_id ) );
+		$this->assertAbilityError( $trash, 'content_cannot_delete_post', 'A direct call should not trash a post the user cannot delete.' );
+		$this->assertSame( 403, $trash->get_error_data()['status'], 'The denial should carry the authorization status.' );
+
+		$delete = $content->execute_content_delete(
+			array(
+				'id'    => $post_id,
+				'force' => true,
+			)
+		);
+		$this->assertAbilityError( $delete, 'content_cannot_delete_post', 'A direct call should not delete a post the user cannot delete.' );
+		$this->assertSame( 'publish', get_post( $post_id )->post_status, 'The post should be untouched.' );
+	}
+
+	/**
+	 * A page is trashed and returned like a post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_page(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Deleted page',
+			)
+		);
+
+		$result = $this->delete(
+			array(
+				'id'     => $page_id,
+				'force'  => false,
+				'fields' => array( 'id', 'post_type', 'status', 'title_raw' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Trashing a page should return the trashed page.' );
+		$this->assertSame( 'page', $result['post_type'], 'The trashed page should keep its post type.' );
+		$this->assertSame( 'Deleted page', $result['title_raw'], 'The trashed page should keep its title.' );
+		$this->assertSame( 'trash', $result['status'], 'The returned status should be trash.' );
+		$this->assertSame( 'trash', get_post( $page_id )->post_status, 'The stored status should be trash.' );
+	}
+
+	/**
 	 * A trashed post can still be read by ID through the query ability.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
@@ -2,10 +2,6 @@
 /**
  * Integration tests for the core/content-delete Ability provided by the plugin.
  *
- * The cases mirror the delete tests of the WordPress core REST posts controller
- * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
- * output shapes.
- *
  * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
  */
 
@@ -81,7 +77,7 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 		$this->assertSame( 'object', $schema['type'], 'The input schema should describe an object.' );
 		$this->assertSame( array( 'id' ), $schema['required'], 'Only the ID should be required.' );
 		$this->assertFalse( $schema['additionalProperties'], 'Unknown properties should be rejected.' );
-		$this->assertSame( array( 'id', 'post_type', 'force', 'fields' ), array_keys( $schema['properties'] ), 'The input should mirror the REST delete arguments plus the field selection.' );
+		$this->assertSame( array( 'id', 'post_type', 'force', 'fields' ), array_keys( $schema['properties'] ), 'The input should take the ID, an optional post type guard, the force flag, and the field selection.' );
 		$this->assertSame( 'boolean', $schema['properties']['force']['type'], 'Force should be a boolean.' );
 		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'The post type guard should only accept exposed post types.' );
 	}
@@ -269,7 +265,7 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * A post type guard that does not match the post denies the deletion, like a mismatched REST route.
+	 * A post type guard that does not match the post denies the deletion.
 	 *
 	 * @since x.x.x
 	 */
@@ -380,8 +376,8 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	/**
 	 * Query-string style inputs are honored, as the DELETE transport delivers them.
 	 *
-	 * The Abilities REST run controller routes destructive idempotent abilities to the
-	 * DELETE method, whose input arrives as strings.
+	 * The Abilities API serves destructive idempotent abilities over the DELETE method,
+	 * whose input arrives as strings.
 	 *
 	 * @since x.x.x
 	 */

--- a/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
@@ -519,6 +519,51 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * A post of a post type registered by another plugin can be trashed and deleted.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_deletes_a_post_type_registered_by_another_plugin(): void {
+		register_post_type(
+			'wpai_book',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_book' ) );
+
+			$trashed = $this->delete(
+				array(
+					'id'     => $post_id,
+					'fields' => array( 'id', 'post_type', 'status' ),
+				)
+			);
+			$this->assertIsArray( $trashed, 'Trashing a book should succeed.' );
+			$this->assertSame( 'wpai_book', $trashed['post_type'], 'The trashed post should keep the custom post type.' );
+			$this->assertSame( 'trash', $trashed['status'], 'The book should be trashed.' );
+
+			$deleted = $this->delete(
+				array(
+					'id'    => $post_id,
+					'force' => true,
+				)
+			);
+			$this->assertIsArray( $deleted, 'Deleting a book should succeed.' );
+			$this->assertTrue( $deleted['deleted'], 'The book should be deleted.' );
+			$this->assertNull( get_post( $post_id ), 'The book should no longer exist.' );
+		} finally {
+			unregister_post_type( 'wpai_book' );
+		}
+	}
+
+	/**
 	 * A trashed post can still be read by ID through the query ability.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
@@ -50,21 +50,6 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The ability is not registered when no post types are exposed to it.
-	 *
-	 * @since x.x.x
-	 */
-	public function test_does_not_register_without_exposed_post_types(): void {
-		foreach ( array( 'post', 'page' ) as $post_type ) {
-			get_post_type_object( $post_type )->show_in_abilities = false;
-		}
-
-		$this->register_ability();
-
-		$this->assertFalse( wp_has_ability( 'core/content-delete' ), 'The delete ability should not register without any exposed post types.' );
-	}
-
-	/**
 	 * The input schema requires an ID, accepts a force flag, a post type guard, and a field selection, and rejects unknown properties.
 	 *
 	 * @since x.x.x
@@ -301,7 +286,7 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_delete_post_for_unexposed_post_type_is_denied(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_hidden_cpt',
 			array(
 				'public'   => true,
@@ -309,19 +294,15 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
 
-			$result = $this->delete( array( 'id' => $post_id ) );
+		$result = $this->delete( array( 'id' => $post_id ) );
 
-			$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
-			$this->assertSame( 'publish', get_post( $post_id )->post_status, 'The post should be untouched.' );
-		} finally {
-			unregister_post_type( 'wpai_hidden_cpt' );
-		}
+		$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
+		$this->assertSame( 'publish', get_post( $post_id )->post_status, 'The post should be untouched.' );
 	}
 
 	/**
@@ -524,7 +505,7 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_deletes_a_post_type_registered_by_another_plugin(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_book',
 			array(
 				'public'            => true,
@@ -533,34 +514,30 @@ class ContentDeleteTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_book' ) );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_book' ) );
 
-			$trashed = $this->delete(
-				array(
-					'id'     => $post_id,
-					'fields' => array( 'id', 'post_type', 'status' ),
-				)
-			);
-			$this->assertIsArray( $trashed, 'Trashing a book should succeed.' );
-			$this->assertSame( 'wpai_book', $trashed['post_type'], 'The trashed post should keep the custom post type.' );
-			$this->assertSame( 'trash', $trashed['status'], 'The book should be trashed.' );
+		$trashed = $this->delete(
+			array(
+				'id'     => $post_id,
+				'fields' => array( 'id', 'post_type', 'status' ),
+			)
+		);
+		$this->assertIsArray( $trashed, 'Trashing a book should succeed.' );
+		$this->assertSame( 'wpai_book', $trashed['post_type'], 'The trashed post should keep the custom post type.' );
+		$this->assertSame( 'trash', $trashed['status'], 'The book should be trashed.' );
 
-			$deleted = $this->delete(
-				array(
-					'id'    => $post_id,
-					'force' => true,
-				)
-			);
-			$this->assertIsArray( $deleted, 'Deleting a book should succeed.' );
-			$this->assertTrue( $deleted['deleted'], 'The book should be deleted.' );
-			$this->assertNull( get_post( $post_id ), 'The book should no longer exist.' );
-		} finally {
-			unregister_post_type( 'wpai_book' );
-		}
+		$deleted = $this->delete(
+			array(
+				'id'    => $post_id,
+				'force' => true,
+			)
+		);
+		$this->assertIsArray( $deleted, 'Deleting a book should succeed.' );
+		$this->assertTrue( $deleted['deleted'], 'The book should be deleted.' );
+		$this->assertNull( get_post( $post_id ), 'The book should no longer exist.' );
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentDeleteTest.php
@@ -1,0 +1,492 @@
+<?php
+/**
+ * Integration tests for the core/content-delete Ability provided by the plugin.
+ *
+ * The cases mirror the delete tests of the WordPress core REST posts controller
+ * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
+ * output shapes.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
+
+use WordPress\AI\Abilities\Content\Content;
+
+/**
+ * Content delete ability test case.
+ *
+ * @since x.x.x
+ */
+class ContentDeleteTest extends Content_Ability_TestCase {
+
+	/**
+	 * Deletes a post through the ability and returns the result.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return mixed The ability result.
+	 */
+	private function delete( array $input ) {
+		return $this->execute_ability( 'core/content-delete', $input );
+	}
+
+	/**
+	 * The ability is registered in the `content` category and flagged as an idempotent destructive write.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_registers_core_content_delete_ability(): void {
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/content-delete' );
+
+		$this->assertNotNull( $ability, 'The core/content-delete ability should be registered.' );
+		$this->assertSame( 'content', $ability->get_category(), 'The registered ability should use the content category.' );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'The ability should be exposed in REST.' );
+
+		$annotations = $ability->get_meta_item( 'annotations', array() );
+		$this->assertFalse( $annotations['readonly'], 'The ability should not be marked read-only.' );
+		$this->assertTrue( $annotations['destructive'], 'Deleting a post is destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'Repeating a deletion has no further effect.' );
+		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
+	}
+
+	/**
+	 * The ability is not registered when no post types are exposed to it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_does_not_register_without_exposed_post_types(): void {
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			get_post_type_object( $post_type )->show_in_abilities = false;
+		}
+
+		$this->register_ability();
+
+		$this->assertFalse( wp_has_ability( 'core/content-delete' ), 'The delete ability should not register without any exposed post types.' );
+	}
+
+	/**
+	 * The input schema requires an ID, accepts a force flag, a post type guard, and a field selection, and rejects unknown properties.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_input_schema_requires_id_and_accepts_force(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/content-delete' )->get_input_schema();
+
+		$this->assertSame( 'object', $schema['type'], 'The input schema should describe an object.' );
+		$this->assertSame( array( 'id' ), $schema['required'], 'Only the ID should be required.' );
+		$this->assertFalse( $schema['additionalProperties'], 'Unknown properties should be rejected.' );
+		$this->assertSame( array( 'id', 'post_type', 'force', 'fields' ), array_keys( $schema['properties'] ), 'The input should mirror the REST delete arguments plus the field selection.' );
+		$this->assertSame( 'boolean', $schema['properties']['force']['type'], 'Force should be a boolean.' );
+		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'The post type guard should only accept exposed post types.' );
+	}
+
+	/**
+	 * Unknown properties fail validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_rejects_unknown_properties(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		$result = $this->delete(
+			array(
+				'id'    => $post_id,
+				'title' => 'Not a delete field',
+			)
+		);
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'Unknown properties should fail validation.' );
+		$this->assertSame( 'publish', get_post( $post_id )->post_status, 'Nothing should be deleted when validation fails.' );
+	}
+
+	/**
+	 * The output schema describes either the trashed post or a deleted flag with the previous post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_output_schema_describes_trashed_and_deleted_responses(): void {
+		$this->register_ability();
+
+		$schema       = wp_get_ability( 'core/content-delete' )->get_output_schema();
+		$query_schema = wp_get_ability( 'core/content-query' )->get_output_schema();
+
+		$this->assertCount( 2, $schema['oneOf'], 'The output should have two shapes.' );
+		$this->assertSame( $query_schema['oneOf'][0], $schema['oneOf'][0], 'The trashed post should have the same shape as a queried post.' );
+		$this->assertSame( array( 'deleted', 'previous' ), $schema['oneOf'][1]['required'], 'A forced deletion should report the deleted flag and the previous post.' );
+		$this->assertSame( $query_schema['oneOf'][0], $schema['oneOf'][1]['properties']['previous'], 'The previous post should have the same shape as a queried post.' );
+	}
+
+	/**
+	 * A post is moved to the trash by default and returned with its new status.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_item(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
+
+		$result = $this->delete(
+			array(
+				'id'     => $post_id,
+				'force'  => false,
+				'fields' => array( 'id', 'status', 'title_raw' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Trashing a post should return the trashed post.' );
+		$this->assertSame( $post_id, $result['id'], 'The trashed post should be returned.' );
+		$this->assertSame( 'Deleted post', $result['title_raw'], 'The trashed post should keep its title.' );
+		$this->assertSame( 'trash', $result['status'], 'The returned status should be trash.' );
+		$this->assertSame( 'trash', get_post( $post_id )->post_status, 'The stored status should be trash.' );
+	}
+
+	/**
+	 * Without a force flag the post is trashed rather than deleted.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_item_trashes_by_default(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		$result = $this->delete( array( 'id' => $post_id ) );
+
+		$this->assertIsArray( $result, 'Trashing a post should return the trashed post.' );
+		$this->assertSame( array( 'id', 'post_type', 'status', 'date', 'slug', 'title_rendered' ), array_keys( $result ), 'The default field set should match the query ability.' );
+		$this->assertSame( 'trash', $result['status'], 'The post should be trashed.' );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $post_id ), 'The post should still exist.' );
+	}
+
+	/**
+	 * A forced deletion removes the post and returns it under `previous`.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_item_skip_trash(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
+
+		$result = $this->delete(
+			array(
+				'id'     => $post_id,
+				'force'  => true,
+				'fields' => array( 'id', 'status', 'title_raw' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Deleting a post should return a result.' );
+		$this->assertSame( array( 'deleted', 'previous' ), array_keys( $result ), 'A forced deletion should report the deleted flag and the previous post.' );
+		$this->assertTrue( $result['deleted'], 'The post should be reported as deleted.' );
+		$this->assertSame( $post_id, $result['previous']['id'], 'The previous post should be the deleted one.' );
+		$this->assertSame( 'Deleted post', $result['previous']['title_raw'], 'The previous post should carry its values before deletion.' );
+		$this->assertSame( 'publish', $result['previous']['status'], 'The previous post should carry its status before deletion.' );
+		$this->assertNull( get_post( $post_id ), 'The post should no longer exist.' );
+	}
+
+	/**
+	 * A forced deletion with an empty field projection still returns an object for the previous post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_item_skip_trash_with_empty_projection(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		// Posts are not hierarchical, so the projection is empty.
+		$result = $this->delete(
+			array(
+				'id'     => $post_id,
+				'force'  => true,
+				'fields' => array( 'parent' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'Deleting a post should return a result.' );
+		$this->assertTrue( $result['deleted'], 'The post should be reported as deleted.' );
+		$this->assertEquals( (object) array(), $result['previous'], 'An empty projection should be an empty object, not a list.' );
+	}
+
+	/**
+	 * Trashing an already trashed post is an error, while forcing still deletes it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_item_already_trashed(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Deleted post' ) );
+
+		$first = $this->delete( array( 'id' => $post_id ) );
+		$this->assertIsArray( $first, 'The first deletion should trash the post.' );
+
+		$second = $this->delete( array( 'id' => $post_id ) );
+		$this->assertAbilityError( $second, 'content_already_trashed', 'Trashing a trashed post should be an error.' );
+		$this->assertSame( 410, $second->get_error_data()['status'], 'An already trashed post should be reported as gone.' );
+
+		$forced = $this->delete(
+			array(
+				'id'    => $post_id,
+				'force' => true,
+			)
+		);
+		$this->assertIsArray( $forced, 'A forced deletion of a trashed post should succeed.' );
+		$this->assertTrue( $forced['deleted'], 'The trashed post should be deleted.' );
+		$this->assertNull( get_post( $post_id ), 'The post should no longer exist.' );
+	}
+
+	/**
+	 * A missing post is denied before execution, and a direct call reports it as not found.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_post_invalid_id(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->delete( array( 'id' => 999999 ) );
+		$this->assertAbilityDenied( $result, 'A missing post should be denied before execution.' );
+
+		$direct = ( new Content() )->execute_content_delete( array( 'id' => 999999 ) );
+		$this->assertAbilityError( $direct, 'content_not_found', 'A direct call should still fail closed on a missing post.' );
+	}
+
+	/**
+	 * A post type guard that does not match the post denies the deletion, like a mismatched REST route.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_post_invalid_post_type(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$mismatched = $this->delete(
+			array(
+				'id'        => $page_id,
+				'post_type' => 'post',
+			)
+		);
+		$this->assertAbilityDenied( $mismatched, 'A mismatched post type guard should deny the deletion.' );
+		$this->assertSame( 'publish', get_post( $page_id )->post_status, 'The page should be untouched.' );
+
+		$matching = $this->delete(
+			array(
+				'id'        => $page_id,
+				'post_type' => 'page',
+				'fields'    => array( 'id', 'status' ),
+			)
+		);
+		$this->assertIsArray( $matching, 'A matching post type guard should allow the deletion.' );
+		$this->assertSame( 'trash', $matching['status'], 'The page should be trashed.' );
+	}
+
+	/**
+	 * A post from a post type not exposed to abilities cannot be deleted.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_post_for_unexposed_post_type_is_denied(): void {
+		register_post_type(
+			'wpai_hidden_cpt',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
+
+			$result = $this->delete( array( 'id' => $post_id ) );
+
+			$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
+			$this->assertSame( 'publish', get_post( $post_id )->post_status, 'The post should be untouched.' );
+		} finally {
+			unregister_post_type( 'wpai_hidden_cpt' );
+		}
+	}
+
+	/**
+	 * Users who cannot delete the post are denied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_post_without_permission(): void {
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_author' => self::$user_ids['editor'] ) );
+
+		wp_set_current_user( 0 );
+		$this->assertAbilityDenied( $this->delete( array( 'id' => $post_id ) ), 'A logged-out user should not delete posts.' );
+
+		$this->login_as( 'subscriber' );
+		$this->assertAbilityDenied( $this->delete( array( 'id' => $post_id ) ), 'A subscriber should not delete posts.' );
+
+		$this->login_as( 'author' );
+		$this->assertAbilityDenied( $this->delete( array( 'id' => $post_id ) ), "An author should not delete another user's post." );
+
+		$this->assertSame( 'publish', get_post( $post_id )->post_status, 'Denied deletions should not write.' );
+	}
+
+	/**
+	 * An author can delete their own draft.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_author_can_delete_own_draft(): void {
+		$author_id = $this->login_as( 'author' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $this->delete(
+			array(
+				'id'     => $post_id,
+				'fields' => array( 'id', 'status' ),
+			)
+		);
+
+		$this->assertIsArray( $result, 'An author should be able to delete their own draft.' );
+		$this->assertSame( 'trash', $result['status'], 'The draft should be trashed.' );
+	}
+
+	/**
+	 * Query-string style inputs are honored, as the DELETE transport delivers them.
+	 *
+	 * The Abilities REST run controller routes destructive idempotent abilities to the
+	 * DELETE method, whose input arrives as strings.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_string_inputs_are_honored(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$content  = new Content();
+		$post_id  = self::factory()->post->create();
+		$as_query = array(
+			'id'     => (string) $post_id,
+			'force'  => 'false',
+			'fields' => 'id,status',
+		);
+
+		$this->assertTrue( $content->check_delete_permission( $as_query ), 'A string ID should resolve the post.' );
+
+		$trashed = $content->execute_content_delete( $as_query );
+		$this->assertIsArray( $trashed, 'A "false" force string should trash the post.' );
+		$this->assertSame( array( 'id', 'status' ), array_keys( $trashed ), 'A CSV field list should be honored.' );
+		$this->assertSame( 'trash', $trashed['status'], 'The post should be trashed.' );
+
+		$deleted = $content->execute_content_delete(
+			array(
+				'id'    => (string) $post_id,
+				'force' => 'true',
+			)
+		);
+		$this->assertIsArray( $deleted, 'A "true" force string should delete the post.' );
+		$this->assertTrue( $deleted['deleted'], 'The post should be deleted.' );
+		$this->assertNull( get_post( $post_id ), 'The post should no longer exist.' );
+	}
+
+	/**
+	 * A trashing that core refuses is reported as a failure.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_reports_a_refused_trash(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		add_filter( 'pre_trash_post', '__return_false' );
+		try {
+			$result = $this->delete( array( 'id' => $post_id ) );
+		} finally {
+			remove_filter( 'pre_trash_post', '__return_false' );
+		}
+
+		$this->assertAbilityError( $result, 'content_cannot_delete', 'A refused trash should be reported.' );
+		$this->assertSame( 500, $result->get_error_data()['status'], 'A refused trash should be a server error.' );
+		$this->assertSame( 'publish', get_post( $post_id )->post_status, 'The post should be untouched.' );
+	}
+
+	/**
+	 * A deletion that core refuses is reported as a failure.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_delete_reports_a_refused_deletion(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		add_filter( 'pre_delete_post', '__return_false' );
+		try {
+			$result = $this->delete(
+				array(
+					'id'    => $post_id,
+					'force' => true,
+				)
+			);
+		} finally {
+			remove_filter( 'pre_delete_post', '__return_false' );
+		}
+
+		$this->assertAbilityError( $result, 'content_cannot_delete', 'A refused deletion should be reported.' );
+		$this->assertInstanceOf( \WP_Post::class, get_post( $post_id ), 'The post should still exist.' );
+	}
+
+	/**
+	 * A trashed post can still be read by ID through the query ability.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_trashed_post_is_still_readable_by_id(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create();
+
+		$this->delete( array( 'id' => $post_id ) );
+
+		$read = $this->execute_ability(
+			'core/content-query',
+			array(
+				'id'     => $post_id,
+				'fields' => array( 'id', 'status' ),
+			)
+		);
+
+		$this->assertIsArray( $read, 'Reading a trashed post by ID should succeed for a user who can edit it.' );
+		$this->assertSame( 'trash', $read['status'], 'The trashed post should report the trash status.' );
+	}
+}

--- a/tests/Integration/Includes/Abilities/Content/ContentTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentTest.php
@@ -128,11 +128,12 @@ class ContentTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The content ability is not registered when no post types are exposed to it.
+	 * No content ability is registered when no post types are exposed to them.
 	 *
 	 * @since 1.2.0
+	 * @since x.x.x Covers the write abilities too.
 	 */
-	public function test_does_not_register_core_content_query_ability_without_exposed_post_types(): void {
+	public function test_does_not_register_content_abilities_without_exposed_post_types(): void {
 		foreach ( array( 'post', 'page' ) as $post_type ) {
 			$object = get_post_type_object( $post_type );
 			$this->assertNotFalse( $object, "Precondition: the {$post_type} post type should exist." );
@@ -142,7 +143,9 @@ class ContentTest extends Content_Ability_TestCase {
 
 		$this->register_ability();
 
-		$this->assertFalse( wp_has_ability( 'core/content-query' ), 'The content ability should not register without any exposed post types.' );
+		foreach ( self::CONTENT_ABILITIES as $ability_name ) {
+			$this->assertFalse( wp_has_ability( $ability_name ), "The {$ability_name} ability should not register without any exposed post types." );
+		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Content/ContentTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentTest.php
@@ -7,25 +7,14 @@
 
 namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
 
-use WP_UnitTestCase;
 use WordPress\AI\Abilities\Content\Content;
-use WordPress\AI\Abilities\Show_In_Abilities;
 
 /**
  * Content ability test case.
  *
  * @since 1.2.0
  */
-class ContentTest extends WP_UnitTestCase {
-
-	/**
-	 * Shared user IDs keyed by role or fixture name.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @var array<string, int>
-	 */
-	private static $user_ids = array();
+class ContentTest extends Content_Ability_TestCase {
 
 	/**
 	 * Shared post IDs keyed by fixture name.
@@ -37,21 +26,14 @@ class ContentTest extends WP_UnitTestCase {
 	private static $post_ids = array();
 
 	/**
-	 * Creates shared users and posts for the content ability tests.
+	 * Creates the shared posts for the content query ability tests.
 	 *
 	 * @since 1.2.0
 	 *
 	 * @param \WP_UnitTest_Factory $factory The unit test factory.
 	 */
 	public static function wpSetUpBeforeClass( $factory ): void {
-		self::$user_ids = array(
-			'administrator'    => $factory->user->create( array( 'role' => 'administrator' ) ),
-			'editor'           => $factory->user->create( array( 'role' => 'editor' ) ),
-			'subscriber'       => $factory->user->create( array( 'role' => 'subscriber' ) ),
-			'contributor'      => $factory->user->create( array( 'role' => 'contributor' ) ),
-			'author'           => $factory->user->create( array( 'role' => 'author' ) ),
-			'author_secondary' => $factory->user->create( array( 'role' => 'author' ) ),
-		);
+		parent::wpSetUpBeforeClass( $factory );
 
 		self::$post_ids = array(
 			'published'                  => $factory->post->create( array( 'post_status' => 'publish' ) ),
@@ -105,132 +87,6 @@ class ContentTest extends WP_UnitTestCase {
 					'post_password' => 'secret',
 					'post_content'  => 'Hidden rendered body.',
 				)
-			),
-		);
-	}
-
-	/**
-	 * Set up test case.
-	 *
-	 * @since 1.2.0
-	 */
-	public function setUp(): void {
-		parent::setUp();
-
-		// Mark the curated core post types (post, page) as exposed to abilities.
-		( new Show_In_Abilities() )->register();
-
-		$this->ensure_ability_category( 'content' );
-
-		/*
-		 * The plugin registers its other abilities on the same abilities-init hook, so
-		 * booting the registry here also registers `core/read-settings` (the `site`
-		 * category) and `core/users-query` (the `user` category). Make sure those
-		 * categories exist too; otherwise their registration emits an "incorrect usage"
-		 * notice that fails these tests.
-		 */
-		$this->ensure_ability_category( 'site' );
-		$this->ensure_ability_category( 'user' );
-	}
-
-	/**
-	 * Tear down test case.
-	 *
-	 * @since 1.2.0
-	 */
-	public function tearDown(): void {
-		foreach ( array( 'core/content-query', 'core/read-content' ) as $ability_name ) {
-			if ( ! wp_has_ability( $ability_name ) ) {
-				continue;
-			}
-
-			wp_unregister_ability( $ability_name );
-		}
-
-		// Restore the curated post types to their unmarked state to avoid leaking into other tests.
-		foreach ( array( 'post', 'page' ) as $post_type ) {
-			$object = get_post_type_object( $post_type );
-			if ( ! $object ) {
-				continue;
-			}
-
-			unset( $object->show_in_abilities );
-		}
-
-		wp_set_current_user( 0 );
-
-		parent::tearDown();
-	}
-
-	/**
-	 * Ensures an ability category exists for an ability to attach to.
-	 *
-	 * @since 1.2.0
-	 *
-	 * @param string $slug The ability category slug.
-	 */
-	private function ensure_ability_category( string $slug ): void {
-		if ( wp_has_ability_category( $slug ) ) {
-			return;
-		}
-
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			wp_register_ability_category(
-				$slug,
-				array(
-					'label'       => ucfirst( $slug ),
-					'description' => ucfirst( $slug ) . '.',
-				)
-			);
-		} finally {
-			array_pop( $wp_current_filter );
-		}
-	}
-
-	/**
-	 * Registers the plugin's core/content-query ability inside a faked init action.
-	 *
-	 * @since 1.2.0
-	 */
-	private function register_ability(): void {
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
-		try {
-			( new Content() )->register();
-		} finally {
-			array_pop( $wp_current_filter );
-		}
-	}
-
-	/**
-	 * Logs in as a user with the given role and returns the user ID.
-	 *
-	 * @param string $role The role to log in as.
-	 * @return int The user ID.
-	 */
-	private function login_as( string $role ): int {
-		$user_id = self::$user_ids[ $role ] ?? self::factory()->user->create( array( 'role' => $role ) );
-		wp_set_current_user( $user_id );
-		return $user_id;
-	}
-
-	/**
-	 * Returns roles that can read public posts but cannot edit another user's post.
-	 *
-	 * @return array<string, array{role: string}> Role test cases.
-	 */
-	public function data_roles_without_edit_access_to_other_users_posts(): array {
-		return array(
-			'subscriber'  => array(
-				'role' => 'subscriber',
-			),
-			'contributor' => array(
-				'role' => 'contributor',
-			),
-			'author'      => array(
-				'role' => 'author',
 			),
 		);
 	}

--- a/tests/Integration/Includes/Abilities/Content/ContentTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentTest.php
@@ -114,6 +114,20 @@ class ContentTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * Registering the content abilities registers the query ability and the three write abilities together.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_registers_all_content_abilities(): void {
+		$this->register_ability();
+
+		foreach ( array( 'core/content-query', 'core/content-create', 'core/content-update', 'core/content-delete' ) as $ability_name ) {
+			$this->assertTrue( wp_has_ability( $ability_name ), "The {$ability_name} ability should be registered." );
+			$this->assertSame( 'content', wp_get_ability( $ability_name )->get_category(), "The {$ability_name} ability should use the content category." );
+		}
+	}
+
+	/**
 	 * The content ability is not registered when no post types are exposed to it.
 	 *
 	 * @since 1.2.0

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -1449,6 +1449,105 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * The title, content, and excerpt can be given as objects with a `raw` key.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_raw(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'title'   => array( 'raw' => 'Raw title' ),
+				'content' => array( 'raw' => 'Raw content' ),
+				'excerpt' => array( 'raw' => 'Raw excerpt' ),
+				'fields'  => array( 'id', 'title_raw', 'content_raw', 'excerpt_raw' ),
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'Raw title', $result['title_raw'], 'The returned raw title should match the raw object.' );
+		$this->assertSame( 'Raw content', $result['content_raw'], 'The returned raw content should match the raw object.' );
+		$this->assertSame( 'Raw excerpt', $result['excerpt_raw'], 'The returned raw excerpt should match the raw object.' );
+		$this->assertSame( 'Raw title', $post->post_title, 'The stored title should match the raw object.' );
+		$this->assertSame( 'Raw content', $post->post_content, 'The stored content should match the raw object.' );
+		$this->assertSame( 'Raw excerpt', $post->post_excerpt, 'The stored excerpt should match the raw object.' );
+	}
+
+	/**
+	 * An empty raw title object is ignored, while empty raw content and excerpt objects clear the fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_empty_raw_objects(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'title'   => array( 'raw' => '' ),
+				'content' => array( 'raw' => '' ),
+				'excerpt' => array( 'raw' => '' ),
+				'fields'  => array( 'id', 'title_raw', 'content_raw', 'excerpt_raw' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'Original title', $result['title_raw'], 'An empty raw title should be ignored.' );
+		$this->assertSame( '', $result['content_raw'], 'An empty raw content should clear the content.' );
+		$this->assertSame( '', $result['excerpt_raw'], 'An empty raw excerpt should clear the excerpt.' );
+	}
+
+	/**
+	 * A raw object without a `raw` string is rejected by the schema.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_invalid_raw_object(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'    => self::$post_id,
+				'title' => array( 'raw' => array( 'nested' ) ),
+			)
+		);
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'A raw value that is not a string should fail validation.' );
+	}
+
+	/**
+	 * The menu order of a page can be set and reset to zero.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_page_menu_order_to_zero(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id = self::factory()->post->create(
+			array(
+				'post_type'  => 'page',
+				'menu_order' => 1,
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'         => $page_id,
+				'menu_order' => 0,
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $page_id );
+		$this->assertSame( 0, $post->menu_order, 'The menu order should be reset to zero.' );
+	}
+
+	/**
 	 * A database failure surfaces as the update error with a server error status.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -2,10 +2,6 @@
 /**
  * Integration tests for the core/content-update Ability provided by the plugin.
  *
- * The cases mirror the update tests of the WordPress core REST posts controller
- * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
- * output shapes.
- *
  * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
  */
 
@@ -60,7 +56,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Returns an update input with every common field set, like the REST test suite's post data.
+	 * Returns an update input with every common field set.
 	 *
 	 * @since x.x.x
 	 *
@@ -96,8 +92,6 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 
 	/**
 	 * Asserts that an update result describes the updated post.
-	 *
-	 * The ability counterpart of the REST suite's check_update_post_response().
 	 *
 	 * @since x.x.x
 	 *
@@ -202,11 +196,11 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The input schema requires an ID, accepts a post type guard and the REST writable fields, and rejects unknown properties.
+	 * The input schema requires an ID, accepts a post type guard and the writable fields, and rejects unknown properties.
 	 *
 	 * @since x.x.x
 	 */
-	public function test_input_schema_requires_id_and_mirrors_the_rest_writable_fields(): void {
+	public function test_input_schema_requires_id_and_lists_the_writable_fields(): void {
 		$this->register_ability();
 
 		$schema = wp_get_ability( 'core/content-update' )->get_input_schema();
@@ -239,7 +233,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 			'tags',
 			'fields',
 		);
-		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should mirror the REST posts item schema, with taxonomies under their REST keys.' );
+		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should be listed, with taxonomies under their rest_base keys.' );
 		$this->assertSame( 1, $schema['properties']['id']['minimum'], 'The ID should be a positive integer.' );
 		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'The post type guard should only accept exposed post types.' );
 
@@ -250,8 +244,8 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	/**
 	 * Read-only post fields are rejected rather than ignored.
 	 *
-	 * The REST controller ignores its read-only properties on update; the strict ability
-	 * schema rejects them, so a caller never believes it changed something it cannot.
+	 * The strict schema rejects read-only post fields, so a caller never believes it changed
+	 * something it cannot.
 	 *
 	 * @since x.x.x
 	 */
@@ -549,7 +543,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * A post type guard that does not match the post denies the update, like a mismatched REST route.
+	 * A post type guard that does not match the post denies the update.
 	 *
 	 * @since x.x.x
 	 */
@@ -617,7 +611,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$invalid = $this->update( $this->post_data( array( 'format' => 'testformat' ) ) );
 		$this->assertAbilityError( $invalid, 'ability_invalid_input', 'An unknown format should fail validation.' );
 
-		// A valid format the theme does not support is still assigned, like REST.
+		// A valid format the theme does not support is still assigned.
 		$unsupported = $this->update( $this->post_data( array( 'format' => 'link' ) ) );
 		$this->assert_updated_post( $unsupported, self::$post_id );
 		$this->assertSame( 'link', get_post_format( self::$post_id ), 'A theme-unsupported format should still be assigned.' );
@@ -725,7 +719,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * The slug is stored and sanitized like the REST slug argument.
+	 * The slug is stored and sanitized like a title.
 	 *
 	 * @since x.x.x
 	 */
@@ -945,7 +939,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Tags are assigned under the REST `tags` key.
+	 * Tags are assigned under the `tags` key.
 	 *
 	 * @since x.x.x
 	 */
@@ -1098,7 +1092,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		);
 		$this->assertAbilityError( $private, 'content_cannot_publish', 'A contributor should not make posts private.' );
 
-		// Sending the current status is always allowed, like the REST status validation.
+		// Sending the current status is always allowed, even when the user could not set it.
 		$same = $this->update(
 			array(
 				'id'     => $post_id,

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -175,8 +175,8 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 
 		$annotations = $ability->get_meta_item( 'annotations', array() );
 		$this->assertFalse( $annotations['readonly'], 'The ability should not be marked read-only.' );
-		$this->assertFalse( $annotations['destructive'], 'Updating keeps revisions, so the ability is not flagged destructive.' );
-		$this->assertTrue( $annotations['idempotent'], 'Repeating the same update leaves the post unchanged.' );
+		$this->assertTrue( $annotations['destructive'], 'Updating overwrites post fields, so the ability is flagged destructive.' );
+		$this->assertFalse( $annotations['idempotent'], 'Every update touches the modified date, and the ability must stay on the POST method.' );
 		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
 	}
 
@@ -1294,12 +1294,29 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$this->assert_updated_post( $set, self::$post_id );
 		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( self::$post_id ), 'The attachment should be the post thumbnail.' );
 
+		// Re-sending the current featured media is not a failure.
+		$unchanged = $this->update( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
+		$this->assert_updated_post( $unchanged, self::$post_id );
+		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( self::$post_id ), 'The attachment should stay the post thumbnail.' );
+
 		$removed = $this->update( $this->post_data( array( 'featured_media' => 0 ) ) );
 		$this->assert_updated_post( $removed, self::$post_id );
 		$this->assertSame( 0, (int) get_post_thumbnail_id( self::$post_id ), 'The post thumbnail should be removed.' );
 
 		$invalid = $this->update( $this->post_data( array( 'featured_media' => 999999 ) ) );
 		$this->assertAbilityError( $invalid, 'content_invalid_featured_media', 'An invalid featured media ID should be reported.' );
+		$this->assertSame( 'Post Title', get_post( self::$post_id )->post_title, 'The previous update should have been applied, and the invalid one not at all.' );
+
+		// A non-image attachment cannot replace an image, and does not remove it either.
+		$this->update( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
+		$text_id  = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/formatting/utf-8/utf-8.txt',
+			0,
+			array( 'post_mime_type' => 'text/plain' )
+		);
+		$non_image = $this->update( $this->post_data( array( 'featured_media' => $text_id ) ) );
+		$this->assertAbilityError( $non_image, 'content_invalid_featured_media', 'A non-image attachment should be rejected as featured media.' );
+		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( self::$post_id ), 'The existing featured image should be kept.' );
 	}
 
 	/**
@@ -1477,7 +1494,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * An empty raw title object is ignored, while empty raw content and excerpt objects clear the fields.
+	 * An empty raw object clears the field exactly like an empty string.
 	 *
 	 * @since x.x.x
 	 */
@@ -1485,20 +1502,33 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$this->login_as( 'editor' );
 		$this->register_ability();
 
+		$fields = array( 'id', 'title_raw', 'content_raw', 'excerpt_raw' );
+
 		$result = $this->update(
 			array(
 				'id'      => self::$post_id,
-				'title'   => array( 'raw' => '' ),
 				'content' => array( 'raw' => '' ),
 				'excerpt' => array( 'raw' => '' ),
-				'fields'  => array( 'id', 'title_raw', 'content_raw', 'excerpt_raw' ),
+				'fields'  => $fields,
 			)
 		);
 
 		$this->assert_updated_post( $result, self::$post_id );
-		$this->assertSame( 'Original title', $result['title_raw'], 'An empty raw title should be ignored.' );
+		$this->assertSame( 'Original title', $result['title_raw'], 'An omitted title should be kept.' );
 		$this->assertSame( '', $result['content_raw'], 'An empty raw content should clear the content.' );
 		$this->assertSame( '', $result['excerpt_raw'], 'An empty raw excerpt should clear the excerpt.' );
+
+		$result = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'title'   => array( 'raw' => '' ),
+				'content' => 'Kept so the post is not empty',
+				'fields'  => $fields,
+			)
+		);
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( '', $result['title_raw'], 'An empty raw title should clear the title, like an empty string.' );
 	}
 
 	/**
@@ -1510,14 +1540,224 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$this->login_as( 'editor' );
 		$this->register_ability();
 
-		$result = $this->update(
+		$nested = $this->update(
 			array(
 				'id'    => self::$post_id,
 				'title' => array( 'raw' => array( 'nested' ) ),
 			)
 		);
+		$this->assertAbilityError( $nested, 'ability_invalid_input', 'A raw value that is not a string should fail validation.' );
 
-		$this->assertAbilityError( $result, 'ability_invalid_input', 'A raw value that is not a string should fail validation.' );
+		$without_raw = $this->update(
+			array(
+				'id'    => self::$post_id,
+				'title' => array( 'rendered' => 'New' ),
+			)
+		);
+		$this->assertAbilityError( $without_raw, 'ability_invalid_input', 'A raw object without a raw key should fail validation.' );
+		$this->assertSame( 'Original title', get_post( self::$post_id )->post_title, 'Nothing should be written when validation fails.' );
+	}
+
+	/**
+	 * A post keeps its current status even when that status is internal, such as trash.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_trashed_post_keeps_its_status(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_title' => 'In the trash' ) );
+		wp_trash_post( $post_id );
+
+		$result = $this->update(
+			array(
+				'id'     => $post_id,
+				'status' => 'trash',
+				'title'  => 'Fixed while trashed',
+				'fields' => array( 'id', 'status', 'title_raw' ),
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $post_id );
+		$this->assertSame( 'trash', $result['status'], 'The trashed post should keep its status.' );
+		$this->assertSame( 'Fixed while trashed', $post->post_title, 'The title should be updated.' );
+	}
+
+	/**
+	 * A status that is not registered, or is internal, cannot be set.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_invalid_status(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$unknown = $this->update( $this->post_data( array( 'status' => 'teststatus' ) ) );
+		$this->assertAbilityError( $unknown, 'content_invalid_status', 'An unknown status should be rejected.' );
+
+		$internal = $this->update( $this->post_data( array( 'status' => 'trash' ) ) );
+		$this->assertAbilityError( $internal, 'content_invalid_status', 'A post cannot be moved to the trash through an update.' );
+		$this->assertSame( 'publish', get_post( self::$post_id )->post_status, 'The post should keep its status.' );
+	}
+
+	/**
+	 * A page accepts an excerpt.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_page_excerpt(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$result = $this->update(
+			array(
+				'id'      => $page_id,
+				'excerpt' => 'Page summary',
+				'fields'  => array( 'id', 'excerpt_raw' ),
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $page_id );
+		$this->assertSame( 'Page summary', $result['excerpt_raw'], 'The excerpt should be returned for the page.' );
+		$this->assertSame( 'Page summary', $post->post_excerpt, 'The excerpt should be stored on the page.' );
+	}
+
+	/**
+	 * A draft child page's slug is made unique among its siblings, not among top-level pages.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_draft_child_page_slug_is_unique_among_siblings(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		self::factory()->post->create(
+			array(
+				'post_type' => 'page',
+				'post_name' => 'team',
+			)
+		);
+		$parent_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+				'post_name'   => 'team',
+			)
+		);
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_parent' => $parent_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'     => $draft_id,
+				'slug'   => 'team',
+				'fields' => array( 'id', 'slug' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $draft_id );
+		$this->assertSame( 'team-2', $result['slug'], 'The slug should be made unique among the sibling pages.' );
+
+		$top_level_draft = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'draft',
+			)
+		);
+		$result          = $this->update(
+			array(
+				'id'     => $top_level_draft,
+				'slug'   => 'about',
+				'fields' => array( 'id', 'slug' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $top_level_draft );
+		$this->assertSame( 'about', $result['slug'], 'A slug that no sibling uses should be kept.' );
+	}
+
+	/**
+	 * A nonexistent term ID is rejected before anything is written.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_unknown_category_is_rejected(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$category = wp_insert_term( 'Existing', 'category' );
+		wp_set_object_terms( self::$post_id, $category['term_id'], 'category' );
+
+		$result = $this->update(
+			$this->post_data(
+				array(
+					'title'      => 'Not applied',
+					'categories' => array( $category['term_id'], 999999 ),
+				)
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_term', 'An unknown term ID should be rejected.' );
+		$this->assertSame( array( $category['term_id'] ), wp_get_post_categories( self::$post_id ), 'The existing category should be kept.' );
+		$this->assertSame( 'Original title', get_post( self::$post_id )->post_title, 'Nothing should be written when a term is unknown.' );
+	}
+
+	/**
+	 * An author of 0 is ignored, so a post can be written back as it was read.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_ignores_author_zero(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'     => self::$post_id,
+				'author' => 0,
+				'title'  => 'Author untouched',
+				'fields' => array( 'id', 'title_raw', 'author' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'Author untouched', $result['title_raw'], 'The title should be updated.' );
+		$this->assertSame( self::$user_ids['editor'], $result['author']['id'], 'The author should be unchanged.' );
+	}
+
+	/**
+	 * Whole floats and numeric strings that pass integer validation resolve the post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_execute_callback_accepts_every_integer_form(): void {
+		$this->login_as( 'editor' );
+
+		$content = new Content();
+
+		foreach ( array( (float) self::$post_id, (string) self::$post_id . '.0', '+' . self::$post_id ) as $id ) {
+			$this->assertTrue( $content->check_update_permission( array( 'id' => $id ) ), 'The permission gate should resolve the post from ' . var_export( $id, true ) . '.' );
+
+			$result = $content->execute_content_update(
+				array(
+					'id'     => $id,
+					'title'  => 'Resolved',
+					'fields' => array( 'id' ),
+				)
+			);
+
+			$this->assertIsArray( $result, 'The post should be updated from ' . var_export( $id, true ) . '.' );
+			$this->assertSame( self::$post_id, $result['id'], 'The resolved post should be the requested one.' );
+		}
 	}
 
 	/**

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -1548,6 +1548,52 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
+	 * A post of a post type registered by another plugin can be updated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_updates_a_post_type_registered_by_another_plugin(): void {
+		register_post_type(
+			'wpai_book',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title', 'editor' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$post_id = self::factory()->post->create(
+				array(
+					'post_type'    => 'wpai_book',
+					'post_title'   => 'A book',
+					'post_content' => 'Chapter one.',
+				)
+			);
+
+			$result = $this->update(
+				array(
+					'id'        => $post_id,
+					'post_type' => 'wpai_book',
+					'title'     => 'A better book',
+					'content'   => 'Chapter two.',
+					'fields'    => array( 'id', 'post_type', 'title_raw', 'content_raw' ),
+				)
+			);
+
+			$this->assert_updated_post( $result, $post_id );
+			$this->assertSame( 'wpai_book', $result['post_type'], 'The post should keep the custom post type.' );
+			$this->assertSame( 'A better book', $result['title_raw'], 'The title should be updated.' );
+			$this->assertSame( 'Chapter two.', $result['content_raw'], 'The content should be updated.' );
+		} finally {
+			unregister_post_type( 'wpai_book' );
+		}
+	}
+
+	/**
 	 * A database failure surfaces as the update error with a server error status.
 	 *
 	 * @since x.x.x

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -23,16 +23,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	 *
 	 * @var int
 	 */
-	private static $post_id;
-
-	/**
-	 * The category the current user is forbidden to assign, when set.
-	 *
-	 * @since x.x.x
-	 *
-	 * @var int
-	 */
-	private $forbidden_category = 0;
+	private static int $post_id = 0;
 
 	/**
 	 * Creates the shared post for the update ability tests.
@@ -110,56 +101,6 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Disables UPDATE queries on the posts table so wp_update_post() fails with a database error.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string $query The database query.
-	 * @return string The query, broken when it updates the posts table.
-	 */
-	public function error_update_query( string $query ): string {
-		global $wpdb;
-
-		if ( 0 === strpos( $query, "UPDATE `{$wpdb->posts}`" ) ) {
-			$query = '],';
-		}
-
-		return $query;
-	}
-
-	/**
-	 * Offers one post template for the tests that need a valid template.
-	 *
-	 * @since x.x.x
-	 *
-	 * @return array<string, string> The post templates keyed by file name.
-	 */
-	public function filter_theme_post_templates(): array {
-		return array(
-			'post-my-test-template.php' => 'My Test Template',
-		);
-	}
-
-	/**
-	 * Revokes the assign_term meta capability for the forbidden category.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string[] $caps    The primitive capabilities.
-	 * @param string   $cap     The meta capability being checked.
-	 * @param int      $user_id The user ID.
-	 * @param mixed[]  $args    The capability arguments.
-	 * @return string[] The primitive capabilities.
-	 */
-	public function revoke_assign_term( array $caps, string $cap, int $user_id, array $args ): array {
-		if ( 'assign_term' === $cap && isset( $args[0] ) && $this->forbidden_category === $args[0] ) {
-			$caps = array( 'do_not_allow' );
-		}
-
-		return $caps;
-	}
-
-	/**
 	 * The ability is registered in the `content` category and flagged as an idempotent write.
 	 *
 	 * @since x.x.x
@@ -178,21 +119,6 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$this->assertTrue( $annotations['destructive'], 'Updating overwrites post fields, so the ability is flagged destructive.' );
 		$this->assertFalse( $annotations['idempotent'], 'Every update touches the modified date, and the ability must stay on the POST method.' );
 		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
-	}
-
-	/**
-	 * The ability is not registered when no post types are exposed to it.
-	 *
-	 * @since x.x.x
-	 */
-	public function test_does_not_register_without_exposed_post_types(): void {
-		foreach ( array( 'post', 'page' ) as $post_type ) {
-			get_post_type_object( $post_type )->show_in_abilities = false;
-		}
-
-		$this->register_ability();
-
-		$this->assertFalse( wp_has_ability( 'core/content-update' ), 'The update ability should not register without any exposed post types.' );
 	}
 
 	/**
@@ -564,7 +490,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_update_post_for_unexposed_post_type_is_denied(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_hidden_cpt',
 			array(
 				'public'   => true,
@@ -572,23 +498,19 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
+		$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
 
-			$result = $this->update(
-				array(
-					'id'    => $post_id,
-					'title' => 'Hidden',
-				)
-			);
+		$result = $this->update(
+			array(
+				'id'    => $post_id,
+				'title' => 'Hidden',
+			)
+		);
 
-			$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
-		} finally {
-			unregister_post_type( 'wpai_hidden_cpt' );
-		}
+		$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
 	}
 
 	/**
@@ -1232,20 +1154,6 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	}
 
 	/**
-	 * Provides fields that a post type does not support.
-	 *
-	 * @return array<string, array{0: string, 1: string, 2: mixed}> Post type, field, and value.
-	 */
-	public function data_unsupported_fields(): array {
-		return array(
-			'parent on a post'     => array( 'post', 'parent', 0 ),
-			'menu order on a post' => array( 'post', 'menu_order', 1 ),
-			'sticky on a page'     => array( 'page', 'sticky', true ),
-			'format on a page'     => array( 'page', 'format', 'aside' ),
-		);
-	}
-
-	/**
 	 * Fields the post type does not support are rejected rather than silently ignored.
 	 *
 	 * @since x.x.x
@@ -1309,7 +1217,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 
 		// A non-image attachment cannot replace an image, and does not remove it either.
 		$this->update( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
-		$text_id  = self::factory()->attachment->create_object(
+		$text_id   = self::factory()->attachment->create_object(
 			DIR_TESTDATA . '/formatting/utf-8/utf-8.txt',
 			0,
 			array( 'post_mime_type' => 'text/plain' )
@@ -1744,8 +1652,14 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 
 		$content = new Content();
 
-		foreach ( array( (float) self::$post_id, (string) self::$post_id . '.0', '+' . self::$post_id ) as $id ) {
-			$this->assertTrue( $content->check_update_permission( array( 'id' => $id ) ), 'The permission gate should resolve the post from ' . var_export( $id, true ) . '.' );
+		$ids = array(
+			'whole float'    => (float) self::$post_id,
+			'decimal string' => (string) self::$post_id . '.0',
+			'signed string'  => '+' . self::$post_id,
+		);
+
+		foreach ( $ids as $label => $id ) {
+			$this->assertTrue( $content->check_update_permission( array( 'id' => $id ) ), "The permission gate should resolve the post from a {$label} ID." );
 
 			$result = $content->execute_content_update(
 				array(
@@ -1755,7 +1669,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 				)
 			);
 
-			$this->assertIsArray( $result, 'The post should be updated from ' . var_export( $id, true ) . '.' );
+			$this->assertIsArray( $result, "The post should be updated from a {$label} ID." );
 			$this->assertSame( self::$post_id, $result['id'], 'The resolved post should be the requested one.' );
 		}
 	}
@@ -1793,7 +1707,7 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 	 * @since x.x.x
 	 */
 	public function test_updates_a_post_type_registered_by_another_plugin(): void {
-		register_post_type(
+		$this->register_test_post_type(
 			'wpai_book',
 			array(
 				'public'            => true,
@@ -1802,35 +1716,31 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 			)
 		);
 
-		try {
-			$this->login_as( 'administrator' );
-			$this->register_ability();
+		$this->login_as( 'administrator' );
+		$this->register_ability();
 
-			$post_id = self::factory()->post->create(
-				array(
-					'post_type'    => 'wpai_book',
-					'post_title'   => 'A book',
-					'post_content' => 'Chapter one.',
-				)
-			);
+		$post_id = self::factory()->post->create(
+			array(
+				'post_type'    => 'wpai_book',
+				'post_title'   => 'A book',
+				'post_content' => 'Chapter one.',
+			)
+		);
 
-			$result = $this->update(
-				array(
-					'id'        => $post_id,
-					'post_type' => 'wpai_book',
-					'title'     => 'A better book',
-					'content'   => 'Chapter two.',
-					'fields'    => array( 'id', 'post_type', 'title_raw', 'content_raw' ),
-				)
-			);
+		$result = $this->update(
+			array(
+				'id'        => $post_id,
+				'post_type' => 'wpai_book',
+				'title'     => 'A better book',
+				'content'   => 'Chapter two.',
+				'fields'    => array( 'id', 'post_type', 'title_raw', 'content_raw' ),
+			)
+		);
 
-			$this->assert_updated_post( $result, $post_id );
-			$this->assertSame( 'wpai_book', $result['post_type'], 'The post should keep the custom post type.' );
-			$this->assertSame( 'A better book', $result['title_raw'], 'The title should be updated.' );
-			$this->assertSame( 'Chapter two.', $result['content_raw'], 'The content should be updated.' );
-		} finally {
-			unregister_post_type( 'wpai_book' );
-		}
+		$this->assert_updated_post( $result, $post_id );
+		$this->assertSame( 'wpai_book', $result['post_type'], 'The post should keep the custom post type.' );
+		$this->assertSame( 'A better book', $result['title_raw'], 'The title should be updated.' );
+		$this->assertSame( 'Chapter two.', $result['content_raw'], 'The content should be updated.' );
 	}
 
 	/**
@@ -1843,14 +1753,13 @@ class ContentUpdateTest extends Content_Ability_TestCase {
 		$this->register_ability();
 
 		global $wpdb;
-		$wpdb->suppress_errors = true;
-		add_filter( 'query', array( $this, 'error_update_query' ) );
-		try {
-			$result = $this->update( $this->post_data() );
-		} finally {
-			remove_filter( 'query', array( $this, 'error_update_query' ) );
-			$wpdb->suppress_errors = false;
-		}
+
+		$result = $this->run_with_failing_query(
+			"UPDATE `{$wpdb->posts}`",
+			function () {
+				return $this->update( $this->post_data() );
+			}
+		);
 
 		$this->assertAbilityError( $result, 'db_update_error', 'A failed update should surface the database error.' );
 		$this->assertSame( 500, $result->get_error_data()['status'], 'A database error should be a server error.' );

--- a/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
+++ b/tests/Integration/Includes/Abilities/Content/ContentUpdateTest.php
@@ -1,0 +1,1479 @@
+<?php
+/**
+ * Integration tests for the core/content-update Ability provided by the plugin.
+ *
+ * The cases mirror the update tests of the WordPress core REST posts controller
+ * test suite (`Tests_REST_Posts_Controller`), adapted to the ability's input and
+ * output shapes.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
+
+use WordPress\AI\Abilities\Content\Content;
+
+/**
+ * Content update ability test case.
+ *
+ * @since x.x.x
+ */
+class ContentUpdateTest extends Content_Ability_TestCase {
+
+	/**
+	 * A published post owned by the editor, updated by most tests.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	private static $post_id;
+
+	/**
+	 * The category the current user is forbidden to assign, when set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	private $forbidden_category = 0;
+
+	/**
+	 * Creates the shared post for the update ability tests.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param \WP_UnitTest_Factory $factory The unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ): void {
+		parent::wpSetUpBeforeClass( $factory );
+
+		self::$post_id = $factory->post->create(
+			array(
+				'post_author'  => self::$user_ids['editor'],
+				'post_status'  => 'publish',
+				'post_title'   => 'Original title',
+				'post_content' => 'Original content',
+				'post_excerpt' => 'Original excerpt',
+			)
+		);
+	}
+
+	/**
+	 * Returns an update input with every common field set, like the REST test suite's post data.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $overrides Input values to override or add.
+	 * @return array<string, mixed> The ability input.
+	 */
+	private function post_data( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'      => self::$post_id,
+				'title'   => 'Post Title',
+				'content' => 'Post content',
+				'excerpt' => 'Post excerpt',
+				'status'  => 'publish',
+				'author'  => get_current_user_id(),
+				'fields'  => array( 'id', 'post_type', 'status', 'date', 'date_gmt', 'modified', 'modified_gmt', 'slug', 'title_raw', 'content_raw', 'excerpt_raw', 'author', 'parent' ),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Updates a post through the ability and returns the result.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array<string, mixed> $input The ability input.
+	 * @return mixed The ability result.
+	 */
+	private function update( array $input ) {
+		return $this->execute_ability( 'core/content-update', $input );
+	}
+
+	/**
+	 * Asserts that an update result describes the updated post.
+	 *
+	 * The ability counterpart of the REST suite's check_update_post_response().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed $result  The ability result.
+	 * @param int   $post_id The ID of the post that was updated.
+	 * @return \WP_Post The updated post.
+	 */
+	private function assert_updated_post( $result, int $post_id ): \WP_Post {
+		$this->assertIsArray( $result, 'Updating a post should return the updated post.' );
+		$this->assertSame( $post_id, $result['id'], 'The returned post should be the updated post.' );
+
+		$post = get_post( $post_id );
+		$this->assertInstanceOf( \WP_Post::class, $post, 'The updated post should still exist.' );
+
+		return $post;
+	}
+
+	/**
+	 * Disables UPDATE queries on the posts table so wp_update_post() fails with a database error.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $query The database query.
+	 * @return string The query, broken when it updates the posts table.
+	 */
+	public function error_update_query( string $query ): string {
+		global $wpdb;
+
+		if ( 0 === strpos( $query, "UPDATE `{$wpdb->posts}`" ) ) {
+			$query = '],';
+		}
+
+		return $query;
+	}
+
+	/**
+	 * Offers one post template for the tests that need a valid template.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, string> The post templates keyed by file name.
+	 */
+	public function filter_theme_post_templates(): array {
+		return array(
+			'post-my-test-template.php' => 'My Test Template',
+		);
+	}
+
+	/**
+	 * Revokes the assign_term meta capability for the forbidden category.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string[] $caps    The primitive capabilities.
+	 * @param string   $cap     The meta capability being checked.
+	 * @param int      $user_id The user ID.
+	 * @param mixed[]  $args    The capability arguments.
+	 * @return string[] The primitive capabilities.
+	 */
+	public function revoke_assign_term( array $caps, string $cap, int $user_id, array $args ): array {
+		if ( 'assign_term' === $cap && isset( $args[0] ) && $this->forbidden_category === $args[0] ) {
+			$caps = array( 'do_not_allow' );
+		}
+
+		return $caps;
+	}
+
+	/**
+	 * The ability is registered in the `content` category and flagged as an idempotent write.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_registers_core_content_update_ability(): void {
+		$this->register_ability();
+
+		$ability = wp_get_ability( 'core/content-update' );
+
+		$this->assertNotNull( $ability, 'The core/content-update ability should be registered.' );
+		$this->assertSame( 'content', $ability->get_category(), 'The registered ability should use the content category.' );
+		$this->assertTrue( $ability->get_meta_item( 'show_in_rest', false ), 'The ability should be exposed in REST.' );
+
+		$annotations = $ability->get_meta_item( 'annotations', array() );
+		$this->assertFalse( $annotations['readonly'], 'The ability should not be marked read-only.' );
+		$this->assertFalse( $annotations['destructive'], 'Updating keeps revisions, so the ability is not flagged destructive.' );
+		$this->assertTrue( $annotations['idempotent'], 'Repeating the same update leaves the post unchanged.' );
+		$this->assertFalse( $annotations['open_world'], 'The ability should be marked closed-world; it only writes to the local database.' );
+	}
+
+	/**
+	 * The ability is not registered when no post types are exposed to it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_does_not_register_without_exposed_post_types(): void {
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			get_post_type_object( $post_type )->show_in_abilities = false;
+		}
+
+		$this->register_ability();
+
+		$this->assertFalse( wp_has_ability( 'core/content-update' ), 'The update ability should not register without any exposed post types.' );
+	}
+
+	/**
+	 * The input schema requires an ID, accepts a post type guard and the REST writable fields, and rejects unknown properties.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_input_schema_requires_id_and_mirrors_the_rest_writable_fields(): void {
+		$this->register_ability();
+
+		$schema = wp_get_ability( 'core/content-update' )->get_input_schema();
+
+		$this->assertSame( 'object', $schema['type'], 'The input schema should describe an object.' );
+		$this->assertSame( array( 'id' ), $schema['required'], 'Only the ID should be required.' );
+		$this->assertFalse( $schema['additionalProperties'], 'Unknown properties should be rejected.' );
+
+		$expected_keys = array(
+			'id',
+			'post_type',
+			'title',
+			'content',
+			'excerpt',
+			'status',
+			'slug',
+			'date',
+			'date_gmt',
+			'author',
+			'password',
+			'parent',
+			'menu_order',
+			'comment_status',
+			'ping_status',
+			'format',
+			'featured_media',
+			'sticky',
+			'template',
+			'categories',
+			'tags',
+			'fields',
+		);
+		$this->assertSame( $expected_keys, array_keys( $schema['properties'] ), 'The writable fields should mirror the REST posts item schema, with taxonomies under their REST keys.' );
+		$this->assertSame( 1, $schema['properties']['id']['minimum'], 'The ID should be a positive integer.' );
+		$this->assertSame( array( 'post', 'page' ), $schema['properties']['post_type']['enum'], 'The post type guard should only accept exposed post types.' );
+
+		$create_schema = wp_get_ability( 'core/content-create' )->get_input_schema();
+		$this->assertSame( $create_schema['properties']['title'], $schema['properties']['title'], 'The create and update abilities should share their write fields.' );
+	}
+
+	/**
+	 * Read-only post fields are rejected rather than ignored.
+	 *
+	 * The REST controller ignores its read-only properties on update; the strict ability
+	 * schema rejects them, so a caller never believes it changed something it cannot.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_rejects_readonly_fields(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'       => self::$post_id,
+				'modified' => '2010-06-01T02:00:00Z',
+				'content'  => 'foo bar baz',
+			)
+		);
+
+		$this->assertAbilityError( $result, 'ability_invalid_input', 'A read-only field should fail validation.' );
+		$this->assertSame( 'Original content', get_post( self::$post_id )->post_content, 'Nothing should be written when validation fails.' );
+	}
+
+	/**
+	 * The output schema describes a single post with the query ability's fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_output_schema_describes_a_post(): void {
+		$this->register_ability();
+
+		$schema       = wp_get_ability( 'core/content-update' )->get_output_schema();
+		$query_schema = wp_get_ability( 'core/content-query' )->get_output_schema();
+
+		$this->assertSame( $query_schema['oneOf'][0], $schema, 'The updated post should have the same shape as a queried post.' );
+	}
+
+	/**
+	 * An editor can update the common fields of a post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_item(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$data   = $this->post_data();
+		$result = $this->update( $data );
+
+		$post = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( $data['title'], $result['title_raw'], 'The returned raw title should match the input.' );
+		$this->assertSame( $data['content'], $result['content_raw'], 'The returned raw content should match the input.' );
+		$this->assertSame( $data['excerpt'], $result['excerpt_raw'], 'The returned raw excerpt should match the input.' );
+		$this->assertSame( $data['title'], $post->post_title, 'The stored title should match the input.' );
+		$this->assertSame( $data['content'], $post->post_content, 'The stored content should match the input.' );
+		$this->assertSame( $data['excerpt'], $post->post_excerpt, 'The stored excerpt should match the input.' );
+	}
+
+	/**
+	 * Omitted fields keep their current values.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_keeps_omitted_fields(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'     => self::$post_id,
+				'title'  => 'Only the title',
+				'fields' => array( 'id', 'title_raw', 'content_raw', 'excerpt_raw', 'status' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'Only the title', $result['title_raw'], 'The title should change.' );
+		$this->assertSame( 'Original content', $result['content_raw'], 'The content should be kept.' );
+		$this->assertSame( 'Original excerpt', $result['excerpt_raw'], 'The excerpt should be kept.' );
+		$this->assertSame( 'publish', $result['status'], 'The status should be kept.' );
+	}
+
+	/**
+	 * Without a field selection the updated post is returned with the lean default fields.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_returns_lean_default_fields(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'    => self::$post_id,
+				'title' => 'Lean',
+			)
+		);
+
+		$this->assertIsArray( $result, 'Updating a post should return the updated post.' );
+		$this->assertSame( array( 'id', 'post_type', 'status', 'date', 'slug', 'title_rendered' ), array_keys( $result ), 'The default field set should match the query ability.' );
+	}
+
+	/**
+	 * An update that changes nothing still succeeds, even when repeated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_item_no_change(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post  = get_post( self::$post_id );
+		$input = array(
+			'id'     => self::$post_id,
+			'author' => (int) $post->post_author,
+		);
+
+		// Run twice to make sure that the update still succeeds even if no DB rows are updated.
+		$this->assert_updated_post( $this->update( $input ), self::$post_id );
+		$this->assert_updated_post( $this->update( $input ), self::$post_id );
+	}
+
+	/**
+	 * A null date resets the post date, leaving a draft with a floating GMT date.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_empty_date(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id     = self::factory()->post->create();
+		$future_date = '2919-07-29T18:00:00';
+
+		$result = $this->update(
+			$this->post_data(
+				array(
+					'id'       => $post_id,
+					'date_gmt' => $future_date,
+					'date'     => $future_date,
+					'title'    => 'update',
+					'status'   => 'draft',
+				)
+			)
+		);
+
+		$this->assert_updated_post( $result, $post_id );
+		$this->assertSame( $future_date . '+00:00', $result['date_gmt'], 'The GMT date should be set to the future date.' );
+		$this->assertSame( $future_date . '+00:00', $result['date'], 'The date should be set to the future date.' );
+		$this->assertNotSame( $result['date_gmt'], $result['modified_gmt'], 'The modified date should differ from the future date.' );
+		$this->assertNotSame( $result['date'], $result['modified'], 'The modified date should differ from the future date.' );
+
+		$result = $this->update(
+			$this->post_data(
+				array(
+					'id'       => $post_id,
+					'date_gmt' => null,
+					'title'    => 'test',
+					'status'   => 'draft',
+				)
+			)
+		);
+
+		$this->assert_updated_post( $result, $post_id );
+		$this->assertSame( $result['date'], $result['date_gmt'], 'A reset draft derives its GMT date from the local date.' );
+		$this->assertNotSame( $future_date . '+00:00', $result['date_gmt'], 'The future GMT date should be gone.' );
+		$this->assertNotSame( $future_date . '+00:00', $result['date'], 'The future date should be gone.' );
+		$this->assertSame( '0000-00-00 00:00:00', get_post( $post_id )->post_date_gmt, 'The stored GMT date should be reset to the floating value.' );
+	}
+
+	/**
+	 * A minimal update with only an ID and a title succeeds.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_without_extra_params(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'title'   => 'Post Title',
+				'content' => 'Post content',
+				'excerpt' => 'Post excerpt',
+			)
+		);
+
+		$this->assert_updated_post( $result, self::$post_id );
+	}
+
+	/**
+	 * An editor who cannot edit published posts is denied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_without_permission(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$this->revoke_current_user_capability( 'edit_published_posts' );
+
+		$result = $this->update( $this->post_data() );
+
+		$this->assertAbilityDenied( $result, 'An editor without edit_published_posts should not update a published post.' );
+	}
+
+	/**
+	 * Logged-out users, subscribers, and authors editing another user's post are denied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_by_users_without_edit_access_is_denied(): void {
+		$this->register_ability();
+
+		wp_set_current_user( 0 );
+		$data = $this->post_data( array( 'title' => 'Nope' ) );
+		unset( $data['author'] );
+		$this->assertAbilityDenied( $this->update( $data ), 'A logged-out user should not update posts.' );
+
+		$this->login_as( 'subscriber' );
+		$this->assertAbilityDenied( $this->update( $this->post_data( array( 'title' => 'Nope' ) ) ), 'A subscriber should not update posts.' );
+
+		$this->login_as( 'author' );
+		$this->assertAbilityDenied( $this->update( $this->post_data( array( 'title' => 'Nope' ) ) ), "An author should not update another user's post." );
+
+		$this->assertSame( 'Original title', get_post( self::$post_id )->post_title, 'Denied updates should not write.' );
+	}
+
+	/**
+	 * An author can update their own draft.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_author_can_update_own_draft(): void {
+		$author_id = $this->login_as( 'author' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'     => $post_id,
+				'title'  => 'My draft',
+				'fields' => array( 'id', 'title_raw' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $post_id );
+		$this->assertSame( 'My draft', $result['title_raw'], 'The author should be able to update their own draft.' );
+	}
+
+	/**
+	 * A contributor cannot make their post sticky.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_sticky_as_contributor(): void {
+		$contributor_id = $this->login_as( 'contributor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $contributor_id,
+				'post_status' => 'pending',
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'     => $post_id,
+				'sticky' => true,
+				'status' => 'pending',
+			)
+		);
+
+		$this->assertAbilityDenied( $result, 'A contributor should not be allowed to make posts sticky.' );
+	}
+
+	/**
+	 * A missing post is denied before execution, and a direct call reports it as not found.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_invalid_id(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update( $this->post_data( array( 'id' => 999999 ) ) );
+		$this->assertAbilityDenied( $result, 'A missing post should be denied before execution.' );
+
+		$direct = ( new Content() )->execute_content_update( array( 'id' => 999999 ) );
+		$this->assertAbilityError( $direct, 'content_not_found', 'A direct call should still fail closed on a missing post.' );
+	}
+
+	/**
+	 * A post type guard that does not match the post denies the update, like a mismatched REST route.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_invalid_route(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$mismatched = $this->update( $this->post_data( array( 'post_type' => 'page' ) ) );
+		$this->assertAbilityDenied( $mismatched, 'A mismatched post type guard should deny the update.' );
+
+		$matching = $this->update( $this->post_data( array( 'post_type' => 'post' ) ) );
+		$this->assert_updated_post( $matching, self::$post_id );
+	}
+
+	/**
+	 * A post from a post type not exposed to abilities cannot be updated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_for_unexposed_post_type_is_denied(): void {
+		register_post_type(
+			'wpai_hidden_cpt',
+			array(
+				'public'   => true,
+				'supports' => array( 'title', 'editor' ),
+			)
+		);
+
+		try {
+			$this->login_as( 'administrator' );
+			$this->register_ability();
+
+			$post_id = self::factory()->post->create( array( 'post_type' => 'wpai_hidden_cpt' ) );
+
+			$result = $this->update(
+				array(
+					'id'    => $post_id,
+					'title' => 'Hidden',
+				)
+			);
+
+			$this->assertAbilityDenied( $result, 'Posts from unexposed post types should be denied.' );
+		} finally {
+			unregister_post_type( 'wpai_hidden_cpt' );
+		}
+	}
+
+	/**
+	 * Post formats can be set, cleared with the standard format, and are validated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_format(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$gallery = $this->update( $this->post_data( array( 'format' => 'gallery' ) ) );
+		$this->assert_updated_post( $gallery, self::$post_id );
+		$this->assertSame( 'gallery', get_post_format( self::$post_id ), 'The gallery format should be assigned.' );
+
+		$standard = $this->update( $this->post_data( array( 'format' => 'standard' ) ) );
+		$this->assert_updated_post( $standard, self::$post_id );
+		$this->assertFalse( get_post_format( self::$post_id ), 'The standard format should clear the format term.' );
+
+		$invalid = $this->update( $this->post_data( array( 'format' => 'testformat' ) ) );
+		$this->assertAbilityError( $invalid, 'ability_invalid_input', 'An unknown format should fail validation.' );
+
+		// A valid format the theme does not support is still assigned, like REST.
+		$unsupported = $this->update( $this->post_data( array( 'format' => 'link' ) ) );
+		$this->assert_updated_post( $unsupported, self::$post_id );
+		$this->assertSame( 'link', get_post_format( self::$post_id ), 'A theme-unsupported format should still be assigned.' );
+	}
+
+	/**
+	 * Dates are stored in the site timezone with their GMT counterpart, whether given as local, GMT, or with an offset.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_post_dates
+	 *
+	 * @param string                $status  The status of the post being updated.
+	 * @param array<string, string> $params  The timezone and date inputs.
+	 * @param array<string, string> $results The expected stored dates.
+	 */
+	public function test_update_post_date( string $status, array $params, array $results ): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		update_option( 'timezone_string', $params['timezone_string'] );
+
+		$post_id = self::factory()->post->create( array( 'post_status' => $status ) );
+
+		$input = array(
+			'id'     => $post_id,
+			'fields' => array( 'id', 'date', 'date_gmt' ),
+		);
+		if ( isset( $params['date'] ) ) {
+			$input['date'] = $params['date'];
+		}
+		if ( isset( $params['date_gmt'] ) ) {
+			$input['date_gmt'] = $params['date_gmt'];
+		}
+
+		$result = $this->update( $input );
+
+		$post = $this->assert_updated_post( $result, $post_id );
+		$this->assertSame( $results['date'], $post->post_date, 'The stored local date should match.' );
+		$this->assertSame( $results['date_gmt'], $post->post_date_gmt, 'The stored GMT date should match.' );
+		$this->assertSame( str_replace( ' ', 'T', $results['date'] ) . '-05:00', $result['date'], 'The returned local date should carry the site offset.' );
+		$this->assertSame( str_replace( ' ', 'T', $results['date_gmt'] ) . '+00:00', $result['date_gmt'], 'The returned GMT date should be the UTC instant.' );
+	}
+
+	/**
+	 * Invalid dates fail validation.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_invalid_date(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$date = $this->update( $this->post_data( array( 'date' => 'foo' ) ) );
+		$this->assertAbilityError( $date, 'ability_invalid_input', 'An invalid date should fail validation.' );
+
+		$date_gmt = $this->update( $this->post_data( array( 'date_gmt' => 'foo' ) ) );
+		$this->assertAbilityError( $date_gmt, 'ability_invalid_input', 'An invalid GMT date should fail validation.' );
+	}
+
+	/**
+	 * Updating the date of a post whose stored GMT date is empty sets both dates.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_empty_post_date_gmt_shimmed_using_post_date(): void {
+		global $wpdb;
+
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		update_option( 'timezone_string', 'America/Chicago' );
+
+		// Set the dates through wpdb, because wp_insert_post() and wp_update_post() validate them.
+		$post_id = self::factory()->post->create();
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+			$wpdb->posts,
+			array(
+				'post_date'     => '2016-02-23 12:00:00',
+				'post_date_gmt' => '0000-00-00 00:00:00',
+			),
+			array( 'ID' => $post_id ),
+			array( '%s', '%s' ),
+			array( '%d' )
+		);
+		wp_cache_delete( $post_id, 'posts' );
+
+		$post = get_post( $post_id );
+		$this->assertSame( '2016-02-23 12:00:00', $post->post_date, 'Precondition: the local date is set.' );
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'Precondition: the GMT date is empty.' );
+
+		$result = $this->update(
+			array(
+				'id'     => $post_id,
+				'date'   => '2016-02-23T13:00:00',
+				'fields' => array( 'id', 'date', 'date_gmt' ),
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $post_id );
+		$this->assertSame( '2016-02-23T13:00:00-06:00', $result['date'], 'The returned local date should match the input.' );
+		$this->assertSame( '2016-02-23T19:00:00+00:00', $result['date_gmt'], 'The returned GMT date should be derived from the input.' );
+		$this->assertSame( '2016-02-23 13:00:00', $post->post_date, 'The stored local date should match the input.' );
+		$this->assertSame( '2016-02-23 19:00:00', $post->post_date_gmt, 'The stored GMT date should be set.' );
+	}
+
+	/**
+	 * The slug is stored and sanitized like the REST slug argument.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_slug(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update( $this->post_data( array( 'slug' => 'sample-slug' ) ) );
+		$post   = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'sample-slug', $result['slug'], 'The returned slug should match the input.' );
+		$this->assertSame( 'sample-slug', $post->post_name, 'The stored slug should match the input.' );
+
+		$accented = $this->update( $this->post_data( array( 'slug' => 'tęst-acceńted-chäræcters' ) ) );
+		$post     = $this->assert_updated_post( $accented, self::$post_id );
+		$this->assertSame( 'test-accented-charaecters', $accented['slug'], 'The returned slug should be sanitized.' );
+		$this->assertSame( 'test-accented-charaecters', $post->post_name, 'The stored slug should be sanitized.' );
+	}
+
+	/**
+	 * A draft slug that collides with another post is made unique.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_draft_post_does_not_have_the_same_slug_as_existing_post(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		self::factory()->post->create( array( 'post_name' => 'sample-slug' ) );
+
+		$result = $this->update(
+			$this->post_data(
+				array(
+					'status' => 'draft',
+					'slug'   => 'sample-slug',
+				)
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'sample-slug-2', $result['slug'], 'The returned slug should be made unique.' );
+		$this->assertSame( 'draft', $post->post_status, 'The post should be a draft.' );
+		$this->assertSame( 'sample-slug-2', $post->post_name, 'The stored slug should be made unique.' );
+	}
+
+	/**
+	 * Sticky can be set, survives unrelated updates, and can be unset.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_sticky(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$this->assert_updated_post( $this->update( $this->post_data( array( 'sticky' => true ) ) ), self::$post_id );
+		$this->assertTrue( is_sticky( self::$post_id ), 'The post should be sticky.' );
+
+		// Updating another field shouldn't change sticky status.
+		$this->assert_updated_post( $this->update( $this->post_data( array( 'title' => 'This should not reset sticky' ) ) ), self::$post_id );
+		$this->assertTrue( is_sticky( self::$post_id ), 'The post should stay sticky.' );
+
+		$this->assert_updated_post( $this->update( $this->post_data( array( 'sticky' => false ) ) ), self::$post_id );
+		$this->assertFalse( is_sticky( self::$post_id ), 'The post should no longer be sticky.' );
+	}
+
+	/**
+	 * The excerpt and content can be set and emptied.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_excerpt_and_content(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$fields = array( 'id', 'excerpt_raw', 'content_raw' );
+
+		$excerpt = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'excerpt' => 'An Excerpt',
+				'fields'  => $fields,
+			)
+		);
+		$this->assertSame( 'An Excerpt', $excerpt['excerpt_raw'], 'The excerpt should be set.' );
+
+		$empty_excerpt = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'excerpt' => '',
+				'fields'  => $fields,
+			)
+		);
+		$this->assertSame( '', $empty_excerpt['excerpt_raw'], 'The excerpt should be emptied.' );
+
+		$content = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'content' => 'Some Content',
+				'fields'  => $fields,
+			)
+		);
+		$this->assertSame( 'Some Content', $content['content_raw'], 'The content should be set.' );
+
+		$empty_content = $this->update(
+			array(
+				'id'      => self::$post_id,
+				'content' => '',
+				'fields'  => $fields,
+			)
+		);
+		$this->assertSame( '', $empty_content['content_raw'], 'The content should be emptied.' );
+	}
+
+	/**
+	 * An empty password removes the password.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_empty_password(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		wp_update_post(
+			array(
+				'ID'            => self::$post_id,
+				'post_password' => 'foo',
+			)
+		);
+
+		$result = $this->update( $this->post_data( array( 'password' => '' ) ) );
+
+		$post = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( '', $post->post_password, 'The password should be removed.' );
+	}
+
+	/**
+	 * A post cannot be both sticky and password protected, in either order.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_password_and_sticky_fails(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$both = $this->update(
+			$this->post_data(
+				array(
+					'password' => '123',
+					'sticky'   => true,
+				)
+			)
+		);
+		$this->assertAbilityError( $both, 'content_invalid_field', 'A post cannot become sticky and password protected at once.' );
+
+		stick_post( self::$post_id );
+		$password_on_sticky = $this->update( $this->post_data( array( 'password' => '123' ) ) );
+		$this->assertAbilityError( $password_on_sticky, 'content_invalid_field', 'A sticky post cannot be password protected.' );
+		unstick_post( self::$post_id );
+
+		wp_update_post(
+			array(
+				'ID'            => self::$post_id,
+				'post_password' => '123',
+			)
+		);
+		$sticky_on_protected = $this->update( $this->post_data( array( 'sticky' => true ) ) );
+		$this->assertAbilityError( $sticky_on_protected, 'content_invalid_field', 'A password protected post cannot be made sticky.' );
+	}
+
+	/**
+	 * Quotes survive the slashing round trip.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_quotes_in_title(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update( $this->post_data( array( 'title' => "Rob O'Rourke's Diary" ) ) );
+
+		$post = $this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( "Rob O'Rourke's Diary", $result['title_raw'], 'The raw title should keep its quotes.' );
+		$this->assertSame( "Rob O'Rourke's Diary", $post->post_title, 'The stored title should keep its quotes.' );
+	}
+
+	/**
+	 * Categories replace the current ones, and an empty list removes them all.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_categories(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$category = wp_insert_term( 'Test Category', 'category' );
+
+		$result = $this->update(
+			$this->post_data(
+				array(
+					'title'      => 'Tester',
+					'categories' => array( $category['term_id'] ),
+				)
+			)
+		);
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( array( $category['term_id'] ), wp_get_post_categories( self::$post_id ), 'The category should replace the default one.' );
+
+		$cleared = $this->update(
+			$this->post_data(
+				array(
+					'title'      => 'Tester',
+					'categories' => array(),
+				)
+			)
+		);
+		$this->assert_updated_post( $cleared, self::$post_id );
+		$this->assertSame( array(), wp_get_post_categories( self::$post_id ), 'An empty list should remove every category.' );
+	}
+
+	/**
+	 * Tags are assigned under the REST `tags` key.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_tags(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$tag = wp_insert_term( 'Test Tag', 'post_tag' );
+
+		$result = $this->update( $this->post_data( array( 'tags' => array( $tag['term_id'] ) ) ) );
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( array( $tag['term_id'] ), wp_get_post_tags( self::$post_id, array( 'fields' => 'ids' ) ), 'The tag should be assigned.' );
+	}
+
+	/**
+	 * Terms the current user cannot assign deny the whole request.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_categories_that_cannot_be_assigned_by_current_user(): void {
+		$categories               = self::factory()->category->create_many( 2 );
+		$this->forbidden_category = $categories[1];
+
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		add_filter( 'map_meta_cap', array( $this, 'revoke_assign_term' ), 10, 4 );
+		try {
+			$result = $this->update(
+				$this->post_data(
+					array(
+						'password'   => 'testing',
+						'categories' => $categories,
+					)
+				)
+			);
+		} finally {
+			remove_filter( 'map_meta_cap', array( $this, 'revoke_assign_term' ), 10 );
+		}
+
+		$this->assertAbilityDenied( $result, 'Terms the user cannot assign should deny the request.' );
+	}
+
+	/**
+	 * A taxonomy that is not registered for the post type is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_page_with_categories_is_rejected(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id  = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$category = wp_insert_term( 'Page Category', 'category' );
+
+		$result = $this->update(
+			array(
+				'id'         => $page_id,
+				'categories' => array( $category['term_id'] ),
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_field', 'Categories should be rejected for pages.' );
+	}
+
+	/**
+	 * A template offered by the theme is assigned, and an empty template clears it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_item_with_template(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		add_filter( 'theme_post_templates', array( $this, 'filter_theme_post_templates' ) );
+		try {
+			$result = $this->update( $this->post_data( array( 'template' => 'post-my-test-template.php' ) ) );
+			$this->assert_updated_post( $result, self::$post_id );
+			$this->assertSame( 'post-my-test-template.php', get_page_template_slug( self::$post_id ), 'The template should be stored on the post.' );
+
+			$none = $this->update( $this->post_data( array( 'template' => '' ) ) );
+			$this->assert_updated_post( $none, self::$post_id );
+			$this->assertSame( '', get_page_template_slug( self::$post_id ), 'An empty template should clear the stored template.' );
+		} finally {
+			remove_filter( 'theme_post_templates', array( $this, 'filter_theme_post_templates' ) );
+		}
+	}
+
+	/**
+	 * A template the theme does not offer is rejected.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_item_with_invalid_template(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$result = $this->update( $this->post_data( array( 'template' => 'post-my-test-template.php' ) ) );
+
+		$this->assertAbilityError( $result, 'content_invalid_template', 'An unavailable template should be rejected.' );
+	}
+
+	/**
+	 * Keeping the template a post already uses is allowed even when the theme no longer offers it.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_item_with_same_template_that_no_longer_exists(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		update_post_meta( self::$post_id, '_wp_page_template', 'post-my-invalid-template.php' );
+
+		$result = $this->update( $this->post_data( array( 'template' => 'post-my-invalid-template.php' ) ) );
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertSame( 'post-my-invalid-template.php', get_page_template_slug( self::$post_id ), 'The existing template should be kept.' );
+	}
+
+	/**
+	 * Changing the status to one that requires publishing is gated by the publish capability.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_status_requires_publish_capability(): void {
+		$contributor_id = $this->login_as( 'contributor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create(
+			array(
+				'post_author' => $contributor_id,
+				'post_status' => 'pending',
+			)
+		);
+
+		$publish = $this->update(
+			array(
+				'id'     => $post_id,
+				'status' => 'publish',
+			)
+		);
+		$this->assertAbilityError( $publish, 'content_cannot_publish', 'A contributor should not publish.' );
+
+		$private = $this->update(
+			array(
+				'id'     => $post_id,
+				'status' => 'private',
+			)
+		);
+		$this->assertAbilityError( $private, 'content_cannot_publish', 'A contributor should not make posts private.' );
+
+		// Sending the current status is always allowed, like the REST status validation.
+		$same = $this->update(
+			array(
+				'id'     => $post_id,
+				'status' => 'pending',
+				'title'  => 'Still pending',
+				'fields' => array( 'id', 'status', 'title_raw' ),
+			)
+		);
+		$this->assert_updated_post( $same, $post_id );
+		$this->assertSame( 'pending', $same['status'], 'The current status should be kept.' );
+		$this->assertSame( 'Still pending', $same['title_raw'], 'The title should be updated.' );
+	}
+
+	/**
+	 * An editor can publish a draft.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_publishes_a_draft(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_status' => 'draft' ) );
+
+		$result = $this->update(
+			array(
+				'id'     => $post_id,
+				'status' => 'publish',
+				'fields' => array( 'id', 'status' ),
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $post_id );
+		$this->assertSame( 'publish', $result['status'], 'The returned status should be publish.' );
+		$this->assertSame( 'publish', $post->post_status, 'The stored status should be publish.' );
+	}
+
+	/**
+	 * The author can be reassigned by users who can edit others' posts, and is validated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_author(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$reassigned = $this->update( $this->post_data( array( 'author' => self::$user_ids['author'] ) ) );
+		$post       = $this->assert_updated_post( $reassigned, self::$post_id );
+		$this->assertSame( self::$user_ids['author'], (int) $post->post_author, 'An editor should be able to reassign the author.' );
+		$this->assertSame( self::$user_ids['author'], $reassigned['author']['id'], 'The returned author should be the new one.' );
+
+		$missing = $this->update( $this->post_data( array( 'author' => 999999 ) ) );
+		$this->assertAbilityError( $missing, 'content_invalid_author', 'A nonexistent author should be rejected.' );
+
+		$author_id = $this->login_as( 'author' );
+		$own_post  = self::factory()->post->create(
+			array(
+				'post_author' => $author_id,
+				'post_status' => 'draft',
+			)
+		);
+		$to_other  = $this->update(
+			array(
+				'id'     => $own_post,
+				'author' => self::$user_ids['author_secondary'],
+			)
+		);
+		$this->assertAbilityDenied( $to_other, 'An author should not reassign a post to another user.' );
+	}
+
+	/**
+	 * A page can be moved under a parent, and the parent is validated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_page_parent(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$parent_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$page_id   = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$result = $this->update(
+			array(
+				'id'     => $page_id,
+				'parent' => $parent_id,
+				'fields' => array( 'id', 'parent' ),
+			)
+		);
+		$this->assert_updated_post( $result, $page_id );
+		$this->assertSame( $parent_id, $result['parent'], 'The returned parent should match.' );
+		$this->assertSame( $parent_id, (int) get_post( $page_id )->post_parent, 'The stored parent should match.' );
+
+		$top_level = $this->update(
+			array(
+				'id'     => $page_id,
+				'parent' => 0,
+				'fields' => array( 'id', 'parent' ),
+			)
+		);
+		$this->assert_updated_post( $top_level, $page_id );
+		$this->assertSame( 0, $top_level['parent'], 'A zero parent should make the page top-level.' );
+
+		$invalid = $this->update(
+			array(
+				'id'     => $page_id,
+				'parent' => 999999,
+			)
+		);
+		$this->assertAbilityError( $invalid, 'content_invalid_parent', 'A nonexistent parent should be rejected.' );
+	}
+
+	/**
+	 * Page attributes and comment settings are stored.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_page_with_menu_order_and_comment_settings(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$page_id = self::factory()->post->create( array( 'post_type' => 'page' ) );
+
+		$result = $this->update(
+			array(
+				'id'             => $page_id,
+				'menu_order'     => 3,
+				'comment_status' => 'closed',
+				'ping_status'    => 'closed',
+			)
+		);
+
+		$post = $this->assert_updated_post( $result, $page_id );
+		$this->assertSame( 3, $post->menu_order, 'The menu order should be stored.' );
+		$this->assertSame( 'closed', $post->comment_status, 'The comment status should be stored.' );
+		$this->assertSame( 'closed', $post->ping_status, 'The ping status should be stored.' );
+	}
+
+	/**
+	 * Provides fields that a post type does not support.
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: mixed}> Post type, field, and value.
+	 */
+	public function data_unsupported_fields(): array {
+		return array(
+			'parent on a post'     => array( 'post', 'parent', 0 ),
+			'menu order on a post' => array( 'post', 'menu_order', 1 ),
+			'sticky on a page'     => array( 'page', 'sticky', true ),
+			'format on a page'     => array( 'page', 'format', 'aside' ),
+		);
+	}
+
+	/**
+	 * Fields the post type does not support are rejected rather than silently ignored.
+	 *
+	 * @since x.x.x
+	 *
+	 * @dataProvider data_unsupported_fields
+	 *
+	 * @param string $post_type The post type of the post to update.
+	 * @param string $field     The unsupported field.
+	 * @param mixed  $value     A valid value for the field.
+	 */
+	public function test_update_rejects_unsupported_fields( string $post_type, string $field, $value ): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$post_id = self::factory()->post->create( array( 'post_type' => $post_type ) );
+
+		$result = $this->update(
+			array(
+				'id'   => $post_id,
+				$field => $value,
+			)
+		);
+
+		$this->assertAbilityError( $result, 'content_invalid_field', "The {$field} field should be rejected for the {$post_type} post type." );
+	}
+
+	/**
+	 * A featured image can be assigned, removed, and is validated.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_featured_media(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$attachment_id = self::factory()->attachment->create_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'menu_order'     => 1,
+			)
+		);
+
+		$set = $this->update( $this->post_data( array( 'featured_media' => $attachment_id ) ) );
+		$this->assert_updated_post( $set, self::$post_id );
+		$this->assertSame( $attachment_id, (int) get_post_thumbnail_id( self::$post_id ), 'The attachment should be the post thumbnail.' );
+
+		$removed = $this->update( $this->post_data( array( 'featured_media' => 0 ) ) );
+		$this->assert_updated_post( $removed, self::$post_id );
+		$this->assertSame( 0, (int) get_post_thumbnail_id( self::$post_id ), 'The post thumbnail should be removed.' );
+
+		$invalid = $this->update( $this->post_data( array( 'featured_media' => 999999 ) ) );
+		$this->assertAbilityError( $invalid, 'content_invalid_featured_media', 'An invalid featured media ID should be reported.' );
+	}
+
+	/**
+	 * The core post insertion hook fires with the previous post.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_fires_wp_after_insert_post(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		$calls    = array();
+		$callback = static function ( $post_id, $post, $update, $post_before ) use ( &$calls ): void {
+			$calls[] = array( $post_id, $update, $post_before );
+		};
+
+		add_action( 'wp_after_insert_post', $callback, 10, 4 );
+		try {
+			$result = $this->update( $this->post_data( array( 'title' => 'Hooked' ) ) );
+		} finally {
+			remove_action( 'wp_after_insert_post', $callback, 10 );
+		}
+
+		$this->assert_updated_post( $result, self::$post_id );
+		$this->assertNotEmpty( $calls, 'wp_after_insert_post should fire.' );
+		$last = end( $calls );
+		$this->assertSame( self::$post_id, $last[0], 'The hook should receive the updated post.' );
+		$this->assertTrue( $last[1], 'The hook should report an update.' );
+		$this->assertInstanceOf( \WP_Post::class, $last[2], 'The hook should receive the previous post.' );
+		$this->assertSame( 'Original title', $last[2]->post_title, 'The previous post should carry the old values.' );
+	}
+
+	/**
+	 * Sending a draft's current date back does not remove its floating GMT date.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_putting_same_publish_date_does_not_remove_floating_date(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$time = gmdate( 'Y-m-d H:i:s' );
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_date'   => $time,
+			)
+		);
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'Precondition: the draft has a floating GMT date.' );
+
+		$read = $this->execute_ability(
+			'core/content-query',
+			array(
+				'id'     => $post->ID,
+				'fields' => array( 'id', 'date', 'date_gmt', 'title_raw', 'content_raw', 'status' ),
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'      => $post->ID,
+				'date'    => $read['date'],
+				'title'   => $read['title_raw'],
+				'content' => $read['content_raw'],
+				'status'  => $read['status'],
+				'fields'  => array( 'id', 'date', 'date_gmt' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $post->ID );
+		$this->assertEqualsWithDelta( strtotime( $read['date'] ), strtotime( $result['date'] ), 2, 'The dates should be equal.' );
+		$this->assertEqualsWithDelta( strtotime( $read['date_gmt'] ), strtotime( $result['date_gmt'] ), 2, 'The GMT dates should be equal.' );
+		$this->assertSame( '0000-00-00 00:00:00', get_post( $post->ID )->post_date_gmt, 'The floating GMT date should be kept.' );
+	}
+
+	/**
+	 * Sending a different date removes a draft's floating GMT date.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_putting_different_publish_date_removes_floating_date(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$time     = gmdate( 'Y-m-d H:i:s' );
+		$new_time = gmdate( 'Y-m-d H:i:s', strtotime( '+1 week' ) );
+		$post     = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_date'   => $time,
+			)
+		);
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'Precondition: the draft has a floating GMT date.' );
+
+		$result = $this->update(
+			array(
+				'id'     => $post->ID,
+				'date'   => mysql_to_rfc3339( $new_time ),
+				'fields' => array( 'id', 'date' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $post->ID );
+		$this->assertEqualsWithDelta( strtotime( mysql_to_rfc3339( $new_time ) ), strtotime( $result['date'] ), 2, 'The dates should be equal.' );
+		$this->assertNotSame( '0000-00-00 00:00:00', get_post( $post->ID )->post_date_gmt, 'The floating GMT date should be replaced.' );
+	}
+
+	/**
+	 * Publishing a draft with its current date removes the floating GMT date.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_publishing_post_with_same_date_removes_floating_date(): void {
+		$this->login_as( 'administrator' );
+		$this->register_ability();
+
+		$time = gmdate( 'Y-m-d H:i:s' );
+		$post = self::factory()->post->create_and_get(
+			array(
+				'post_status' => 'draft',
+				'post_date'   => $time,
+			)
+		);
+		$this->assertSame( '0000-00-00 00:00:00', $post->post_date_gmt, 'Precondition: the draft has a floating GMT date.' );
+
+		$read = $this->execute_ability(
+			'core/content-query',
+			array(
+				'id'     => $post->ID,
+				'fields' => array( 'id', 'date', 'date_gmt' ),
+			)
+		);
+
+		$result = $this->update(
+			array(
+				'id'     => $post->ID,
+				'date'   => $read['date'],
+				'status' => 'publish',
+				'fields' => array( 'id', 'date', 'date_gmt' ),
+			)
+		);
+
+		$this->assert_updated_post( $result, $post->ID );
+		$this->assertEqualsWithDelta( strtotime( $read['date'] ), strtotime( $result['date'] ), 2, 'The dates should be equal.' );
+		$this->assertEqualsWithDelta( strtotime( $read['date_gmt'] ), strtotime( $result['date_gmt'] ), 2, 'The GMT dates should be equal.' );
+		$this->assertNotSame( '0000-00-00 00:00:00', get_post( $post->ID )->post_date_gmt, 'Publishing should set the GMT date.' );
+	}
+
+	/**
+	 * A database failure surfaces as the update error with a server error status.
+	 *
+	 * @since x.x.x
+	 */
+	public function test_update_post_with_db_error(): void {
+		$this->login_as( 'editor' );
+		$this->register_ability();
+
+		global $wpdb;
+		$wpdb->suppress_errors = true;
+		add_filter( 'query', array( $this, 'error_update_query' ) );
+		try {
+			$result = $this->update( $this->post_data() );
+		} finally {
+			remove_filter( 'query', array( $this, 'error_update_query' ) );
+			$wpdb->suppress_errors = false;
+		}
+
+		$this->assertAbilityError( $result, 'db_update_error', 'A failed update should surface the database error.' );
+		$this->assertSame( 500, $result->get_error_data()['status'], 'A database error should be a server error.' );
+	}
+}

--- a/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
+++ b/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
@@ -228,7 +228,7 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Provides the date inputs of the REST posts controller suite's data_post_dates().
+	 * Provides date inputs for the create and update tests.
 	 *
 	 * Each case sets the site timezone to America/New_York and expects the stored local
 	 * and GMT dates, whether the date is given as local, as GMT, or with an offset.

--- a/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
+++ b/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
@@ -1,0 +1,248 @@
+<?php
+/**
+ * Shared base for the content abilities integration tests.
+ *
+ * @package WordPress\AI\Tests\Integration\Includes\Abilities\Content
+ */
+
+namespace WordPress\AI\Tests\Integration\Includes\Abilities\Content;
+
+use WP_UnitTestCase;
+use WordPress\AI\Abilities\Content\Content;
+use WordPress\AI\Abilities\Show_In_Abilities;
+
+/**
+ * Base test case for the content abilities.
+ *
+ * Provides the shared users, the ability registration and category set-up, and the
+ * assertion helpers used by the query, create, update, and delete test cases.
+ *
+ * @since x.x.x
+ */
+abstract class Content_Ability_TestCase extends WP_UnitTestCase {
+
+	/**
+	 * The ability names registered by the Content class.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string[]
+	 */
+	protected const CONTENT_ABILITIES = array(
+		'core/content-query',
+		'core/read-content',
+		'core/content-create',
+		'core/content-update',
+		'core/content-delete',
+	);
+
+	/**
+	 * Shared user IDs keyed by role or fixture name.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @var array<string, int>
+	 */
+	protected static $user_ids = array();
+
+	/**
+	 * Creates the shared users for the content ability tests.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param \WP_UnitTest_Factory $factory The unit test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ): void {
+		self::$user_ids = array(
+			'administrator'    => $factory->user->create( array( 'role' => 'administrator' ) ),
+			'editor'           => $factory->user->create( array( 'role' => 'editor' ) ),
+			'subscriber'       => $factory->user->create( array( 'role' => 'subscriber' ) ),
+			'contributor'      => $factory->user->create( array( 'role' => 'contributor' ) ),
+			'author'           => $factory->user->create( array( 'role' => 'author' ) ),
+			'author_secondary' => $factory->user->create( array( 'role' => 'author' ) ),
+		);
+	}
+
+	/**
+	 * Set up test case.
+	 *
+	 * @since 1.2.0
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mark the curated core post types (post, page) as exposed to abilities.
+		( new Show_In_Abilities() )->register();
+
+		$this->ensure_ability_category( 'content' );
+
+		/*
+		 * The plugin registers its other abilities on the same abilities-init hook, so
+		 * booting the registry here also registers `core/read-settings` (the `site`
+		 * category) and `core/users-query` (the `user` category). Make sure those
+		 * categories exist too; otherwise their registration emits an "incorrect usage"
+		 * notice that fails these tests.
+		 */
+		$this->ensure_ability_category( 'site' );
+		$this->ensure_ability_category( 'user' );
+	}
+
+	/**
+	 * Tear down test case.
+	 *
+	 * @since 1.2.0
+	 */
+	public function tearDown(): void {
+		foreach ( self::CONTENT_ABILITIES as $ability_name ) {
+			if ( ! wp_has_ability( $ability_name ) ) {
+				continue;
+			}
+
+			wp_unregister_ability( $ability_name );
+		}
+
+		// Restore the curated post types to their unmarked state to avoid leaking into other tests.
+		foreach ( array( 'post', 'page' ) as $post_type ) {
+			$object = get_post_type_object( $post_type );
+			if ( ! $object ) {
+				continue;
+			}
+
+			unset( $object->show_in_abilities );
+		}
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensures an ability category exists for an ability to attach to.
+	 *
+	 * @since 1.2.0
+	 *
+	 * @param string $slug The ability category slug.
+	 */
+	protected function ensure_ability_category( string $slug ): void {
+		if ( wp_has_ability_category( $slug ) ) {
+			return;
+		}
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			wp_register_ability_category(
+				$slug,
+				array(
+					'label'       => ucfirst( $slug ),
+					'description' => ucfirst( $slug ) . '.',
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Registers the plugin's content abilities inside a faked init action.
+	 *
+	 * @since 1.2.0
+	 */
+	protected function register_ability(): void {
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Faking the action context to register within it.
+		try {
+			( new Content() )->register();
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Logs in as a user with the given role and returns the user ID.
+	 *
+	 * @param string $role The role to log in as.
+	 * @return int The user ID.
+	 */
+	protected function login_as( string $role ): int {
+		$user_id = self::$user_ids[ $role ] ?? self::factory()->user->create( array( 'role' => $role ) );
+		wp_set_current_user( $user_id );
+		return $user_id;
+	}
+
+	/**
+	 * Executes a registered ability through WP_Ability::execute().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string       $ability_name The ability name.
+	 * @param array<mixed> $input        The ability input.
+	 * @return mixed The ability result.
+	 */
+	protected function execute_ability( string $ability_name, array $input ) {
+		$ability = wp_get_ability( $ability_name );
+		$this->assertNotNull( $ability, sprintf( 'The %s ability should be registered.', $ability_name ) );
+
+		return $ability->execute( $input );
+	}
+
+	/**
+	 * Asserts that a result is a WP_Error with the given code.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed  $result  The ability result.
+	 * @param string $code    The expected error code.
+	 * @param string $message The assertion message.
+	 */
+	protected function assertAbilityError( $result, string $code, string $message ): void {
+		$this->assertWPError( $result, $message );
+		$this->assertSame( $code, $result->get_error_code(), $message );
+	}
+
+	/**
+	 * Asserts that a result is the generic permission denial.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param mixed  $result  The ability result.
+	 * @param string $message The assertion message.
+	 */
+	protected function assertAbilityDenied( $result, string $message ): void {
+		$this->assertAbilityError( $result, 'ability_invalid_permissions', $message );
+	}
+
+	/**
+	 * Removes a capability from the current user and flushes the capability cache.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $capability The capability to remove.
+	 */
+	protected function revoke_current_user_capability( string $capability ): void {
+		$user = wp_get_current_user();
+		$user->add_cap( $capability, false );
+		// Flush capabilities, https://core.trac.wordpress.org/ticket/28374
+		$user->get_role_caps();
+		$user->update_user_level_from_caps();
+	}
+
+	/**
+	 * Returns roles that can read public posts but cannot edit another user's post.
+	 *
+	 * @return array<string, array{role: string}> Role test cases.
+	 */
+	public function data_roles_without_edit_access_to_other_users_posts(): array {
+		return array(
+			'subscriber'  => array(
+				'role' => 'subscriber',
+			),
+			'contributor' => array(
+				'role' => 'contributor',
+			),
+			'author'      => array(
+				'role' => 'author',
+			),
+		);
+	}
+}

--- a/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
+++ b/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
@@ -228,6 +228,76 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Provides the date inputs of the REST posts controller suite's data_post_dates().
+	 *
+	 * Each case sets the site timezone to America/New_York and expects the stored local
+	 * and GMT dates, whether the date is given as local, as GMT, or with an offset.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, array{0: string, 1: array<string, string>, 2: array<string, string>}> Status, inputs, and expected stored dates.
+	 */
+	public function data_post_dates(): array {
+		$all_statuses = array( 'draft', 'publish', 'future', 'pending', 'private' );
+
+		$cases_short = array(
+			'set date without timezone'     => array(
+				'statuses' => $all_statuses,
+				'params'   => array(
+					'timezone_string' => 'America/New_York',
+					'date'            => '2016-12-12T14:00:00',
+				),
+				'results'  => array(
+					'date'     => '2016-12-12 14:00:00',
+					'date_gmt' => '2016-12-12 19:00:00',
+				),
+			),
+			'set date_gmt without timezone' => array(
+				'statuses' => $all_statuses,
+				'params'   => array(
+					'timezone_string' => 'America/New_York',
+					'date_gmt'        => '2016-12-12T19:00:00',
+				),
+				'results'  => array(
+					'date'     => '2016-12-12 14:00:00',
+					'date_gmt' => '2016-12-12 19:00:00',
+				),
+			),
+			'set date with timezone'        => array(
+				'statuses' => array( 'draft', 'publish' ),
+				'params'   => array(
+					'timezone_string' => 'America/New_York',
+					'date'            => '2016-12-12T18:00:00-01:00',
+				),
+				'results'  => array(
+					'date'     => '2016-12-12 14:00:00',
+					'date_gmt' => '2016-12-12 19:00:00',
+				),
+			),
+			'set date_gmt with timezone'    => array(
+				'statuses' => array( 'draft', 'publish' ),
+				'params'   => array(
+					'timezone_string' => 'America/New_York',
+					'date_gmt'        => '2016-12-12T18:00:00-01:00',
+				),
+				'results'  => array(
+					'date'     => '2016-12-12 14:00:00',
+					'date_gmt' => '2016-12-12 19:00:00',
+				),
+			),
+		);
+
+		$cases = array();
+		foreach ( $cases_short as $description => $case ) {
+			foreach ( $case['statuses'] as $status ) {
+				$cases[ $description . ', status=' . $status ] = array( $status, $case['params'], $case['results'] );
+			}
+		}
+
+		return $cases;
+	}
+
+	/**
 	 * Returns roles that can read public posts but cannot edit another user's post.
 	 *
 	 * @return array<string, array{role: string}> Role test cases.

--- a/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
+++ b/tests/Integration/Includes/Abilities/Content/Content_Ability_TestCase.php
@@ -26,9 +26,9 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since x.x.x
 	 *
-	 * @var string[]
+	 * @var list<string>
 	 */
-	protected const CONTENT_ABILITIES = array(
+	protected const CONTENT_ABILITIES = array( // phpcs:ignore SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition -- This is used as an array const.
 		'core/content-query',
 		'core/read-content',
 		'core/content-create',
@@ -43,7 +43,25 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	 *
 	 * @var array<string, int>
 	 */
-	protected static $user_ids = array();
+	protected static array $user_ids = array();
+
+	/**
+	 * Post types and taxonomies registered for one test, in registration order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var list<array{type: string, name: string}>
+	 */
+	private array $registered_objects = array();
+
+	/**
+	 * The category the current user is forbidden to assign, when set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @var int
+	 */
+	protected int $forbidden_category = 0;
 
 	/**
 	 * Creates the shared users for the content ability tests.
@@ -93,6 +111,18 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	 * @since 1.2.0
 	 */
 	public function tearDown(): void {
+		// Unregister in reverse order, so a taxonomy goes before the post type it was registered for.
+		foreach ( array_reverse( $this->registered_objects ) as $object ) {
+			if ( 'taxonomy' === $object['type'] ) {
+				unregister_taxonomy( $object['name'] );
+				continue;
+			}
+
+			unregister_post_type( $object['name'] );
+		}
+
+		$this->registered_objects = array();
+
 		foreach ( self::CONTENT_ABILITIES as $ability_name ) {
 			if ( ! wp_has_ability( $ability_name ) ) {
 				continue;
@@ -159,7 +189,135 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Registers a post type for one test, unregistered again in tearDown().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string               $name The post type name.
+	 * @param array<string, mixed> $args The post type registration arguments.
+	 */
+	protected function register_test_post_type( string $name, array $args ): void {
+		register_post_type( $name, $args ); // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.NotStringLiteral -- The slug is passed by each test.
+
+		$this->registered_objects[] = array(
+			'type' => 'post_type',
+			'name' => $name,
+		);
+	}
+
+	/**
+	 * Registers a taxonomy for one test, unregistered again in tearDown().
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string               $name        The taxonomy name.
+	 * @param string|list<string>  $object_type The post types the taxonomy is registered for.
+	 * @param array<string, mixed> $args        The taxonomy registration arguments.
+	 */
+	protected function register_test_taxonomy( string $name, $object_type, array $args ): void {
+		register_taxonomy( $name, $object_type, $args );
+
+		$this->registered_objects[] = array(
+			'type' => 'taxonomy',
+			'name' => $name,
+		);
+	}
+
+	/**
+	 * Registers a post type that only supports titles, for the unsupported-field tests.
+	 *
+	 * @since x.x.x
+	 */
+	protected function register_title_only_post_type(): void {
+		$this->register_test_post_type(
+			'wpai_title_only',
+			array(
+				'public'            => true,
+				'show_in_abilities' => true,
+				'supports'          => array( 'title' ),
+			)
+		);
+	}
+
+	/**
+	 * Runs a callback while queries with the given prefix fail.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string   $sql_prefix The prefix of the queries to break.
+	 * @param callable $callback   The callback to run.
+	 * @return mixed The callback result.
+	 */
+	protected function run_with_failing_query( string $sql_prefix, callable $callback ) {
+		global $wpdb;
+
+		$break_query = static function ( string $query ) use ( $sql_prefix ): string {
+			return 0 === strpos( $query, $sql_prefix ) ? '],' : $query;
+		};
+
+		$wpdb->suppress_errors = true;
+		add_filter( 'query', $break_query );
+
+		try {
+			return $callback();
+		} finally {
+			remove_filter( 'query', $break_query );
+			$wpdb->suppress_errors = false;
+		}
+	}
+
+	/**
+	 * Offers one post template for the tests that need a valid template.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, string> The post templates keyed by file name.
+	 */
+	public function filter_theme_post_templates(): array {
+		return array(
+			'post-my-test-template.php' => 'My Test Template',
+		);
+	}
+
+	/**
+	 * Revokes the assign_term meta capability for the forbidden category.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param list<string> $caps    The primitive capabilities.
+	 * @param string       $cap     The meta capability being checked.
+	 * @param int          $user_id The user ID.
+	 * @param list<mixed>  $args    The capability arguments.
+	 * @return list<string> The primitive capabilities.
+	 */
+	public function revoke_assign_term( array $caps, string $cap, int $user_id, array $args ): array {
+		if ( 'assign_term' === $cap && isset( $args[0] ) && $this->forbidden_category === $args[0] ) {
+			$caps = array( 'do_not_allow' );
+		}
+
+		return $caps;
+	}
+
+	/**
+	 * Provides fields that the post and page post types do not support.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array<string, array{0: string, 1: string, 2: mixed}> Post type, field, and value.
+	 */
+	public function data_unsupported_fields(): array {
+		return array(
+			'parent on a post'     => array( 'post', 'parent', 0 ),
+			'menu order on a post' => array( 'post', 'menu_order', 1 ),
+			'sticky on a page'     => array( 'page', 'sticky', true ),
+			'format on a page'     => array( 'page', 'format', 'aside' ),
+		);
+	}
+
+	/**
 	 * Logs in as a user with the given role and returns the user ID.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @param string $role The role to log in as.
 	 * @return int The user ID.
@@ -299,6 +457,8 @@ abstract class Content_Ability_TestCase extends WP_UnitTestCase {
 
 	/**
 	 * Returns roles that can read public posts but cannot edit another user's post.
+	 *
+	 * @since 1.2.0
 	 *
 	 * @return array<string, array{role: string}> Role test cases.
 	 */

--- a/tests/e2e/specs/abilities/core-content-write.spec.js
+++ b/tests/e2e/specs/abilities/core-content-write.spec.js
@@ -1,0 +1,219 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+/**
+ * Internal dependencies
+ */
+const {
+	enableExperiment,
+	enableExperiments,
+} = require( '../../utils/helpers' );
+
+/**
+ * Runs an ability through the client-side Abilities API, exactly as a consumer
+ * would in the browser.
+ *
+ * Mirrors the plugin's own sequence in `src/utils/run-ability.ts`: importing
+ * `@wordpress/core-abilities` initializes the client store, so we await `ready`
+ * before calling `executeAbility` from `@wordpress/abilities`. The client
+ * modules are only present in the page's import map once an AI experiment is
+ * enabled in the block editor (it declares them as `module_dependencies`).
+ *
+ * @param {import('@playwright/test').Page} page      The Playwright page.
+ * @param {string}                          abilityId The ability to run.
+ * @param {Object}                          input     The ability input.
+ * @return {Promise<Object>} `{ ok: true, result }` or `{ ok: false, code }`.
+ */
+async function runAbility( page, abilityId, input ) {
+	return page.evaluate(
+		async ( { id, abilityInput } ) => {
+			const { ready } = await import( '@wordpress/core-abilities' );
+			if ( ready ) {
+				await ready;
+			}
+
+			const { executeAbility } = await import( '@wordpress/abilities' );
+
+			try {
+				const result = await executeAbility( id, abilityInput );
+				return { ok: true, result };
+			} catch ( e ) {
+				return { ok: false, code: e && e.code ? e.code : null };
+			}
+		},
+		{ id: abilityId, abilityInput: input }
+	);
+}
+
+test.describe( 'core/content-create, core/content-update, and core/content-delete abilities (client-side Abilities API)', () => {
+	let editorPostId;
+	const createdPostIds = [];
+
+	test.beforeAll( async ( { requestUtils } ) => {
+		// The global setup deletes all `post` entries, so seed one to open the
+		// block editor on; the abilities client modules are only loaded there.
+		const post = await requestUtils.createPost( {
+			title: 'core/content-write host post',
+			status: 'publish',
+		} );
+		editorPostId = post.id;
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		// Remove only the posts created here, leaving any other specs' content alone.
+		await Promise.all(
+			[ editorPostId, ...createdPostIds ].map( ( id ) =>
+				requestUtils
+					.rest( {
+						method: 'DELETE',
+						path: `/wp/v2/posts/${ id }`,
+						params: { force: true },
+					} )
+					.catch( () => {} )
+			)
+		);
+		createdPostIds.length = 0;
+	} );
+
+	test.beforeEach( async ( { admin, page } ) => {
+		// Enabling an experiment loads its block-editor script, which declares the
+		// `@wordpress/abilities` + `@wordpress/core-abilities` modules as dependencies
+		// and so adds them to the editor's import map.
+		await enableExperiments( admin, page );
+		await enableExperiment( admin, page, 'Excerpt Generation' );
+
+		// The content abilities are gated behind the Custom Abilities experiment,
+		// so enable it to register them server-side.
+		await enableExperiment( admin, page, 'Custom Abilities' );
+
+		// Run from the block editor, where the abilities client modules are available.
+		await admin.editPost( editorPostId );
+	} );
+
+	test( 'creates, updates, trashes, and deletes a post', async ( {
+		page,
+	} ) => {
+		const fields = [ 'id', 'status', 'title_raw', 'content_raw' ];
+
+		const created = await runAbility( page, 'core/content-create', {
+			post_type: 'post',
+			title: 'Written by an ability',
+			content:
+				'<!-- wp:paragraph --><p>Body written by an ability.</p><!-- /wp:paragraph -->',
+			status: 'draft',
+			fields,
+		} );
+
+		expect( created.ok ).toBe( true );
+		expect( created.result.status ).toBe( 'draft' );
+		expect( created.result.title_raw ).toBe( 'Written by an ability' );
+		expect( Object.keys( created.result ).sort() ).toEqual(
+			[ ...fields ].sort()
+		);
+		createdPostIds.push( created.result.id );
+
+		const updated = await runAbility( page, 'core/content-update', {
+			id: created.result.id,
+			title: 'Updated by an ability',
+			status: 'publish',
+			fields,
+		} );
+
+		expect( updated.ok ).toBe( true );
+		expect( updated.result.id ).toBe( created.result.id );
+		expect( updated.result.status ).toBe( 'publish' );
+		expect( updated.result.title_raw ).toBe( 'Updated by an ability' );
+		// Omitted fields keep their current values.
+		expect( updated.result.content_raw ).toBe( created.result.content_raw );
+
+		const trashed = await runAbility( page, 'core/content-delete', {
+			id: created.result.id,
+			fields: [ 'id', 'status' ],
+		} );
+
+		expect( trashed.ok ).toBe( true );
+		expect( trashed.result.id ).toBe( created.result.id );
+		expect( trashed.result.status ).toBe( 'trash' );
+
+		const trashedAgain = await runAbility( page, 'core/content-delete', {
+			id: created.result.id,
+		} );
+
+		expect( trashedAgain.ok ).toBe( false );
+		expect( trashedAgain.code ).toBe( 'content_already_trashed' );
+
+		const deleted = await runAbility( page, 'core/content-delete', {
+			id: created.result.id,
+			force: true,
+			fields: [ 'id', 'title_raw' ],
+		} );
+
+		expect( deleted.ok ).toBe( true );
+		expect( deleted.result.deleted ).toBe( true );
+		expect( deleted.result.previous.id ).toBe( created.result.id );
+		expect( deleted.result.previous.title_raw ).toBe(
+			'Updated by an ability'
+		);
+
+		// The post is gone, so reading it is denied.
+		const read = await runAbility( page, 'core/content-query', {
+			id: created.result.id,
+		} );
+
+		expect( read.ok ).toBe( false );
+	} );
+
+	test( 'rejects a field the post type does not support', async ( {
+		page,
+	} ) => {
+		const outcome = await runAbility( page, 'core/content-create', {
+			post_type: 'page',
+			title: 'Sticky page',
+			sticky: true,
+		} );
+
+		expect( outcome.ok ).toBe( false );
+		expect( outcome.code ).toBe( 'content_invalid_field' );
+	} );
+
+	test( 'rejects unknown properties', async ( { page } ) => {
+		const outcome = await runAbility( page, 'core/content-create', {
+			post_type: 'post',
+			title: 'Read-only field',
+			modified: '2010-06-01T02:00:00Z',
+		} );
+
+		expect( outcome.ok ).toBe( false );
+		expect( outcome.code ).toBe( 'ability_invalid_input' );
+	} );
+
+	test( 'writes a post type registered by another active plugin', async ( {
+		page,
+	} ) => {
+		// The `e2e-testing` plugin (mapped in .wp-env.test.json) registers the
+		// `ai_e2e_sample` post type with `show_in_abilities`.
+		const created = await runAbility( page, 'core/content-create', {
+			post_type: 'ai_e2e_sample',
+			title: 'Sample written by an ability',
+			status: 'publish',
+			fields: [ 'id', 'post_type', 'title_rendered' ],
+		} );
+
+		expect( created.ok ).toBe( true );
+		expect( created.result.post_type ).toBe( 'ai_e2e_sample' );
+		expect( created.result.title_rendered ).toBe(
+			'Sample written by an ability'
+		);
+
+		// The sample post type has no REST route, so clean up through the ability.
+		const deleted = await runAbility( page, 'core/content-delete', {
+			id: created.result.id,
+			force: true,
+		} );
+
+		expect( deleted.ok ).toBe( true );
+		expect( deleted.result.deleted ).toBe( true );
+	} );
+} );

--- a/tests/e2e/specs/abilities/core-content-write.spec.js
+++ b/tests/e2e/specs/abilities/core-content-write.spec.js
@@ -49,7 +49,9 @@ async function runAbility( page, abilityId, input ) {
 
 test.describe( 'core/content-create, core/content-update, and core/content-delete abilities (client-side Abilities API)', () => {
 	let editorPostId;
-	const createdPostIds = [];
+
+	// Every post written by this spec, as { postType, id }, removed in `afterAll`.
+	const createdPosts = [];
 
 	test.beforeAll( async ( { requestUtils } ) => {
 		// The global setup deletes all `post` entries, so seed one to open the
@@ -62,19 +64,20 @@ test.describe( 'core/content-create, core/content-update, and core/content-delet
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		// Remove only the posts created here, leaving any other specs' content alone.
+		// Remove only the posts written here, leaving any other specs' content alone.
 		await Promise.all(
-			[ editorPostId, ...createdPostIds ].map( ( id ) =>
-				requestUtils
-					.rest( {
-						method: 'DELETE',
-						path: `/wp/v2/posts/${ id }`,
-						params: { force: true },
-					} )
-					.catch( () => {} )
+			[ { postType: 'posts', id: editorPostId }, ...createdPosts ].map(
+				( { postType, id } ) =>
+					requestUtils
+						.rest( {
+							method: 'DELETE',
+							path: `/wp/v2/${ postType }/${ id }`,
+							params: { force: true },
+						} )
+						.catch( () => {} )
 			)
 		);
-		createdPostIds.length = 0;
+		createdPosts.length = 0;
 	} );
 
 	test.beforeEach( async ( { admin, page } ) => {
@@ -112,7 +115,7 @@ test.describe( 'core/content-create, core/content-update, and core/content-delet
 		expect( Object.keys( created.result ).sort() ).toEqual(
 			[ ...fields ].sort()
 		);
-		createdPostIds.push( created.result.id );
+		createdPosts.push( { postType: 'posts', id: created.result.id } );
 
 		const updated = await runAbility( page, 'core/content-update', {
 			id: created.result.id,
@@ -202,12 +205,18 @@ test.describe( 'core/content-create, core/content-update, and core/content-delet
 		} );
 
 		expect( created.ok ).toBe( true );
+
+		// Registered before the assertions below, so a failure still cleans up.
+		createdPosts.push( {
+			postType: 'ai_e2e_sample',
+			id: created.result.id,
+		} );
+
 		expect( created.result.post_type ).toBe( 'ai_e2e_sample' );
 		expect( created.result.title_rendered ).toBe(
 			'Sample written by an ability'
 		);
 
-		// The sample post type has no REST route, so clean up through the ability.
 		const deleted = await runAbility( page, 'core/content-delete', {
 			id: created.result.id,
 			force: true,


### PR DESCRIPTION
## What?

Adds three write abilities next to `core/content-query`: `core/content-create`, `core/content-update`, and `core/content-delete`.

## Why?

The content ability only reads posts. Agents also need to create, update, and delete them, with the same rules the REST API applies.

## How?

- The abilities live in `includes/Abilities/Content/Content.php`, next to the query ability, and are gated by the same Custom Abilities experiment.
- Create and update share one write pipeline. It rejects fields the post type does not support, prepares the post, validates the objects the input refers to (template, featured media, terms), writes it, and applies the parts that live outside the posts table.
- The input mirrors the posts endpoints: a title, content, excerpt, status, slug, dates, author, password, parent, menu order, comment and ping status, format, featured media, sticky flag, template, and taxonomy terms under their `rest_base` keys. The title, content, and excerpt take a string or an object with a `raw` key. The written post is returned through the query ability's field projection.
- Anything the request cannot honour fails loudly instead of being dropped: an unsupported field, an unknown term, parent, author, or featured media ID, or a template the theme does not offer. Everything is validated before the post is written.
- `core/content-delete` trashes by default and deletes permanently with `force`, returning `{ deleted, previous }`.
- The integration tests port the create, update, and delete cases of the core REST posts controller suite, plus pages, custom post types, and custom taxonomies. Shared fixtures live in a base test case.

## Testing Instructions

1. Enable the Custom Abilities experiment.
2. Run `core/content-create` with `{ "post_type": "post", "title": "Hello", "status": "draft" }`, then `core/content-update` and `core/content-delete` with the returned `id`.
3. Run the PHP tests:
   ```
   npm run test:php -- --filter 'ContentTest|ContentCreateTest|ContentUpdateTest|ContentDeleteTest'
   ```
4. Run the e2e specs:
   ```
   npm run test:e2e -- tests/e2e/specs/abilities
   ```

## Changelog Entry

> Added - New `core/content-create`, `core/content-update`, and `core/content-delete` abilities that mirror the REST API posts endpoints.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1025-b74edf2fa172eabe74f72e32141639b1b3847873.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->