### PR TITLE
Feat/suggest reply comment edit page

### DIFF
--- a/includes/Experiments/Suggest_Reply/Suggest_Reply.php
+++ b/includes/Experiments/Suggest_Reply/Suggest_Reply.php
@@ -111,7 +111,8 @@ class Suggest_Reply extends Abstract_Feature {
 	 * @param string $hook_suffix The current admin page hook suffix.
 	 */
 	public function enqueue_assets( string $hook_suffix ): void {
-		if ( ! in_array( $hook_suffix, array( 'edit-comments.php', 'index.php' ), true ) ) {
+		$allowed_hooks = array( 'edit-comments.php', 'index.php', 'comment.php' );
+		if ( ! in_array( $hook_suffix, $allowed_hooks, true ) ) {
 			return;
 		}
 
@@ -121,10 +122,25 @@ class Suggest_Reply extends Abstract_Feature {
 			array( 'include_core_abilities' => true )
 		);
 		Asset_Loader::enqueue_style( 'suggest_reply', 'experiments/suggest-reply' );
+
+		$localize_data = array( 'enabled' => $this->is_enabled() );
+
+		if ( 'comment.php' === $hook_suffix ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$action     = isset( $_GET['action'] ) ? sanitize_key( $_GET['action'] ) : '';
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$comment_id = isset( $_GET['c'] ) ? absint( $_GET['c'] ) : 0;
+
+			if ( 'editcomment' === $action && $comment_id > 0 ) {
+				$localize_data['is_edit_page'] = true;
+				$localize_data['comment_id']   = $comment_id;
+			}
+		}
+
 		Asset_Loader::localize_script(
 			'suggest_reply',
 			'SuggestReplyData',
-			array( 'enabled' => $this->is_enabled() )
+			$localize_data
 		);
 	}
 }

--- a/src/experiments/suggest-reply/components/SuggestReply.ts
+++ b/src/experiments/suggest-reply/components/SuggestReply.ts
@@ -453,6 +453,11 @@ function openReplyFormThen( commentId: number, callback: () => void ): void {
  * "Suggest reply" row action link immediately opens the reply form and starts
  * AI generation.
  */
+/**
+ * Attaches a delegated click listener on the comment list so that clicking a
+ * "Suggest reply" row action link immediately opens the reply form and starts
+ * AI generation.
+ */
 export function init(): void {
 	const commentList = document.querySelector( '#the-comment-list' );
 
@@ -490,4 +495,330 @@ export function init(): void {
 			void generateAndInsertReply( commentId );
 		}
 	} );
+}
+
+const EDIT_ERROR_NOTICE_ID = 'wpai-suggest-reply-edit-error';
+const EDIT_CONTROLS_WRAPPER_ID = 'wpai-suggest-reply-edit-controls';
+const EDIT_SUGGEST_BTN_ID = 'wpai-suggest-reply-edit-btn';
+
+/** Writes text into the edit-comment page textarea (#content). */
+function populateEditTextarea( text: string ): void {
+	const textarea =
+		document.querySelector< HTMLTextAreaElement >( '#content' );
+
+	if ( ! textarea ) {
+		return;
+	}
+
+	textarea.value = text;
+	textarea.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	textarea.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+
+	const win = window as unknown as {
+		tinymce?: {
+			get: (
+				id: string
+			) => { setContent: ( content: string ) => void } | null;
+		};
+	};
+	if ( win.tinymce?.get( 'content' ) ) {
+		win.tinymce.get( 'content' )?.setContent( text );
+	}
+}
+
+/** Sets or clears a placeholder on the edit-comment page textarea. */
+function setEditTextareaPlaceholder( message: string ): void {
+	const textarea =
+		document.querySelector< HTMLTextAreaElement >( '#content' );
+
+	if ( textarea ) {
+		textarea.placeholder = message;
+	}
+}
+
+/** Disables / re-enables the edit-page textarea, Update button and our controls. */
+function setEditFormDisabled( disabled: boolean ): void {
+	const elements: Array<
+		HTMLTextAreaElement | HTMLButtonElement | HTMLInputElement | null
+	> = [
+		document.querySelector< HTMLTextAreaElement >( '#content' ),
+		document.querySelector< HTMLInputElement >( '#save' ),
+		document.getElementById(
+			EDIT_SUGGEST_BTN_ID
+		) as HTMLButtonElement | null,
+		document.querySelector< HTMLButtonElement >(
+			`#${ EDIT_CONTROLS_WRAPPER_ID } .wpai-split-button__toggle`
+		),
+	];
+
+	document
+		.querySelectorAll< HTMLButtonElement >(
+			`#${ EDIT_CONTROLS_WRAPPER_ID } .wpai-dropdown-item`
+		)
+		.forEach( ( item ) => elements.push( item ) );
+
+	document
+		.querySelectorAll< HTMLInputElement | HTMLButtonElement >(
+			'#qt_content_toolbar .ed_button'
+		)
+		.forEach( ( item ) => {
+			if (
+				item instanceof HTMLInputElement ||
+				item instanceof HTMLButtonElement
+			) {
+				elements.push( item );
+			}
+		} );
+
+	elements.forEach( ( el ) => {
+		if ( el ) {
+			el.disabled = disabled;
+		}
+	} );
+}
+
+/** Removes any previously injected error notice on the edit page. */
+function clearEditErrorNotice(): void {
+	document.getElementById( EDIT_ERROR_NOTICE_ID )?.remove();
+}
+
+/** Shows an error notice below our controls on the edit page. */
+function showEditErrorNotice( message: string ): void {
+	clearEditErrorNotice();
+
+	const container = document.getElementById( EDIT_CONTROLS_WRAPPER_ID );
+
+	if ( ! container ) {
+		return;
+	}
+
+	const notice = document.createElement( 'div' );
+	notice.id = EDIT_ERROR_NOTICE_ID;
+	notice.className =
+		'notice notice-error notice-alt inline wpai-suggest-reply-error';
+
+	const p = document.createElement( 'p' );
+	p.textContent = message;
+	notice.appendChild( p );
+
+	container.appendChild( notice );
+}
+
+/** Sets the edit-page Suggest Reply button into a loading / idle state. */
+function setEditSuggestBtnLoading( loading: boolean ): void {
+	const btn = document.getElementById(
+		EDIT_SUGGEST_BTN_ID
+	) as HTMLButtonElement | null;
+
+	if ( btn ) {
+		btn.disabled = loading;
+		btn.textContent = loading ? LOADING_TEXT : SUGGEST_BTN_TEXT;
+	}
+
+	if ( loading ) {
+		const dropdownMenu = document.querySelector< HTMLElement >(
+			`#${ EDIT_CONTROLS_WRAPPER_ID } .wpai-split-button__dropdown`
+		);
+		const toggleBtn = document.querySelector< HTMLButtonElement >(
+			`#${ EDIT_CONTROLS_WRAPPER_ID } .wpai-split-button__toggle`
+		);
+
+		if ( dropdownMenu ) {
+			dropdownMenu.hidden = true;
+		}
+		if ( toggleBtn ) {
+			toggleBtn.setAttribute( 'aria-expanded', 'false' );
+		}
+	}
+}
+
+/** Returns the tone currently selected in the edit-page split button dropdown. */
+function getEditSelectedTone(): Tone {
+	const container = document.querySelector< HTMLElement >(
+		`#${ EDIT_CONTROLS_WRAPPER_ID } .wpai-split-button`
+	);
+
+	return ( container?.getAttribute( TONE_ATTR ) as Tone ) ?? DEFAULT_TONE;
+}
+
+/**
+ * Creates a split-button specifically wired for the edit-comment page.
+ * Clicking the main action button triggers generation into #content.
+ */
+function createEditPageSplitButtonControls( commentId: number ): HTMLElement {
+	let currentTone: Tone = DEFAULT_TONE;
+
+	const container = document.createElement( 'div' );
+	container.className = 'wpai-split-button';
+	container.setAttribute( TONE_ATTR, currentTone );
+
+	const actionBtn = document.createElement( 'button' );
+	actionBtn.id = EDIT_SUGGEST_BTN_ID;
+	actionBtn.type = 'button';
+	actionBtn.className = 'button wpai-split-button__action';
+	actionBtn.textContent = SUGGEST_BTN_TEXT;
+
+	actionBtn.addEventListener( 'click', () => {
+		void runGenerationEditPage( commentId );
+	} );
+
+	const toggleBtn = document.createElement( 'button' );
+	toggleBtn.type = 'button';
+	toggleBtn.className = 'button wpai-split-button__toggle';
+	toggleBtn.setAttribute( 'aria-expanded', 'false' );
+	toggleBtn.setAttribute( 'aria-haspopup', 'true' );
+	toggleBtn.setAttribute( 'aria-label', __( 'Change reply tone', 'ai' ) );
+	toggleBtn.innerHTML =
+		'<span class="dashicons dashicons-arrow-down-alt2"></span>';
+
+	const dropdownMenu = document.createElement( 'div' );
+	dropdownMenu.className = 'wpai-split-button__dropdown';
+	dropdownMenu.hidden = true;
+
+	const updateSelectionUI = () => {
+		dropdownMenu
+			.querySelectorAll( '.wpai-dropdown-item' )
+			.forEach( ( item ) => {
+				if ( item.getAttribute( TONE_ATTR ) === currentTone ) {
+					item.classList.add( 'is-selected' );
+					item.setAttribute( 'aria-selected', 'true' );
+				} else {
+					item.classList.remove( 'is-selected' );
+					item.setAttribute( 'aria-selected', 'false' );
+				}
+			} );
+
+		container.setAttribute( TONE_ATTR, currentTone );
+	};
+
+	TONE_OPTIONS.forEach( ( { label, value } ) => {
+		const itemBtn = document.createElement( 'button' );
+		itemBtn.type = 'button';
+		itemBtn.className = 'wpai-dropdown-item';
+		itemBtn.setAttribute( TONE_ATTR, value );
+		itemBtn.innerHTML = `<span class="dashicons dashicons-yes wpai-selected-icon"></span> ${ label }`;
+
+		itemBtn.addEventListener( 'click', () => {
+			currentTone = value as Tone;
+			updateSelectionUI();
+			dropdownMenu.hidden = true;
+			toggleBtn.setAttribute( 'aria-expanded', 'false' );
+			toggleBtn.focus();
+		} );
+
+		dropdownMenu.appendChild( itemBtn );
+	} );
+
+	updateSelectionUI();
+
+	toggleBtn.addEventListener( 'click', () => {
+		const isExpanded = toggleBtn.getAttribute( 'aria-expanded' ) === 'true';
+		toggleBtn.setAttribute(
+			'aria-expanded',
+			isExpanded ? 'false' : 'true'
+		);
+
+		dropdownMenu.hidden = isExpanded;
+	} );
+
+	container.addEventListener( 'keydown', ( event ) => {
+		if ( event.key !== 'Escape' || dropdownMenu.hidden ) {
+			return;
+		}
+
+		dropdownMenu.hidden = true;
+		toggleBtn.setAttribute( 'aria-expanded', 'false' );
+		toggleBtn.focus();
+	} );
+
+	document.addEventListener( 'click', ( e ) => {
+		if ( ! container.contains( e.target as Node ) ) {
+			dropdownMenu.hidden = true;
+			toggleBtn.setAttribute( 'aria-expanded', 'false' );
+		}
+	} );
+
+	container.appendChild( actionBtn );
+	container.appendChild( toggleBtn );
+	container.appendChild( dropdownMenu );
+
+	return container;
+}
+
+/**
+ * Injects the Suggest Reply split-button below the editor on the Edit Comment page.
+ */
+function injectEditPageControls( commentId: number ): void {
+	if ( document.getElementById( EDIT_CONTROLS_WRAPPER_ID ) ) {
+		return;
+	}
+
+	// On comment.php?action=editcomment, the editor container is #postdiv (or #postdivrich).
+	const editorContainer =
+		document.querySelector< HTMLElement >( '#postdiv' ) ??
+		document.querySelector< HTMLElement >( '#postdivrich' ) ??
+		document.querySelector< HTMLElement >( '#wp-content-wrap' ) ??
+		document.querySelector< HTMLElement >( '#content' );
+
+	if ( ! editorContainer ) {
+		return;
+	}
+
+	const wrapper = document.createElement( 'div' );
+	wrapper.id = EDIT_CONTROLS_WRAPPER_ID;
+	wrapper.className =
+		'wpai-suggest-reply-controls wpai-suggest-reply-edit-controls-wrapper';
+
+	wrapper.appendChild( createEditPageSplitButtonControls( commentId ) );
+
+	// Insert right after the editor container.
+	editorContainer.insertAdjacentElement( 'afterend', wrapper );
+}
+
+/**
+ * Generation logic for the Edit Comment page.
+ * Calls the AI ability with the comment ID and selected tone,
+ * then populates the #content textarea.
+ */
+async function runGenerationEditPage( commentId: number ): Promise< void > {
+	const tone = getEditSelectedTone();
+
+	clearEditErrorNotice();
+	setEditTextareaPlaceholder( LOADING_PLACEHOLDER );
+	setEditFormDisabled( true );
+	setEditSuggestBtnLoading( true );
+
+	try {
+		const result = await runAbility< string >( 'ai/suggest-reply', {
+			comment_id: commentId,
+			tone,
+		} );
+
+		setEditTextareaPlaceholder( '' );
+		populateEditTextarea( result ?? '' );
+	} catch ( err: any ) {
+		setEditTextareaPlaceholder( '' );
+
+		const message = err?.message ? err.message : GENERIC_ERROR_MESSAGE;
+
+		showEditErrorNotice( message );
+	} finally {
+		setEditFormDisabled( false );
+		setEditSuggestBtnLoading( false );
+
+		// Return focus to the textarea after re-enabling.
+		const textarea =
+			document.querySelector< HTMLTextAreaElement >( '#content' );
+		textarea?.focus();
+	}
+}
+
+/**
+ * Initialises the Suggest Reply feature on the Edit Comment admin page
+ * (comment.php?action=editcomment).
+ *
+ * @param commentId The ID of the comment being edited.
+ */
+export function initEditPage( commentId: number ): void {
+	injectEditPageControls( commentId );
 }

--- a/src/experiments/suggest-reply/index.scss
+++ b/src/experiments/suggest-reply/index.scss
@@ -22,7 +22,8 @@
 	overflow: visible !important;
 }
 
-#wpai-suggest-reply-btn {
+#wpai-suggest-reply-btn,
+#wpai-suggest-reply-edit-btn {
 	margin-right: 0 !important;
 }
 
@@ -103,5 +104,16 @@
 			visibility: visible;
 			color: var(--wp-admin-theme-color, #3858e9);
 		}
+	}
+}
+
+/* Edit comment page controls wrapper */
+.wpai-suggest-reply-edit-controls-wrapper {
+	margin-top: 10px;
+	display: block;
+	overflow: visible;
+
+	.wpai-split-button {
+		vertical-align: middle;
 	}
 }

--- a/src/experiments/suggest-reply/index.tsx
+++ b/src/experiments/suggest-reply/index.tsx
@@ -10,13 +10,15 @@ import domReady from '@wordpress/dom-ready';
 /**
  * Internal dependencies
  */
-import { init } from './components/SuggestReply';
+import { init, initEditPage } from './components/SuggestReply';
 import './index.scss';
 
 declare global {
 	interface Window {
 		aiSuggestReplyData?: {
-			enabled: boolean;
+			enabled: boolean | string;
+			is_edit_page?: boolean | string;
+			comment_id?: number | string;
 		};
 	}
 }
@@ -24,7 +26,23 @@ declare global {
 domReady( () => {
 	const data = window.aiSuggestReplyData;
 
-	if ( ! data?.enabled ) {
+	const isEnabled =
+		data?.enabled === true ||
+		data?.enabled === '1' ||
+		data?.enabled === 'true';
+
+	if ( ! isEnabled ) {
+		return;
+	}
+
+	const isEditPage =
+		data?.is_edit_page === true ||
+		data?.is_edit_page === '1' ||
+		data?.is_edit_page === 'true';
+	const commentId = data?.comment_id ? Number( data.comment_id ) : 0;
+
+	if ( isEditPage && commentId > 0 ) {
+		initEditPage( commentId );
 		return;
 	}
 

--- a/tests/Integration/Includes/Experiments/Suggest_Reply/Suggest_ReplyTest.php
+++ b/tests/Integration/Includes/Experiments/Suggest_Reply/Suggest_ReplyTest.php
@@ -172,4 +172,29 @@ class Suggest_ReplyTest extends WP_UnitTestCase {
 
 		$this->assertFalse( wp_script_is( 'suggest_reply', 'enqueued' ) );
 	}
+
+	/**
+	 * Test enqueue_assets() enqueues assets and localizes data on comment.php edit screen.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_enqueue_assets_enqueues_on_comment_edit_screen() {
+		$_GET['action'] = 'editcomment';
+		$_GET['c']      = 42;
+
+		$experiment = new Suggest_Reply();
+		$experiment->enqueue_assets( 'comment.php' );
+
+		$this->assertTrue( wp_script_is( 'ai_suggest_reply', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'ai_suggest_reply', 'enqueued' ) );
+
+		global $wp_scripts;
+		$localized = $wp_scripts->get_data( 'ai_suggest_reply', 'data' );
+
+		$this->assertStringContainsString( 'is_edit_page', $localized );
+		$this->assertStringContainsString( 'comment_id', $localized );
+		$this->assertStringContainsString( '"comment_id":"42"', $localized );
+
+		unset( $_GET['action'], $_GET['c'] );
+	}
 }


### PR DESCRIPTION
## What?
Closes #1024

Adds "Suggest Reply" support to the WordPress Edit Comment admin screen.

## Why?
Previously, the Suggest Reply experiment was only available on the Comments list table and the Dashboard Activity widget. When site editors opened the dedicated Edit Comment screen, the Suggest Reply action was missing, preventing them from generating AI reply suggestions directly in the full comment editor.

### Use of AI Tools
AI assistance: Yes
Tool(s): Claude Code
Model(s): Claude Sonnet 4.6
Used for: Validating bug, suggesting a fix.

## Testing Instructions
1. Navigate to **AI > Experiments** and ensure the **Suggest Reply** experiment is enabled.
2. Go to **Comments** and click **Edit** on an existing comment.
3. Verify that the **Suggest Reply** button is displayed beneath the comment editor textarea.
4. Click the dropdown chevron button to verify that tone options (**Friendly**, **Professional**, **Casual**) are available and selectable (with **Friendly** selected by default).
5. Click **Suggest Reply**.
6. Verify the button transitions to a loading state and, once completed, the generated reply populates the comment textarea.

## Screenshots or screencast

https://github.com/user-attachments/assets/5085bf7f-407f-48a1-9c6b-a9bfd66c64ba

https://github.com/user-attachments/assets/d45e2f20-58c3-4f43-a0e7-926b824abad9


## Changelog Entry

> Added - Suggest Reply support to the Edit Comment admin screen.

<!-- wp-playground-preview:start -->
<a href="https://playground.wordpress.net?blueprint-url=data:application/json,%7B%22preferredVersions%22%3A%7B%22wp%22%3A%22latest%22%7D%2C%22login%22%3Atrue%2C%22landingPage%22%3A%22%2Fwp-admin%2Fadmin.php%3Fpage%3Dai-wp-admin%22%2C%22steps%22%3A%5B%7B%22step%22%3A%22installPlugin%22%2C%22pluginData%22%3A%7B%22resource%22%3A%22url%22%2C%22url%22%3A%22https%3A%2F%2Fgithub.com%2FWordPress%2Fai%2Freleases%2Fdownload%2Fci-artifacts%2Fpr-1028-793565203453bfc3b8715149a277b19731b5534a.zip%22%7D%7D%5D%7D" target="_blank" rel="noopener noreferrer">
  <img src="https://raw.githubusercontent.com/adamziel/playground-preview/refs/heads/trunk/assets/playground-preview-button.svg" alt="Open WordPress Playground Preview" width="220" height="57" />
</a>
<!-- wp-playground-preview:end -->
